### PR TITLE
Put libunicodenames back in same place

### DIFF
--- a/fontforge/bitmapview.c
+++ b/fontforge/bitmapview.c
@@ -26,14 +26,6 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
-#include <gkeysym.h>
-#include <utype.h>
-#include <ustring.h>
-#include <math.h>
-#include <locale.h>
-#include <gresource.h>
-#include <gresedit.h>
-
 #ifndef _NO_LIBUNINAMESLIST
 #include <uninameslist.h>
 #else
@@ -42,6 +34,14 @@
 extern uninm_names_db names_db; /* Unicode character names and annotations database */
 #endif
 #endif
+#include <gkeysym.h>
+#include <utype.h>
+#include <ustring.h>
+#include <math.h>
+#include <locale.h>
+#include <gresource.h>
+#include <gresedit.h>
+
 
 int bv_width = 270, bv_height=250;
 
@@ -191,7 +191,7 @@ static char *BVMakeTitles(BitmapView *bv, BDFChar *bc,char *buf) {
 #ifndef _NO_LIBUNINAMESLIST
     if ( (uniname=uniNamesList_name(sc->unicodeenc))!=NULL ) {
 #else
-    if ( sc->unicodeenc!=-1 && (uniname=uninm_name(names_db,(unsigned int) sc->unicodeenc))!=NULL ) {
+    if ( sc->unicodeenc!=-1 && (uniname=uninm_name(names_db,(unsigned int) sc->unicodeenc))!= NULL) {
 #endif
 	strcat(buf, " ");
 	strcpy(buf+strlen(buf), uniname);

--- a/fontforge/charinfo.c
+++ b/fontforge/charinfo.c
@@ -27,14 +27,6 @@
  */
 
 #include "fontforgeui.h"
-#include <ustring.h>
-#include <math.h>
-#include <utype.h>
-#include <chardata.h>
-#include "ttf.h"		/* For MAC_DELETED_GLYPH_NAME */
-#include <gkeysym.h>
-#include "is_LIGATURE.h"
-
 #ifndef _NO_LIBUNINAMESLIST
 #include <uninameslist.h>
 #else
@@ -43,6 +35,13 @@
 extern uninm_names_db names_db; /* Unicode character names and annotations database */
 #endif
 #endif
+#include <ustring.h>
+#include <math.h>
+#include <utype.h>
+#include <chardata.h>
+#include "ttf.h"		/* For MAC_DELETED_GLYPH_NAME */
+#include <gkeysym.h>
+#include "is_LIGATURE.h"
 
 extern int lookup_hideunused;
 

--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -27,6 +27,14 @@
 
 #include "fontforgeui.h"
 #include "cvruler.h"
+#ifndef _NO_LIBUNINAMESLIST
+#include <uninameslist.h>
+#else
+#ifndef _NO_LIBUNICODENAMES
+#include <libunicodenames.h>
+extern uninm_names_db names_db; /* Unicode character names and annotations database */
+#endif
+#endif
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>
@@ -41,14 +49,6 @@ extern int _GScrollBar_Width;
 #endif
 #include "dlist.h"
 
-#ifndef _NO_LIBUNINAMESLIST
-#include <uninameslist.h>
-#else
-#ifndef _NO_LIBUNICODENAMES
-#include <libunicodenames.h>
-extern uninm_names_db names_db; /* Unicode character names and annotations database */
-#endif
-#endif
 
 #include "gutils/prefs.h"
 #include "collabclient.h"

--- a/fontforge/startui.c
+++ b/fontforge/startui.c
@@ -27,6 +27,10 @@
 
 #include <fontforge-config.h>
 #include "fontforgeui.h"
+#ifndef _NO_LIBUNICODENAMES
+#include <libunicodenames.h>	/* need to open a database when we start */
+extern uninm_names_db names_db; /* Unicode character names and annotations database */
+#endif
 #include <gfile.h>
 #include <gresource.h>
 #include <ustring.h>
@@ -42,10 +46,6 @@
 #include "../gdraw/hotkeys.h"
 #include "gutils/prefs.h"
 
-#ifndef _NO_LIBUNICODENAMES
-#include <libunicodenames.h>	/* need to open a database when we start */
-extern uninm_names_db names_db; /* Unicode character names and annotations database */
-#endif
 
 #define GTimer GTimer_GTK
 #include <glib.h>


### PR DESCRIPTION
Moved to same spots in #include order.
Missed these moves during the copy done earlier on 2013-03-13 20:04:26
