### PR TITLE
Compile of splinerefigure.lo should not predefine _FF_CONFIG_H.

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -205,7 +205,7 @@ AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 # optimization turns out to have disastrous effects. Compile it
 # without optimization.
 splinerefigure.lo: $(srcdir)/splinerefigure.c $(srcdir)/splinefont.h
-	$(LIBTOOL) --mode=compile $(CC) -g -D_FF_CONFIG_H -c -o		\
+	$(LIBTOOL) --mode=compile $(CC) -g -c -o		\
 		splinerefigure.lo $(AM_CPPFLAGS) $(srcdir)/splinerefigure.c
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
This prevents the contents of config.h from taking effect, with
extremely undesirable results.
