### PR TITLE
Support for the "openwith" event, tested under osx 10.8.

### DIFF
--- a/Portfile
+++ b/Portfile
@@ -6,7 +6,7 @@ PortSystem      1.0
 name            fontforge
 version         2.0.0_beta1
 set docversion  2.0.0_beta1
-revision        53
+revision        57
 categories      graphics fonts
 platforms       darwin
 maintainers     Ben Martin
@@ -28,8 +28,8 @@ worksrcdir      ${name}-${version}
 
 master_sites        file:///Users/ben/Work/FontForge/2012/mac-build/categories/fontforge
 checksums fontforge-2.0.0_beta1.tar.gz \
- sha1    8350f0986cc2b068892d25497c3fe0682428c2d9 \
- rmd160  fb49c33bf0b6a7c01e25f2a8706f3928031c142f
+ sha1    e709c835500409a44cce0ba638357a43d9cff586 \
+ rmd160  bc050a231a89d401ae4e2c2871d4f06b085d042f
 
 # fetch.type      git
 # git.url         https://github.com/monkeyiq/fontforge-fork.git

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -45,6 +45,12 @@ lib_LTLIBRARIES = libfontforge.la libfontforgeexe.la
 
 #--------------------------------------------------------------------------
 
+macobjective.o: macobjective.m
+	clang -g -arch x86_64 -arch i386 -c "${srcdir}/macobjective.m" -o macobjective.o
+
+
+#--------------------------------------------------------------------------
+
 SUBDIRS = pixmaps
 
 FFSCRIPT_HEADER = "\#!$(bindir)/fontforge -lang=ff"
@@ -154,7 +160,7 @@ libfontforgeexe_la_SOURCES = alignment.c anchorsaway.c   \
 	scstylesui.c searchview.c sftextfield.c showatt.c simplifydlg.c	\
 	splashimage.c startui.c statemachine.c tilepath.c transform.c	\
 	ttfinstrsui.c uiutil.c windowmenu.c justifydlg.c deltaui.c		\
-	usermenu.c 
+	usermenu.c macobjective.h
 
 else !GRAPHICAL_USER_INTERFACE
 
@@ -164,8 +170,12 @@ endif !GRAPHICAL_USER_INTERFACE
 
 nodist_libfontforgeexe_la_SOURCES = exelibstamp.c
 
+if MACINTOSH
+MACFFEXE_LIBADD=macobjective.o
+endif MACINTOSH
+
 libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS)
-libfontforgeexe_la_LIBADD = libfontforge.la $(LTDLDEPS) $(LIBADD) $(GUILIBADD)
+libfontforgeexe_la_LIBADD = libfontforge.la $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD)
 
 # Using -release instead of -version-info seems appropriate in the
 # absence of a well defined ABI.
@@ -202,7 +212,7 @@ splinerefigure.lo: $(srcdir)/splinerefigure.c $(srcdir)/splinefont.h
 
 EXTRA_DIST = fontimage.pe fontlint.pe sfddiff.pe libstamp.pre	\
 	exelibstamp.pre fontimage.1 fontlint.1 sfddiff.1			\
-	MacFontForgeApp.zip darwinsetup.in
+	MacFontForgeApp.zip darwinsetup.in macobjective.m 
 MOSTLYCLEANFILES = fontimage fontlint sfddiff libstamp.c	\
 	exelibstamp.c
 

--- a/fontforge/macobjective.h
+++ b/fontforge/macobjective.h
@@ -1,0 +1,31 @@
+/* Copyright (C) 2000-2012 by George Williams */
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Cocoa/Cocoa.h>
+
+
+

--- a/fontforge/macobjective.m
+++ b/fontforge/macobjective.m
@@ -1,0 +1,34 @@
+/* Copyright (C) 2000-2012 by George Williams */
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "macobjective.h"
+
+void setup_cocoa_app() 
+{
+   [NSApplication sharedApplication];
+}
+

--- a/fontforge/startui.c
+++ b/fontforge/startui.c
@@ -42,6 +42,10 @@
 #include <sys/types.h>
 #include "../gdraw/hotkeys.h"
 
