### PR TITLE
Allow hotkeys to be shown for items in the popup menus.

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -10761,6 +10761,7 @@ static void _CharViewCreate(CharView *cv, SplineChar *sc, FontView *fv,int enc) 
     wattrs.event_masks = -1;
     wattrs.cursor = ct_mypointer;
     cv->v = GWidgetCreateSubWindow(cv->gw,&pos,v_e_h,cv,&wattrs);
+    GDrawSetWindowTypeName(cv->v, "CharView");
 
     if ( GDrawRequestDeviceEvents(cv->v,input_em_cnt,input_em)>0 ) {
 	/* Success! They've got a wacom tablet */

--- a/fontforge/cvpalettes.c
+++ b/fontforge/cvpalettes.c
@@ -3212,7 +3212,7 @@ void CVToolsPopup(CharView *cv, GEvent *event) {
     }
 
     cv->had_control = (event->u.mouse.state&ksm_control)?1:0;
-    GMenuCreatePopupMenu(cv->v,event, mi);
+    GMenuCreatePopupMenuWithName(cv->v,event, "Popup", mi);
 }
 
 static void CVPaletteCheck(CharView *cv) {

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -5549,6 +5549,8 @@ GMenuItem2 helplist[] = {
 };
 
 GMenuItem fvpopupmenu[] = {
+    { { (unichar_t *) N_("New O_utline Window"), 0, COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 'u' }, '\0', ksm_control, NULL, NULL, FVMenuOpenOutline, MID_OpenOutline },
+    GMENUITEM2_LINE,
     { { (unichar_t *) N_("Cu_t"), (GImage *) "editcut.png", COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 't' }, '\0', ksm_control, NULL, NULL, FVMenuCut, MID_Cut },
     { { (unichar_t *) N_("_Copy"), (GImage *) "editcopy.png", COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 'C' }, '\0', ksm_control, NULL, NULL, FVMenuCopy, MID_Copy },
     { { (unichar_t *) N_("C_opy Reference"), (GImage *) "editcopyref.png", COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 'o' }, '\0', ksm_control, NULL, NULL, FVMenuCopyRef, MID_CopyRef },
@@ -6580,7 +6582,7 @@ return;
 		FVToggleCharSelected(fv,pos);
 	    }
 	    if ( event->u.mouse.button==3 )
-		GMenuCreatePopupMenu(fv->v,event, fvpopupmenu);
+		GMenuCreatePopupMenuWithName(fv->v,event, "Popup", fvpopupmenu);
 	    else
 		fv->pressed = GDrawRequestTimer(fv->v,200,100,NULL);
 	}
