### PR TITLE
Allow the tab and shift+tab keys to move to the next and previous point when in the glyph window.

### DIFF
--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1814,7 +1814,7 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 
     /* then look for hotkeys everywhere */
 	
-//	printf("looking for hotkey in new system...keysym:%d\n", event->u.chr.keysym );
+//    printf("looking for hotkey in new system...state:%d keysym:%d\n", event->u.chr.state, event->u.chr.keysym );
 	struct dlistnodeExternal* hklist = hotkeyFindAllByEvent( top, event );
 	struct dlistnodeExternal* node = hklist;
 	for( ; node; node=node->next ) {

--- a/gdraw/gtextinfo.c
+++ b/gdraw/gtextinfo.c
@@ -33,6 +33,15 @@
 #include "hotkeys.h"
 #include "gkeysym.h"
 
+/////////////////////////////////////////////////////////////////
+// The below keys are from this file, when/if we move to GTK+
+// then perhaps we should include this file instead of the inline
+// definitions
+//#include <gdk/gdkkeysyms.h>
+#define GDK_KEY_Tab 0xff09
+#define GDK_KEY_ISO_Left_Tab 0xfe20
+/////////////////////////////////////////////////////////////////
+
 int GTextInfoGetWidth(GWindow base,GTextInfo *ti,FontInstance *font) {
     int width=0;
     int iwidth=0;
@@ -943,12 +952,20 @@ void HotkeyParse( Hotkey* hk, const char *shortcut ) {
     // The user really means lower case keys unless they have
     // given the "shift" modifier too. Like: Ctl+Shft+L
     //
+//    fprintf(stderr,"HotkeyParse(1) spec:%d hk->keysym:%d shortcut:%s\n", GK_Special, hk->keysym, shortcut );
     if( hk->keysym < GK_Special ) {
 	hk->keysym = tolower(hk->keysym);
 	if( hk->state & ksm_shift ) {
 	    hk->keysym = toupper(hk->keysym);
 	}
     }
+    if( hk->keysym == GDK_KEY_Tab ) {
+	if( hk->state & ksm_shift ) {
+	    hk->keysym = GDK_KEY_ISO_Left_Tab;
+	}
+    }
+    
+//    fprintf(stderr,"HotkeyParse(end) spec:%d hk->state:%d hk->keysym:%d shortcut:%s\n", GK_Special, hk->state, hk->keysym, shortcut );
 }
     
 void GMenuItemParseShortCut(GMenuItem *mi,char *shortcut) {

--- a/hotkeys/default
+++ b/hotkeys/default
@@ -37,6 +37,8 @@ CharView.Menu.Edit.Select.First Point:Ctl+.
 CharView.Menu.Edit.Select.First Point, Next Contour:Alt+Ctl+.
 CharView.Menu.Edit.Select.Next Point:Ctl+Shft+}
 CharView.Menu.Edit.Select.Prev Point:Ctl+Shft+{
++CharView.Menu.Edit.Select.Next Point:Tab
++CharView.Menu.Edit.Select.Prev Point:Shft+Tab
 CharView.Menu.Edit.Select.Next Control Point:Ctl+;
 CharView.Menu.Edit.Select.Prev Control Point:Ctl+Shft+:
 CharView.Menu.Edit.Select.Points on Selected Contours:Alt+Ctl+,


### PR DESCRIPTION
The old key bindings are still effective too.
