### PR TITLE
The most recent version of the new double linked list implementation.

### DIFF
--- a/gutils/Makefile.am
+++ b/gutils/Makefile.am
@@ -36,7 +36,7 @@ libgutils_la_SOURCES = divisors.c fsys.c gcol.c gimage.c				\
 	gimagewritegimage.c gimagewritejpeg.c gimagewritepng.c				\
 	gimagewritexbm.c gimagewritexpm.c gwwintl.c gio.c giofile.c			\
 	giohosts.c giomime.c giothread.c giotrans.c gimagebmpP.h			\
-	giofuncP.h gioP.h
+	giofuncP.h gioP.h dlist.c
 
 libgutils_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 	$(MY_CFLAGS)

--- a/gutils/dlist.c
+++ b/gutils/dlist.c
@@ -1,0 +1,126 @@
+/* Copyright (C) 2012 by Ben Martin */
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdlib.h>
+#include <stdio.h>              /* for NULL */
+#include "dlist.h"
+
+void dlist_pushfront( struct dlistnode** list, struct dlistnode* node ) {
+    if( *list ) {
+	node->next = *list;
+	node->next->prev = node;
+    }
+    *list = node;
+}
+
+int dlist_size( struct dlistnode** list ) {
+    struct dlistnode* node = *list;
+    int ret = 0;
+    for( ; node; node=node->next ) {
+	ret++;
+    }
+    return ret;
+}
+
+int dlist_isempty( struct dlistnode** list ) {
+    return *list == NULL;
+}
+
+void dlist_erase( struct dlistnode** list, struct dlistnode* node ) {
+    if( !node )
+	return;
+    if( *list == node ) {
+	*list = node->next;
+	if( node->next ) {
+	    node->next->prev = 0;
+	}
+	return 0;
+    }
+    if( node->prev ) {
+	node->prev->next = node->next;
+    }
+    if( node->next ) {
+	node->next->prev = node->prev;
+    }
+}
+
+void dlist_foreach( struct dlistnode** list, dlist_foreach_func_type func )
+{
+    struct dlistnode* node = *list;
+    while( node ) {
+	struct dlistnode* t = node;
+	node = node->next;
+	func( t );
+    }
+}
+
+void dlist_foreach_udata( struct dlistnode** list, dlist_foreach_udata_func_type func, void* udata )
+{
+    struct dlistnode* node = *list;
+    while( node ) {
+	struct dlistnode* t = node;
+	node = node->next;
+	func( t, udata );
+    }
+}
+
+static struct dlistnode* dlist_last( struct dlistnode* node )
+{
+    while( node->next ) {
+	node = node->next;
+    }
+    return node;
+}
+
+void dlist_foreach_reverse_udata( struct dlistnode** list, dlist_foreach_udata_func_type func, void* udata )
+{
+    struct dlistnode* node = dlist_last(*list);
+    while( node ) {
+	struct dlistnode* t = node;
+	node = node->prev;
+	func( t, udata );
+    }
+}
+
+void dlist_pushfront_external( struct dlistnode** list, void* ptr )
+{
+    struct dlistnodeExternal* n = calloc(1,sizeof(struct dlistnodeExternal));
+    n->ptr = ptr;
+    dlist_pushfront( list, n );
+}
+
+static void freenode(struct dlistnode* node )
+{
+    free(node);
+}
+
+void dlist_free_external( struct dlistnode** list )
+{
+    if( !list || !(*list) )
+	return;
+    dlist_foreach( list, freenode );
+}
+

--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -33,7 +33,7 @@
 pkginclude_HEADERS = basics.h chardata.h charset.h config.h dynamic.h	\
 	fileutil.h gdraw.h gfile.h ggadget.h gicons.h gimage.h gio.h		\
 	gkeysym.h gprogress.h gresedit.h gresource.h gwidget.h gwwiconv.h	\
-	intl.h ustring.h utype.h annotations_base.h
+	intl.h ustring.h utype.h annotations_base.h dlist.h
 
 noinst_HEADERS = pluginloading.h
 

