### PR TITLE
Smarter revisions strategy, no revisions created unless already there or explicitly requested.

### DIFF
--- a/fontforge/prefs.c
+++ b/fontforge/prefs.c
@@ -185,7 +185,7 @@ extern int show_kerning_pane_in_class;		/* kernclass.c */
 extern int AutoSaveFrequency;			/* autosave.c */
 extern int UndoRedoLimitToSave;  /* sfd.c */
 extern int UndoRedoLimitToLoad;  /* sfd.c */
-extern int PrefMaxBackupsToKeep; /* sfd.c */
+extern int prefRevisionsToRetain; /* sfd.c */
 
 extern NameList *force_names_when_opening;
 extern NameList *force_names_when_saving;
@@ -306,7 +306,7 @@ static struct prefs_list {
 	{ N_("ExportClipboard"), pr_bool, &export_clipboard, NULL, NULL, '\0', NULL, 0, N_( "If you are running an X11 clipboard manager you might want\nto turn this off. FF can put things into its internal clipboard\nwhich it cannot export to X11 (things like copying more than\none glyph in the fontview). If you have a clipboard manager\nrunning it will force these to be exported with consequent\nloss of data.") },
 	{ N_("EnsureCorrectSaveExtension"), pr_bool, &prefs_ensure_correct_extension, NULL, NULL, '\0', NULL, 0, N_( "When inputting a name in the Save or SaveAs dialogs, FontForge can ensure that the correct filename extension (SFD or SFDIR) is always used. This prevents you from accidentally naming your source file with a binary extension (such as .otf), out of habit.") },
 	{ N_("AutoSaveFrequency"), pr_int, &AutoSaveFrequency, NULL, NULL, '\0', NULL, 0, N_( "The number of seconds between autosaves. If you set this to 0 there will be no autosaves.") },
-	{ N_("PrefMaxBackupsToKeep"), pr_int, &PrefMaxBackupsToKeep, NULL, NULL, '\0', NULL, 0, N_( "The number of file.sfd~n backups to create when saving. If you set this to 0 there will be no backups created.") },
+	{ N_("RevisionsToRetain"), pr_int, &prefRevisionsToRetain, NULL, NULL, '\0', NULL, 0, N_( "When Saving, keep this number of previous versions of the file. file.sfd-01 will be the last saved file, file.sfd-02 will be the file saved before that, and so on. If you set this to 0 then no revisions will be retained.") },
 	{ N_("UndoRedoLimitToSave"), pr_int, &UndoRedoLimitToSave, NULL, NULL, '\0', NULL, 0, N_( "The number of undo and redo operations which will be saved in sfd files.\nIf you set this to 0 undo/redo information is not saved to sfd files.\nIf set to -1 then all available undo/redo information is saved without limit.") },
 	PREFS_LIST_EMPTY
 },

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -52,6 +52,8 @@ int no_windowing_ui = false;
 int running_script = false;
 int use_utf8_in_script = true;
 
+extern int prefRevisionsToRetain; /* sfd.c */
+
 #ifndef _NO_FFSCRIPT
 static int verbose = -1;
 static struct dictionary globals;
@@ -1744,17 +1746,32 @@ static void bRevertToBackup(Context *c) {
     FVRevertBackup(c->curfv);
 }
 
+
 static void bSave(Context *c) {
     SplineFont *sf = c->curfv->sf;
     char *t, *pt;
     char *locfilename;
     int s2d = false;
+    int localRevisionsToRetain = -1;
 
-    if ( c->a.argc>2 )
+    if ( c->a.argc>3 )
 	ScriptError( c, "Wrong number of arguments");
-    if ( c->a.argc==2 ) {
+
+    // Grab the optional number of backups that are desired argument
+    if ( c->a.argc==3 ) {
+	/**
+	 * A call Save( wheretosave, revisioncount )
+	 */
+	if ( c->a.vals[2].type!=v_int )
+	    ScriptError(c,"The second argument to Save() must be a number of revisions to keep (integer)");
+	localRevisionsToRetain = c->a.vals[2].u.ival;
+    }
+    
+    if ( c->a.argc>=2 )
+    {
 	if ( c->a.vals[1].type!=v_str )
 	    ScriptError(c,"If an argument is given to Save it must be a filename");
+	
 	t = script2utf8_copy(c->a.vals[1].u.sval);
 	locfilename = utf82def_copy(t);
 #ifdef VMS
@@ -1766,14 +1783,30 @@ static void bSave(Context *c) {
 	if ( pt!=NULL && strmatch(pt,".sfdir")==0 )
 	    s2d = true;
 #endif
-	if ( !SFDWrite(locfilename,sf,c->curfv->map,c->curfv->normal,s2d))
-	    ScriptError(c,"Save As failed" );
+
+	int rc = SFDWriteBakExtended( locfilename,
+				      sf,c->curfv->map,c->curfv->normal,s2d,
+				      localRevisionsToRetain );
+	if ( !rc )
+	    ScriptError(c,"Save failed" );
+	    
 	/* Hmmm. We don't set the filename, nor the save_to_dir bit */
 	free(t); free(locfilename);
-    } else {
+    }
+    else
+    {
 	if ( sf->filename==NULL )
 	    ScriptError(c,"This font has no associated sfd file yet, you must specify a filename" );
-	if ( !SFDWriteBak(sf,c->curfv->map,c->curfv->normal) )
+
+	/**
+	 * If there are no existing backup files, don't start creating them here.
+	 * Otherwise, save as many as the user wants.
+	 */
+	int s2d = false;
+	int rc = SFDWriteBakExtended( sf->filename,
+				      sf,c->curfv->map,c->curfv->normal,s2d,
+				      localRevisionsToRetain );
+	if ( !rc )
 	    ScriptError(c,"Save failed" );
     }
 }

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2708,8 +2708,13 @@ extern Encoding *_FindOrMakeEncoding(const char *name,int make_it);
 extern Encoding *FindOrMakeEncoding(const char *name);
 extern void SFDDumpMacFeat(FILE *sfd,MacFeat *mf);
 extern MacFeat *SFDParseMacFeatures(FILE *sfd, char *tok);
+extern int SFDDoesAnyBackupExist(char* filename);
 extern int SFDWrite(char *filename,SplineFont *sf,EncMap *map,EncMap *normal, int todir);
 extern int SFDWriteBak(SplineFont *sf,EncMap *map,EncMap *normal);
+extern int SFDWriteBakExtended(char* locfilename,
+			       SplineFont *sf,EncMap *map,EncMap *normal,
+			       int s2d,
+			       int localPrefMaxBackupsToKeep );
 extern SplineFont *SFDRead(char *filename);
 extern SplineFont *_SFDRead(char *filename,FILE *sfd);
 extern SplineFont *SFDirRead(char *filename);


### PR DESCRIPTION
Save()
fontforge.activeFont().save()
  if there are revisions already, then new revisions are created.
  Otherwise no revisions.

Save("foo.sfd")
fontforge.activeFont().save("/tmp/norev.sfd")
fontforge.activeFont().save("/tmp/withrev.sfd")
  if there are revisions already, then new revisions are created.
  Otherwise no revisions.

Save("foo.sfd",32)
fontforge.activeFont().save("/tmp/norev.sfd",32)
fontforge.activeFont().save("/tmp/withrev.sfd",32)
  Revisions are created. if foo.sfd didn't exist then only foo.sfd
  exists after the call. If foo.sfd existed then it will be foo.sfd-01
  and a new foo.sfd written.
