### PR TITLE
Revert "Always go for the Command key binding on the mac."

### DIFF
--- a/fontforge/startui.c
+++ b/fontforge/startui.c
@@ -917,12 +917,9 @@ int fontforge_main( int argc, char **argv ) {
     /*  gettext will not. So I don't bother to check for null strings or "C"  */
     /*  or "POSIX". If they've mucked with the locale perhaps they know what  */
     /*  they are doing */
-
-    // Always try to use the Command key, if their X11 doesn't pass it to us
-    // then we have the control-N fallbacks in place
-    hotkeySystemSetCanUseMacCommand( 1 );
     { int did_keybindings = 0;
     if ( local_x && !get_mac_x11_prop("enable_key_equivalents") ) {
+	hotkeySystemSetCanUseMacCommand( 1 );
 	
 	/* Ok, we get the command key */
 	if ( getenv("LANG")==NULL && getenv("LC_MESSAGES")==NULL ) {


### PR DESCRIPTION
With apologies to @monkeyiq, this change appears to make arrow keys stop working on Mac OSX (10.8).  By which I mean that with the change, the arrow keys only scroll the viewport, rather than move the selection as was the previous behavior.

This reverts commit 0e186efed1fa794972d3203ec4e99f48fc6d7c82.
