### PR TITLE
small detail, but important - need to keep variables that got removed earlier.

### DIFF
--- a/fontforge/bitmapview.c
+++ b/fontforge/bitmapview.c
@@ -181,6 +181,7 @@ static char *BVMakeTitles(BitmapView *bv, BDFChar *bc,char *buf) {
 	    sc!=NULL ? sc->name : "<Nameless>", bv->enc, bdf->pixelsize, sc==NULL ? "" : sc->parent->fontname);
     title = copy(buf);
 #ifndef _NO_LIBUNINAMESLIST
+    const char *uniname;
     if ( (uniname=uniNamesList_name(sc->unicodeenc))!=NULL ) {
 	strcat(buf, " ");
 	strcpy(buf+strlen(buf), uniname);

--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -2987,6 +2987,7 @@ static char *CVMakeTitles(CharView *cv,char *buf) {
 	strcat(buf," *");
     title = copy(buf);
 #ifndef _NO_LIBUNINAMESLIST
+    const char *uniname;
     if ( (uniname=uniNamesList_name(sc->unicodeenc))!=NULL ) {
 	strcat(buf, " ");
 	strcpy(buf+strlen(buf), uniname);

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -6299,6 +6299,7 @@ return;
 #ifndef _NO_LIBUNINAMESLIST
     /* Get unicode "Name" as defined in NameList.txt */
     if (uni != -1) {
+	const char *uniname;
 	if ( (uniname=uniNamesList_name(uni))!=NULL ) {
             utf82u_strncpy(ubuffer+u_strlen(ubuffer),uniname,80);
 //	    strncat(buffer,uniname,80);
@@ -6577,6 +6578,8 @@ void SCPreparePopup(GWindow gw,SplineChar *sc,struct remap *remap, int localenc,
     }
 
 #ifndef _NO_LIBUNINAMESLIST
+    const char *uniname;
+    const char *uniannot;
     if ( !done ) {
 	if ( (uniname=uniNamesList_name(upos))!=NULL ) {
 	    /* uniname=unicode "Name" as defined in NameList.txt */


### PR DESCRIPTION
Prior GCC cleanup removed them, but they're needed if libuninameslist used.
