### PR TITLE
Correct a formula for top side bearing

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -733,7 +733,7 @@ static void ttfdumpmetrics(SplineChar *sc,struct glyphinfo *gi,DBounds *b) {
     if ( sc->parent->hasvmetrics ) {
 	if ( sc->ttf_glyph<=gi->lastvwidth )
 	    putshort(gi->vmtx,vwidth);
-	putshort(gi->vmtx,/*sc->parent->vertical_origin-*/b->maxy);
+	putshort(gi->vmtx, sc->parent->ascent - b->maxy);
     }
     if ( sc->ttf_glyph==gi->lasthwidth )
 	gi->hfullcnt = sc->ttf_glyph+1;


### PR DESCRIPTION
to fix an issue that glyphs shift below in vertical writing

This patch is cherry picked from http://www.akenotsuki.com/eyeben/fonts/kanren.html
