### PR TITLE
Test to see if command key is pressed and control key is not pressed before proceeding to substitute control key.

### DIFF
--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1881,8 +1881,10 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 
     if( hotkeySystemGetCanUseMacCommand() )
     {
-	event->u.chr.state &= ~ksm_cmdmacosx;
-	event->u.chr.state |= ksm_control;
+	if (event->u.chr.state & (ksm_cmdmacosx|ksm_control) == ksm_cmdmacosx) {
+	    event->u.chr.state &= ~ksm_cmdmacosx;
+	    event->u.chr.state |= ksm_control;
+	}
     }
     
 	


### PR DESCRIPTION
Additional change required by issue #443.
