### PR TITLE
A subtle interaction between incr/decr on the items in the metrics view

### DIFF
--- a/fontforge/metricsview.c
+++ b/fontforge/metricsview.c
@@ -3972,25 +3972,32 @@ static void MVChar(MetricsView *mv,GEvent *event) {
 	    GGadget *active = GWindowGetFocusGadgetOfWindow(mv->gw);
 	    if(!active)
 		return;
- 	    unichar_t *end;
-	    double val = u_strtod(_GGadgetGetTitle(active),&end);
-	    if (isValidInt(end)) {
-		int dir = ( event->u.chr.keysym == GK_Up || event->u.chr.keysym==GK_KP_Up ) ? 1 : -1;
-		if( event->u.chr.state&ksm_control && event->u.chr.state&ksm_shift ) {
-		    dir *= pref_mv_control_shift_and_arrow_skip;
-		}
-		else if( event->u.chr.state&ksm_shift ) {
-		    dir *= pref_mv_shift_and_arrow_skip;
-		}
-		val += dir;
-		char buf[100];
-		snprintf(buf,99,"%.0f",val);
-		GGadgetSetTitle8(active, buf);
 
-		event->u.control.u.tf_changed.from_pulldown=-1;
-		event->type=et_controlevent;
-		event->u.control.subtype = et_textchanged;
-		GGadgetDispatchEvent(active,event);
+	    // MIQ: We do not want to increment and decrement the integer
+	    //      value of the kerning word on up/down now, instead we
+	    //      should always move up/down in the list of kerning words.
+	    if( active != mv->text )
+	    {
+		unichar_t *end;
+		double val = u_strtod(_GGadgetGetTitle(active),&end);
+		if (isValidInt(end)) {
+		    int dir = ( event->u.chr.keysym == GK_Up || event->u.chr.keysym==GK_KP_Up ) ? 1 : -1;
+		    if( event->u.chr.state&ksm_control && event->u.chr.state&ksm_shift ) {
+			dir *= pref_mv_control_shift_and_arrow_skip;
+		    }
+		    else if( event->u.chr.state&ksm_shift ) {
+			dir *= pref_mv_shift_and_arrow_skip;
+		    }
+		    val += dir;
+		    char buf[100];
+		    snprintf(buf,99,"%.0f",val);
+		    GGadgetSetTitle8(active, buf);
+
+		    event->u.control.u.tf_changed.from_pulldown=-1;
+		    event->type=et_controlevent;
+		    event->u.control.subtype = et_textchanged;
+		    GGadgetDispatchEvent(active,event);
+		}
 	    }
     }
     if ( event->u.chr.keysym == GK_Up || event->u.chr.keysym==GK_KP_Up ||


### PR DESCRIPTION
and the kerning word list entry where it used to add/subtract from the kerning
word if that word happened to be an integer.

Note that you can't move the below if() block up or unexpected things happen too.
So the best seems to be to selectively avoid the add/subtract just on the kerning
word list entry box.