@@ -7103,6 +7105,7 @@ static void FVCreateInnards(FontView *fv,GRect *pos) {
     wattrs.background_color = view_bgcol;
     fv->v = GWidgetCreateSubWindow(gw,pos,v_e_h,fv,&wattrs);
     GDrawSetVisible(fv->v,true);
+    GDrawSetWindowTypeName(fv->v, "FontView");
 
     fv->gic   = GDrawCreateInputContext(fv->v,gic_root|gic_orlesser);
     fv->gwgic = GDrawCreateInputContext(fv->gw,gic_root|gic_orlesser);

--- a/fontforge/metricsview.c
+++ b/fontforge/metricsview.c
@@ -4936,6 +4936,8 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
     wattrs.event_masks = -1;
     wattrs.cursor = ct_mypointer;
     mv->v = GWidgetCreateSubWindow(mv->gw,&pos,mv_v_e_h,mv,&wattrs);
+    GDrawSetWindowTypeName(mv->v, "MetricsView");
+    
     MVSetFeatures(mv);
     MVMakeLabels(mv);
     MVResize(mv);

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -167,6 +167,7 @@ typedef struct gmenu {
     FontInstance *font;
     void (*donecallback)(GWindow owner);
     GIC *gic;
+    char subMenuName[100];
     /* The code below still contains the old code for using up/down arrows */
     /*  in the menu instead of a scrollbar. If vsb==NULL and the menu doesn't */
     /*  fit on the screen, then the old code will be implemented (normally */
@@ -508,7 +509,7 @@ static int GMenuDrawMenuLine(struct gmenu *m, GMenuItem *mi, int y,GWindow pixma
     int r2l = false;
     int x;
 
-    /* printf("GMenuDrawMenuLine(top)\n"); */
+    //printf("GMenuDrawMenuLine(top)\n");
     /* if(mi->ti.text) */
     /* 	printf("GMenuDrawMenuLine() mi:%s\n",u_to_c(mi->ti.text)); */
 	
@@ -557,25 +558,33 @@ static int GMenuDrawMenuLine(struct gmenu *m, GMenuItem *mi, int y,GWindow pixma
 	 * to get the hotkey if there is one for that menu item.
 	 */
 	GMenuBar* toplevel = getTopLevelMenubar(m);
+	Hotkey* hk = 0;
 	if( toplevel )
 	{
-	    short_mask = 0;
-	    uc_strcpy(shortbuf,"");
+	    hk = hotkeyFindByMenuPath( toplevel->g.base,
+				       GMenuGetMenuPath( toplevel->mi, mi ));
+	}
+	else if( m->owner && strlen(m->subMenuName) ) 
+	{
+	    hk = hotkeyFindByMenuPathInSubMenu( m->owner, m->subMenuName,
+						GMenuGetMenuPath( m->mi, mi ));
+	}
+	
+	short_mask = 0;
+	uc_strcpy(shortbuf,"");
+	
+	if( hk )
+	{
 	    /* printf("m->menubar->mi: %p\n", toplevel->mi ); */
 	    /* printf("m->menubar->window: %p\n", toplevel->g.base ); */
-	    Hotkey* hk = hotkeyFindByMenuPath( toplevel->g.base,
-					       GMenuGetMenuPath( toplevel->mi, mi ));
-//	    printf("hk: %p\n", hk );
-	    if(hk)
+	    /* printf("drawline... hk: %p\n", hk ); */
+	    short_mask = hk->state;
+	    char* keydesc = hk->text;
+	    if( mac_menu_icons )
 	    {
-		short_mask = hk->state;
-		char* keydesc = hk->text;
-		if( mac_menu_icons )
-		{
-		    keydesc = hotkeyTextWithoutModifiers( keydesc );
-		}
-		uc_strcpy( shortbuf, keydesc );
+		keydesc = hotkeyTextWithoutModifiers( keydesc );
 	    }
+	    uc_strcpy( shortbuf, keydesc );
 	}
 	
 	width = GDrawGetTextWidth(pixmap,shortbuf,-1);
@@ -606,6 +615,7 @@ static int gmenu_expose(struct gmenu *m, GEvent *event,GWindow pixmap) {
     GRect r;
     int i;
 
+    /* printf("gmenu_expose() m:%p ev:%p\n",m,event); */
     GDrawPushClip(pixmap,&event->u.expose.rect,&old1);
     r.x = 0; r.width = m->width; r.y = 0; r.height = m->height;
     GBoxDrawBackground(pixmap,&r,m->box,gs_active,false);
@@ -1463,7 +1473,9 @@ static GMenu *_GMenu_Create( GMenuBar* toplevel,
 			     GMenuItem *mi,
 			     GPoint *where,
 			     int awidth, int aheight,
-			     GFont *font, int disable) {
+			     GFont *font, int disable,
+			     char* subMenuName )
+{
     GMenu *m = gcalloc(1,sizeof(GMenu));
     GRect pos;
     GDisplay *disp = GDrawGetDisplayOfWindow(owner);
@@ -1482,7 +1494,8 @@ static GMenu *_GMenu_Create( GMenuBar* toplevel,
     m->box = &menu_box;
     m->tickoff = m->tioff = m->bp = GBoxBorderWidth(owner,m->box);
     m->line_with_mouse = -1;
-
+    if( subMenuName )
+	strncpy(m->subMenuName,subMenuName,sizeof(m->subMenuName)-1);
 /* Mnemonics in menus don't work under gnome. Turning off nodecor makes them */
 /*  work, but that seems a high price to pay */
     pattrs.mask = wam_events|wam_nodecor|wam_positioned|wam_cursor|wam_transient|wam_verytransient;
@@ -1521,18 +1534,29 @@ static GMenu *_GMenu_Create( GMenuBar* toplevel,
 	 * first and then add the modifier icons if there are to be
 	 * any for the key combination.
 	 */
+//	printf("_gmenu_create() toplevel:%p owner:%p\n", toplevel, owner );
+
+	Hotkey* hk = 0;
 	if( toplevel ) {
-	    Hotkey* hk = hotkeyFindByMenuPath( toplevel->g.base,
-					       GMenuGetMenuPath( toplevel->mi, &mi[i] ));
-	    if(hk) {
-		short_mask = hk->state;
-		char* keydesc = hk->text;
-		if( mac_menu_icons )
-		{
-		    keydesc = hotkeyTextWithoutModifiers( keydesc );
-		}
-		uc_strcpy( buffer, keydesc );
+	    hk = hotkeyFindByMenuPath( toplevel->g.base,
+				       GMenuGetMenuPath( toplevel->mi, &mi[i] ));
+	}
+	else if( owner && strlen(m->subMenuName) )
+	{
+	    hk = hotkeyFindByMenuPathInSubMenu( owner, m->subMenuName,
+						GMenuGetMenuPath( mi, &mi[i] ));
+	}
+	
+//	printf("hk:%p\n", hk);
+	if( hk )
+	{
+	    short_mask = hk->state;
+	    char* keydesc = hk->text;
+	    if( mac_menu_icons )
+	    {
+		keydesc = hotkeyTextWithoutModifiers( keydesc );
 	    }
+	    uc_strcpy( buffer, keydesc );
 	    
 	    temp = GDrawGetTextWidth(m->w,buffer,-1);
 	    if( short_mask && mac_menu_icons ) {
@@ -1625,12 +1649,13 @@ return( m );
 static GMenu *GMenuCreateSubMenu(GMenu *parent,GMenuItem *mi,int disable) {
     GPoint p;
     GMenu *m;
-
+    char *subMenuName = 0;
+    
     p.x = parent->width;
     p.y = (parent->line_with_mouse-parent->offtop)*parent->fh + parent->bp;
     GDrawTranslateCoordinates(parent->w,GDrawGetRoot(GDrawGetDisplayOfWindow(parent->w)),&p);
     m = _GMenu_Create(getTopLevelMenubar(parent),parent->owner,mi,&p,-parent->width,parent->fh,
-	    parent->font, disable);
+		      parent->font, disable, subMenuName );
     m->parent = parent;
     m->pressed = parent->pressed;
 return( m );
@@ -1639,22 +1664,34 @@ return( m );
 static GMenu *GMenuCreatePulldownMenu(GMenuBar *mb,GMenuItem *mi,int disabled) {
     GPoint p;
     GMenu *m;
+    char *subMenuName = 0;
 
     p.x = mb->g.inner.x + mb->xs[mb->entry_with_mouse]-
 	    GBoxDrawnWidth(mb->g.base,&menu_box );
     p.y = mb->g.r.y + mb->g.r.height;
     GDrawTranslateCoordinates(mb->g.base,GDrawGetRoot(GDrawGetDisplayOfWindow(mb->g.base)),&p);
-    m = _GMenu_Create(mb,mb->g.base,mi,&p,
-	    mb->xs[mb->entry_with_mouse+1]-mb->xs[mb->entry_with_mouse],
-	    -mb->g.r.height,mb->font, disabled);
+    m = _GMenu_Create( mb, mb->g.base, mi, &p,
+		       mb->xs[mb->entry_with_mouse+1]-mb->xs[mb->entry_with_mouse],
+		       -mb->g.r.height,
+		       mb->font, disabled, subMenuName );
     m->menubar = mb;
     m->pressed = mb->pressed;
     _GWidget_SetPopupOwner((GGadget *) mb);
 return( m );
 }
 
-GWindow _GMenuCreatePopupMenu(GWindow owner,GEvent *event, GMenuItem *mi,
-	void (*donecallback)(GWindow) ) {
+GWindow _GMenuCreatePopupMenu( GWindow owner,GEvent *event, GMenuItem *mi,
+			       void (*donecallback)(GWindow) )
+{
+    char *subMenuName = 0;
+    return _GMenuCreatePopupMenuWithName( owner, event, mi, subMenuName, donecallback );
+}
+
+
+GWindow _GMenuCreatePopupMenuWithName( GWindow owner,GEvent *event, GMenuItem *mi,
+				       char *subMenuName,
+				       void (*donecallback)(GWindow) )
+{
     GPoint p;
     GMenu *m;
     GEvent e;
@@ -1665,7 +1702,8 @@ GWindow _GMenuCreatePopupMenu(GWindow owner,GEvent *event, GMenuItem *mi,
     p.x = event->u.mouse.x;
     p.y = event->u.mouse.y;
     GDrawTranslateCoordinates(owner,GDrawGetRoot(GDrawGetDisplayOfWindow(owner)),&p);
-    m = _GMenu_Create(0,owner,GMenuItemArrayCopy(mi,NULL),&p,0,0,menu_font,false);
+    m = _GMenu_Create( 0, owner, GMenuItemArrayCopy(mi,NULL), &p,
+		       0, 0, menu_font,false, subMenuName );
     m->any_unmasked_shortcuts = GMenuItemArrayAnyUnmasked(m->mi);
     GDrawPointerUngrab(GDrawGetDisplayOfWindow(owner));
     GDrawPointerGrab(m->w);
@@ -1678,9 +1716,18 @@ GWindow _GMenuCreatePopupMenu(GWindow owner,GEvent *event, GMenuItem *mi,
 return( m->w );
 }
 
-GWindow GMenuCreatePopupMenu(GWindow owner,GEvent *event, GMenuItem *mi) {
-return( _GMenuCreatePopupMenu(owner,event,mi,NULL));
+GWindow GMenuCreatePopupMenu(GWindow owner,GEvent *event, GMenuItem *mi)
+{
+    char* subMenuName = 0;
+    return( _GMenuCreatePopupMenuWithName(owner,event,mi,subMenuName,NULL));
 }
+
+GWindow GMenuCreatePopupMenuWithName(GWindow owner,GEvent *event,
+				     char* subMenuName, GMenuItem *mi)
+{
+    return( _GMenuCreatePopupMenuWithName(owner,event,mi,subMenuName,NULL));
+}
+
 
 int GMenuPopupCheckKey(GEvent *event) {
 

--- a/gdraw/hotkeys.c
+++ b/gdraw/hotkeys.c
@@ -360,6 +360,17 @@ static Hotkey* hotkeyFindByAction( char* action ) {
     return 0;
 }
 
+Hotkey* hotkeyFindByMenuPathInSubMenu( GWindow w, char* subMenuName, char* path ) {
+
+    char* wt = GDrawGetWindowTypeName(w);
+    if(!wt)
+	return 0;
+
+    char line[PATH_MAX+1];
+    snprintf(line,PATH_MAX,"%s.%s%s%s",wt, subMenuName, ".Menu.", path );
+//    printf("line:%s\n",line);
+    return(hotkeyFindByAction(line));
+}
 
 Hotkey* hotkeyFindByMenuPath( GWindow w, char* path ) {
 

--- a/gdraw/hotkeys.h
+++ b/gdraw/hotkeys.h
@@ -189,6 +189,7 @@ extern char*   hotkeyTextWithoutModifiers( char* hktext );
  * Do not free the return value, it's not yours! 
  */
 extern Hotkey* hotkeyFindByMenuPath( GWindow w, char* path );
+extern Hotkey* hotkeyFindByMenuPathInSubMenu( GWindow w, char* subMenuName, char* path );
 
 
 /**

--- a/hotkeys/default
+++ b/hotkeys/default
@@ -258,6 +258,14 @@ CharView.Menu.Help.Index:Ctl+F1
 CharView.Menu.Help.About...: No Shortcut
 CharView.Menu.Help.License...: No Shortcut
 
+CharView.Popup.Menu.Get Info...:Ctl+I
+CharView.Popup.Menu.Pointer: v
+CharView.Popup.Menu.Magnify: a
+CharView.Popup.Menu.Draw a freehand curve: f
+CharView.Popup.Menu.Scroll by hand: h
+CharView.Popup.Menu.Add Anchor:Ctl+0
+
+
 FontView.Menu.File.New: Ctl+N
 FontView.Menu.File.Hangul.New Composition...:Ctl+Shft+N
 FontView.Menu.File.Hangul.Modify Composition...: No Shortcut
@@ -486,6 +494,91 @@ FontView.Menu.Help.Overview:Shft+F1
 FontView.Menu.Help.Index:Ctl+F1
 FontView.Menu.Help.About...: No Shortcut
 FontView.Menu.Help.License...: No Shortcut
+
+FontView.Popup.Menu.FontView.Menu.Metrics.Set Vertical Advance...: No Shortcut
+FontView.Menu.Metrics.Auto Width...:Ctl+Shft+W
+FontView.Menu.Metrics.Kern By Classes...: No Shortcut
+FontView.Menu.Metrics.Remove All Kern Pairs: No Shortcut
+FontView.Menu.Metrics.Kern Pair Closeup...: No Shortcut
+FontView.Menu.Metrics.VKern By Classes...: No Shortcut
+FontView.Menu.Metrics.VKern From HKern: No Shortcut
+FontView.Menu.Metrics.Remove All VKern Pairs: No Shortcut
+FontView.Menu.CID.Convert to CID: No Shortcut
+FontView.Menu.CID.Convert By CMap: No Shortcut
+FontView.Menu.CID.Flatten: No Shortcut
+FontView.Menu.CID.FlattenByCMap: No Shortcut
+FontView.Menu.CID.Insert Font...: No Shortcut
+FontView.Menu.CID.Insert Blank: No Shortcut
+FontView.Menu.CID.Remove Font: No Shortcut
+FontView.Menu.CID.Change Supplement...: No Shortcut
+FontView.Menu.CID.CID Font Info...: No Shortcut
+FontView.Menu.MM.Create MM...: No Shortcut
+FontView.Menu.MM.MM Validity Check: No Shortcut
+FontView.Menu.MM.MM Info...: No Shortcut
+FontView.Menu.MM.Blend to New Font...: No Shortcut
+FontView.Menu.MM.MM Change Default Weights...: No Shortcut
+FontView.Menu.Window.New Outline Window:Ctl+H
+FontView.Menu.Window.New Bitmap Window:Ctl+J
+FontView.Menu.Window.New Metrics Window:Ctl+K
+FontView.Menu.Window.Warnings: No Shortcut
+FontView.Menu.Help.Help:F1
+FontView.Menu.Help.Overview:Shft+F1
+FontView.Menu.Help.Index:Ctl+F1
+FontView.Menu.Help.About...: No Shortcut
+FontView.Menu.Help.License...: No Shortcut
+
+FontView.Popup.Menu.FontView.Menu.Metrics.Set Vertical Advance...: No Shortcut
+FontView.Menu.Metrics.Auto Width...:Ctl+Shft+W
+FontView.Menu.Metrics.Kern By Classes...: No Shortcut
+FontView.Menu.Metrics.Remove All Kern Pairs: No Shortcut
+FontView.Menu.Metrics.Kern Pair Closeup...: No Shortcut
+FontView.Menu.Metrics.VKern By Classes...: No Shortcut
+FontView.Menu.Metrics.VKern From HKern: No Shortcut
+FontView.Menu.Metrics.Remove All VKern Pairs: No Shortcut
+FontView.Menu.CID.Convert to CID: No Shortcut
+FontView.Menu.CID.Convert By CMap: No Shortcut
+FontView.Menu.CID.Flatten: No Shortcut
+FontView.Menu.CID.FlattenByCMap: No Shortcut
+FontView.Menu.CID.Insert Font...: No Shortcut
+FontView.Menu.CID.Insert Blank: No Shortcut
+FontView.Menu.CID.Remove Font: No Shortcut
+FontView.Menu.CID.Change Supplement...: No Shortcut
+FontView.Menu.CID.CID Font Info...: No Shortcut
+FontView.Menu.MM.Create MM...: No Shortcut
+FontView.Menu.MM.MM Validity Check: No Shortcut
+FontView.Menu.MM.MM Info...: No Shortcut
+FontView.Menu.MM.Blend to New Font...: No Shortcut
+FontView.Menu.MM.MM Change Default Weights...: No Shortcut
+FontView.Menu.Window.New Outline Window:Ctl+H
+FontView.Menu.Window.New Bitmap Window:Ctl+J
+FontView.Menu.Window.New Metrics Window:Ctl+K
+FontView.Menu.Window.Warnings: No Shortcut
+FontView.Menu.Help.Help:F1
+FontView.Menu.Help.Overview:Shft+F1
+FontView.Menu.Help.Index:Ctl+F1
+FontView.Menu.Help.About...: No Shortcut
+FontView.Menu.Help.License...: No Shortcut
+
+FontView.Popup.Menu.New Outline Window:Ctl+H
+FontView.Popup.Menu.Cut:Ctl+X
+FontView.Popup.Menu.Copy:Ctl+C
+FontView.Popup.Menu.Copy Reference:Ctl+G
+FontView.Popup.Menu.Copy Width:Ctl+W
+FontView.Popup.Menu.Paste:Ctl+V
+FontView.Popup.Menu.Clear: No Shortcut
+FontView.Popup.Menu.Copy Fg To Bg:Ctl+Shft+C
+FontView.Popup.Menu.Unlink Reference:Ctl+U
+FontView.Popup.Menu.Glyph Info...:Ctl+I
+FontView.Popup.Menu.Transformations.Transform...:Ctl+\
+FontView.Popup.Menu.Expand Stroke...:Ctl+Shft+E
+FontView.Popup.Menu.Round.To Int:Ctl+Shft+_
+FontView.Popup.Menu.Correct Direction:Ctl+Shft+D
+FontView.Popup.Menu.AutoHint:Ctl+Shft+H
+FontView.Popup.Menu.Center in Width: No Shortcut
+FontView.Popup.Menu.Thirds in Width: No Shortcut
+FontView.Popup.Menu.Set Width...:Ctl+Shft+L
+FontView.Popup.Menu.Set Vertical Advance...: No Shortcut
+
 
 
 MetricsView.Menu.Window.New Outline Window:Ctl+H

--- a/inc/ggadget.h
+++ b/inc/ggadget.h
@@ -107,6 +107,7 @@ typedef struct gmenuitem2 {
     int mid;
 } GMenuItem2;
 
+#define GMENUITEM2_LINE   { { NULL, NULL, COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 1, 0, 0, 0, '\0' }, '\0', 0, NULL, NULL, NULL, 0 }
 #define GMENUITEM2_EMPTY { GTEXTINFO_EMPTY, NULL, NULL, NULL, NULL, 0 }
 
 
@@ -529,8 +530,13 @@ enum fchooserret GFileChooserDefFilter(GGadget *g,struct gdirentry *ent,
 	const unichar_t *dir);
 
 GWindow GMenuCreatePopupMenu(GWindow owner,GEvent *event, GMenuItem *mi);
+GWindow GMenuCreatePopupMenuWithName(GWindow owner,GEvent *event, char* subMenuName,GMenuItem *mi);
 GWindow _GMenuCreatePopupMenu(GWindow owner,GEvent *event, GMenuItem *mi,
-	void (*donecallback)(GWindow owner));
+			      void (*donecallback)(GWindow owner));
+GWindow _GMenuCreatePopupMenuWithName(GWindow owner,GEvent *event, GMenuItem *mi,
+				      char* subMenuName, 
+				      void (*donecallback)(GWindow owner));
+
 
 GGadget *GLineCreate(struct gwindow *base, GGadgetData *gd,void *data);
 GGadget *GGroupCreate(struct gwindow *base, GGadgetData *gd,void *data);


### PR DESCRIPTION
Note that these bindings are the same as their corresponding items in
the main menu bar for each window type. That is a deliberate choice at
the moment so that if the user sees that Control+j will perform
operation foo in the popup menu for the fontview then they can use
Control+j in the fontview itself to perform that same operation. The
principal of least surprise.

Also, since the popups are transient objects, from a pragmatic point
of view things are much simpler because you don't have to worry about
if the popup menu is created or visible. We can instead only show the
user the hints and rely on the hotkey system to trigger the right
event from the main menu bar of the window.