--- a/inc/dlist.h
+++ b/inc/dlist.h
@@ -1,0 +1,126 @@
+/* Copyright (C) 2012 by Ben Martin */
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _DLIST_H
+#define _DLIST_H
+
+/**
+ * Doubly linked list abstraction. Putting a full member of this
+ * struct first in another struct means you can treat it as a
+ * dlinkedlist. You can have a struct in many lists simply by
+ * embedding another dlistnode member and handing a pointer to that
+ * member to the dlist() helper functions. Double linking has big
+ * advantages in removal of single elements where you do not need to
+ * rescan to find removeme->prev;
+ */
+struct dlistnode {
+    struct dlistnode* next;
+    struct dlistnode* prev;
+};
+
+/**
+ * DEVELOPERS: make sure the start of this struct is compatible with
+ * dlistnode. While I could use the dlistnode as a first member, using
+ * a copy of the members in the same order as dlistnode has them
+ * allows callers using this struct a bit simpler access.
+ * 
+ * While one can embed a dlistnode member into a struct to create
+ * linked lists, sometimes you want to return a splice of one of those
+ * lists. For example, if you have a double linked list of all your
+ * hotkeys, you might like to return only the ones that have a
+ * modifier of the Control key. You want to leave the hotkey structs
+ * in their original list, but create a new kust that references just
+ * a desired selection of objects.
+ *
+ * In other words, if you have some data you want to return in a
+ * double linked list, then use this node type. You can build one up
+ * using dlist_pushfront_external() and the caller can freee that list
+ * using dlist_free_external(). Any of the foreach() functions will
+ * work to iterate a list of dlistnodeExternal as this list is
+ * identical to a dlistnode with an extra ptr payload.
+ */
+struct dlistnodeExternal {
+    struct dlistnode* next;
+    struct dlistnode* prev;
+    void* ptr;
+};
+
+
+/**
+ * Push the node onto the head of the list
+ */
+extern void dlist_pushfront( struct dlistnode** list, struct dlistnode* node );
+
+/**
+ * the number of nodes in the list
+ */
+extern int  dlist_size( struct dlistnode** list );
+
+/**
+ * is the list empty
+ */
+extern int  dlist_isempty( struct dlistnode** list );
+
+/**
+ * Remove the node from the list. The node itself is not free()ed.
+ * That is still up to the caller. All this function does is preserve
+ * the list structure without the node being in it.
+ */
+extern void dlist_erase( struct dlistnode** list, struct dlistnode* node );
+typedef void (*dlist_foreach_func_type)( struct dlistnode* );
+
+/**
+ * Call func for every node in the list. This is a defensive
+ *  implementation, if you want to remove a node from the list inside
+ *  func() that is perfectly fine.
+ */
+extern void dlist_foreach( struct dlistnode** list, dlist_foreach_func_type func );
+typedef void (*dlist_foreach_udata_func_type)( struct dlistnode*, void* udata );
+
+/**
+ * Like dlist_foreach(), defensive coding still, but the udata pointer
+ * is passed back to your visitor function.
+ */
+extern void dlist_foreach_udata( struct dlistnode** list, dlist_foreach_udata_func_type func, void* udata );
+
+/**
+ * Like dlist_foreach_udata() but nodes are visited in reverse order.
+ */
+extern void dlist_foreach_reverse_udata( struct dlistnode** list, dlist_foreach_udata_func_type func, void* udata );
+
+/**
+ * Assuming list is an externalNode list, push a newly allocated list node with
+ * a dlistnodeExternal.ptr = ptr passed.
+ */
+extern void dlist_pushfront_external( struct dlistnode** list, void* ptr );
+
+/**
+ * Free a list of externalNode type. The externalNode memory is
+ * free()ed, whatever externalNode.ptr is pointing to is not free()ed.
+ */
+extern void dlist_free_external( struct dlistnode** list );
+
+#endif // _DLIST_H


### PR DESCRIPTION
This has visitors, both raw and with a user void\* to pass back to the
visitor. There is also an external dlist which stores a pointer to
other interesting data without being intrusive to the struct that is
stored in the list.

Since a few of my pull requests include some or all of this dlist stuff, I thought I'd separate that part out here and commit it. The dlist code has been around in one form or another in a few requests that have been floating around for a while.
