### PR TITLE
Lets make the point info window not a modal one.

### DIFF
--- a/fontforge/cvpointer.c
+++ b/fontforge/cvpointer.c
@@ -700,6 +700,7 @@ return;
     }
     if ( needsupdate )
 	SCUpdateAll(cv->b.sc);
+    
     /* lastselpt is set by our caller */
 }
 

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -35,6 +35,26 @@ struct gfi_data;
 struct contextchaindlg;
 struct statemachinedlg;
 
+/**
+ * Doubly linked list abstraction. Putting a full member of this
+ * struct first in another struct means you can treat it as a
+ * dlinkedlist. You can have a struct in many lists simply by
+ * embedding another dlistnode member and handing a pointer to that
+ * member to the dlist() helper functions. Double linking has big
+ * advantages in removal of single elements where you do not need to
+ * rescan to find removeme->prev;
+ */
+struct dlistnode {
+    struct dlistnode* next;
+    struct dlistnode* prev;
+};
+extern void dlist_pushfront( struct dlistnode** list, struct dlistnode* node );
+extern int  dlist_size( struct dlistnode** list );
+extern int  dlist_isempty( struct dlistnode** list );
+extern void dlist_erase( struct dlistnode** list, struct dlistnode* node );
+typedef void (*dlist_foreach_func_type)(struct dlistnode*);
+extern void dlist_foreach( struct dlistnode** list, dlist_foreach_func_type func );
+
 extern struct cvshows {
     int showfore, showback, showgrids, showhhints, showvhints, showdhints;
     int showpoints, showfilled;
@@ -252,6 +272,7 @@ typedef struct charview {
     int guide_pos;
     struct qg_data *qg;
     int16 note_x, note_y;
+    struct dlistnode* pointInfoDialogs;
 } CharView;
 
 typedef struct bitmapview {
@@ -1185,4 +1206,5 @@ extern char *GlyphSetFromSelection(SplineFont *sf,int def_layer,char *current);
 extern void ME_ListCheck(GGadget *g,int r, int c, SplineFont *sf);
 extern void ME_SetCheckUnique(GGadget *g,int r, int c, SplineFont *sf);
 extern void ME_ClassCheckUnique(GGadget *g,int r, int c, SplineFont *sf);
+extern void PI_Destroy(struct dlistnode *node);
 #endif	/* _VIEWS_H */

--- a/inc/gwidget.h
+++ b/inc/gwidget.h
@@ -172,7 +172,7 @@ extern struct hslrgba GWidgetColorA(const char *title,struct hslrgba *defcol,str
 #define gwwv_open_filename(tit,def,filter,filtfunc)	GWidgetOpenFile8(tit,def,filter,NULL,filtfunc)
 #define gwwv_open_filename_with_path(tit,def,filter,filtfunc,path)	GWidgetOpenFileWPath8(tit,def,filter,NULL,filtfunc,path)
 #define gwwv_save_filename(tit,def,filter)		GWidgetSaveAsFile8(tit,def,filter,NULL,NULL)
-#define gwwv_save_filename_with_gadget(tit,def,filter,gcd)		GWidgetSaveAsFileWithGadget8(tit,def,filter,NULL,NULL,gcd)
+#define gwwv_save_filename_with_gadget(tit,def,filter,gcd)		GWidgetSaveAsFileWithGadget8(tit,def,filter,NULL,NULL,NULL,gcd)
 
 void GWidgetCreateInsChar(void);	/* takes input even when a modal dlg is active */
 		/* but is not modal itself */


### PR DESCRIPTION
If you have many of these open they track their respective point in
the charview if that point is moved. If the charview is closed then
all the point info dialogs are closed too.

dlistnode is the start of a generic double linked list abstraction. Note that the foreach for dlists is defensive in that it allows the callback function to unlink a node and will continue on working. See for example the line in the patch which passes PI_Destroy to the foreach to cleanup the existing dialogs when a charview is closed. A fairly to the point single line of code ;)

The advantages over single linked lists are quite a few, a major one is being able to simply remove any element. No more tracking "prev" explicitly in a loop so current can be skipped if desired.
