### PR TITLE
Mac updates: Shift+Tab to work again.

### DIFF
--- a/Portfile
+++ b/Portfile
@@ -6,7 +6,7 @@ PortSystem      1.0
 name            fontforge
 version         2.0.0_beta1
 set docversion  2.0.0_beta1
-revision        61
+revision        62
 categories      graphics fonts
 platforms       darwin
 maintainers     Ben Martin

--- a/fontforge/cvpalettes.c
+++ b/fontforge/cvpalettes.c
@@ -2942,7 +2942,7 @@ return( cvlayers );
     ++i;
 
      /* "Layers" label next to the add and remove buttons */
-    label[2].text = (unichar_t *) _("");
+    label[2].text = (unichar_t *) "";
     label[2].text_is_1byte = true;
     gcd[i].gd.label = &label[2];
     gcd[i].gd.pos.x = 47; gcd[i].gd.pos.y = 5; 

--- a/gdraw/gtextinfo.c
+++ b/gdraw/gtextinfo.c
@@ -960,9 +960,11 @@ void HotkeyParse( Hotkey* hk, const char *shortcut ) {
 	}
     }
     if( hk->keysym == GDK_KEY_Tab ) {
+#ifndef __Mac
 	if( hk->state & ksm_shift ) {
 	    hk->keysym = GDK_KEY_ISO_Left_Tab;
 	}
+#endif
     }
     
 //    fprintf(stderr,"HotkeyParse(end) spec:%d hk->state:%d hk->keysym:%d shortcut:%s\n", GK_Special, hk->state, hk->keysym, shortcut );


### PR DESCRIPTION
Palette label to not show version information by mistake.
