### PR TITLE
Add __version__ and __date__ to python modules.

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -17372,10 +17372,10 @@ static void SetPythonModuleMetadata( PyObject *module ) {
     pyver = STRING_TO_PY(ver);
     Py_INCREF(pyver);
     PyModule_AddObject(module, "__version__", pyver);
-    snprintf(isodate, sizeof(isodate), "%04d-%02d-%02d",
-	     (dt / 10000), (dt / 100) % 100, dt % 100 );
 
     /* Make __date__ string */
+    snprintf(isodate, sizeof(isodate), "%04d-%02d-%02d",
+	     (dt / 10000), (dt / 100) % 100, dt % 100 );
     pydate = STRING_TO_PY(isodate);
     Py_INCREF(pydate);
     PyModule_AddObject(module, "__date__", pydate);


### PR DESCRIPTION
This adds standard Python metadata variables to the python extension modules "fontforge" and "psMat".  In particular it adds "<code>&#95;&#95;version&#95;&#95;</code>" and "<code>&#95;&#95;date&#95;&#95;</code>".  This will work with both python 2 and 3.

This patch does not alter the return value of the fontforge.version() function (yet?).

For FF version 1.0 (those using the date as the effective "version"), the variables will look like:

``` python
fontforge.__version__ = '1.0.20120731'
fontforge.__date__ = '2012-07-31'
```

For FF version 2.0+ (starting with the "autotools" merge) the datestamp is dropped from the version:

``` python
fontforge.__version__ = '2.0'
fontforge.__date__ = '2012-09-10'
```

For information, the "<code>&#95;&#95;date&#95;&#95;</code>" by convention is given in ISO-8601 format (YYYY-MM-DD).  The "<code>&#95;&#95;version&#95;&#95;</code>" is a little more structured, and follows Python PEP 396 and 386:
http://www.python.org/dev/peps/pep-0396/
http://www.python.org/dev/peps/pep-0386/
