### PR TITLE
Cleanup to allow building without-x.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -256,6 +256,15 @@ FONTFORGE_ARG_WITH_ICONV
 FONTFORGE_ARG_WITH_ZEROMQ
 FONTFORGE_ARG_WITH_LIBREADLINE
 
+if test x"${i_do_have_x}" = xyes; then
+   AC_DEFINE(HAVE_GUI,[1],[Have GUI])
+fi
+if test x"${i_do_have_x}" = xyes; then
+   if test x"${i_do_have_libzmq}" = xyes; then 
+      AC_DEFINE(BUILD_COLLAB,[1],[Build the Collab Code])
+   fi
+fi
+
 # We have both libraries but did not choose which one to use yet
 if test x"${i_do_have_libuninameslist}" = xyes; then
    if test x"${i_do_have_libunicodenames}" = xyes; then

--- a/fontforge/autosave.c
+++ b/fontforge/autosave.c
@@ -137,12 +137,16 @@ return( false );
 		FontViewCreate(sf,false);
 	    fprintf( stderr, " Done\n" );
 
+	    
 	    /* Ask user to save-as file */
+#ifdef HAVE_GUI
 	    char *buts[4];
 	    buts[0] = _("_OK");
 	    buts[1] = 0;
 	    gwwv_ask( _("Recovery Complete"),(const char **) buts,0,1,_("Your file %s has been recovered.\nYou must now Save your file to continue working on it."), sf->filename );
-	    _FVMenuSaveAs( sf->fv );
+	    _FVMenuSaveAs( (FontView*)sf->fv );
+#endif
+	    
 	}
     }
     closedir(dir);

--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -4022,7 +4022,7 @@ return;
 	    // If we are in a collab session, we might like to preserve here
 	    // so that we can send a change of selected points to other members
 	    // of the group
-	    if( collabclient_inSession( cv ) )
+	    if( collabclient_inSession( &cv->b ) )
 	    {
 		CVPreserveState(&cv->b);
 		selectionChanged = 1;
@@ -6904,12 +6904,12 @@ static void CVUndo(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) 
 	/*     printf("r.len:%d\n", len ); */
 	/* } */
 	
-	if( collabclient_inSession( cv ) )
+	if( collabclient_inSession( &cv->b ) )
 	{
 	    printf("in-session!\n");
-	    collabclient_performLocalUndo( cv );
+	    collabclient_performLocalUndo( &cv->b );
 	    cv->lastselpt = NULL;
-	    _CVCharChangedUpdate(cv,1);
+	    _CVCharChangedUpdate(&cv->b,1);
 	    return;
 	}
     }
@@ -6924,12 +6924,12 @@ static void CVRedo(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) 
     Undoes *undo = cv->b.layerheads[cv->b.drawmode]->redoes;
     if( undo )
     {
-	if( collabclient_inSession( cv ) )
+	if( collabclient_inSession( &cv->b ) )
 	{
 	    printf("in-session (redo)!\n");
-	    collabclient_performLocalRedo( cv );
+	    collabclient_performLocalRedo( &cv->b );
 	    cv->lastselpt = NULL;
-	    _CVCharChangedUpdate(cv,1);
+	    _CVCharChangedUpdate(&cv->b,1);
 	    return;
 	}
     }

--- a/fontforge/collabclient.c
+++ b/fontforge/collabclient.c
@@ -30,6 +30,7 @@
 #include <glib.h>
 #undef GTimer
 
+#include "inc/config.h"
 #include "inc/ustring.h"
 #include "collabclient.h"
 #include "inc/gfile.h"
@@ -40,16 +41,10 @@
 int pref_collab_sessionJoinTimeoutMS = 1000;
 int pref_collab_roundTripTimerMS = 2000;
 
-
-#ifndef _NO_LIBZMQ
-#define BUILD_COLLAB
-#endif
-
 #ifdef BUILD_COLLAB
 #include "collab/zmq_kvmsg.h"
 #include "czmq.h"
 #endif
-
 
 #define MAGIC_VALUE 0xbeef
 #define SUBTREE "/client/"

