### PR TITLE
A fix for cairo fill mode in the glyph window.

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -1215,6 +1215,11 @@ void CVDrawSplineSetSpecialized(CharView *cv, GWindow pixmap, SplinePointList *s
     if ( cv->inactive )
 	dopoints = false;
 
+    if( strokeFillMode == sfm_fill ) {
+	CVDrawSplineSetOutlineOnly( cv, pixmap, set,
+				    fg, dopoints, clip, strokeFillMode );
+    }
+    
     GDrawSetFont(pixmap,cv->small);		/* For point numbers */
     for ( spl = set; spl!=NULL; spl = spl->next ) {
 	if ( spl->contour_name!=NULL )
@@ -1244,10 +1249,6 @@ void CVDrawSplineSetSpecialized(CharView *cv, GWindow pixmap, SplinePointList *s
 	}
     }
 
-    if( strokeFillMode == sfm_fill ) {
-	CVDrawSplineSetOutlineOnly( cv, pixmap, set,
-				    fg, dopoints, clip, strokeFillMode );
-    }
     if( strokeFillMode != sfm_nothing ) {
 	/*
 	 * If we were filling, we have to stroke the outline again to properly show


### PR DESCRIPTION
The nodes were being drawn too early in the painting process. Because
of that, the cairo fill was covering part of some of the information.
Having the cairo fill earlier in the expose process allows everything
to be seen again.

Hopefully this fixes
https://github.com/fontforge/fontforge/issues/73
