### PR TITLE
Make the context menu more to the point when a point is right clicked in the charview

### DIFF
--- a/fontforge/cvpalettes.c
+++ b/fontforge/cvpalettes.c
@@ -2996,7 +2996,6 @@ void CVToolsPopup(CharView *cv, GEvent *event) {
     static char *selectables[] = { N_("Get Info..."), N_("Open Reference"), N_("Add Anchor"), NULL };
 
     memset(mi,'\0',sizeof(mi));
-
     anysel = CVTestSelectFromEvent(cv,event);
     if( !anysel ) {
 	for ( i=0;i<=cvt_skew; ++i ) {


### PR DESCRIPTION
Remove all the tool options and layer name options from the context menu shown when in the Glyph window when you right click a point.
