### PR TITLE
Improved handling of class based kerning in metrics view

### DIFF
--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -4406,6 +4406,27 @@ return( true );
 return( false );
 }
 
+
+int KernClassFindIndexContaining( char **firsts_or_seconds,
+				  int firsts_or_seconds_size,
+				  const char *name )
+{
+    int ret = -1;
+    int i = 0 ;
+
+    for ( i=1; i < firsts_or_seconds_size; ++i )
+    {
+	if ( PSTContains(firsts_or_seconds[i],name) )
+	{
+	    ret = i;
+	    break;
+	}
+    }
+    
+    return ret;
+}
+
+
 int KernClassContains(KernClass *kc, char *name1, char *name2, int ordered ) {
     int infirst=0, insecond=0, scpos1, kwpos1, scpos2, kwpos2;
     int i;

--- a/fontforge/lookups.h
+++ b/fontforge/lookups.h
@@ -1,3 +1,29 @@
 extern char *lookup_type_names[2][10];
 extern void SortInsertLookup(SplineFont *sf, OTLookup *newotl);
 extern char *SuffixFromTags(FeatureScriptLangList *fl);
+
+/**
+ * Get the index into the char* array "firsts_or_seconds" that contains "name".
+ * Or -1 if no such entry was found.
+ *
+ * This is handy when using KernClass* kc objects,
+ * you can pass in kc->firsts and kc->first_cnt and the name of a glyph
+ * to see if that char is contained in the first part of a pairing.
+ *
+ * This can be useful if you want to check if a digraph of chars
+ * "ab" and "xy" are in the same cell of a KernClass or not (handled in the same class).
+ * first do
+ * int idxx = KernClassFindIndexContaining( kc->firsts,  kc->first_cnt,  "x" );
+ * int idxy = KernClassFindIndexContaining( kc->seconds, kc->second_cnt, "y" );
+ * 
+ * then to test any diagrap, say "ab" h for being in the same cell:
+ * int idxa = KernClassFindIndexContaining( kc->firsts,  kc->first_cnt,  "a" );
+ * int idxb = KernClassFindIndexContaining( kc->seconds, kc->second_cnt, "b" );
+ *
+ * and they are in the same cell of the kernclass
+ * if (idxx==idxa && idxy==idxb) {}
+ * 
+ */
+extern int KernClassFindIndexContaining( char **firsts_or_seconds,
+					 int firsts_or_seconds_size,
+					 const char *name );


### PR DESCRIPTION
When the user changes a value for the kerning of two glyphs, try to
find all other digraphs in the current metrics view which are in the
same kerning class and update them at the same time.

For example, consider a class with TcToTe in it and a metrics view
with:
xTcToTefiAV
being displayed.

If the kerning between the "To" glyphs is altered, fontforge will now
also alter the Tc and Te automatically and show the kerning updates in
the main portion of the metrics window.
