### PR TITLE
Added parentheses around bitwise & expr in comparison, and added comment

### DIFF
--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1881,9 +1881,9 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 
     if( hotkeySystemGetCanUseMacCommand() )
     {
-	if (event->u.chr.state & (ksm_cmdmacosx|ksm_control) == ksm_cmdmacosx) {
-	    event->u.chr.state &= ~ksm_cmdmacosx;
-	    event->u.chr.state |= ksm_control;
+	// If Mac command key was pressed, swap with the control key.
+	if ((event->u.chr.state & (ksm_cmdmacosx|ksm_control)) == ksm_cmdmacosx) {
+	    event->u.chr.state ^= (ksm_cmdmacosx|ksm_control);
 	}
     }
     


### PR DESCRIPTION
Addresses compiler warning mentioned in comments to e9dcc159043593f8e3a84f78e258b5bf05660143.
