### PR TITLE
More explicit info line in charview for the layer info.

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -3273,11 +3273,12 @@ static void CVCharUp(CharView *cv, GEvent *event ) {
 #endif
 }
 
-static void CVInfoDrawText(CharView *cv, GWindow pixmap ) {
+void CVInfoDrawText(CharView *cv, GWindow pixmap ) {
     GRect r;
     Color bg = GDrawGetDefaultBackground(GDrawGetDisplayOfWindow(pixmap));
     Color fg = GDrawGetDefaultForeground(GDrawGetDisplayOfWindow(pixmap));
-    char buffer[50];
+    const int buffersz = 50;
+    char buffer[buffersz+1];
     int ybase = cv->mbh+(cv->infoh-cv->sfh)/2+cv->sas;
     real xdiff, ydiff;
     SplinePoint *sp, dummy;
@@ -3315,14 +3316,22 @@ static void CVInfoDrawText(CharView *cv, GWindow pixmap ) {
     else
 	sprintf( buffer, "%.3g%%", (double) (100*cv->scale));
     GDrawDrawBiText8(pixmap,MAG_DATA,ybase,buffer,-1,NULL,fg);
-    GDrawDrawBiText8(pixmap,LAYER_DATA,ybase,
-/* GT: Guide layer, make it short */
-		cv->b.drawmode==dm_grid ?                      _("Guide") :
-/* GT: Background, make it short */
+
+    const int layernamesz = 100;
+    char layername[layernamesz+1];
+    strcpy(layername,_("Guide"));
+    if(cv->b.drawmode!=dm_grid) {
+	int idx = CVLayer((CharViewBase *) cv);
+	if(idx >= 0 && idx < cv->b.sc->parent->layer_cnt) {
+	    strncpy(layername,cv->b.sc->parent->layers[idx].name,layernamesz);
+	}
+    }
+    snprintf( buffer, buffersz, "Active Layer: %s (%s)",
+	      ( cv->b.drawmode==dm_grid ? _("Guide") :
 		cv->b.layerheads[cv->b.drawmode]->background ? _("Back") :
-/* GT: Foreground, make it short */
-								_("Fore"),
-	    -1,NULL,fg);
+		_("Fore") ),
+	      layername );
+    GDrawDrawBiText8(pixmap,LAYER_DATA,ybase,buffer,-1,NULL,fg);
     if ( cv->coderange!=cr_none ) {
 	GDrawDrawBiText8(pixmap,CODERANGE_DATA,ybase,
 		cv->coderange==cr_fpgm ? _("'fpgm'") :

--- a/fontforge/cvpalettes.c
+++ b/fontforge/cvpalettes.c
@@ -1976,6 +1976,7 @@ static void CVLRemoveEdit(CharView *cv, int save) {
 	GDrawRequestExpose(cvlayers,NULL,false);
 
 	layerinfo.rename_active = 0;
+	CVInfoDrawText(cv,cv->gw);
     }
 }
 
@@ -2468,6 +2469,7 @@ return;
     if (cvlayers)  GDrawRequestExpose(cvlayers,NULL,false);
     if ( dm!=cv->b.drawmode )
         GDrawRequestExpose(cv->gw,NULL,false); /* the logo (where the scrollbars join) shows what layer we are in */
+    CVInfoDrawText(cv,cv->gw);
 }
 
 static int cvlayers_e_h(GWindow gw, GEvent *event) {


### PR DESCRIPTION
More explicit info line in charview for the layer info.

"Active Layer: $layerName ($layerType)" which would be eg
"Active Layer: Fore (Fore)" by default,
and eg if a user adds a background layer they call "Scribbles"
then it would be
"Active Layer: Scribbles (Back)"

The patch also includes updating the info line when a layer is renamed,
and when a new layer is chosen from the cv layer palette.
