### PR TITLE
Don't crash when moving bezier control points in collab mode.

### DIFF
--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -666,10 +666,5 @@ extern void AutoKern2BuildClasses(SplineFont *sf,int layer,
 
 extern void MVSelectFirstKerningTable(struct metricsview *mv);
 
-extern FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* ), void* udata );
-extern int FontViewFind_byXUID(      FontViewBase* fv, void* udata );
-extern int FontViewFind_byXUIDConnected( FontViewBase* fv, void* udata );
-extern int FontViewFind_byCollabPtr(  FontViewBase* fv, void* udata );
-extern int FontViewFind_bySplineFont( FontViewBase* fv, void* udata );
 
 #endif

--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -4020,20 +4020,32 @@ return;
 	if( lastSel.lastselpt != fs.p->sp
 	    || lastSel.lastselcp != fs.p->spiro )
 	{
+#define BASEPOINT_IS_EMPTY(p) ( p.x == p.y == (real)0.0 )
+	    
 	    // If we are in a collab session, we might like to preserve here
 	    // so that we can send a change of selected points to other members
 	    // of the group
 	    if( collabclient_inSession( &cv->b ) )
 	    {
-		CVPreserveState(&cv->b);
-		selectionChanged = 1;
+		if( BASEPOINT_IS_EMPTY( fs.p->cp ) )
+		{
+		    //
+		    // Do not send clicks on bezier control points.
+		    //
+		    printf("skipping!\n");
+		}
+		else
+		{
+		    CVPreserveState(&cv->b);
+		    selectionChanged = 1;
+		}
 	    }
 	}
 	cv->lastselpt = fs.p->sp;
 	cv->lastselcp = fs.p->spiro;
 	if( selectionChanged )
 	{
-	    collabclient_sendRedo( &cv->b );    
+//	    collabclient_sendRedo( &cv->b );    
 	}
 	break;
       case cvt_magnify: case cvt_minify:

--- a/fontforge/collabclientui.c
+++ b/fontforge/collabclientui.c
@@ -67,7 +67,7 @@ static void zeromq_subscriber_process_update( cloneclient_t* cc, kvmsg_t *kvmsg,
     byte* data = kvmsg_body (kvmsg);
     size_t data_size = kvmsg_size (kvmsg);
 
-    printf("uuid:%s\n", uuid );
+    printf("cc process_update() uuid:%s\n", uuid );
     FontView* fv = FontViewFind( FontViewFind_byXUIDConnected, uuid );
     printf("fv:%p\n", fv );
     if( fv )

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -8000,6 +8000,57 @@ return( ret );
 }
 
 
+/****************************************/
+/****************************************/
+/****************************************/
+
+
+int FontViewFind_byXUID( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return !strcmp( fv->sf->xuid, (char*)udata );
+}
+
+int FontViewFind_byXUIDConnected( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return ( fv->collabState == cs_server || fv->collabState == cs_client )
+	&& !strcmp( fv->sf->xuid, (char*)udata );
+}
+
+int FontViewFind_byCollabPtr( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return fv->collabClient == udata;
+}
+
+int FontViewFind_bySplineFont( FontViewBase* fv, void* udata )
+{
+    if( !fv || !fv->sf )
+	return 0;
+    return fv->sf == udata;
+}
+
+FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* udata ), void* udata )
+{
+    FontViewBase *fv;
+    printf("FontViewFind(top) fv_list:%p\n", fv_list );
+    for ( fv=fv_list; fv!=NULL; fv=fv->next )
+    {
+	if( testFunc( fv, udata ))
+	    return fv;
+    }
+    return 0;
+}
+
+
+/****************************************/
+/****************************************/
+/****************************************/
+
 
 
 /* local variables: */

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -1910,7 +1910,8 @@ static FontViewBase *FontViewBase_Create(SplineFont *sf,int hide) {
 return( fv );
 }
 
-static FontViewBase *FontViewBase_Append(FontViewBase *fv) {
+static FontViewBase *FontViewBase_Append(FontViewBase *fv)
+{
     /* Normally fontviews get added to the fv list when their windows are */
     /*  created. but we don't create any windows here, so... */
     FontViewBase *test;
@@ -2097,51 +2098,3 @@ void FF_SetMVInterface(struct mv_interface *mvi) {
     mv_interface = mvi;
 }
 
-
-/****************************************/
-/****************************************/
-/****************************************/
-
-int FontViewFind_byXUID( FontViewBase* fv, void* udata )
-{
-    if( !fv || !fv->sf )
-	return 0;
-    return !strcmp( fv->sf->xuid, (char*)udata );
-}
-
-int FontViewFind_byXUIDConnected( FontViewBase* fv, void* udata )
-{
-    if( !fv || !fv->sf )
-	return 0;
-    return ( fv->collabState == cs_server || fv->collabState == cs_client )
-	&& !strcmp( fv->sf->xuid, (char*)udata );
-}
-
-int FontViewFind_byCollabPtr( FontViewBase* fv, void* udata )
-{
-    if( !fv || !fv->sf )
-	return 0;
-    return fv->collabClient == udata;
-}
-
-int FontViewFind_bySplineFont( FontViewBase* fv, void* udata )
-{
-    if( !fv || !fv->sf )
-	return 0;
-    return fv->sf == udata;
-}
-
-FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* udata ), void* udata )
-{
-    FontViewBase *fv;
-    for ( fv=fv_list; fv!=NULL; fv=(FontViewBase *) (fv->next) )
-    {
-	if( testFunc( fv, udata ))
-	    return fv;
-    }
-    return 0;
-}
-
-/****************************************/
-/****************************************/
-/****************************************/

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1331,6 +1331,11 @@ extern void SFDDumpUndo(FILE *sfd,SplineChar *sc,Undoes *u, char* keyPrefix, int
 extern void Prefs_LoadDefaultPreferences( void );
 
 
+extern FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* ), void* udata );
+extern int FontViewFind_byXUID(      FontViewBase* fv, void* udata );
+extern int FontViewFind_byXUIDConnected( FontViewBase* fv, void* udata );
+extern int FontViewFind_byCollabPtr(  FontViewBase* fv, void* udata );
+extern int FontViewFind_bySplineFont( FontViewBase* fv, void* udata );
 
 
 #endif	/* _VIEWS_H */


### PR DESCRIPTION
Collab movement is working again. It was snagged on the fact that there
are two fontview lists being kept, and the one in the fontviewbase wasn't
seeing graphical fontviews (so the fvfind function couldn't find those).

So, the FontViewFind() functions are moved again back to fontview.c.
I would like them to be on the base fontview but there are two fv_list
lists one in each fontview file (fontview.c and fontviewbase.c). I
tried to keep those lists in sync but failed on some edge cases. IMHO
it would be better to instead move to using glib2 double linked lists
for maintianing the list of active fontviews in fontviewbase.c
possibly with some downcasting functions so that fontview.c can
downcast if it wants.

I tested the FontViewFind() shuffle with a non x build too. Just using
python from the command line and
import fontforge