+#ifdef __Mac
+extern void setup_cocoa_app();
+#endif
+
 #ifdef _NO_LIBPNG
 #  define PNGLIBNAME	"libpng"
 #else
@@ -1204,6 +1208,7 @@ exit( 0 );
     if ( listen_to_apple_events ) {
 	install_apple_event_handlers();
 	install_mac_timer();
+	setup_cocoa_app();
 	RunApplicationEventLoop();
     } else
 #endif

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -35,7 +35,7 @@ AC_ARG_ENABLE([python-scripting],
         [i_do_have_python_scripting=yes])
 if test x"${i_do_have_python_scripting}" = xyes; then
    AM_PATH_PYTHON([2.3])
-   PKG_CHECK_MODULES([PYTHON],[python-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=no])
+   PKG_CHECK_MODULES([PYTHON],[pythonXX-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=no; force_off_python_extension=yes])
 fi
 if test x"${i_do_have_python_scripting}" != xyes; then
    AC_DEFINE([_NO_PYTHON],1,[Define if not using Python.])
@@ -54,6 +54,10 @@ AC_ARG_ENABLE([python-extension],
                           even if they were included in this source distribution])],
          [i_do_have_python_extension="${enableval}"],
          [i_do_have_python_extension=yes])
+dnl don't try to make the module unless we have python
+if test x"${force_off_python_extension}" = xyes; then
+         i_do_have_python_extension=no
+fi
 AM_CONDITIONAL([PYTHON_EXTENSION],[test x"${i_do_have_python_extension}" = xyes])
 ])
 

--- a/m4/fontforge_platform_specifics.m4
+++ b/m4/fontforge_platform_specifics.m4
@@ -8,6 +8,7 @@ AC_CANONICAL_HOST
 
 m4_define([default_SDK],[/])
 m4_define([default_CARBON],[System/Library/Frameworks/Carbon.framework/Carbon])
+m4_define([default_COCOA],[/System/Library/Frameworks/Cocoa.framework/Cocoa])
 m4_define([default_CORESERVICES],[System/Library/Frameworks/CoreServices.framework/CoreServices])
 
 AS_CASE([$host],
@@ -48,6 +49,7 @@ AS_CASE([$host],
 
       AC_ARG_VAR([SDK],[(Macintosh only) path to software development kit; defaults to ]default_SDK)
       AC_ARG_VAR([CARBON],[(Macintosh only) path to Carbon; defaults to SDK/]default_CARBON)
+      AC_ARG_VAR([COCOA],[(Macintosh only) path to Cocoa; defaults to SDK/]default_COCOA)
       AC_ARG_VAR([CORESERVICES],[(Macintosh only) path to CoreServices; defaults to SDK/]default_CORESERVICES)
 
       test x"${SDK}" = x && SDK="default_SDK"
@@ -57,11 +59,13 @@ AS_CASE([$host],
          derooted_SDK="${SDK}"
       fi
       test x"${CARBON}" = x && CARBON="${derooted_SDK}/default_CARBON"
+      test x"${COCOA}" = x && CARBON="${derooted_SDK}/default_COCOA"
       test x"${CORESERVICES}" = x && CORESERVICES="${derooted_SDK}/default_CORESERVICES"
 
       if test x"${cross_compiling}" != xyes; then
          test x"${CORESERVICES}" != x && LIBS="-Wl,${CORESERVICES} ${LIBS}"
          test x"${CARBON}" != x && LIBS="-Wl,${CARBON} ${LIBS}"
+         test x"${COCOA}" != x && LIBS="-Wl,${COCOA} ${LIBS}"
          # I would like to be able to just leave the framework as a
          # filename. But if I do that, libtool eats it and gcc doesn't
          # get it and ld doesn't get it and we get undefined symbols.


### PR DESCRIPTION
It seems that unless you have atleast forced a Cocoa application
into existance then you do not get the openwith events under 10.8.
This also opens the door for the macobjective file to contain
an NSApp delegate in the future if we want to do some more fancy
things like bounce the dock icon or other osxey stuff.