--- a/fontforge/cvpointer.c
+++ b/fontforge/cvpointer.c
@@ -442,7 +442,7 @@ void CVCheckResizeCursors(CharView *cv) {
 Undoes *CVPreserveMaybeState(CharView *cv, int isTState) {
     if( isTState )
 	return CVPreserveTState( cv );
-    return CVPreserveState( cv );
+    return CVPreserveState( &cv->b );
 }
 
 Undoes *CVPreserveTState(CharView *cv) {

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -3580,13 +3580,13 @@ static void FontViewSetTitle(FontView *fv) {
 return;
 
     char* collabStateString = "";
-    if( collabclient_inSessionFV( fv ))
+    if( collabclient_inSessionFV( &fv->b ))
     {
 	printf("collabclient_getState( fv ) %d %d\n",
 	       fv->b.collabState,
-	       collabclient_getState( fv ) );
+	       collabclient_getState( &fv->b ) );
 	collabStateString = collabclient_stateToString(
-	    collabclient_getState( fv ));
+	    collabclient_getState( &fv->b ));
     }
     
     enc = SFEncodingName(fv->b.sf,fv->b.normal?fv->b.normal:fv->b.map);
@@ -5668,7 +5668,7 @@ static void FVMenuCollabCloseLocalServer(GWindow gw, struct gmenuitem *UNUSED(mi
     }
     
     collabclient_sessionDisconnect( &fv->b );
-    collabclient_closeLocalServer( fv );
+    collabclient_closeLocalServer( &fv->b );
 }
 
 static void collablistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e))
@@ -7461,47 +7461,12 @@ return( -1 );
 return( fv->rowoff*fv->colcnt );
 }
 
-int FontViewFind_byXUID( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return !strcmp( fv->b.sf->xuid, (char*)udata );
-}
-
-int FontViewFind_byXUIDConnected( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return ( fv->b.collabState == cs_server || fv->b.collabState == cs_client )
-	&& !strcmp( fv->b.sf->xuid, (char*)udata );
-}
-
-int FontViewFind_byCollabPtr( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return fv->b.collabClient == udata;
-}
-
-int FontViewFind_bySplineFont( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return fv->b.sf == udata;
-}
 
 
 
-FontView* FontViewFind( int (*testFunc)( FontView*, void* udata ), void* udata )
-{
-    FontView *fv;
-    for ( fv=fv_list; fv!=NULL; fv=(FontView *) (fv->b.next) )
-    {
-	if( testFunc( fv, udata ))
-	    return fv;
-    }
-    return 0;
-}
+
+
+
 
 
 static FontViewBase *FVAny(void) { return (FontViewBase *) fv_list; }
@@ -8033,6 +7998,57 @@ char *GlyphSetFromSelection(SplineFont *sf,int def_layer,char *current) {
     GDrawDestroyWindow(gs.gw);
 return( ret );
 }
+
+
+
+/****************************************/
+/****************************************/
+/****************************************/
+
+int FontViewFind_byXUID( FontView* fv, void* udata )
+{
+    if( !fv || !fv->b.sf )
+	return 0;
+    return !strcmp( fv->b.sf->xuid, (char*)udata );
+}
+
+int FontViewFind_byXUIDConnected( FontView* fv, void* udata )
+{
+    if( !fv || !fv->b.sf )
+	return 0;
+    return ( fv->b.collabState == cs_server || fv->b.collabState == cs_client )
+	&& !strcmp( fv->b.sf->xuid, (char*)udata );
+}
+
+int FontViewFind_byCollabPtr( FontView* fv, void* udata )
+{
+    if( !fv || !fv->b.sf )
+	return 0;
+    return fv->b.collabClient == udata;
+}
+
+int FontViewFind_bySplineFont( FontView* fv, void* udata )
+{
+    if( !fv || !fv->b.sf )
+	return 0;
+    return fv->b.sf == udata;
+}
+
+FontView* FontViewFind( int (*testFunc)( FontView*, void* udata ), void* udata )
+{
+    FontView *fv;
+    for ( fv=fv_list; fv!=NULL; fv=(FontView *) (fv->b.next) )
+    {
+	if( testFunc( fv, udata ))
+	    return fv;
+    }
+    return 0;
+}
+
+/****************************************/
+/****************************************/
+/****************************************/
+
 
 /* local variables: */
 /* tab-width: 8     */

