### PR TITLE
Theme based hotkeys for selecting your tool from the charview

### DIFF
--- a/fontforge/cvpalettes.c
+++ b/fontforge/cvpalettes.c
@@ -218,7 +218,6 @@ static void CVMenuTool(GWindow gw,struct gmenuitem *mi,GEvent *e) {
     CVToolsSetCursor(cv,0,NULL);
 }
 
-static void CVChangeSpiroMode(CharView *cv);
 static void CVMenuSpiroSet(GWindow gw,struct gmenuitem *mi,GEvent *e) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
     CVChangeSpiroMode(cv);
@@ -770,6 +769,11 @@ static void CVPolyStar(CharView *cv) {
     ps_pointcnt = temp;
 }
 
+void CVSelectTool(CharView *cv,enum cvtools sel) {
+    cv->b1_tool = sel;
+    CVToolsRedraw();
+}
+
 static void ToolsExpose(GWindow pixmap, CharView *cv, GRect *r) {
     GRect old;
     /* Note: If you change this ordering, change enum cvtools */
@@ -844,10 +848,12 @@ static void ToolsExpose(GWindow pixmap, CharView *cv, GRect *r) {
 /*	else								 */
 	    GDrawDrawImage(pixmap,buttons[mi][j],NULL,j*27+1,i*27+1);
 	norm = (mi*2+j!=tool);
-	GDrawDrawLine(pixmap,j*27,i*27,j*27+25,i*27,norm?0xe0e0e0:0x707070);
-	GDrawDrawLine(pixmap,j*27,i*27,j*27,i*27+25,norm?0xe0e0e0:0x707070);
-	GDrawDrawLine(pixmap,j*27,i*27+25,j*27+25,i*27+25,norm?0x707070:0xe0e0e0);
-	GDrawDrawLine(pixmap,j*27+25,i*27,j*27+25,i*27+25,norm?0x707070:0xe0e0e0);
+	if( !norm ) {
+	    GDrawDrawLine(pixmap,j*27,i*27,j*27+25,i*27,norm?0xe0e0e0:0x707070);
+	    GDrawDrawLine(pixmap,j*27,i*27,j*27,i*27+25,norm?0xe0e0e0:0x707070);
+	    GDrawDrawLine(pixmap,j*27,i*27+25,j*27+25,i*27+25,norm?0x707070:0xe0e0e0);
+	    GDrawDrawLine(pixmap,j*27+25,i*27,j*27+25,i*27+25,norm?0x707070:0xe0e0e0);
+	}
     }
     GDrawSetFont(pixmap,toolsfont);
     temp.x = 52-16; temp.y = i*27; temp.width = 16; temp.height = 4*12;
@@ -1028,7 +1034,7 @@ static void SCCheckForSSToOptimize(SplineChar *sc, SplineSet *ss,int order2) {
     }
 }
 
-static void CVChangeSpiroMode(CharView *cv) {
+void CVChangeSpiroMode(CharView *cv) {
     if ( hasspiro() ) {
 	cv->b.sc->inspiro = !cv->b.sc->inspiro;
 	cv->showing_tool = cvt_none;
@@ -4131,4 +4137,8 @@ void PalettesChangeDocking(void) {
 
 int BVPalettesWidth(void) {
 return( GGadgetScale(BV_LAYERS_WIDTH));
+}
+
+void CVToolsRedraw() {
+    GDrawRequestExpose(cvtools,NULL,false);
 }

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1185,4 +1185,8 @@ extern char *GlyphSetFromSelection(SplineFont *sf,int def_layer,char *current);
 extern void ME_ListCheck(GGadget *g,int r, int c, SplineFont *sf);
 extern void ME_SetCheckUnique(GGadget *g,int r, int c, SplineFont *sf);
 extern void ME_ClassCheckUnique(GGadget *g,int r, int c, SplineFont *sf);
+
+extern void CVToolsRedraw();
+extern void CVChangeSpiroMode(CharView *cv);
+
 #endif	/* _VIEWS_H */

--- a/htdocs/xres.html
+++ b/htdocs/xres.html
@@ -335,6 +335,75 @@ fontforge.FontView.FontFamily: Helvetica, GillSans
       Select the font used to display the information shown in the window associated
       with the measure tool.
     <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.Zoom</CODE>
+    <DD>
+      The keyboard shortcut that you desire to switch to the zoom tool. For example:
+fontforge.CharView.Hotkey.Tool.Zoom: z
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.Ruler</CODE>
+    <DD>
+      The keyboard shortcut to select the ruler tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.Pointer</CODE>
+    <DD>
+      The keyboard shortcut to select the pointer tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.Hand</CODE>
+    <DD>
+      The keyboard shortcut to select the hand tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.PointCurve</CODE>
+    <DD>
+      The keyboard shortcut to select the point curve tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.PointHVCurve</CODE>
+    <DD>
+      The keyboard shortcut to select the point hv curve tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.PointCorner</CODE>
+    <DD>
+      The keyboard shortcut to select the point corner tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.PointTangent</CODE>
+    <DD>
+      The keyboard shortcut to select the point tangent tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.Freehand</CODE>
+    <DD>
+      The keyboard shortcut to select the point Freehand tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.PointTangent</CODE>
+    <DD>
+      The keyboard shortcut to select the point tangent tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.Pen</CODE>
+    <DD>
+      The keyboard shortcut to select the point Pen tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.SpiroToggle</CODE>
+    <DD>
+      Toggle spiro mode on if it is available.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.SpiroG4</CODE>
+    <DD>
+      SpiroG4 tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.SpiroCorner</CODE>
+    <DD>
+      SpiroCorner tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.SpiroLeft</CODE>
+    <DD>
+      SpiroLeft tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.SpiroRight</CODE>
+    <DD>
+      SpiroRight tool.
+    <DT>
+      <CODE>fontforge.CharView.Hotkey.Tool.Knife</CODE>
+    <DD>
+      Knife tool.
+    <DT>
       <CODE>fontforge.DebugView.Font</CODE>
     <DD>
       Select the font used to display the truetype instructions being debugged.


### PR DESCRIPTION
Added hotkey support for selecting your current tool while in the charview (glyph editor).

Some hints for your theme file are:

fontforge.CharView.Hotkey.Tool.Zoom: z
fontforge.CharView.Hotkey.Tool.Ruler: r
fontforge.CharView.Hotkey.Tool.Pointer: v
fontforge.CharView.Hotkey.Tool.Hand: h
fontforge.CharView.Hotkey.Tool.PointCurve: 1
fontforge.CharView.Hotkey.Tool.PointHVCurve: 2
fontforge.CharView.Hotkey.Tool.PointCorner: 3
fontforge.CharView.Hotkey.Tool.PointTangent: 4
fontforge.CharView.Hotkey.Tool.Freehand: f
fontforge.CharView.Hotkey.Tool.Pen: p
fontforge.CharView.Hotkey.Tool.SpiroToggle: s
fontforge.CharView.Hotkey.Tool.SpiroG4: 2
fontforge.CharView.Hotkey.Tool.SpiroCorner: 3
fontforge.CharView.Hotkey.Tool.SpiroLeft: 4
fontforge.CharView.Hotkey.Tool.SpiroRight: 5
fontforge.CharView.Hotkey.Tool.Knife: k

Note that the hotkeys are currently limited to no qualifiers.
