### PR TITLE
Add NamesList.txt version access via native or python scripting

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -882,19 +882,13 @@ static PyObject *PyFF_UnicodeAnnotationFromLib(PyObject *UNUSED(self), PyObject 
 /* This function may be used in conjunction with UnicodeNameFromLib(n) */
     PyObject *ret;
     char *temp;
-
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    temp=NULL;
-#else
     long val;
 
     if ( !PyArg_ParseTuple(args,"|i",&val) )
 	return( NULL );
 
-    temp=unicode_annot(val);
-#endif
-    if ( temp==NULL ) {
-	temp=galloc(1*sizeof(char)); temp='\0';
+    if ( (temp=unicode_annot(val))==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
     }
     ret=Py_BuildValue("s",temp); free(temp);
     return( ret );
@@ -905,19 +899,13 @@ static PyObject *PyFF_UnicodeNameFromLib(PyObject *UNUSED(self), PyObject *args)
 /* This function may be used in conjunction with UnicodeAnnotationFromLib(n) */
     PyObject *ret;
     char *temp;
-
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    temp=NULL;
-#else
     long val;
 
     if ( !PyArg_ParseTuple(args,"|i",&val) )
 	return( NULL );
 
-    temp=unicode_name(val);
-#endif
-    if ( temp==NULL ) {
-	temp=galloc(1*sizeof(char)); temp='\0';
+    if ( (temp=unicode_name(val))==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
     }
     ret=Py_BuildValue("s",temp); free(temp);
     return( ret );
@@ -926,33 +914,23 @@ static PyObject *PyFF_UnicodeNameFromLib(PyObject *UNUSED(self), PyObject *args)
 static PyObject *PyFF_UnicodeBlockStartFromLib(PyObject *UNUSED(self), PyObject *args) {
 /* If the library is available, then get the official start for this unicode block */
 /* Use this function with UnicodeBlockNameFromLib(n) & UnicodeBlockEndFromLib(n). */
-
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    return( Py_BuildValue("i", -1) );
-#else
     long val;
 
     if ( !PyArg_ParseTuple(args,"|i",&val) )
 	return( NULL );
 
     return( Py_BuildValue("i", unicode_block_start(val)) );
-#endif
 }
 
 static PyObject *PyFF_UnicodeBlockEndFromLib(PyObject *UNUSED(self), PyObject *args) {
 /* If the library is available, then get the official end for this unicode block. */
 /* Use this function with UnicodeBlockStartFromLib(n), UnicodeBlockNameFromLib(n) */
-
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    return( Py_BuildValue("i", -1) );
-#else
     long val;
 
     if ( !PyArg_ParseTuple(args,"|i",&val) )
 	return( NULL );
 
     return( Py_BuildValue("i", unicode_block_end(val)) );
-#endif
 }
 
 static PyObject *PyFF_UnicodeBlockNameFromLib(PyObject *UNUSED(self), PyObject *args) {
@@ -960,19 +938,25 @@ static PyObject *PyFF_UnicodeBlockNameFromLib(PyObject *UNUSED(self), PyObject *
 /* Use this function with UnicodeBlockStartFromLib(n), UnicodeBlockEndFromLib(n). */
     PyObject *ret;
     char *temp;
-
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    temp=NULL;
-#else
     long val;
 
     if ( !PyArg_ParseTuple(args,"|i",&val) )
 	return( NULL );
 
-    temp=unicode_block_name(val);
-#endif
-    if ( temp==NULL ) {
-	temp=galloc(1*sizeof(char)); temp='\0';
+    if ( (temp=unicode_block_name(val))==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
+    }
+    ret=Py_BuildValue("s",temp); free(temp);
+    return( ret );
+}
+
+static PyObject *PyFF_UnicodeNamesListVersion(PyObject *UNUSED(self), PyObject *args) {
+/* If the library is available, then return the Nameslist Version number */
+    PyObject *ret;
+    char *temp;
+
+    if ( (temp=unicode_library_version())==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
     }
     ret=Py_BuildValue("s",temp); free(temp);
     return( ret );
@@ -18110,6 +18094,7 @@ static PyMethodDef module_fontforge_methods[] = {
     { "UnicodeBlockStartFromLib", PyFF_UnicodeBlockStartFromLib, METH_VARARGS, "Return the www.unicode.org block start, for example block[0]={0..127} -> 0" },
     { "UnicodeBlockEndFromLib", PyFF_UnicodeBlockEndFromLib, METH_VARARGS, "Return the www.unicode.org block end, for example block[1]={128..255} -> 255" },
     { "UnicodeBlockNameFromLib", PyFF_UnicodeBlockNameFromLib, METH_VARARGS, "Return the www.unicode.org block name, for example block[2]={256..383} -> Latin Extended-A" },
+    { "UnicodeNamesListVersion", PyFF_UnicodeNamesListVersion, METH_NOARGS, "Return the www.unicode.org NamesList version for this library" },
     { "version", PyFF_Version, METH_NOARGS, "Returns a string containing the current version of FontForge, as 20061116" },
     { "runInitScripts", PyFF_RunInitScripts, METH_NOARGS, "Run the system and user initialization scripts, if not already run" },
     { "scriptPath", PyFF_GetScriptPath, METH_NOARGS, "Returns a list of the directories searched for scripts"},

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -1097,11 +1097,8 @@ static void bUnicodeBlockEndFromLib(Context *c) {
     else if ( c->a.vals[1].type!=v_int && c->a.vals[1].type!=v_unicode )
 	ScriptError( c, "Bad type for argument" );
     c->return_val.type=v_int;
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    c->return_val.u.ival=-1;
-#else
+
     c->return_val.u.ival=unicode_block_end(c->a.vals[1].u.ival);
-#endif
 }
 
 static void bUnicodeBlockNameFromLib(Context *c) {
@@ -1113,13 +1110,9 @@ static void bUnicodeBlockNameFromLib(Context *c) {
     else if ( c->a.vals[1].type!=v_int && c->a.vals[1].type!=v_unicode )
 	ScriptError( c, "Bad type for argument" );
     c->return_val.type = v_str;
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    temp=NULL;
-#else
-    temp=unicode_block_name(c->a.vals[1].u.ival);
-#endif
-    if ( temp==NULL ) {
-	temp=galloc(1*sizeof(char)); temp='\0';
+
+    if ( (temp=unicode_block_name(c->a.vals[1].u.ival))==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
     }
     c->return_val.u.sval=temp;
 }
@@ -1131,11 +1124,8 @@ static void bUnicodeBlockStartFromLib(Context *c) {
     else if ( c->a.vals[1].type!=v_int && c->a.vals[1].type!=v_unicode )
 	ScriptError( c, "Bad type for argument" );
     c->return_val.type=v_int;
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    c->return_val.u.ival=-1;
-#else
+
     c->return_val.u.ival=unicode_block_start(c->a.vals[1].u.ival);
-#endif
 }
 
 static void bUnicodeNameFromLib(Context *c) {
@@ -1147,13 +1137,9 @@ static void bUnicodeNameFromLib(Context *c) {
     else if ( c->a.vals[1].type!=v_int && c->a.vals[1].type!=v_unicode )
 	ScriptError( c, "Bad type for argument" );
     c->return_val.type = v_str;
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    temp = NULL;
-#else
-    temp = unicode_name(c->a.vals[1].u.ival);
-#endif
-    if ( temp==NULL ) {
-	temp = galloc(1*sizeof(char)); temp = '\0';
+
+    if ( (temp=unicode_name(c->a.vals[1].u.ival))==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
     }
     c->return_val.u.sval = temp;
 }
@@ -1166,14 +1152,24 @@ static void bUnicodeAnnotationFromLib(Context *c) {
     else if ( c->a.vals[1].type!=v_int && c->a.vals[1].type!=v_unicode )
 	ScriptError( c, "Bad type for argument" );
     c->return_val.type = v_str;
-#if _NO_LIBUNINAMESLIST && _NO_LIBUNICODENAMES
-    temp = NULL;
-#else
-    temp = unicode_annot(c->a.vals[1].u.ival);
-#endif
-    if ( temp==NULL ) {
-	temp = galloc(1*sizeof(char)); temp = '\0';
+
+    if ( (temp=unicode_annot(c->a.vals[1].u.ival))==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
     }
+    c->return_val.u.sval = temp;
+}
+
+static void bUnicodeNamesListVersion(Context *c) {
+/* If the library is available, then return the Nameslist Version */
+    char *temp;
+
+    if ( c->a.argc!=1 )
+	ScriptError( c, "Wrong number of arguments" );
+
+    if ( (temp=unicode_library_version())==NULL ) {
+	temp=galloc(1*sizeof(char)); *temp='\0';
+    }
+    c->return_val.type = v_str;
     c->return_val.u.sval = temp;
 }
 
@@ -8172,6 +8168,7 @@ static struct builtins { char *name; void (*func)(Context *); int nofontok; } bu
     { "UnicodeBlockStartFromLib", bUnicodeBlockStartFromLib, 1 },
     { "UnicodeNameFromLib", bUnicodeNameFromLib, 1 },
     { "UnicodeAnnotationFromLib", bUnicodeAnnotationFromLib, 1 },
+    { "UnicodeNamesListVersion", bUnicodeNamesListVersion, 1 },
     { "Chr", bChr, 1 },
     { "Ord", bOrd, 1 },
     { "Real", bReal, 1 },

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2766,12 +2766,15 @@ extern char **NamesReadMacBinary(char *filename);
 extern void SFSetOrder(SplineFont *sf,int order2);
 extern int SFFindOrder(SplineFont *sf);
 
+/* These functions are used with uninameslist or unicodenames library, if */
+/* available  (oldest function listed first, latest function listed last) */
 extern void inituninameannot(void);
 extern char *unicode_name(int32 unienc);
 extern char *unicode_annot(int32 unienc);
 extern int32 unicode_block_start(int32 block_i);
 extern int32 unicode_block_end(int32 block_i);
 extern char *unicode_block_name(int32 block_i);
+extern char *unicode_library_version(void);
 
 
 extern const char *UnicodeRange(int unienc);

--- a/fontforge/unicodelibinfo.c
+++ b/fontforge/unicodelibinfo.c
@@ -297,3 +297,24 @@ char *unicode_block_name(int32 block_i) {
     return( name_data );
 #endif
 }
+
+char *unicode_library_version(void) {
+/* Return the unicode version for this library. Sometimes users still use */
+/* older libuninameslist or libunincodenames libraries because they don't */
+/* realize that these need to be updated to keep current too but not made */
+/* at same time that FontForge is released (release dates not in sync).   */
+
+#if !(_NO_LIBUNINAMESLIST) && _LIBUNINAMESLIST_FUN
+    /* libuninameslist-0.3.20130501-1 and later have a "version" function */
+    char *version_str;
+
+    version_str=copy(uniNamesList_NamesListVersion());
+
+    return( version_str );
+#else
+    /* Libunicodenames and older versions of libuninames don't have a ver */
+    /* function so we need to either test various annotations to find out */
+    /* what version we have, or we keep it simple and just return nothing */
+    return( NULL );
+#endif
+}

--- a/htdocs/python.html
+++ b/htdocs/python.html
@@ -317,6 +317,18 @@
 	then return empty string "". It can execute with no current font.</TD>
     </TR>
     <TR>
+      <TD><CODE>UnicodeNamesListVersion</CODE></TD>
+      <TD><CODE>()</CODE></TD>
+      <TD>Return the Unicode Nameslist Version (as described by www.unicode.org).
+	libuninameslist and libunicodenames are released on schedules depending on
+	when www.unicode.org releases new information. These dates do not match
+	FontForge release dates, therefore users might not keep this optional library
+	upto current updates. This instruction can be used to test if the Nameslist
+	library is recent for your script. This function currently works only for
+	libuninameslist ver_0.3.20130501 or later, else it returns empty string "".
+	This can execute with no current font.</TD>
+    </TR>
+    <TR>
       <TD><CODE>version</CODE></TD>
       <TD><CODE>()</CODE></TD>
       <TD>Returns fontforge's version number. This will be a large number like

--- a/htdocs/scripting-alpha.html
+++ b/htdocs/scripting-alpha.html
@@ -3216,6 +3216,17 @@ SetGasp([8,2,16,1,65535,3])
 	    If there is no unicode name for this value, or no library available,
 	    then return empty string "". It can execute with no current font.
 	  <DT>
+	    <A NAME="UnicodeNamesListVersion">U</A>nicodeNamesListVersion()
+	  <DD>
+	    Return the Unicode Nameslist Version (as described by www.unicode.org).
+	    libuninameslist and libunicodenames are released on schedules depending on
+	    when www.unicode.org releases new information. These dates do not match
+	    FontForge release dates, therefore users might not keep this optional library
+	    upto current updates. This instruction can be used to test if the Nameslist
+	    library is recent for your script. This function currently works only for
+	    libuninameslist ver_0.3.20130501 or later, else it returns empty string "".
+	    This can execute with no current font.
+	  <DT>
 	    <A NAME="UnlinkReference" HREF="editmenu.html#Unlink">UnlinkReference</A>
 	  <DD>
 	    Unlinks all references within all selected glyphs

--- a/m4/fontforge_arg_with.m4
+++ b/m4/fontforge_arg_with.m4
@@ -33,7 +33,7 @@ AC_DEFUN([FONTFORGE_ARG_WITH],
 
 dnl FONTFORGE_ARG_WITH_LIBNAMESLIST
 dnl -------------------------------
-dnl Check if libuninameslist exists, and if yes, then also see if it has 2 newer functions in it
+dnl Check if libuninameslist exists, and if yes, then also see if it has 3 newer functions in it
 AC_DEFUN([FONTFORGE_ARG_WITH_LIBUNINAMESLIST],
 [
    FONTFORGE_ARG_WITH_BASE([libuninameslist],
@@ -46,8 +46,8 @@ AC_DEFUN([FONTFORGE_ARG_WITH_LIBUNINAMESLIST],
          [i_do_have_libuninameslist=yes
           AC_SUBST([LIBUNINAMESLIST_CFLAGS],[""])
           AC_SUBST([LIBUNINAMESLIST_LIBS],["${found_lib}"])
-          AC_CHECK_FUNC([uniNamesList_name],[AC_DEFINE([_LIBUNINAMESLIST_FUN],
-                        [1],[Libuninameslist library has 2 new functions.])])],
+          AC_CHECK_FUNC([uniNamesList_NamesListVersion],[AC_DEFINE([_LIBUNINAMESLIST_FUN],
+                        [1],[Libuninameslist library has 3 new functions.])])],
          [i_do_have_libuninameslist=no])
        ])
 ])


### PR DESCRIPTION
During earlier debugging for routines there was some difficulty in remotely
troubleshooting problems concerning libuninameslist/libunicodenames access.
Also fixed pointer error with temp (should point to '\0', not become '\0'),
and simplified scripting and python routines since functions always called.

This adds a scripting function which lets you know which version of unicode
NamesList is available right now. Currently it only reports version 6.2 for
the latest libuninameslist version 0.3.20130501 library and should be able
to give version values for future Nameslist updates if/when the library is
updated. To keep function unicode_library_version() simple, older versions
of libuninameslist will return NULL or empty string since they do not have
version numbers stored within them and we avoid having to figure-out what
version an older library is, based on updates that were done to NamesLists.
Similarly with libunicodenames - wait for a version-function to be added.
