### PR TITLE
Fix Ubuntu build

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -85,7 +85,7 @@ if THE_PROGRAMS
 
 fontforge_SOURCES = main.c
 fontforge_CPPFLAGS = $(AM_CPPFLAGS)
-fontforge_LDADD = libfontforgeexe.la $(LDADD)
+fontforge_LDADD = libfontforgeexe.la libfontforge.la $(LDADD)
 fontforge_LDFLAGS = $(MY_CFLAGS) $(MY_LIBS) -export-dynamic
 
 endif THE_PROGRAMS


### PR DESCRIPTION
I got similar errors in #143 again.
I'm using Ubuntu 12.04 with latest GNU tools in the DNS ppa

I'm not familiar with how .la files work but I guess it doesn't hurt to link fontforge with libfontforge.la, which fixes the build.
