### PR TITLE
Move some gadget utility routines from the private to the public headers

### DIFF
--- a/fontforge/charinfo.c
+++ b/fontforge/charinfo.c
@@ -4170,7 +4170,6 @@ return;
 
     if ( !boxset ) {
 	extern GBox _ggadget_Default_Box;
-	extern void GGadgetInit(void);
 	GGadgetInit();
 	smallbox = _ggadget_Default_Box;
 	smallbox.padding = 1;

--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -1120,11 +1120,9 @@ void CVDrawSplineSet(CharView *cv, GWindow pixmap, SplinePointList *set,
     CVDrawSplineSetSpecialized( cv, pixmap, set, fg, dopoints, clip, sfm_stroke );
 }
 
-void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *set,
+static void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *set,
 				Color fg, int dopoints, DRect *clip, enum outlinesfm_flags strokeFillMode ) {
-    Spline *spline, *first;
     SplinePointList *spl;
-    int truetype_markup = set==cv->b.gridfit && cv->dv!=NULL;
     int currentSplineCounter = 0;
 
     if( strokeFillMode == sfm_fill ) {
@@ -2307,7 +2305,7 @@ return;				/* no points. no side bearings */
 }
 
 static int CVExposeGlyphFill(CharView *cv, GWindow pixmap, GEvent *event, DRect* clip ) {
-    int i, layer, rlayer, cvlayer = CVLayer((CharViewBase *) cv);
+    int layer, cvlayer = CVLayer((CharViewBase *) cv);
     int filled = 0;
     if (( cv->showfore || cv->b.drawmode==dm_fore ) && cv->showfilled &&
 	cv->filled!=NULL ) {
@@ -7276,8 +7274,6 @@ static void cv_ptlistcheck(CharView *cv, struct gmenuitem *mi) {
     int acceptable = -1;
     uint16 junk;
     int i;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
 
     if ( cv->showing_spiro_pt_menu != (cv->b.sc->inspiro && hasspiro())) {
 	GMenuItemArrayFree(mi->sub);
@@ -9986,7 +9982,6 @@ static void ap2listbuild(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     GMenuItem *sub;
     int k, cnt;
     AnchorPoint *ap;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
 
     if ( mi->sub!=NULL ) {
 	GMenuItemArrayFree(mi->sub);
@@ -10054,9 +10049,6 @@ static void aplistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     SplineChar *sc = cv->b.sc, **glyphs;
     SplineFont *sf = sc->parent;
     AnchorPoint *ap, *found;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern void GMenuItem2ArrayFree(GMenuItem2 *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
     GMenuItem2 *mit;
     int cnt;
 
@@ -10215,8 +10207,6 @@ static GMenuItem2 mvlist[] = {
 static void mvlistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
     int i, base, j;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
     MMSet *mm = cv->b.sc->parent->mm;
     uint32 submask;
     SplineFont *sub;
@@ -10294,8 +10284,6 @@ static void CVMenuShowSubChar(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e
 static void mmlistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
     int i, base, j;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
     MMSet *mm = cv->b.sc->parent->mm;
     SplineFont *sub;
     GMenuItem2 *mml;

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -325,7 +325,7 @@ return( NULL );
 return( ret );
 }
 
-int PSDictFindEntry(struct psdict *dict, char *key) {
+int PSDictFindEntry(struct psdict *dict, const char *key) {
     int i;
 
     if ( dict==NULL )
@@ -338,7 +338,7 @@ return( i );
 return( -1 );
 }
 
-char *PSDictHasEntry(struct psdict *dict, char *key) {
+char *PSDictHasEntry(struct psdict *dict, const char *key) {
     int i;
 
     if ( dict==NULL )
@@ -367,7 +367,7 @@ return( false );
 return( true );
 }
 
-int PSDictRemoveEntry(struct psdict *dict, char *key) {
+int PSDictRemoveEntry(struct psdict *dict, const char *key) {
     int i;
 
     if ( dict==NULL )
@@ -390,7 +390,7 @@ return( false );
 return( true );
 }
 
-int PSDictChangeEntry(struct psdict *dict, char *key, char *newval) {
+int PSDictChangeEntry(struct psdict *dict, const char *key, char *newval) {
     int i;
 
     if ( dict==NULL )

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -542,7 +542,7 @@ return;
 static Encoding *ParseConsortiumEncodingFile(FILE *file) {
     char buffer[200];
     int32 encs[0x10000];
-    int enc, unienc, max, i;
+    int enc, unienc, max;
     Encoding *item;
 
     memset(encs, 0, sizeof(encs));

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -4662,10 +4662,7 @@ static void fea_ParsePosition(struct parseState *tok, int enumer) {
     /* <marked glyph pos sequence> => context chaining */
     /* [ignore pos] <marked glyph sequence> (, <marked g sequence>)* */
     struct markedglyphs *glyphs = fea_ParseMarkedGlyphs(tok,true,true,false), *g;
-    int cnt, i;
-    struct feat_item *item;
-    char *start, *pt, ch;
-    SplineChar *sc;
+    int cnt;
 
     fea_ParseTok(tok);
     for ( cnt=0, g=glyphs; g!=NULL; g=g->next, ++cnt );

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -4562,7 +4562,6 @@ static GMenuItem2 dummyall[] = {
 /* Builds up a menu containing all the anchor classes */
 static void aplistbuild(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
-    extern void GMenuItemArrayFree(GMenuItem *mi);
 
     GMenuItemArrayFree(mi->sub);
     mi->sub = NULL;
@@ -4638,7 +4637,6 @@ static GMenuItem2 emptymenu[] = {
 
 static void FVEncodingMenuBuild(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
-    extern void GMenuItemArrayFree(GMenuItem *mi);
 
     if ( mi->sub!=NULL ) {
 	GMenuItemArrayFree(mi->sub);
@@ -4704,7 +4702,6 @@ return;
 
 static void FVForceEncodingMenuBuild(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
-    extern void GMenuItemArrayFree(GMenuItem *mi);
 
     if ( mi->sub!=NULL ) {
 	GMenuItemArrayFree(mi->sub);
@@ -4998,7 +4995,6 @@ static GMenuItem2 lylist[] = {
 static void lylistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
     SplineFont *sf = fv->b.sf;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
     int ly;
     GMenuItem *sub;
 
@@ -5059,8 +5055,6 @@ static void vwlistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     int i, base;
     BDFFont *bdf;
     char buffer[50];
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
     int pos;
     SplineFont *sf = fv->b.sf;
     SplineFont *master = sf->cidmaster ? sf->cidmaster : sf;
@@ -5281,8 +5275,6 @@ static GMenuItem2 cdlist[] = {
 static void cdlistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
     int i, base, j;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
     SplineFont *sub, *cidmaster = fv->b.cidmaster;
 
     for ( i=0; cdlist[i].mid!=MID_CIDFontInfo; ++i );
@@ -5345,8 +5337,6 @@ static GMenuItem2 mmlist[] = {
 static void mmlistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
     int i, base, j;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
     MMSet *mm = fv->b.sf->mm;
     SplineFont *sub;
     GMenuItem2 *mml;

--- a/fontforge/images.c
+++ b/fontforge/images.c
@@ -12241,9 +12241,6 @@ void InitToolIconClut(Color bg) {
     }
 }
 
-/* Among other things, this routine sets global icon cache up. */
-extern void GGadgetInit(void);
-
 /* Some icons in this file, so that FontForge could show anything meaningful */
 /* when devoid of its external images. But if these are available and set up */
 /* by means of X resources, this routine polls them for fancy icons to use */

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -641,7 +641,7 @@ return(resstarts);
 enum psstyle_flags { psf_bold = 1, psf_italic = 2, psf_outline = 4,
 	psf_shadow = 0x8, psf_condense = 0x10, psf_extend = 0x20 };
 
-uint16 _MacStyleCode( char *styles, SplineFont *sf, uint16 *psstylecode ) {
+uint16 _MacStyleCode( const char *styles, SplineFont *sf, uint16 *psstylecode ) {
     unsigned short stylecode= 0, psstyle=0;
 
     if ( strstrmatch( styles, "Bold" ) || strstrmatch(styles,"Demi") ||
@@ -703,8 +703,6 @@ return( stylecode );
 }
 
 uint16 MacStyleCode( SplineFont *sf, uint16 *psstylecode ) {
-    char *styles;
-
     if ( sf->cidmaster!=NULL )
 	sf = sf->cidmaster;
 
@@ -714,8 +712,7 @@ uint16 MacStyleCode( SplineFont *sf, uint16 *psstylecode ) {
 return( sf->macstyle );
     }
 
-    styles = SFGetModifiers(sf);
-return( _MacStyleCode(styles,sf,psstylecode));
+return( _MacStyleCode(SFGetModifiers(sf),sf,psstylecode));
 }
 
 static uint32 SFToFOND(FILE *res,SplineFont *sf,uint32 id,int dottf,
@@ -2550,7 +2547,7 @@ return( copy(buffer));
 
 static int GuessStyle(char *fontname,int *styles,int style_cnt) {
     int which, style;
-    char *stylenames = _GetModifiers(fontname,NULL,NULL);
+    const char *stylenames = _GetModifiers(fontname,NULL,NULL);
 
     style = _MacStyleCode(stylenames,NULL,NULL);
     for ( which = style_cnt; which>=0; --which )

--- a/fontforge/metricsview.c
+++ b/fontforge/metricsview.c
@@ -3219,7 +3219,6 @@ static GMenuItem2 dummyall[] = {
 /* Builds up a menu containing all the anchor classes */
 static void aplistbuild(GWindow base,struct gmenuitem *mi,GEvent *e) {
     MetricsView *mv = (MetricsView *) GDrawGetUserData(base);
-    extern void GMenuItemArrayFree(GMenuItem *mi);
 
     GMenuItemArrayFree(mi->sub);
     mi->sub = NULL;
@@ -3278,7 +3277,6 @@ static GMenuItem2 lylist[] = {
 static void lylistcheck(GWindow gw,struct gmenuitem *mi, GEvent *e) {
     MetricsView *mv = (MetricsView *) GDrawGetUserData(gw);
     SplineFont *sf = mv->fv->b.sf;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
     int ly;
     GMenuItem *sub;
 
@@ -3536,8 +3534,6 @@ static void vwlistcheck(GWindow gw,struct gmenuitem *mi,GEvent *e) {
     int i, j, base, aselection;
     BDFFont *bdf;
     char buffer[60];
-    extern void GMenuItemArrayFree(GMenuItem *mi);
-    extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
 
     aselection = false;
     for ( j=0; j<mv->glyphcnt; ++j )

--- a/fontforge/savefontdlg.c
+++ b/fontforge/savefontdlg.c
@@ -2042,7 +2042,6 @@ return( true );
 }
 
 static int e_h(GWindow gw, GEvent *event) {
-    extern int GGadgetWithin(GGadget *g, int x, int y);
 
     if ( event->type==et_close ) {
 	struct gfc_data *d = GDrawGetUserData(gw);

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -1342,7 +1342,7 @@ static const char *modifierlistfull[] = { "Italic", "Oblique", "Kursive", "Cursi
 static const char **mods[] = { knownweights, modifierlist, NULL };
 static const char **fullmods[] = { realweights, modifierlistfull, NULL };
 
-char *_GetModifiers(char *fontname, char *familyname,char *weight) {
+const char *_GetModifiers(char *fontname, char *familyname,char *weight) {
     char *pt, *fpt;
     int i, j;
 
@@ -1396,7 +1396,7 @@ return( fpt );
 return( weight==NULL || *weight=='\0' ? "Regular": weight );
 }
 
-char *SFGetModifiers(SplineFont *sf) {
+const char *SFGetModifiers(SplineFont *sf) {
 return( _GetModifiers(sf->fontname,sf->familyname,sf->weight));
 }
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2032,8 +2032,8 @@ extern int SFForceEncoding(SplineFont *sf,EncMap *old,Encoding *new_map);
 extern int CountOfEncoding(Encoding *encoding_name);
 extern void SFMatchGlyphs(SplineFont *sf,SplineFont *target,int addempties);
 extern void MMMatchGlyphs(MMSet *mm);
-extern char *_GetModifiers(char *fontname, char *familyname,char *weight);
-extern char *SFGetModifiers(SplineFont *sf);
+extern const char *_GetModifiers(char *fontname, char *familyname,char *weight);
+extern const char *SFGetModifiers(SplineFont *sf);
 extern const unichar_t *_uGetModifiers(const unichar_t *fontname, const unichar_t *familyname,
 	const unichar_t *weight);
 extern void SFSetFontName(SplineFont *sf, char *family, char *mods, char *full);
@@ -2641,7 +2641,7 @@ extern char *Decompress(char *name, int compression);
 extern SplineFont *SFFromBDF(char *filename,int ispk,int toback);
 extern SplineFont *SFFromMF(char *filename);
 extern void SFCheckPSBitmap(SplineFont *sf);
-extern uint16 _MacStyleCode( char *styles, SplineFont *sf, uint16 *psstyle );
+extern uint16 _MacStyleCode( const char *styles, SplineFont *sf, uint16 *psstyle );
 extern uint16 MacStyleCode( SplineFont *sf, uint16 *psstyle );
 extern SplineFont *SFReadIkarus(char *fontname);
 extern SplineFont *_SFReadPdfFont(FILE *ttf,char *filename,enum openflags openflags);
@@ -2742,11 +2742,11 @@ extern void SFClearAutoSave(SplineFont *sf);
 extern void PSCharsFree(struct pschars *chrs);
 extern void PSDictFree(struct psdict *chrs);
 extern struct psdict *PSDictCopy(struct psdict *dict);
-extern int PSDictFindEntry(struct psdict *dict, char *key);
-extern char *PSDictHasEntry(struct psdict *dict, char *key);
+extern int PSDictFindEntry(struct psdict *dict, const char *key);
+extern char *PSDictHasEntry(struct psdict *dict, const char *key);
 extern int PSDictSame(struct psdict *dict1, struct psdict *dict2);
-extern int PSDictRemoveEntry(struct psdict *dict, char *key);
-extern int PSDictChangeEntry(struct psdict *dict, char *key, char *newval);
+extern int PSDictRemoveEntry(struct psdict *dict, const char *key);
+extern int PSDictChangeEntry(struct psdict *dict, const char *key, char *newval);
 extern int SFPrivateGuess(SplineFont *sf,int layer, struct psdict *private,
 	char *name, int onlyone);
 

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -360,22 +360,22 @@ static int PListOutputTrailer(FILE *plist) {
 return( ret );
 }
 
-static void PListOutputInteger(FILE *plist, char *key, int value) {
+static void PListOutputInteger(FILE *plist, const char *key, int value) {
     fprintf( plist, "\t<key>%s</key>\n", key );
     fprintf( plist, "\t<integer>%d</integer>\n", value );
 }
 
-static void PListOutputReal(FILE *plist, char *key, double value) {
+static void PListOutputReal(FILE *plist, const char *key, double value) {
     fprintf( plist, "\t<key>%s</key>\n", key );
     fprintf( plist, "\t<real>%g</real>\n", value );
 }
 
-static void PListOutputBoolean(FILE *plist, char *key, int value) {
+static void PListOutputBoolean(FILE *plist, const char *key, int value) {
     fprintf( plist, "\t<key>%s</key>\n", key );
     fprintf( plist, value ? "\t<true/>\n" : "\t<false/>\n" );
 }
 
-static void PListOutputDate(FILE *plist, char *key, time_t timestamp) {
+static void PListOutputDate(FILE *plist, const char *key, time_t timestamp) {
     struct tm *tm = gmtime(&timestamp);
 
     fprintf( plist, "\t<key>%s</key>\n", key );
@@ -384,7 +384,7 @@ static void PListOutputDate(FILE *plist, char *key, time_t timestamp) {
 	    tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec );
 }
 
-static void PListOutputString(FILE *plist, char *key, char *value) {
+static void PListOutputString(FILE *plist, const char *key, const char *value) {
     if ( value==NULL ) value = "";
     fprintf( plist, "\t<key>%s</key>\n", key );
     fprintf( plist, "\t<string>" );
@@ -400,7 +400,7 @@ static void PListOutputString(FILE *plist, char *key, char *value) {
     fprintf(plist, "</string>\n" );
 }
 
-static void PListOutputNameString(FILE *plist, char *key, SplineFont *sf, int strid) {
+static void PListOutputNameString(FILE *plist, const char *key, SplineFont *sf, int strid) {
     char *value=NULL, *nonenglish=NULL, *freeme=NULL;
     struct ttflangname *nm;
 
@@ -422,7 +422,7 @@ static void PListOutputNameString(FILE *plist, char *key, SplineFont *sf, int st
     free(freeme);
 }
 
-static void PListOutputIntArray(FILE *plist, char *key, char *entries, int len) {
+static void PListOutputIntArray(FILE *plist, const char *key, char *entries, int len) {
     int i;
 
     fprintf( plist, "\t<key>%s</key>\n", key );
@@ -432,7 +432,7 @@ static void PListOutputIntArray(FILE *plist, char *key, char *entries, int len) 
     fprintf( plist, "\t</array>\n" );
 }
 
-static void PListOutputPrivateArray(FILE *plist, char *key, struct psdict *private) {
+static void PListOutputPrivateArray(FILE *plist, const char *key, struct psdict *private) {
     char *value;
     int skipping;
 
@@ -464,7 +464,7 @@ return;
     fprintf( plist, "\t</array>\n" );
 }
 
-static void PListOutputPrivateThing(FILE *plist, char *key, struct psdict *private, char *type) {
+static void PListOutputPrivateThing(FILE *plist, const char *key, struct psdict *private, char *type) {
     char *value;
 
     if ( private==NULL )
@@ -678,7 +678,7 @@ return( false );
 return( PListOutputTrailer(plist));
 }
 
-static void KerningPListOutputGlyph(FILE *plist, char *key,KernPair *kp) {
+static void KerningPListOutputGlyph(FILE *plist, const char *key,KernPair *kp) {
     fprintf( plist, "\t<key>%s</key>\n", key );
     fprintf( plist, "\t<dict>\n" );
     while ( kp!=NULL ) {
@@ -1615,7 +1615,7 @@ static void UFOAddName(SplineFont *sf,char *value,int strid) {
     names->names[strid] = value;
 }
 
-static void UFOAddPrivate(SplineFont *sf,char *key,char *value) {
+static void UFOAddPrivate(SplineFont *sf,const char *key,char *value) {
     char *pt;
 
     if ( sf->private==NULL )
@@ -1627,7 +1627,7 @@ static void UFOAddPrivate(SplineFont *sf,char *key,char *value) {
     PSDictChangeEntry(sf->private, key, value);
 }
 
-static void UFOAddPrivateArray(SplineFont *sf,char *key,xmlDocPtr doc,xmlNodePtr value) {
+static void UFOAddPrivateArray(SplineFont *sf,const char *key,xmlDocPtr doc,xmlNodePtr value) {
     char space[400], *pt, *end;
     xmlNodePtr kid;
 

--- a/fontforge/windowmenu.c
+++ b/fontforge/windowmenu.c
@@ -29,8 +29,6 @@
 # include "splinefont.h"
 #  include "ustring.h"
 
-extern void GMenuItemArrayFree(struct gmenuitem *mi);
-
 static void WindowSelect(GWindow base,struct gmenuitem *mi,GEvent *e) {
     GDrawRaise(mi->ti.userdata);
 }
@@ -55,7 +53,6 @@ void WindowMenuBuild(GWindow basew,struct gmenuitem *mi,GEvent *e) {
     BitmapView *bv;
     GMenuItem *sub;
     BDFFont *bdf;
-    extern void GMenuItemArrayFree(GMenuItem *mi);
 
     precnt = 6;
     cnt = precnt;
@@ -125,7 +122,6 @@ static void RecentSelect(GWindow base,struct gmenuitem *mi,GEvent *e) {
 void MenuRecentBuild(GWindow base,struct gmenuitem *mi,GEvent *e) {
     int i, cnt, cnt1;
     FontViewBase *fv;
-    extern void GMenuItemArrayFree(struct gmenuitem *mi);
     GMenuItem *sub;
 
     if ( mi->sub!=NULL ) {

--- a/gdraw/ggadgetP.h
+++ b/gdraw/ggadgetP.h
@@ -560,10 +560,6 @@ extern GTextInfo **GTextInfoArrayFromList(GTextInfo *ti, uint16 *cnt);
 extern GTextInfo **GTextInfoArrayCopy(GTextInfo **ti);
 extern int GTextInfoArrayCount(GTextInfo **ti);
 extern int GTextInfoCompare(GTextInfo *ti1, GTextInfo *ti2);
-extern void GMenuItemArrayFree(GMenuItem *mi);
-extern GMenuItem *GMenuItemArrayCopy(GMenuItem *mi, uint16 *cnt);
-extern void GMenuItem2ArrayFree(GMenuItem2 *mi);
-extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
 extern int GMenuItemArrayMask(GMenuItem *mi);
 extern int GMenuItemArrayAnyUnmasked(GMenuItem *mi);
 

--- a/gdraw/ggadgets.c
+++ b/gdraw/ggadgets.c
@@ -61,7 +61,6 @@ int _GGadget_Skip = 6;
 int _GGadget_TextImageSkip = 4;
 char *_GGadget_ImagePath = NULL;
 static int _ggadget_inited=0;
-extern void GGadgetInit(void);
 static Color popup_foreground=0, popup_background=COLOR_CREATE(0xff,0xff,0xc0);
 static int popup_delay=1000, popup_lifetime=20000;
 

--- a/inc/ggadget.h
+++ b/inc/ggadget.h
@@ -565,4 +565,14 @@ extern void GMenuItemParseShortCut(GMenuItem *mi,char *shortcut);
 extern int GMenuItemParseMask(char *shortcut);
 
 extern int GGadgetUndoMacEnglishOptionCombinations(GEvent *event);
+
+/* Among other things, this routine sets global icon cache up. */
+extern void GGadgetInit(void);
+
+extern void GMenuItemArrayFree(GMenuItem *mi);
+extern GMenuItem *GMenuItemArrayCopy(GMenuItem *mi, uint16 *cnt);
+extern void GMenuItem2ArrayFree(GMenuItem2 *mi);
+extern GMenuItem *GMenuItem2ArrayCopy(GMenuItem2 *mi, uint16 *cnt);
+extern int GGadgetWithin(GGadget *g, int x, int y);
+
 #endif


### PR DESCRIPTION
and stop declaring them in the rest of the C files. Leave the ones
Starting with underscore for now.
Delete unused variables.
Make key strings const.
This reduces a large part of the warning noise.

... and extern function declaration in C files.
extern variable declarations in C files should eventually be cleanup up...
