### PR TITLE
Fix crash when renaming a glyph to an existing name

### DIFF
--- a/fontforge/charinfo.c
+++ b/fontforge/charinfo.c
@@ -1220,6 +1220,7 @@ static SplineChar *CI_SCDuplicate(SplineChar *sc) {
 
     newsc = chunkalloc(sizeof(SplineChar));
     newsc->name = copy(sc->name);
+    newsc->parent = sc->parent;
     newsc->unicodeenc = sc->unicodeenc;
     newsc->orig_pos = sc->orig_pos;
     newsc->comment = copy(sc->comment);


### PR DESCRIPTION
CI_CheckMetaData() checks if the new glyph name is used anywhere else
and prompts the user if he wants to swap glyph names, later we will
crash because the cachedsc of that CharInfo will end up with NULL sf.
