### PR TITLE
remove the gui code from the DoAutoRecovery().

### DIFF
--- a/fontforge/autosave.c
+++ b/fontforge/autosave.c
@@ -113,7 +113,9 @@ return;
     }
 }
 
-int DoAutoRecovery(int inquire) {
+
+int DoAutoRecoveryExtended(int inquire, DoAutoRecoveryPostRecoverFunc PostRecoverFunc )
+{
     char buffer[1025];
     char *recoverdir = getAutoDirName(buffer);
     DIR *dir;
@@ -136,22 +138,21 @@ return( false );
 	    if ( sf->fv==NULL )		/* Doesn't work, cli arguments not parsed yet */
 		FontViewCreate(sf,false);
 	    fprintf( stderr, " Done\n" );
-
-	    
-	    /* Ask user to save-as file */
-#ifdef HAVE_GUI
-	    char *buts[4];
-	    buts[0] = _("_OK");
-	    buts[1] = 0;
-	    gwwv_ask( _("Recovery Complete"),(const char **) buts,0,1,_("Your file %s has been recovered.\nYou must now Save your file to continue working on it."), sf->filename );
-	    _FVMenuSaveAs( (FontView*)sf->fv );
-#endif
-	    
 	}
     }
     closedir(dir);
 return( any );
 }
+
+static void DoAutoRecoveryPostRecover_DontPrompt(SplineFont *sf)
+{
+}
+
+int DoAutoRecovery(int inquire )
+{
+    return DoAutoRecoveryExtended( inquire, DoAutoRecoveryPostRecover_DontPrompt );
+}
+
 
 void CleanAutoRecovery(void) {
     char buffer[1025];

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -666,4 +666,10 @@ extern void AutoKern2BuildClasses(SplineFont *sf,int layer,
 
 extern void MVSelectFirstKerningTable(struct metricsview *mv);
 
+extern FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* ), void* udata );
+extern int FontViewFind_byXUID(      FontViewBase* fv, void* udata );
+extern int FontViewFind_byXUIDConnected( FontViewBase* fv, void* udata );
+extern int FontViewFind_byCollabPtr(  FontViewBase* fv, void* udata );
+extern int FontViewFind_bySplineFont( FontViewBase* fv, void* udata );
+
 #endif

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -8001,54 +8001,6 @@ return( ret );
 
 
 
-/****************************************/
-/****************************************/
-/****************************************/
-
-int FontViewFind_byXUID( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return !strcmp( fv->b.sf->xuid, (char*)udata );
-}
-
-int FontViewFind_byXUIDConnected( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return ( fv->b.collabState == cs_server || fv->b.collabState == cs_client )
-	&& !strcmp( fv->b.sf->xuid, (char*)udata );
-}
-
-int FontViewFind_byCollabPtr( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return fv->b.collabClient == udata;
-}
-
-int FontViewFind_bySplineFont( FontView* fv, void* udata )
-{
-    if( !fv || !fv->b.sf )
-	return 0;
-    return fv->b.sf == udata;
-}
-
-FontView* FontViewFind( int (*testFunc)( FontView*, void* udata ), void* udata )
-{
-    FontView *fv;
-    for ( fv=fv_list; fv!=NULL; fv=(FontView *) (fv->b.next) )
-    {
-	if( testFunc( fv, udata ))
-	    return fv;
-    }
-    return 0;
-}
-
-/****************************************/
-/****************************************/
-/****************************************/
-
 
 /* local variables: */
 /* tab-width: 8     */

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -2096,3 +2096,52 @@ struct mv_interface *mv_interface = &noui_mv;
 void FF_SetMVInterface(struct mv_interface *mvi) {
     mv_interface = mvi;
 }
+
+
+/****************************************/
+/****************************************/
+/****************************************/
+
+int FontViewFind_byXUID( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return !strcmp( fv->sf->xuid, (char*)udata );
+}
+
+int FontViewFind_byXUIDConnected( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return ( fv->collabState == cs_server || fv->collabState == cs_client )
+	&& !strcmp( fv->sf->xuid, (char*)udata );
+}
+
+int FontViewFind_byCollabPtr( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return fv->collabClient == udata;
+}
+
+int FontViewFind_bySplineFont( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return fv->sf == udata;
+}
+
+FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* udata ), void* udata )
+{
+    FontViewBase *fv;
+    for ( fv=fv_list; fv!=NULL; fv=(FontViewBase *) (fv->next) )
+    {
+	if( testFunc( fv, udata ))
+	    return fv;
+    }
+    return 0;
+}
+
+/****************************************/
+/****************************************/
+/****************************************/

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2853,6 +2853,8 @@ extern char *getPfaEditDir(char *buffer);
 extern void _DoAutoSaves(struct fontviewbase *);
 extern void CleanAutoRecovery(void);
 extern int DoAutoRecovery(int);
