### PR TITLE
Fix a segmentation fault

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -4802,7 +4802,7 @@ return( NULL );			/* No variation selectors */
     }
 
     for ( i=0; i<vs_cnt; ++i ) {
-	memset(avail,0,unicode4_size);
+	memset(avail,0,unicode4_size*sizeof(uint32));
 	any = 0;
 	for ( gid=mingid; gid<=maxgid; ++gid ) if ( (sc=sf->glyphs[gid])!=NULL ) {
 	    for ( altuni = sc->altuni; altuni!=NULL; altuni=altuni->next ) {


### PR DESCRIPTION
There is a bug in clearing an array using memset.

Fix it by assigning correct value to the third parameter of memset.
