### PR TITLE
Include ieeefp.h as well as math.h, rather than instead of math.h.

### DIFF
--- a/fontforge/bezctx_ff.c
+++ b/fontforge/bezctx_ff.c
@@ -8,9 +8,8 @@
 #include "fontforgevw.h"		/* For LogError, else splinefont.h */
 #ifdef HAVE_IEEEFP_H
 # include <ieeefp.h>		/* Solaris defines isnan in ieeefp rather than math.h */
-#else
-# include <math.h>
 #endif
+#include <math.h>
 
 typedef struct {
     bezctx base;


### PR DESCRIPTION
On FreeBSD finite() is just in math.h.
