### PR TITLE
fix for Irix compiler - brackets required

### DIFF
--- a/fontforge/contextchain.c
+++ b/fontforge/contextchain.c
@@ -2408,7 +2408,7 @@ void ContextChainEdit(SplineFont *sf,FPST *fpst,
 	ggcd[i][k].gd.popup_msg = (unichar_t *) _("Set this glyph list from a selection.");
 	ggcd[i][k].gd.flags = gg_visible | gg_enabled | gg_utf8_popup;
 	ggcd[i][k].gd.handle_controlevent = CCD_FromSelection;
-	ggcd[i][k].data = (void *) (intpt) CID_GlyphList+(0*100+i*20);
+	ggcd[i][k].data=(void *)((intpt)CID_GlyphList+(0*100+i*20));
 	ggcd[i][k++].creator = GButtonCreate;
 	subvarray[i][0] = &ggcd[i][k-1];
 


### PR DESCRIPTION
Irix complains about void\* pointer. Brackets required.
See Re: [Fontforge-devel] problem in contextchain.c, 2013mar12
