### PR TITLE
Fixed address[] and changed constant to CAPS

### DIFF
--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -5591,34 +5591,33 @@ static void FVMenuCollabStart(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *
 
     int port_default = 5556;
     int port = port_default;
-    char* address[ipaddress_string_length_t];
+    char address[IPADDRESS_STRING_LENGTH_T];
     if( !getNetworkAddress( address ))
     {
-	snprintf( address, ipaddress_string_length_t-1,
+	snprintf( address, IPADDRESS_STRING_LENGTH_T-1,
 		  "%s", HostPortPack( "127.0.0.1", port ));
     }
     else
     {
-	snprintf( address, ipaddress_string_length_t-1,
+	snprintf( address, IPADDRESS_STRING_LENGTH_T-1,
 		  "%s", HostPortPack( address, port ));
     }
-    
+
     printf("host address:%s\n",address);
-    
+
     char* res = gwwv_ask_string(
 	"Starting Collab Server",
 	address,
 	"FontForge has determined that your computer can be accessed"
 	" using the below address. Share that address with other people"
 	" who you wish to collaborate with...\n\nPress OK to start the collaboration server...");
-    
+
     if( res )
     {
 	HostPortUnpack( address, &port, port_default );
 	
 	printf("address:%s\n", address );
 	printf("port:%d\n", port );
-
 	
 	void* cc = collabclient_new( address, port );
 	fv->b.collabClient = cc;
@@ -5641,15 +5640,15 @@ static void FVMenuCollabConnect(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent
     {
 	int port_default = 5556;
 	int port = port_default;
-	char* address[ipaddress_string_length_t];
-	strncpy( address, res, ipaddress_string_length_t-1 );
+	char address[IPADDRESS_STRING_LENGTH_T];
+	strncpy( address, res, IPADDRESS_STRING_LENGTH_T-1 );
 	HostPortUnpack( address, &port, port_default );
 	
 	void* cc = collabclient_new( address, port );
 	fv->b.collabClient = cc;
 	collabclient_sessionJoin( cc, fv );
     }
-    
+
     printf("FVMenuCollabConnect(done)\n");
 }
 

--- a/gutils/gnetwork.c
+++ b/gutils/gnetwork.c
@@ -61,7 +61,7 @@ char* getNetworkAddress( char* outstring )
     }
     
     inet_ntop( he->h_addrtype, he->h_addr_list[0],
-	       outstring, ipaddress_string_length_t-1 );
+	       outstring, IPADDRESS_STRING_LENGTH_T-1 );
 
     return outstring;
 }

--- a/inc/gnetwork.h
+++ b/inc/gnetwork.h
@@ -28,7 +28,7 @@
 #ifndef _ALREADY_INCLUDED_GNETWORK_H_
 #define _ALREADY_INCLUDED_GNETWORK_H_
 
-#define ipaddress_string_length_t 100
+#define IPADDRESS_STRING_LENGTH_T 100
 
 
 /**


### PR DESCRIPTION
Error. Don't need char_, only need char when address[] with brackets.
we do not need to also do char_ unless we are doing an array of strings.
Fixes fontview.c:5606:5: warning: format '%s' expects type 'char _', but
argument 2 has type 'char *_'

Changed constant from lower case to uppercase since it wasn't clear that
this was a constant value while diagnosing error.

This fixes several compiler warnings.
