### PR TITLE
Ability to define the ` key that causes toggle preview in charview

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -47,6 +47,8 @@ extern int _GScrollBar_Width;
 
 #include "gutils/unicodelibinfo.h"
 
+#include "gdraw/hotkeys.h"
+
 /* Barry wants to be able to redefine menu bindings only in the charview (I think) */
 /*  the menu parser will first check for something like "CV*Open|Ctl+O", and */
 /*  if that fails will strip off "CV*" and check for "Open|Ctl+O" */
@@ -3357,6 +3359,7 @@ static uint16 HaveModifiers = 0;
 static uint16 PressingTilde = 0;
 static uint16 PrevCharEventWasCharUpOnControl = 0;
 
+
 static void CVCharUp(CharView *cv, GEvent *event ) {
 
     if ( !event->u.chr.autorepeat && !HaveModifiers && event->u.chr.keysym==' ' ) {
@@ -3366,12 +3369,12 @@ static void CVCharUp(CharView *cv, GEvent *event ) {
 //    printf("CVCharUp() ag:%d key:%d\n", cv_auto_goto, event->u.chr.keysym );
     if( !cv_auto_goto )
     {
-	if( event->u.chr.keysym=='`' ) {
+	bool isImmediateKeyTogglePreview = isImmediateKey( cv->gw, "TogglePreview", event );
+	if( isImmediateKeyTogglePreview ) {
 	    PressingTilde = 1;
 	}
 
-	if( PrevCharEventWasCharUpOnControl
-	    && event->u.chr.keysym=='`' )
+	if( PrevCharEventWasCharUpOnControl && isImmediateKeyTogglePreview )
 	{
 	    HaveModifiers = 0;
 	    PrevCharEventWasCharUpOnControl = 0;
@@ -3389,16 +3392,16 @@ static void CVCharUp(CharView *cv, GEvent *event ) {
 	    }
 	}
 	
-	if ( !event->u.chr.autorepeat && !HaveModifiers && event->u.chr.keysym=='`' ) {
+	if ( !event->u.chr.autorepeat && !HaveModifiers && isImmediateKeyTogglePreview ) {
 	    PressingTilde = 0;
 	    CVPreviewModeSet( cv->gw, false );
 	    return;
 	}
 	
-	if ( !event->u.chr.autorepeat && event->u.chr.keysym=='`' ) {
+	if ( !event->u.chr.autorepeat && isImmediateKeyTogglePreview ) {
 	    PressingTilde = 0;
 	}
-	if ( event->u.chr.autorepeat && HaveModifiers && event->u.chr.keysym=='`' ) {
+	if ( event->u.chr.autorepeat && HaveModifiers && isImmediateKeyTogglePreview ) {
 	    return;
 	}
     }
@@ -6492,14 +6495,16 @@ void CVChar(CharView *cv, GEvent *event ) {
     extern float arrowAmount, arrowAccelFactor;
     extern int navigation_mask;
 
-    if( !cv_auto_goto ) {
+    if( !cv_auto_goto )
+    {
 	if( event->u.chr.keysym == GK_Control_L
 	    || event->u.chr.keysym == GK_Control_R )
 	{
 	    HaveModifiers = 1;
 	}
-	
-	if( !HaveModifiers && event->u.chr.keysym=='`' ) {
+	bool isImmediateKeyTogglePreview = isImmediateKey( cv->gw, "TogglePreview", event );
+
+	if( !HaveModifiers && isImmediateKeyTogglePreview ) {
 	    PressingTilde = 1;
 	    CVPreviewModeSet( cv->gw, true );
 	    return;

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1905,7 +1905,8 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 	    if( !skipkey )
 	    {
 		mi = GMenuSearchAction(mb->g.base,mb->mi,hk->action,event,mb->child==NULL);
-		if ( mi ) {
+		if ( mi )
+		{
 		    if ( mi->ti.checkable && !mi->ti.disabled )
 			mi->ti.checked = !mi->ti.checked;
 		    if ( mi->invoke!=NULL && !mi->ti.disabled )
@@ -1913,8 +1914,10 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 		    if ( mb->child != NULL )
 			GMenuDestroy(mb->child);
 		    return( true );
-		} else {
-		    printf("hotkey found for event must be a non menu action... action:%s\n", hk->action );
+		}
+		else
+		{
+//		    printf("hotkey found for event must be a non menu action... action:%s\n", hk->action );
 		
 		}
 	    }

--- a/gdraw/hotkeys.c
+++ b/gdraw/hotkeys.c
@@ -369,6 +369,28 @@ static Hotkey* hotkeyFindByAction( char* action ) {
     return 0;
 }
 
+Hotkey* isImmediateKey( GWindow w, char* path, GEvent *event )
+{
+    char* wt = GDrawGetWindowTypeName(w);
+    if(!wt)
+	return 0;
+
+    char* subMenuName = "_ImmediateKeys";
+    char line[PATH_MAX+1];
+    snprintf(line,PATH_MAX,"%s.%s.%s",wt, subMenuName, path );
+//    printf("line:%s\n",line);
+    Hotkey* hk = hotkeyFindByAction( line );
+    if( !hk )
+	return 0;
+    if( hk && !hk->action )
+	return 0;
+    
+    if( event->u.chr.keysym == hk->keysym )
+	return hk;
+
+    return 0;
+}
+
 Hotkey* hotkeyFindByMenuPathInSubMenu( GWindow w, char* subMenuName, char* path ) {
 
     char* wt = GDrawGetWindowTypeName(w);

--- a/gdraw/hotkeys.h
+++ b/gdraw/hotkeys.h
@@ -192,6 +192,18 @@ extern char*   hotkeyTextWithoutModifiers( char* hktext );
 extern Hotkey* hotkeyFindByMenuPath( GWindow w, char* path );
 extern Hotkey* hotkeyFindByMenuPathInSubMenu( GWindow w, char* subMenuName, char* path );
 
+/**
+ * Immediate keys are hotkeys like the ` key to turn on preview mode in charview.
+ * They are perhaps toggle keys, or just keys which code wants to respond to a keypress
+ * but also allow the user to configure what that key is using their hotkeys file.
+ * Instead of doing event->u.chr.keysym == '`' code can pass the event and a text name
+ * like "TogglePreview" and a window (to determine the prefix like CharView) and this
+ * function will tell you if that event matches the key that the user has defined to
+ * trigger your event.
+ */
+extern Hotkey* isImmediateKey( GWindow w, char* path, GEvent *event );
+
+
 
 /**
  * Set a hotkey to trigger the given action. If append is not true

--- a/hotkeys/default
+++ b/hotkeys/default
@@ -671,3 +671,4 @@ CharView.Menu.View.Show.Tab.Tab3: Alt+4
 CharView.Menu.View.Show.Tab.Tab4: Alt+5
 CharView.Menu.View.Show.Tab.Tab5: Alt+6
 
++CharView._ImmediateKeys.TogglePreview:`


### PR DESCRIPTION
The key must not have a qualifier at the moment. No hard reason for this,
can be changed if desired.

This also paves the way for any other parts of the code which expect a fixed
key to do something special to reuse this system so that that fixed key can
instead be set by the user instead of hard coded.
