### PR TITLE
Wrap some strtod() into setlocale to avoid locale problems

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -1622,11 +1622,14 @@ static void CVDrawBlues(CharView *cv,GWindow pixmap,char *bluevals,char *others,
 	Color col) {
     double blues[24];
     char *pt, *end;
+    char oldloc[24];
     int i=0, bcnt=0;
     GRect r;
     char buf[20];
     int len,len2;
 
+    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    setlocale(LC_NUMERIC,"C");
     if ( bluevals!=NULL ) {
 	for ( pt = bluevals; isspace( *pt ) || *pt=='['; ++pt);
 	while ( i<14 && *pt!='\0' && *pt!=']' ) {
@@ -1651,6 +1654,7 @@ static void CVDrawBlues(CharView *cv,GWindow pixmap,char *bluevals,char *others,
 	}
 	if ( i&1 ) --i;
     }
+    setlocale(LC_NUMERIC,oldloc);
     bcnt = i;
     if ( i==0 )
 return;

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -1174,7 +1174,10 @@ static int CheckBluePair(char *blues, char *others, int bluefuzz,
     int bluevals[10+14], cnt, pos=0, maxzoneheight;
     int err = 0;
     char *end;
+    char oldloc[24];
 
+    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    setlocale(LC_NUMERIC,"C");
     if ( others!=NULL ) {
 	while ( *others==' ' ) ++others;
 	if ( *others=='[' || *others=='{' ) ++others;
@@ -1240,12 +1243,14 @@ static int CheckBluePair(char *blues, char *others, int bluefuzz,
 
     if ( maxzoneheight>0 && (magicpointsize-.49)*maxzoneheight>=240 )
 	err |= pds_toobig;
+    setlocale(LC_NUMERIC,oldloc);
 
 return( err );
 }
 
 static int CheckStdW(struct psdict *dict,char *key ) {
     char *str_val, *end;
+    char oldloc[24];
     bigreal val;
 
     if ( (str_val = PSDictHasEntry(dict,key))==NULL )
@@ -1255,7 +1260,10 @@ return( true );
 return( false );
     ++str_val;
 
+    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    setlocale(LC_NUMERIC,"C");
     val = strtod(str_val,&end);
+    setlocale(LC_NUMERIC,oldloc);
     while ( *end==' ' ) ++end;
     if ( *end!=']' && *end!='}' )
 return( false );
@@ -1269,6 +1277,7 @@ return( true );
 
 static int CheckStemSnap(struct psdict *dict,char *snapkey, char *stdkey ) {
     char *str_val, *end;
+    char oldloc[24];
     bigreal std_val = -1;
     bigreal stems[12], temp;
     int cnt, found;
@@ -1277,7 +1286,10 @@ static int CheckStemSnap(struct psdict *dict,char *snapkey, char *stdkey ) {
     if ( (str_val = PSDictHasEntry(dict,stdkey))!=NULL ) {
 	while ( *str_val==' ' ) ++str_val;
 	if ( *str_val=='[' && *str_val!='{' ) ++str_val;
+	strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+	setlocale(LC_NUMERIC,"C");
 	std_val = strtod(str_val,&end);
+	setlocale(LC_NUMERIC,oldloc);
     }
 
     if ( (str_val = PSDictHasEntry(dict,snapkey))==NULL )
@@ -1292,7 +1304,10 @@ return( false );
 	while ( *str_val==' ' ) ++str_val;
 	if ( *str_val==']' && *str_val!='}' )
     break;
-	temp = strtod(str_val,&end);
+	strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+	setlocale(LC_NUMERIC,"C");
+       temp = strtod(str_val,&end);
+	setlocale(LC_NUMERIC,oldloc);
 	if ( end==str_val )
 return( false );
 	str_val = end;
@@ -1313,6 +1328,7 @@ return( true );
 int ValidatePrivate(SplineFont *sf) {
     int errs = 0;
     char *blues, *bf, *test, *end;
+    char oldloc[24];
     int fuzz = 1;
     bigreal bluescale = .039625;
     int magicpointsize;
@@ -1327,7 +1343,10 @@ return( pds_missingblue );
     }
 
     if ( (test=PSDictHasEntry(sf->private,"BlueScale"))!=NULL ) {
-	bluescale = strtod(test,&end);
+	strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+	setlocale(LC_NUMERIC,"C");
+        bluescale = strtod(test,&end);
+	setlocale(LC_NUMERIC,oldloc);
 	if ( *end!='\0' || end==test || bluescale<0 )
 	    errs |= pds_badbluescale;
     }

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -2573,6 +2573,7 @@ static void SplineFontFromType1(SplineFont *sf, FontDict *fd, struct pscontext *
 
 static SplineFont *SplineFontFromMMType1(SplineFont *sf, FontDict *fd, struct pscontext *pscontext) {
     char *pt, *end, *origweight;
+    char oldloc[24];
     MMSet *mm;
     int ipos, apos, ppos, item, i;
     real blends[12];	/* At most twelve points/axis in a blenddesignmap */
@@ -2589,6 +2590,8 @@ return( NULL );
     mm = chunkalloc(sizeof(MMSet));
 
     pt = fd->weightvector;
+    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    setlocale(LC_NUMERIC,"C");
     while ( *pt==' ' || *pt=='[' ) ++pt;
     while ( *pt!=']' && *pt!='\0' ) {
 	pscontext->blend_values[ pscontext->instance_count ] =
@@ -2745,6 +2748,7 @@ return( NULL );
 		}
 	    }
 	}
+	setlocale(LC_NUMERIC,oldloc);
 	fd->private->private = PSDictCopy(sf->private);
 	if ( fd->blendprivate!=NULL ) {
 	    static char *arrnames[] = { "BlueValues", "OtherBlues", "FamilyBlues", "FamilyOtherBlues", "StdHW", "StdVW", "StemSnapH", "StemSnapV", NULL };


### PR DESCRIPTION
The patch is made according to Jose Da Silva recommendations in the mailing list.

This patch is aimed to fix issue 630:

https://github.com/fontforge/fontforge/issues/630
