### PR TITLE
Updates for automated build support for osx.

### DIFF
--- a/create-osx-app-bundle.sh
+++ b/create-osx-app-bundle.sh
@@ -63,8 +63,9 @@ cp -av /opt/local/share/mime/magic      opt/local/share/mime
 
 
 cd $TEMPDIR
-zip -r ~/FontForge.app.zip FontForge.app
-cp -f ~/FontForge.app.zip /tmp/
+rm -f  ~/FontForge.app.zip
+zip -9 -r ~/FontForge.app.zip FontForge.app
+cp -f  ~/FontForge.app.zip /tmp/
 chmod o+r /tmp/FontForge.app.zip
 
 echo "Completed at `date`"


### PR DESCRIPTION
make sure the old zip is gone first, choose the best compression
mode (slower but smaller file) by default.
