### PR TITLE
Make compilable on Cygwin

### DIFF
--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -30,7 +30,7 @@
 #include <utype.h>
 #include "inc/gfile.h"
 
-#if defined(__MINGW32__)
+#if defined(__MINGW32__)||defined(__CYGWIN__)
 // no backtrace on windows yet
 #else
     #include <execinfo.h>

--- a/gdraw/gdraw.c
+++ b/gdraw/gdraw.c
@@ -1053,7 +1053,7 @@ GDrawRemoveReadFD( GDisplay *gdisp,
 
 void MacServiceReadFDs()
 {
-#if !defined(__MINGW32__)
+#if (!defined(__MINGW32__))&&(!defined(__CYGWIN__))
     int ret = 0;
     
     GDisplay *gdisp = GDrawGetDisplayOfWindow(0);


### PR DESCRIPTION
This patch makes FF compilable on Cygwin. HEAD as of Aug 04 11:30JST (8792171e8c805692c3815e10101c1ff3c74c2f9e) doesn't compile, complaining:

```
gdraw.c: In function 'MacServiceReadFDs':
gdraw.c:1063:20: error: storage size of 'timeout' isn't known
gdraw.c:1076:2: error: implicit declaration of function 'select' [-Werror=implicit-function-declaration]
gdraw.c:1063:20: warning: unused variable 'timeout' [-Wunused-variable]
cc1: some warnings being treated as errors
Makefile:771: recipe for target `libgdraw_la-gdraw.lo' failed
make[2]: *** [libgdraw_la-gdraw.lo] Error 1
make[2]: ディレクトリ `/home/TT/git/fontforge/gdraw' から出ます
Makefile:785: recipe for target `all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: ディレクトリ `/home/TT/git/fontforge' から出ます
Makefile:635: recipe for target `all' failed
make: *** [all] Error 2
```

MinGW-specific codes should also be applied for Cygwin build. While `MacServiceReadFDs()` turns empty (i.e. does nothing) on MinGW, Cygwin's compiler attempts to use the _unknown_ `struct timeval`. Cygwin also tries to read the _unavailable_ `execinfo.h` for backtrace.
