### PR TITLE
In the font info dialog: Help the user to fill in the Name for Humans

### DIFF
--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -878,3 +878,12 @@ return( false );
     }
 return( true );
 }
+
+int u_endswith(const unichar_t *haystack,const unichar_t *needle) {
+    int haylen = u_strlen( haystack );
+    int nedlen = u_strlen( needle );
+    if( haylen < nedlen )
+	return 0;
+    unichar_t* p = u_strstr( haystack + haylen - nedlen, needle );
+    return p == ( haystack + haylen - nedlen );
+}

--- a/fontforge/fontinfo.c
+++ b/fontforge/fontinfo.c
@@ -2195,8 +2195,21 @@ static int GFI_NameChange(GGadget *g, GEvent *e) {
 	    if ( noticeweights[j][i]!=NULL )
 	break;
 	}
-	if ( gfi->human_untitled )
-	    GGadgetSetTitle(GWidgetGetControl(gw,CID_Human),uname);
+	if ( gfi->human_untitled ) {
+	    unichar_t *cp = u_copy(uname);
+	    int i=0;
+	    for( i=u_strlen(cp); i>=0; i-- ) {
+		if( cp[i] == '-' ) {
+		    cp[i] = ' ';
+		    break;
+		}
+	    }
+	    if(u_endswith(cp,c_to_u(" Regular")) || u_endswith(cp,c_to_u(" regular"))) {
+		cp[u_strlen(cp) - strlen(" Regular")] ='\0';
+	    }
+	    GGadgetSetTitle(GWidgetGetControl(gw,CID_Human),cp);
+	    free(cp);
+	}
 	if ( gfi->family_untitled ) {
 	    const unichar_t *ept = uname+u_strlen(uname); unichar_t *temp;
 	    for ( i=0; knownweights[i]!=NULL; ++i ) {

--- a/inc/ustring.h
+++ b/inc/ustring.h
@@ -124,4 +124,7 @@ extern int u_vsnprintf(unichar_t *str, int len, const unichar_t *format, va_list
 extern int uAllAscii(const unichar_t *str);
 extern int AllAscii(const char *);
 extern char *StripToASCII(const char *utf8_str);
+
+extern int u_endswith(const unichar_t *haystack,const unichar_t *needle);
+
 #endif


### PR DESCRIPTION
In Font Info, PS Names, when the user types a Fontname with one or more - chars, the last one should be converted into a space in the Name For Humans field below where the Fontname string is copied to. Also if the end of the Name For Humans string is then " Regular" then that substring should be removed from the string.

Ref: http://scripts.sil.org/cms/scripts/page.php?item_id=IWS-Chapter08#3054f18b
