### PR TITLE
Incremental additions to measure tool.

### DIFF
--- a/fontforge/cvruler.h
+++ b/fontforge/cvruler.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2000-2012 by George Williams */
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _CVRULER_H
+#define _CVRULER_H
+
+extern int measuretoolshowhorizontolvertical;
+extern Color measuretoollinecol;
+extern Color measuretoolpointcol;
+extern Color measuretoolpointsnappedcol;
+extern Color measuretoolcanvasnumberscol;
+extern Color measuretoolcanvasnumberssnappedcol;
+extern Color measuretoolwindowforegroundcol;
+extern Color measuretoolwindowbackgroundcol;
+extern Color measuretoolwindowforegroundcol;
+
+extern void CVRulerExpose(GWindow pixmap,CharView *cv);
+
+#endif


### PR DESCRIPTION
To measure tool, add:
        - snap to points, configurable snap distance
        - configurable line and and text colors
        - configurable window forground and background colors
        - lingering measurement, including floating window, cancelled by mouse-down of measure tool
        - measure tool dialog on double-click of measure tool icon
        - optional horizontal and vertical distance indication on canvas

In a little while, though, a rework should remove the floating windows entirely, uncluttering the main canvas, and allow the measure tool to stay active during editing, updating and following snapped points.
