### PR TITLE
Fixed scripting function Strtod() to actually work.

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -717,7 +717,7 @@ static void bStrtod(Context *c) {
 	ScriptError( c, "Bad type for argument" );
 
     c->return_val.type = v_real;
-    c->return_val.u.ival = strtod(c->a.vals[1].u.sval,NULL);
+    c->return_val.u.fval = (float)strtod(c->a.vals[1].u.sval,NULL);
 }
 
 static void bStrskipint(Context *c) {


### PR DESCRIPTION
Return type is v_real, but the value from strtod() was being stored to .ival instead.
