### PR TITLE
Select a font in a PDF file

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -2033,8 +2033,8 @@ return( NULL );
 return( list );
 }
 
-SplineFont *_SFReadPdfFont(FILE *pdf,char *filename,char *select_this_font,
-	enum openflags openflags) {
+SplineFont *_SFReadPdfFont(FILE *pdf,char *filename, enum openflags openflags) {
+    char *select_this_font = NULL, *pt;
     struct pdfcontext pc;
     SplineFont *sf = NULL;
     char oldloc[24];
@@ -2062,6 +2062,12 @@ return( NULL );
 	pcFree(&pc);
 	setlocale(LC_NUMERIC,oldloc);
 return( NULL );
+    }
+    // parse the chosen font name
+    if((pt = strchr(filename, '(')) != NULL) {
+        select_this_font = copy(pt+1);
+        if((pt = strchr(select_this_font, ')')) != NULL)
+            *pt = '\0';
     }
     if ( pc.fcnt==1 ) {
 	sf = pdf_loadfont(&pc,0);
@@ -2094,29 +2100,21 @@ return( NULL );
     }
     setlocale(LC_NUMERIC,oldloc);
     pcFree(&pc);
+    free(select_this_font);
 return( sf );
 }
 
 SplineFont *SFReadPdfFont(char *filename,enum openflags openflags) {
-    char *pt, *freeme=NULL, *freeme2=NULL, *select_this_font=NULL;
     SplineFont *sf;
     FILE *pdf;
-
-    if ( (pt=strchr(filename,'('))!=NULL ) {
-	freeme = filename = copyn(filename,pt-filename);
-	freeme2 = select_this_font = copy(pt+1);
-	if ( (pt=strchr(select_this_font,')'))!=NULL )
-	    *pt = '\0';
-    }
 
     pdf = fopen(filename,"r");
     if ( pdf==NULL )
 	sf = NULL;
     else {
-	sf = _SFReadPdfFont(pdf,filename,select_this_font,openflags);
+	sf = _SFReadPdfFont(pdf,filename,openflags);
 	fclose(pdf);
     }
-    free(freeme); free(freeme2);
 return( sf );
 }
 

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -1083,7 +1083,7 @@ return( NULL );
 	    sf = _SFReadPostScript(file,fullname);
 	    checked = 'p';
 	} else if ( ch1=='%' && ch2=='P' && ch3=='D' && ch4=='F' ) {
-	    sf = _SFReadPdfFont(file,fullname,NULL,openflags);
+	    sf = _SFReadPdfFont(file,fullname,openflags);
 	    checked = 'P';
 	} else if ( ch1==1 && ch2==0 && ch3==4 ) {
 	    int len;

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2714,7 +2714,7 @@ extern void SFCheckPSBitmap(SplineFont *sf);
 extern uint16 _MacStyleCode( char *styles, SplineFont *sf, uint16 *psstyle );
 extern uint16 MacStyleCode( SplineFont *sf, uint16 *psstyle );
 extern SplineFont *SFReadIkarus(char *fontname);
-extern SplineFont *_SFReadPdfFont(FILE *ttf,char *filename,char *select_this_font, enum openflags openflags);
+extern SplineFont *_SFReadPdfFont(FILE *ttf,char *filename,enum openflags openflags);
 extern SplineFont *SFReadPdfFont(char *filename, enum openflags openflags);
 extern char **GetFontNames(char *filename);
 extern char **NamesReadPDF(char *filename);


### PR DESCRIPTION
Selecting font by name using the FILENAME(FONTNAME) scheme has been implemented in SFReadPdfFont but not _SFReadPdfFont

However the latter is the one used by script, python and UI, which is weird.

I just move the font selection part from SF... to _SF...
