### PR TITLE
We want the DOCDIR to trickle right down to the help() function so it can use it.

### DIFF
--- a/fontforge/Makefile.dynamic.in
+++ b/fontforge/Makefile.dynamic.in
@@ -4,6 +4,7 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 
 sharedir = @prefix@/share/fontforge
+docdir = @prefix@/share/doc/fontforge
 srcdir = @srcdir@
 top_srcdir = @top_srcdir@
 top_builddir = ..
@@ -63,7 +64,7 @@ fontforge_SCRIPTOBJ = startnoui.o stamp.o
 ACORNOBJS = acorn2sfd.o stamp.o
 
 _CFLAGS = -I$(top_srcdir)/inc -I../inc -I$(srcdir) -I. @WFLAGS@ $(X_CFLAGS) \
-    @DEFS@ '-DSHAREDIR="$(sharedir)"' -DLIBDIR='"$(libdir)"' \
+    @DEFS@ '-DSHAREDIR="$(sharedir)"' '-DDOCDIR="$(docdir)"' -DLIBDIR='"$(libdir)"' \
     @CPPFLAGS@ '-DPREFIX="@prefix@"'
 CFLAGS = @CFLAGS@ @CPPFLAGS@ $(_CFLAGS)
 

--- a/fontforge/Makefile.static.in
+++ b/fontforge/Makefile.static.in
@@ -4,6 +4,7 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 
 sharedir = @prefix@/share/fontforge
+docdir = @prefix@/share/doc/fontforge
 srcdir = @srcdir@
 top_srcdir = @top_srcdir@
 VPATH = @srcdir@
@@ -55,7 +56,7 @@ fontforge_OBJECTS=$(fontforge_LIBOBJECTS) $(@exeOBJECTS@)
 ACORNOBJS = acorn2sfd.o stamp.o $(fontforge_LIBOBJECTS) 
 
 _CFLAGS = -I$(top_srcdir)/inc -I../inc -I$(srcdir) -I. @WFLAGS@ $(X_CFLAGS) \
-    @DEFS@ '-DSHAREDIR="$(sharedir)"' -DLIBDIR='"$(libdir)"' \
+    @DEFS@ '-DSHAREDIR="$(sharedir)"' '-DDOCDIR="$(docdir)"' -DLIBDIR='"$(libdir)"' \
     @CPPFLAGS@ '-DPREFIX="@prefix@"'
 CFLAGS = @CFLAGS@ @CPPFLAGS@ $(_CFLAGS)
 

--- a/fontforge/uiutil.c
+++ b/fontforge/uiutil.c
@@ -302,7 +302,7 @@ void help(char *file) {
 
 void help(char *file) {
     char fullspec[1024], *temp, *pt;
-
+    
     if ( browser[0]=='\0' )
 	findbrowser();
 #ifndef __CygWin
@@ -323,8 +323,9 @@ return;
 #else
 		strcpy(fullspec,"/usr/local/share/doc/fontforge/");
 #endif
-	    } else
+	    } else {
 		strcpy(fullspec,helpdir);
+	    }
 	}
 	strcat(fullspec,file);
 	if (( pt = strrchr(fullspec,'#') )!=NULL ) *pt ='\0';


### PR DESCRIPTION
The patch lets help(), and other functions, see the DOCDIR so they can check if the local doc files are installed and use those instead of the website if it can. 

laptops without 3g for the win.
