### PR TITLE
Metricsview keybindings to incr/decr the value and move around.

### DIFF
--- a/fontforge/prefs.c
+++ b/fontforge/prefs.c
@@ -91,6 +91,8 @@ extern int save_to_dir;			/* in fontview, use sfdir rather than sfd */
 extern int palettes_docked;		/* in cvpalettes */
 extern int cvvisible[2], bvvisible[3];	/* in cvpalettes.c */
 extern int maxundoes;			/* in cvundoes */
+extern int pref_mv_shift_and_arrow_skip;         /* in metricsview.c */
+extern int pref_mv_control_shift_and_arrow_skip; /* in metricsview.c */
 extern int prefer_cjk_encodings;	/* in parsettf */
 extern int onlycopydisplayed, copymetadata, copyttfinstr;
 extern struct cvshows CVShows;
@@ -325,6 +327,8 @@ static struct prefs_list {
 	{ N_("UndoDepth"), pr_int, &maxundoes, NULL, NULL, '\0', NULL, 0, N_("The maximum number of Undoes/Redoes stored in a glyph") },
 	{ N_("UpdateFlex"), pr_bool, &updateflex, NULL, NULL, '\0', NULL, 0, N_("Figure out flex hints after every change") },
 	{ N_("AutoKernDialog"), pr_bool, &default_autokern_dlg, NULL, NULL, '\0', NULL, 0, N_("Open AutoKern dialog for new kerning subtables") },
+	{ N_("MetricsShiftSkip"), pr_int, &pref_mv_shift_and_arrow_skip, NULL, NULL, '\0', NULL, 0, N_("Number of units to increment/decrement a table value by in the metrics window when shift is held") },
+	{ N_("MetricsControlShiftSkip"), pr_int, &pref_mv_control_shift_and_arrow_skip, NULL, NULL, '\0', NULL, 0, N_("Number of units to increment/decrement a table value by in the metrics window when both control and shift is held") },
 	PREFS_LIST_EMPTY
 },
   sync_list[] = {

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -329,6 +329,7 @@ typedef struct metricsview {
 	int16 kernafter;
 	unsigned int selected: 1;
 	GGadget *width, *lbearing, *rbearing, *kern, *name;
+	GGadget* updownkparray[10]; /* Cherry picked elements from width...kern allowing up/down key navigation */
     } *perchar;
     SplineChar **sstr;		/* Character input stream */
     int16 mwidth, mbase;


### PR DESCRIPTION
add key bindings to increasing/decreasing side-bearing and kerning
values by using the up, down, left, right arrow keys and alt and
shift etc combinations.

EG, User selects LBearing for a char in the metrics window table.

Changing current value:
  Arrow up increases,
  arrow down decreases side bearing by 1 unit.
  Shift + arrow increases by 10 units.
  Shift + ctl + arrow increases by 5 units.

Moving with alt+direction:
  Alt+up selects table field above,
  Alt+down selects field below,
  Alt+left selects value in table for the char to the left,
  Alt+right selects value in table for the char to the right.

The shift and shift-alt unit scales are set in Prefernces, Editing.
If the prefs.c names are OK then I'll send another pull req with the docs for these new options.
