### PR TITLE
By default open contours are now rendered in a darkish red color.

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -62,6 +62,7 @@ int updateflex = false;
 extern int clear_tt_instructions_when_needed;
 int use_freetype_with_aa_fill_cv = 1;
 int interpCPsOnMotion=false;
+int DrawOpenContoursWithHighlight = 1;
 int default_cv_width = 540;
 int default_cv_height = 540;
 
@@ -149,6 +150,7 @@ static Color gridfitoutlinecol = 0x009800;
 static Color backoutlinecol = 0x009800;
 static Color foreoutlinecol = 0x000000;
 static Color clippathcol = 0x0000ff;
+static Color opencontourcol = 0x880000;
 static Color backimagecol = 0x707070;
 static Color fillcol = 0x80707070;		/* Translucent */
 static Color tracecol = 0x008000;
@@ -199,7 +201,8 @@ static struct resed charview2_re[] = {
     { N_("Grid Fit Color"), "GridFitOutlineColor", rt_color, &gridfitoutlinecol, N_("The color of grid-fit outlines"), NULL, { 0 }, 0, 0 },
     { N_("Inactive Layer Color"), "BackgroundOutlineColor", rt_color, &backoutlinecol, N_("The color of outlines in inactive layers"), NULL, { 0 }, 0, 0 },
     { N_("Active Layer Color"), "ForegroundOutlineColor", rt_color, &foreoutlinecol, N_("The color of outlines in the active layer"), NULL, { 0 }, 0, 0 },
-    { N_("Clip Path Color"), "ClipPathColor", rt_color, &clippathcol, N_("The color of the clip path"), NULL, { 0 }, 0, 0 },
+    { N_("Clip Path Color"),    "ClipPathColor",    rt_color, &clippathcol,    N_("The color of the clip path"), NULL, { 0 }, 0, 0 },
+    { N_("Open Contour Color"), "OpenContourColor", rt_color, &opencontourcol, N_("The color of the an open contour"), NULL, { 0 }, 0, 0 },
     { N_("Background Image Color"), "BackgroundImageColor", rt_coloralpha, &backimagecol, N_("The color used to draw bitmap (single bit) images which do not specify a clut"), NULL, { 0 }, 0, 0 },
     { N_("Fill Color"), "FillColor", rt_coloralpha, &fillcol, N_("The color used to fill the outline if that mode is active"), NULL, { 0 }, 0, 0 },
     { N_("Preview Fill Color"), "PreviewFillColor", rt_coloralpha, &previewfillcol, N_("The color used to fill the outline when in preview mode"), NULL, { 0 }, 0, 0 },
@@ -653,6 +656,16 @@ static void DrawPoint(CharView *cv, GWindow pixmap, SplinePoint *sp,
     char buf[12];
     int isfake;
 
+    if ( DrawOpenContoursWithHighlight
+	 && cv->b.drawmode==dm_fore
+	 && spl->first
+	 && spl->first->prev==NULL )
+    {
+	if( sp!=spl->first )
+	    col = opencontourcol;
+    }
+    
+    
     if ( cv->markextrema && SpIsExtremum(sp) )
 	 col = extremepointcol;
     if ( sp->selected )
@@ -1156,6 +1169,16 @@ void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *s
 	GDrawFillRuleSetWinding(pixmap);
     }
     for ( spl = set; spl!=NULL; spl = spl->next ) {
+
+	Color fc  = spl->is_clip_path ? clippathcol : fg;
+	if ( DrawOpenContoursWithHighlight
+	     && cv->b.drawmode==dm_fore
+	     && spl->first
+	     && spl->first->prev==NULL )
+	{
+	    fc = opencontourcol;
+	}
+	
 	if ( GDrawHasCairo(pixmap)&gc_buildpath ) {
 	    Spline *first, *spline;
 	    double x,y, cx1, cy1, cx2, cy2, dx,dy;
@@ -1201,8 +1224,8 @@ void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *s
 		GDrawPathClose(pixmap);
 
 	    switch( strokeFillMode ) {
-	    case sfm_stroke:
-		GDrawPathStroke(pixmap,(spl->is_clip_path ? clippathcol : fg)|0xff000000);
+	    case sfm_stroke: 
+		GDrawPathStroke( pixmap, fc | 0xff000000 );
 		break;
 	    case sfm_fill:
 	    case sfm_nothing:
@@ -1211,7 +1234,7 @@ void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *s
 	} else {
 	    GPointList *gpl = MakePoly(cv,spl), *cur;
 	    for ( cur=gpl; cur!=NULL; cur=cur->next )
-		GDrawDrawPoly(pixmap,cur->gp,cur->cnt,spl->is_clip_path ? clippathcol : fg);
+		GDrawDrawPoly(pixmap,cur->gp,cur->cnt,fc);
 	    GPLFree(gpl);
 	}
     }

--- a/fontforge/prefs.c
+++ b/fontforge/prefs.c
@@ -162,6 +162,7 @@ extern int prefs_ensure_correct_extension;      /* in fontview.c */
 extern int default_cv_width;			/* in charview.c */
 extern int default_cv_height;			/* in charview.c */
 extern int interpCPsOnMotion;			/* in charview.c */
+extern int DrawOpenContoursWithHighlight;       /* in charview.c */
 extern int mv_width;				/* in metricsview.c */
 extern int mv_height;				/* in metricsview.c */
 extern int bv_width;				/* in bitmapview.c */
@@ -331,6 +332,7 @@ static struct prefs_list {
 	{ N_("ItalicConstrained"), pr_bool, &ItalicConstrained, NULL, NULL, '\0', NULL, 0, N_("In the Outline View, the Shift key constrains motion to be parallel to the ItalicAngle rather than constraining it to be vertical.") },
 	{ N_("ArrowMoveSize"), pr_real, &arrowAmount, NULL, NULL, '\0', NULL, 0, N_("The number of em-units by which an arrow key will move a selected point") },
 	{ N_("ArrowAccelFactor"), pr_real, &arrowAccelFactor, NULL, NULL, '\0', NULL, 0, N_("Holding down the Alt (or Meta) key will speed up arrow key motion by this factor") },
+	{ N_("DrawOpenContoursWithHighlight"), pr_bool, &DrawOpenContoursWithHighlight, NULL, NULL, '\0', NULL, 0, N_("Open Contours should be drawn in a special highlight color to make them more apparent.") },
 	{ N_("InterpolateCPsOnMotion"), pr_bool, &interpCPsOnMotion, NULL, NULL, '\0', NULL, 0, N_("When moving one end point of a spline but not the other\ninterpolate the control points between the two.") },
 	{ N_("SnapDistance"), pr_real, &snapdistance, NULL, NULL, '\0', NULL, 0, N_("When the mouse pointer is within this many pixels\nof one of the various interesting features (baseline,\nwidth, grid splines, etc.) the pointer will snap\nto that feature.") },
 	{ N_("SnapDistanceMeasureTool"), pr_real, &snapdistancemeasuretool, NULL, NULL, '\0', NULL, 0, N_("When the measure tool is active and when the mouse pointer is within this many pixels\nof one of the various interesting features (baseline,\nwidth, grid splines, etc.) the pointer will snap\nto that feature.") },

--- a/htdocs/prefs.html
+++ b/htdocs/prefs.html
@@ -224,6 +224,19 @@
       When holding down the Alt (Meta) key, the arrow keys will move faster. This
       preference item says how much faster.
     <DT>
+      <A NAME="DrawOpenContoursWithHighlight">DrawOpenContoursWithHighlight</A>
+    <DD>
+      When drawing a foreground layer, render the outline of open
+      contours in a specific color to highlight a potential mistake.
+      When drawing a new path, the incremental stages will be shown in
+      a red, and when the contour is closed it will revert back to the
+      normal color.
+
+      By default this open contour highlight color is a red, it can be
+      changed using the OpenContourColor resource. To do this see the
+      Outline View 2 section of the X Resource Editor available
+      through the File menu.
+    <DT>
       <A NAME="SnapDistance">SnapDistance</A>
     <DD>
       The maximum distance at which pointer motion in the glyph view will be snapped


### PR DESCRIPTION
When you complete a contour by joining back to the starting point then
that path is rendered in a normal color. Advanced users can turn off
this functionality by turning "Off" the preference
Editing/DrawOpenContoursWithHighlight.
