### PR TITLE
2nd parameter for load_encoding

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -587,7 +587,7 @@ void RemoveMultiples(Encoding *item) {
 	DeleteEncoding(test);
 }
 
-char *ParseEncodingFile(char *filename) {
+char *ParseEncodingFile(char *filename, char *encodingname) {
     FILE *file;
     char *orig = filename;
     Encoding *head, *item, *prev, *next;
@@ -609,7 +609,11 @@ return( NULL );
     }
     ungetc(ch,file);
     if ( ch=='#' || ch=='0' )
-	head = ParseConsortiumEncodingFile(file);
+    {
+        head = ParseConsortiumEncodingFile(file);
+        if(encodingname)
+            head->enc_name = copy(encodingname);
+    }
     else
 	head = PSSlurpEncodings(file);
     fclose(file);
@@ -675,7 +679,7 @@ return( copy( head->enc_name ) );
 }
 
 void LoadPfaEditEncodings(void) {
-    ParseEncodingFile(NULL);
+    ParseEncodingFile(NULL, NULL);
 }
 
 void DumpPfaEditEncodings(void) {

--- a/fontforge/encodingui.c
+++ b/fontforge/encodingui.c
@@ -229,7 +229,7 @@ void LoadEncodingFile(void) {
     if ( fn==NULL )
 return;
     filename = utf82def_copy(fn);
-    ParseEncodingFile(filename);
+    ParseEncodingFile(filename, NULL);
     free(fn); free(filename);
     DumpPfaEditEncodings();
 }

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -522,12 +522,13 @@ Py_RETURN_NONE;
 
 static PyObject *PyFF_LoadEncodingFile(PyObject *self, PyObject *args) {
     const char *filename;
+    char * encodingname = NULL;
 
     /* here we do want the default encoding */
-    if ( !PyArg_ParseTuple(args,"s", &filename) )
+    if ( !PyArg_ParseTuple(args,"s|s", &filename, &encodingname) )
 return( NULL );
 
-return( Py_BuildValue("s", ParseEncodingFile((char *) filename)) );
+return( Py_BuildValue("s", ParseEncodingFile((char *) filename, encodingname)) );
 }
 
 static PyObject *PyFF_LoadNamelist(PyObject *self, PyObject *args) {

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -3211,14 +3211,15 @@ static void bHasPreservedTable(Context *c) {
 static void bLoadEncodingFile(Context *c) {
     char *t; char *locfilename;
 
-    if ( c->a.argc!=2 )
+    if ( c->a.argc != 2 && c->a.argc != 3 )
 	ScriptError( c, "Wrong number of arguments");
-    else if ( c->a.vals[1].type!=v_str )
+    else if ((c->a.vals[1].type!=v_str ) ||
+            (c->a.argc >= 3 && c->a.vals[2].type !=v_str))
 	ScriptError(c,"Bad argument type");
 
     t = script2utf8_copy(c->a.vals[1].u.sval);
     locfilename = utf82def_copy(t);
-    ParseEncodingFile(locfilename);
+    ParseEncodingFile(locfilename, (c->a.argc>=3 ? c->a.vals[2].u.sval : NULL));
     free(locfilename); free(t);
     /*DumpPfaEditEncodings();*/
 }

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2422,7 +2422,7 @@ extern SplineFont *InterpolateFont(SplineFont *base, SplineFont *other, real amo
 double SFSerifHeight(SplineFont *sf);
 
 extern void DumpPfaEditEncodings(void);
-extern char *ParseEncodingFile(char *filename);
+extern char *ParseEncodingFile(char *filename, char *encodingname);
 extern void LoadPfaEditEncodings(void);
 
 extern int GenerateScript(SplineFont *sf,char *filename,char *bitmaptype,


### PR DESCRIPTION
Currently we don't have a change to name a newly loaded Consortium encoding file in scripts.
And fontforge will drop encoding files without a name.

Which means Consortium encoding files cannot be loaded in scripts at all.

I added a 2nd parameter for LoadEncodingFile, which is useful for Consortium encoding file only.