+typedef void (*DoAutoRecoveryPostRecoverFunc)(SplineFont *sf);
+extern int DoAutoRecoveryExtended(int inquire, DoAutoRecoveryPostRecoverFunc PostRecoverFunc );
 extern SplineFont *SFRecoverFile(char *autosavename,int inquire, int *state);
 extern void SFAutoSave(SplineFont *sf,EncMap *map);
 extern void SFClearAutoSave(SplineFont *sf);

--- a/fontforge/startui.c
+++ b/fontforge/startui.c
@@ -782,6 +782,15 @@ static void ensureDotFontForgeIsSetup() {
     ffensuredir( basedir, ".FontForge/python", S_IRWXU );
 }
 
+static void DoAutoRecoveryPostRecover_PromptUserGraphically(SplineFont *sf)
+{
+    /* Ask user to save-as file */
+    char *buts[4];
+    buts[0] = _("_OK");
+    buts[1] = 0;
+    gwwv_ask( _("Recovery Complete"),(const char **) buts,0,1,_("Your file %s has been recovered.\nYou must now Save your file to continue working on it."), sf->filename );
+    _FVMenuSaveAs( (FontView*)sf->fv );
+}
 
 
 int fontforge_main( int argc, char **argv ) {
@@ -1148,7 +1157,11 @@ exit( 0 );
     if ( recover==-1 )
 	CleanAutoRecovery();
     else if ( recover )
-	any = DoAutoRecovery(recover-1);
+    {
+	any = DoAutoRecoveryExtended( recover-1,
+				      DoAutoRecoveryPostRecover_PromptUserGraphically );
+    }
+    
 
     openflags = 0;
     for ( i=1; i<argc; ++i ) {

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1331,11 +1331,6 @@ extern void SFDDumpUndo(FILE *sfd,SplineChar *sc,Undoes *u, char* keyPrefix, int
 extern void Prefs_LoadDefaultPreferences( void );
 
 
-extern FontView* FontViewFind( int (*testFunc)( FontView*, void* ), void* udata );
-extern int FontViewFind_byXUID(      FontView* fv, void* udata );
-extern int FontViewFind_byXUIDConnected( FontView* fv, void* udata );
-extern int FontViewFind_byCollabPtr(  FontView* fv, void* udata );
-extern int FontViewFind_bySplineFont( FontView* fv, void* udata );
 
 
 #endif	/* _VIEWS_H */

--- a/pyhook/fontforgepyhook.c
+++ b/pyhook/fontforgepyhook.c
@@ -8,6 +8,34 @@
 extern PyMODINIT_FUNC FFPY_PYTHON_ENTRY_FUNCTION(const char* modulename);
 
 
+/**
+ * These only need to be here because some of the code in python.c calls
+ * these functions, if that code is moved to python-ff.c and only compiled into
+ * a gui fontforge exe then we can remove these down to the next *** block
+ */
+typedef struct fontview {
+} FontView;
+int _FVMenuSaveAs(FontView *fv);
+int _FVMenuSaveAs(FontView *fv) {
+    return 0;
+}
+typedef struct charview CharView;
+typedef struct splinechar SplineChar;
+CharView *CharViewCreate(SplineChar *sc,FontView *fv,int enc);
+CharView *CharViewCreate(SplineChar *sc,FontView *fv,int enc)
+{
+    return 0;
+}
+void MacServiceReadFDs(void);
+void MacServiceReadFDs(void)
+{
+}
+
+/*********************************************/
+/*********************************************/
+/*********************************************/
+
+
 #if PY_MAJOR_VERSION >= 3
 /* Python 3 module initialization */
 PyMODINIT_FUNC PyInit_fontforge(void);


### PR DESCRIPTION
Instead, there is now an extended DoAutoRecovery function too which takes the function to
call after recovering a splinefont. That function takes a "SplineFont
*sf" arg which is the font that was recovered. This way the GUI code
can pass in a function that is called after each font recovery and the
non gui code (or python plugin, other app linking with libfontforge
etc), can enjoy not having those symbols.
