### PR TITLE
Unicode Library access to Names and Annotations (python)

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -861,6 +861,50 @@ return( NULL );
 return( ret );
 }
 
+static PyObject *PyFF_UnicodeAnnotationFromLib(PyObject *UNUSED(self), PyObject *args) {
+/* If the library is available, then get the official annotation for this unicode value */
+/* This function may be used in conjunction with UnicodeNameFromLib(n) */
+    PyObject *ret;
+    char *temp;
+    long val;
+
+    if ( !PyArg_ParseTuple(args,"|i",&val) )
+	return( NULL );
+
+#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
+    temp=NULL;
+#else
+    temp=unicode_annot(val);
+#endif
+    if ( temp==NULL ) {
+	temp=galloc(1*sizeof(char)); temp='\0';
+    }
+    ret=Py_BuildValue("s",temp); free(temp);
+    return( ret );
+}
+
+static PyObject *PyFF_UnicodeNameFromLib(PyObject *UNUSED(self), PyObject *args) {
+/* If the library is available, then get the official name for this unicode value */
+/* This function may be used in conjunction with UnicodeAnnotationFromLib(n) */
+    PyObject *ret;
+    char *temp;
+    long val;
+
+    if ( !PyArg_ParseTuple(args,"|i",&val) )
+	return( NULL );
+
+#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
+    temp=NULL;
+#else
+    temp=unicode_name(val);
+#endif
+    if ( temp==NULL ) {
+	temp=galloc(1*sizeof(char)); temp='\0';
+    }
+    ret=Py_BuildValue("s",temp); free(temp);
+    return( ret );
+}
+
 static PyObject *PyFF_Version(PyObject *UNUSED(self), PyObject *UNUSED(args)) {
     char buffer[20];
 
@@ -2154,8 +2198,8 @@ static PyObject *PyFFContour_Slice( PyObject *self, Py_ssize_t start, Py_ssize_t
     int len, i;
 
     /* When passed in, start,end >= -cont->pt_cnt */
-    /* However, start,end can be arbitrarily large, particularly when the notation c[i:] 
-	is used, in which case end is a very large value (max size of uint). */ 
+    /* However, start,end can be arbitrarily large, particularly when the notation c[i:]
+	is used, in which case end is a very large value (max size of uint). */
     if ( start<0 )
 	start += cont->pt_cnt;
     if ( start>cont->pt_cnt )
@@ -2165,7 +2209,7 @@ static PyObject *PyFFContour_Slice( PyObject *self, Py_ssize_t start, Py_ssize_t
     if ( end>cont->pt_cnt )
 	end = cont->pt_cnt;
 
-    if ( end<start ) 
+    if ( end<start )
 	len = end - start + cont->pt_cnt;
     else
 	len = end - start;
@@ -2198,7 +2242,7 @@ static int PyFFContour_SliceAssign( PyObject *_self, Py_ssize_t start, Py_ssize_
 	PyErr_Format(PyExc_TypeError, "Replacement must be a (FontForge) Contour");
 return( -1 );
     }
-    
+
     if ( start<0 )
 	start += self->pt_cnt;
     if ( start>self->pt_cnt )
@@ -2207,7 +2251,7 @@ return( -1 );
 	end += self->pt_cnt;
     if ( end>self->pt_cnt )
 	end = self->pt_cnt;
-    
+
     if ( end<start ) {
 	PyErr_Format(PyExc_ValueError, "Slice specification out of order" );
 return( -1 );
@@ -3028,7 +3072,7 @@ return( NULL );
 	do_pycall(pen,"endPath",tuple);
     if ( PyErr_Occurred())
 return( NULL );
-	    
+
 Py_RETURN( self );
 }
 
@@ -4047,7 +4091,7 @@ static PyObject *PyFFLayer_ReverseDirection(PyFF_Layer *self, PyObject *UNUSED(a
     int i;
 
     for ( i=0; i<self->cntr_cnt; ++i )
-	PyFFContour_ReverseDirection(self->contours[i],NULL); 
+	PyFFContour_ReverseDirection(self->contours[i],NULL);
 Py_RETURN( self );
 }
 
@@ -4908,7 +4952,7 @@ return( NULL );
 	SplineMake(ss->last,ss->first,sc->layers[layer].order2);
     }
     ss->last = ss->first;
-	
+
     ((PyFF_GlyphPen *) self)->ended = true;
 Py_RETURN( self );
 }
@@ -4941,7 +4985,7 @@ return( NULL );
 	GlyphClear(self);
 
     memset(m,0,sizeof(m));
-    m[0] = m[3] = 1; 
+    m[0] = m[3] = 1;
     if ( !PyArg_ParseTuple(args,"s|(dddddd)",&str,
 	    &m[0], &m[1], &m[2], &m[3], &m[4], &m[5]) )
 return( NULL );
@@ -4953,7 +4997,7 @@ return( NULL );
     for ( j=0; j<6; ++j )
 	transform[j] = m[j];
     _SCAddRef(sc,rsc,layer,transform);
-    
+
 Py_RETURN( self );
 }
 
@@ -6542,7 +6586,7 @@ static int PyFF_Glyph_set_dhints(PyFF_Glyph *self,PyObject *value, void *UNUSED(
     if ( cnt==-1 )
 return( -1 );
     for ( i=0; i<cnt; ++i ) {
-	if ( !PyArg_ParseTuple(PySequence_GetItem(value,i),"(dd)(dd)(dd)", 
+	if ( !PyArg_ParseTuple(PySequence_GetItem(value,i),"(dd)(dd)(dd)",
             &lx,&ly,&rx,&ry,&ux,&uy ))
 return( -1 );
         if ( ux == 0 && uy == 0 ) {
@@ -6765,7 +6809,7 @@ static int PyFF_Glyph_set_anchorPoints(PyFF_Glyph *self,PyObject *value, void *U
 	PyErr_Format(PyExc_TypeError, "Expected a tuple of anchor points" );
 return( -1 );
     }
-    
+
     for ( i=0; i<PySequence_Size(value); ++i ) {
 	ap = APFromTuple(sc,PySequence_GetItem(value,i));
 	if ( ap==NULL )
@@ -7383,7 +7427,7 @@ return( embolden_error );
 	zones->top_zone = 3*zones->top_bound/4;
 	zones->bottom_zone = zones->top_bound/4;
     }
-	
+
 return( type );
 }
 
@@ -7432,7 +7476,7 @@ static PyObject *PyFFGlyph_AddReference(PyObject *self, PyObject *args) {
     int j;
 
     memset(m,0,sizeof(m));
-    m[0] = m[3] = 1; 
+    m[0] = m[3] = 1;
     if ( !PyArg_ParseTuple(args,"s|(dddddd)",&str,
 	    &m[0], &m[1], &m[2], &m[3], &m[4], &m[5]) )
 return( NULL );
@@ -10375,7 +10419,7 @@ static PyObject *fontiter_iternextkey(fontiterobject *di) {
 		tempdict = PyDict_New();
 		PyFF_Glyph_set_temporary((PyFF_Glyph *)glyph, tempdict,  NULL);
 	    }
-	    
+
 	    matched = Py_BuildValue((char *) dictfmt,
 		    "findMatchedRefs", di->sv->matched_refs,
 		    "findMatchedContours", di->sv->matched_ss,
@@ -11924,7 +11968,7 @@ Py_RETURN_NONE;
 	    }
 	}
     }
-return( ret );    
+return( ret );
 }
 
 static PyObject *PyFF_Font_get_horizontal_baseline(PyFF_Font *self, void *closure) {
@@ -12094,7 +12138,7 @@ return( -1 );
 		PyObject *feat = PyTuple_GetItem(features,k);
 		char *tag;
 		int min,max;
-    
+
 		if ( !PyArg_ParseTuple(feat,"sii",&tag,&min,&max)) {
 		    BaseFree(base);
 return( -1 );
@@ -12402,7 +12446,7 @@ return( -1 );
     }
     OtfNameListFree(sf->fontstyle_name);
     sf->fontstyle_name = head;
-    
+
 return( 0 );
 }
 
@@ -12608,7 +12652,7 @@ return -1;
     fv->selected = gcalloc(fv->map->enccount,sizeof(char));
     if ( !no_windowing_ui )
 	FontViewReformatAll(fv->sf);
-    
+
 #if PY_MAJOR_VERSION >= 3
     Py_DECREF(bytes);
 #endif
@@ -12762,7 +12806,7 @@ return( -1 );
     sf->mark_class_cnt = cnt+1; /* +1 because index 0 was skipped */
     sf->mark_classes = classes;
     sf->mark_class_names = names;
-    
+
 return( 0 );
 }
 
@@ -13336,7 +13380,7 @@ static PyGetSetDef PyFF_Font_getset[] = {
 /* ************************************************************************** */
 /* Font Methods */
 /* ************************************************************************** */
-		    
+
 static PyObject *PyFFFont_GetTableData(PyFF_Font *self, PyObject *args) {
     char *table_name;
     uint32 tag;
@@ -13423,7 +13467,7 @@ return( NULL );
 	SFRemoveSavedTable(self->fv->sf,tag);
 Py_RETURN(self);
     }
-	
+
     if ( !PySequence_Check(tuple)) {
 	PyErr_Format(PyExc_TypeError, "Argument must be a tuple" );
 return( NULL );
@@ -13655,7 +13699,7 @@ return (NULL);
 	PyErr_Format(PyExc_EnvironmentError,"This font is not a CID keyed font." );
 return( NULL );
     }
-    
+
     SFFlatten(sf->cidmaster);
 Py_RETURN( self );
 }
@@ -13671,10 +13715,10 @@ return (NULL);
 	PyErr_Format(PyExc_EnvironmentError,"This font is not a CID keyed font." );
 return( NULL );
     }
-    
+
     if ( !PyArg_ParseTuple(args,"s", &locfilename ))
 return( NULL );
-    
+
     if ( !SFFlattenByCMap(sf,locfilename)) {
 	PyErr_Format(PyExc_EnvironmentError,"Can't find (or can't parse) cmap file: %s", locfilename);
 return( NULL );
@@ -14358,8 +14402,8 @@ return( NULL );
     if ( first!=second )
 	free(second);
 Py_RETURN( self );
-}    
-    
+}
+
 static PyObject *PyFFFont_removeLookup(PyFF_Font *self, PyObject *args) {
     SplineFont *sf;
     char *lookup;
@@ -15377,8 +15421,8 @@ static PyObject *PyFFFont_Save(PyFF_Font *self, PyObject *args) {
 	if ( !PyArg_ParseTuple(args,"es","UTF-8",&filename) )
 	    return( NULL );
     }
-    
-    
+
+
     if ( haveFilename )
     {
 	/* Save As - Filename was provided */
@@ -15434,9 +15478,9 @@ static PyObject *PyFFFont_Save(PyFF_Font *self, PyObject *args) {
 	    strcat(locfilename,".sfd");
 	}
 	char* targetfilename = locfilename;
-	if ( !targetfilename ) 
+	if ( !targetfilename )
 	    targetfilename = fv->sf->filename;
-	
+
 	/**
 	 * If there are no existing backup files, don't start creating them here.
 	 * Otherwise, save as many as the user wants.
@@ -15710,7 +15754,7 @@ return( NULL );
 	    PyErr_Format(PyExc_TypeError, "Unknown bitmap format");
 return( NULL );
 	}
-    }	
+    }
     if ( namelist!=NULL ) {
 	rename_to = NameListByName(namelist);
 	if ( rename_to==NULL ) {
@@ -16094,7 +16138,7 @@ return( NULL );
 	arg = PyTuple_GetItem(args,1);
 	if ( PyInt_Check(arg)) {
 	    int val = PyInt_AsLong(arg);
-	    if ( val>0 ) { 
+	    if ( val>0 ) {
 		pointsizes = gcalloc(2,sizeof(int32));
 		pointsizes[0] = val;
 	    }
@@ -16321,7 +16365,7 @@ return( NULL );
 Py_RETURN( self );
 }
 
-static char *italicize_keywords[] = { 
+static char *italicize_keywords[] = {
     "italic_angle", "ia",
     "lc_condense", "lc",
     "uc_condense", "uc",
@@ -16459,7 +16503,7 @@ return (NULL);
     if ( !Parse_ItalicArgs(&ii,args,keywds))
 return( NULL );
     MakeItalic(fv,NULL,&ii);
-    
+
 Py_RETURN( self );
 }
 
@@ -17777,6 +17821,8 @@ static PyMethodDef module_fontforge_methods[] = {
     { "preloadCidmap", PyFF_PreloadCidmap, METH_VARARGS, "Load a cidmap file" },
     { "unicodeFromName", PyFF_UnicodeFromName, METH_VARARGS, "Given a name, look it up in the namelists and find what unicode code point it maps to (returns -1 if not found)" },
     { "nameFromUnicode", PyFF_NameFromUnicode, METH_VARARGS, "Given a unicode code point and (optionally) a namelist, find the corresponding glyph name" },
+    { "UnicodeNameFromLib", PyFF_UnicodeNameFromLib, METH_VARARGS, "Return the www.unicode.org name for a given unicode character value" },
+    { "UnicodeAnnotationFromLib", PyFF_UnicodeAnnotationFromLib, METH_VARARGS, "Return the www.unicode.org annotation(s) for a given unicode character value" },
     { "version", PyFF_Version, METH_NOARGS, "Returns a string containing the current version of FontForge, as 20061116" },
     { "runInitScripts", PyFF_RunInitScripts, METH_NOARGS, "Run the system and user initialization scripts, if not already run" },
     { "scriptPath", PyFF_GetScriptPath, METH_NOARGS, "Returns a list of the directories searched for scripts"},

--- a/htdocs/python.html
+++ b/htdocs/python.html
@@ -273,10 +273,24 @@
 	namelist is specified the name will be taken from that.</TD>
     </TR>
     <TR>
+      <TD><CODE>UnicodeAnnotationFromLib</CODE></TD>
+      <TD><CODE>(n)</CODE></TD>
+      <TD>Returns the Unicode Annotations for this value as described by www.unicode.org.
+	If there is no unicode annotation for this value, or no library available,
+	then return empty string "". It can execute with no current font.</TD>
+    </TR>
+    <TR>
       <TD><CODE>unicodeFromName</CODE></TD>
       <TD><CODE>(glyphname)</CODE></TD>
       <TD>Looks up glyph name in its dictionary and if it is associated with a
 	unicode code point returns that number. Otherwise it returns -1</TD>
+    </TR>
+    <TR>
+      <TD><CODE>UnicodeNameFromLib</CODE></TD>
+      <TD><CODE>(n)</CODE></TD>
+      <TD>Returns the Unicode Name for this value as described by www.unicode.org.
+	If there is no unicode name for this value, or no library available,
+	then return empty string "". It can execute with no current font.</TD>
     </TR>
     <TR>
       <TD><CODE>version</CODE></TD>


### PR DESCRIPTION
If the library exists, then return the official name and annotations as
given by Unicode NameList.txt (using python). Also removed trailing spaces.

---Test script---
# !/usr/local/bin/fontforge

import fontforge;
print "start names";
print fontforge.UnicodeNameFromLib(65);
print "x";
print fontforge.UnicodeNameFromLib(69);
print "x";
print fontforge.UnicodeNameFromLib(200);
print "done names";
print "start annotation";
print fontforge.UnicodeAnnotationFromLib(65);
print "x";
print fontforge.UnicodeAnnotationFromLib(66);
print "x";
print fontforge.UnicodeAnnotationFromLib(0x300);
print "done annotation";

---resulting output---
start names
LATIN CAPITAL LETTER A
x
LATIN CAPITAL LETTER E
x
LATIN CAPITAL LETTER E WITH GRAVE
done names
start annotation
None
x
        → (script capital b - 212C)
x
        = Greek varia
        → (grave accent - 0060)
        → (modifier letter grave accent - 02CB)
done annotation
