### PR TITLE
Debian Bug report logs - #664789

### DIFF
--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -2810,7 +2810,7 @@ return( NULL );
     for ( doit=0; doit<2; ++doit ) {
 	cnt=0;
 	for ( i=0; i<len; ++i ) {
-	    if ( u_strncmp(ti[i]->text,spt,match_len)==0 ) {
+	    if ( ti[i]->text && u_strncmp(ti[i]->text,spt,match_len)==0 ) {
 		if ( doit )
 		    ret[cnt] = u_copy(ti[i]->text);
 		++cnt;


### PR DESCRIPTION
after Hitting 'a<Tab>' as Test Pattern in the Kerning Metrics Window.
See http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=664789
Patch shown was applied here.
