### PR TITLE
Minor Code cleanup - remove another stamp.c

### DIFF
--- a/gtkui/Makefile.in
+++ b/gtkui/Makefile.in
@@ -25,7 +25,7 @@ X_PRE_LIBS = @X_PRE_LIBS@
 STATIC_LIBS = @STATIC_LIBS@
 
 ffgtk_OBJECTS = fontview.o startgtk.o uiutil.o cursors.o windowmenu.o prefs.o \
-    openfontdlg.o stamp.o pythonui.o
+    openfontdlg.o ../fontforge/stamp.o pythonui.o
 gtk_widget_OBJECTS = gwwvmenubar.o gwwvask.o gwwvprogress.o
 glade_OBJECTS = ff_interface.o support.o
 
@@ -49,7 +49,8 @@ fontforgegtk: $(ffgtk_OBJECTS) $(gtk_widget_OBJECTS) $(glade_OBJECTS) stubs.o
 #ff_interface.c: interface.c add-my-widgets.sed
 #	sed -f add-my-widgets.sed < interface.c > ff_interface.c
 
-%.o: %.c $(srcdir)../fontforge/splinefont.h $(srcdir)/viewsgtk.h  $(srcdir)/../fontforge/uiinterface.h $(srcdir)/../fontforge/fontforgevw.h
+%.o: %.c $(srcdir)../fontforge/splinefont.h $(srcdir)/viewsgtk.h  $(srcdir)/../fontforge/uiinterface.h \
+	$(srcdir)/../fontforge/fontforgevw.h $(srcdir)/../fontforge/libffstamp.h $(srcdir)/../fontforge/stamp.c
 	$(CC) $(CFLAGS) -c $<
 
 clean:
@@ -65,3 +66,6 @@ install:
 	mkdir -p $(DESTDIR)$(bindir)
 	-$(INSTALL_DATA) $(srcdir)/pixmaps/*.{png,xbm} $(sharedir)/pixmaps
 	$(LIBTOOL) --mode=install $(INSTALL) -c fontforgegtk $(DESTDIR)$(bindir)
+
+strip:
+	-strip .libs/fontforgegtk

--- a/gtkui/stamp.c
+++ b/gtkui/stamp.c
@@ -1,5 +1,0 @@
-#include <time.h>
-
-const time_t source_modtime = 1342457142L;
-const char *source_modtime_str = "16:45 GMT 16-Jul-2012";
-const char *source_version_str = "20120716";


### PR DESCRIPTION
...ow.

While grepping libffstamp.h found that gtkui directory had an "old" stamp.c
and, therefore removed it so that it is one less file for developers to see
This was originally in pull request #83 earlier
