### PR TITLE
Need to set sf->save_to_dir from value of s2d, or else saving .sfdir to .sfd will save as directory.

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -3011,6 +3011,8 @@ int SFDWriteBakExtended(char* locfilename,
     char* cacheSFFilename = sf->filename;
 
     sf->filename = locfilename;
+    sf->save_to_dir = s2d;
+
     if( localRevisionsToRetain < 0 )
     {
 	// If there are no backups, then don't start creating any


### PR DESCRIPTION
Test case:

Open("test1.sfdir")  # test1.sfdir is any font in directory form
Save("test2.sfd")   # test2.sfd should be same font as a regular file

Broken as of 2bf376ed03cafc08b773a5870218982b4909b6e8, worked correctly prior to that.
