### PR TITLE
issues/417: Fix command key modifier detection

### DIFF
--- a/fontforge/startui.c
+++ b/fontforge/startui.c
@@ -919,6 +919,8 @@ int fontforge_main( int argc, char **argv ) {
     /*  they are doing */
     { int did_keybindings = 0;
     if ( local_x && !get_mac_x11_prop("enable_key_equivalents") ) {
+	hotkeySystemSetCanUseMacCommand( 1 );
+	
 	/* Ok, we get the command key */
 	if ( getenv("LANG")==NULL && getenv("LC_MESSAGES")==NULL ) {
 	    setenv("LC_MESSAGES","en_US.UTF-8",0);

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -336,6 +336,16 @@ static int GMenuDrawMacIcons(struct gmenu *m, Color fg, int ybase, int x, int ma
     int h = 3*(m->as/3);
     int seg = h/3;
 
+    if( hotkeySystemGetCanUseMacCommand() )
+    {
+	if( mask & ksm_control )
+	{
+	    mask |= ksm_cmdmacosx;
+	    mask ^= ksm_control;
+	}
+    }
+    
+    
     if ( mask&ksm_cmdmacosx ) {
 	GDrawDrawLine(m->w,x,ybase-1,x,ybase-(seg-1),fg);
 	GDrawDrawLine(m->w,x,ybase-(2*seg),x,ybase-(h-2),fg);
@@ -394,6 +404,15 @@ static int GMenuMacIconsWidth(struct gmenu *m, int mask ) {
     int seg = h/3;
     int x=0;
 
+    if( hotkeySystemGetCanUseMacCommand() )
+    {
+	if( mask & ksm_control )
+	{
+	    mask |= ksm_cmdmacosx;
+	    mask ^= ksm_control; 
+	}
+    }
+    
     if ( mask&ksm_cmdmacosx ) {
 	x += h+seg-1;
     }
@@ -594,7 +613,7 @@ static int GMenuDrawMenuLine(struct gmenu *m, GMenuItem *mi, int y,GWindow pixma
 	width = GDrawGetTextWidth(pixmap,shortbuf,-1);
 	if( mac_menu_icons )
 	    width += GMenuMacIconsWidth( m, short_mask );
-	
+
 	if ( r2l )
 	{
 	    int x = GDrawDrawText(pixmap,m->bp,ybase,shortbuf,-1,fg);
@@ -1858,7 +1877,15 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 
     /* then look for hotkeys everywhere */
 	
-//    printf("looking for hotkey in new system...state:%d keysym:%d\n", event->u.chr.state, event->u.chr.keysym );
+    printf("looking1 for hotkey in new system...state:%d keysym:%d\n", event->u.chr.state, event->u.chr.keysym );
+
+    if( hotkeySystemGetCanUseMacCommand() )
+    {
+	event->u.chr.state &= ~ksm_cmdmacosx;
+	event->u.chr.state |= ksm_control;
+    }
+    
+	
 	struct dlistnodeExternal* node= hotkeyFindAllByEvent( top, event );
 	struct dlistnode* hklist = (struct dlistnode*)node;
 	for( ; node; node=(struct dlistnodeExternal*)(node->next) ) {

--- a/gdraw/hotkeys.c
+++ b/gdraw/hotkeys.c
@@ -39,6 +39,8 @@
 #define fsync _commit
 #endif
 
+static int hotkeySystemCanUseMacCommand = 0;
+
 extern char *getPfaEditDir(char *buffer);
 
 struct dlistnode* hotkeys = 0;
@@ -404,3 +406,12 @@ char* hotkeyTextWithoutModifiers( char* hktext ) {
 }
 
 
+void hotkeySystemSetCanUseMacCommand( int v )
+{
+    hotkeySystemCanUseMacCommand = v;
+}
+
+int hotkeySystemGetCanUseMacCommand()
+{
+    return hotkeySystemCanUseMacCommand;
+}

--- a/gdraw/hotkeys.h
+++ b/gdraw/hotkeys.h
@@ -34,6 +34,7 @@
 #define HOTKEY_ACTION_MAX_SIZE 200
 #define HOTKEY_TEXT_MAX_SIZE   100
 
+
 /**
  * A hotkey binds some keyboard combination to an abstract "action"
  *
@@ -203,5 +204,11 @@ extern Hotkey* hotkeySet( char* action, char* keydefinition, int append );
 
 extern void HotkeyParse( Hotkey* hk, const char *shortcut );
 
+/**
+ * Set to true if the hotkey system can use the Command key for its
+ * own actions.
+ */
+extern void hotkeySystemSetCanUseMacCommand( int v );
+extern int hotkeySystemGetCanUseMacCommand(void);
 
 #endif // _HOTKEYS_H


### PR DESCRIPTION
Command key can now be optionally used on the mac osx.
