### PR TITLE
only use glib.h, but do some nasty #define guards on it to keep GTimer from clashing with the GTimer that FontForge itself uses.

### DIFF
--- a/fontforge/prefs.c
+++ b/fontforge/prefs.c
@@ -48,7 +48,9 @@
 # include <langinfo.h>
 #endif
 
-#include <glib/grand.h>
+#define GTimer GTimer_GTK
+#include <glib.h>
+#undef GTimer
 
 #define RAD2DEG	(180/3.1415926535897932)
 

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -41,7 +41,10 @@
 #include <dirent.h>
 #include <limits.h>		/* For NAME_MAX or _POSIX_NAME_MAX */
 
-#include <glib/gfileutils.h>
+#define GTimer GTimer_GTK
+#include <glib.h>
+#undef GTimer
+
 
 #ifndef NAME_MAX
 # ifndef  _POSIX_NAME_MAX


### PR DESCRIPTION
The whole GTimer rename is a little bit intrusive, this way the glib timer is brought into the namespace but doesn't clash.
