### PR TITLE
make sure the library paths for the internal collab server all point inside the app bundle on osx. 

### DIFF
--- a/create-osx-app-bundle.sh
+++ b/create-osx-app-bundle.sh
@@ -24,10 +24,10 @@ dylibbundler --overwrite-dir --bundle-deps --fix-file \
   ./fontforge \
   --install-path @executable_path/../lib \
   --dest-dir ../lib
-dylibbundler                 --bundle-deps --fix-file \
+dylibbundler --overwrite-dir --bundle-deps --fix-file \
   ./FontForgeInternal/fontforge-internal-collab-server \
-  --install-path @executable_path/../lib \
-  --dest-dir ../lib
+  --install-path @executable_path/collablib \
+  --dest-dir ./FontForgeInternal/collablib
 
 mkdir -p $bundle_lib
 cp -av /opt/local/lib/pango   $bundle_lib


### PR DESCRIPTION
At the moment this means duplicated shared libraries for the collab server...
