### PR TITLE
Make setting up class based kerning a little simpler.

### DIFF
--- a/fontforge/kernclass.c
+++ b/fontforge/kernclass.c
@@ -2962,6 +2962,14 @@ static int KCL_Done(GGadget *g, GEvent *e) {
 
     if ( e->type==et_controlevent && e->u.control.subtype == et_buttonactivate ) {
 	kcld = GDrawGetUserData(GGadgetGetWindow(g));
+	//
+	// Update any metrics views for the splinefont.
+	//
+	if( kcld && kcld->sf )
+	{
+	    MVReFeatureAll(kcld->sf);
+	    MVReKernAll(kcld->sf);
+	}
 	GDrawDestroyWindow(kcld->gw);
     }
 return( true );

--- a/fontforge/metricsview.c
+++ b/fontforge/metricsview.c
@@ -3963,6 +3963,7 @@ static void MVChar(MetricsView *mv,GEvent *event) {
 		snprintf(buf,99,"%.0f",val);
 		GGadgetSetTitle8(active, buf);
 
+		event->u.control.u.tf_changed.from_pulldown=-1;
 		event->type=et_controlevent;
 		event->u.control.subtype = et_textchanged;
 		GGadgetDispatchEvent(active,event);


### PR DESCRIPTION
You no longer have to visit the element/font info dialog after using
metrics/kern by classes to setup a class based kerning table.

Also, paging through the lines in a loaded word list no longer crashes
fontforge. This was interesting, if you have a line that is a number
then fontforge will decrement/increment that value on an up/down arrow
press instead of advancing/retreating the current line in your word
list file. Unfortunately, when that happened (by chance) then an event
would also be explicitly triggered which would investigate some stale
data and explode.

Two birds, on commit :/
