### PR TITLE
Fix Python script loading on Windows

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -17197,7 +17197,11 @@ void PyFF_Main(int argc,char **argv,int start) {
 #endif /* PY_MAJOR_VERSION >= 3 -------------------------------------------------*/
 
 void PyFF_ScriptFile(FontViewBase *fv,SplineChar *sc, char *filename) {
+#ifndef __MINGW32__
     FILE *fp = fopen(filename,"r");
+#else
+    PyObject *fp = PyFile_FromString(filename,"r");
+#endif
 
     fv_active_in_ui = fv;		/* Make fv known to interpreter */
     sc_active_in_ui = sc;		/* Make sc known to interpreter */
@@ -17207,8 +17211,12 @@ void PyFF_ScriptFile(FontViewBase *fv,SplineChar *sc, char *filename) {
     if ( fp==NULL )
 	LogError(_("Can't open %s"), filename );
     else {
+#ifndef __MINGW32__
 	PyRun_SimpleFile(fp,filename);
 	fclose(fp);
+#else
+    PyRun_SimpleFile(PyFile_AsFile(fp),filename);
+#endif
     }
 }
 
@@ -17257,13 +17265,21 @@ return;
 	if ( pt==NULL )
     continue;
 	if ( strcmp(pt,".py")==0 ) {
-	    FILE *fp;
 	    sprintf( buffer, "%s/%s", dir, ent->d_name );
+#ifndef __MINGW32__
+	    FILE *fp;
 	    fp = fopen(buffer,"r");
+#else
+	    PyObject *fp = PyFile_FromString(buffer,"r");
+#endif
 	    if ( fp==NULL )
     continue;
+#ifndef __MINGW32__
 	    PyRun_SimpleFile(fp,buffer);
 	    fclose(fp);
+#else
+	    PyRun_SimpleFile(PyFile_AsFile(fp),buffer);
+#endif
 	}
     }
     closedir(diro);


### PR DESCRIPTION
There are some FILE\* structure incompatibilities between MinGW, used to build FontForge, and MSVC, used to build Python, causing the normal Python C API calls used to load a script to fail, resulting in a crash. This uses some alternative calls when built under MinGW to resolve the issue.
