### PR TITLE
Minor improvement.

### DIFF
--- a/Unicode/ucharmap.c
+++ b/Unicode/ucharmap.c
@@ -25,7 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #include <gwwiconv.h>

--- a/fontforge/flaglist.c
+++ b/fontforge/flaglist.c
@@ -1,5 +1,5 @@
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #include "basics.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -28,7 +28,7 @@
 
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include <config.h>
 #endif
 
 #ifndef _NO_PYTHON

--- a/fontforge/pythonui.c
+++ b/fontforge/pythonui.c
@@ -27,7 +27,7 @@
 /*			   Python Interface to FontForge		      */
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #ifndef _NO_PYTHON

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -26,7 +26,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #ifndef _NO_PYTHON

--- a/gdraw/gxdrawP.h
+++ b/gdraw/gxdrawP.h
@@ -58,7 +58,7 @@ capable of using composite.
 #include <vms_x_fix.h>
 #endif
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #ifndef X_DISPLAY_MISSING

--- a/gutils/gimagereadpng.c
+++ b/gutils/gimagereadpng.c
@@ -25,7 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 

--- a/gutils/gimagereadtiff.c
+++ b/gutils/gimagereadtiff.c
@@ -25,7 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #ifdef _NO_LIBTIFF

--- a/gutils/gimagewritejpeg.c
+++ b/gutils/gimagewritejpeg.c
@@ -25,7 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #ifdef _NO_LIBJPEG

--- a/gutils/gimagewritepng.c
+++ b/gutils/gimagewritepng.c
@@ -25,7 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include <config.h>
 #endif
 
 #ifdef _NO_LIBPNG


### PR DESCRIPTION
README for Autoconf recommends using < > instead of " " for accessing files
within ../inc directory to ensure you are using that one and not a possible
copy within another directory. See:
http://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Configuration-Headers.html#Configuration-Headers