--- a/fontforge/metricsview.c
+++ b/fontforge/metricsview.c
@@ -986,7 +986,7 @@ static real GGadgetToReal(GGadget *g)
  */
 static void MV_handle_collabclient_sendRedo( MetricsView *mv, SplineChar *sc )
 {
-    if( collabclient_inSessionFV( mv->fv ) )
+    if( collabclient_inSessionFV( &mv->fv->b ) )
     {
 	collabclient_sendRedo_SC( sc );
 	
@@ -1018,7 +1018,7 @@ return( true );
 	else if ( !mv->vertical && val!=sc->width ) {
 //	    dumpUndoChain( "before SCPreserveWidth...", sc, &sc->layers[ly_fore].undoes );
 	    SCPreserveWidth(sc);
-	    if( collabclient_inSessionFV( mv->fv ) )
+	    if( collabclient_inSessionFV( &mv->fv->b ) )
 	    {
 		int dohints = 0;
 		SCPreserveState( sc, dohints );
@@ -1084,7 +1084,7 @@ return( true );
 	if (!isValidInt(end))
 	    GDrawBeep(NULL);
 	else if ( !mv->vertical && val!=bb.minx ) {
-	    if( collabclient_inSessionFV( mv->fv ) )
+	    if( collabclient_inSessionFV( &mv->fv->b ) )
 	    {
 		int dohints = 0;
 		SCPreserveState( sc, dohints );
@@ -1142,7 +1142,7 @@ return( true );
 	    /* Width is an integer. Adjust the lbearing so that the rbearing */
 	    /*  remains what was just typed in */
 	    if ( newwidth!=bb.maxx+val ) {
-		if( collabclient_inSessionFV( mv->fv ) )
+		if( collabclient_inSessionFV( &mv->fv->b ) )
 		{
 		    int dohints = 0;
 		    SCPreserveState( sc, dohints );

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1330,10 +1330,12 @@ extern void SFDDumpUndo(FILE *sfd,SplineChar *sc,Undoes *u, char* keyPrefix, int
 
 extern void Prefs_LoadDefaultPreferences( void );
 
+
 extern FontView* FontViewFind( int (*testFunc)( FontView*, void* ), void* udata );
-extern int FontViewFind_byXUID(          FontView* fv, void* udata );
-extern int FontViewFind_byCollabPtr(     FontView* fv, void* udata );
+extern int FontViewFind_byXUID(      FontView* fv, void* udata );
 extern int FontViewFind_byXUIDConnected( FontView* fv, void* udata );
-extern int FontViewFind_bySplineFont(    FontView* fv, void* udata );
+extern int FontViewFind_byCollabPtr(  FontView* fv, void* udata );
+extern int FontViewFind_bySplineFont( FontView* fv, void* udata );
+
 
 #endif	/* _VIEWS_H */

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -790,8 +790,9 @@ int GFileWriteAll(char* filepath, char *data)
 {
     FILE* fp = fopen( filepath, "w" );
     int bwrite = fwrite( data, 1, strlen(data), fp );
-    printf("GFileWriteAll() data.len:%d bwrite:%d\n", strlen(data), bwrite );
+    printf("GFileWriteAll() data.len:%ld bwrite:%d\n", strlen(data), bwrite );
     fclose(fp);
+    return 0;
 }
 
 


### PR DESCRIPTION
This fixes the issue https://github.com/fontforge/fontforge/issues/414
by only prompting the user to save the font file if we have a GUI. If
it is on the command line only then we don't want to halt there and ask
the user because it might well be a script and not expecting this new prompt.

Ohter FD monitoring stuff is also handled without x. Note that the
background timers do not function without an X server around.
