### PR TITLE
When the metricsview is open allow things like rectangles to still be drawn in the charview.

### DIFF
--- a/fontforge/cvshapes.c
+++ b/fontforge/cvshapes.c
@@ -126,6 +126,7 @@ return;
     }
     SplineMake(last,cv->active_shape->first,false);
     cv->active_shape->last = cv->active_shape->first;
+    cv->b.sc->suspendMetricsViewEventPropagation = 1;
     SCUpdateAll(cv->b.sc);
 }
 
@@ -307,6 +308,7 @@ return;
       break;
     }
     RedoActiveSplineSet(cv->active_shape);
+    cv->b.sc->suspendMetricsViewEventPropagation = 1;
     SCUpdateAll(cv->b.sc);
 }
 
@@ -363,4 +365,7 @@ return;
 	cv->active_shape->spiro_max = cv->active_shape->spiro_cnt;
     }
     cv->active_shape = NULL;
+
+    cv->b.sc->suspendMetricsViewEventPropagation = 0;
+    SCUpdateAll(cv->b.sc);
 }

--- a/fontforge/metricsview.c
+++ b/fontforge/metricsview.c
@@ -875,16 +875,25 @@ void MVReKern(MetricsView *mv) {
 void MVRegenChar(MetricsView *mv, SplineChar *sc) {
     int i;
 
-    if ( mv->bdf==NULL && sc->orig_pos<mv->show->glyphcnt ) {
-	BDFCharFree(mv->show->glyphs[sc->orig_pos]);
-	mv->show->glyphs[sc->orig_pos] = NULL;
+    if( !sc->suspendMetricsViewEventPropagation )
+    {
+	if ( mv->bdf==NULL && sc->orig_pos<mv->show->glyphcnt )
+	{
+	    BDFCharFree(mv->show->glyphs[sc->orig_pos]);
+	    mv->show->glyphs[sc->orig_pos] = NULL;
+	}
     }
+    
     for ( i=0; i<mv->glyphcnt; ++i ) {
+	MVRefreshValues(mv,i);
+    }
+    for ( i=0; i<mv->glyphcnt; ++i )
+    {
 	if ( mv->glyphs[i].sc == sc )
-    break;
+	    break;
     }
     if ( i>=mv->glyphcnt )
-return;		/* Not displayed */
+	return;		/* Not displayed */
     MVRemetric(mv);
     GDrawRequestExpose(mv->v,NULL,false);
 }

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -1447,7 +1447,8 @@ typedef struct splinechar {
     unsigned int unlink_rm_ovrlp_save_undo: 1;
     unsigned int inspiro: 1;
     unsigned int lig_caret_cnt_fixed: 1;
-    /* 6 bits left (one more if we ignore compositionunit below) */
+    unsigned int suspendMetricsViewEventPropagation: 1; /* rect tool might do this while drawing */
+    /* 5 bits left (one more if we ignore compositionunit below) */
 #if HANYANG
     unsigned int compositionunit: 1;
     int16 jamo, varient;


### PR DESCRIPTION
When the metricsview is open and the user decides to draw a shape in the class of a rectangle (cvshape) then suspend live updates to the metricsview until the shape has been completed (ie, the mouse button released).

Something is treading on its own feet in the live update process here. The core of that is triggered by MVRegenChar() in the two lines of BDFCharFree() followed by NULLing the mv->show->glyphs[sc->orig_pos]. If those lines happen then the shape is no longer drawn properly in the active charview and things are generally not what the user expects.
