### PR TITLE
On the mingw32 builds, it seems iconv wants to return its data in reverse byte ordering.

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2445,7 +2445,24 @@ return( -1 );
 return( -1 );
 	}
 	if ( tpt-(char *) to == sizeof(unichar_t) )
-return( to[0] );
+	{
+#if defined(__MINGW32__)
+	    {
+		printf("UniFromEnc(original ret) enc:%d initial result:%ld\n", enc, to[0] );
+		// For whatever reason the mingw32 build seems to always produce
+		// a result in byte swapped order.
+		unichar_t t = to[0];
+		printf("UniFromEnc(ret1) %ld\n",t );
+		unichar_t low16  = t & 0xFFFF;
+		unichar_t high16 = t >> 16;
+		t = (low16<<16) | high16;
+		printf("UniFromEnc(ret2) enc:%d final result:%ld\n", enc, t );
+		to[0] = t;
+	    }
+	    printf("UniFromEnc(final ret) %ld\n",to[0] );
+#endif	    
+	    return( to[0] );
+	}
     } else if ( encname->tounicode_func!=NULL ) {
 return( (encname->tounicode_func)(enc) );
     }


### PR DESCRIPTION
I've tried the BE and LE unicode stipulations and its always badly
byte ordered on return. So I have this flipper for mingw which makes
the A char = 0x41 instead of 0x410000. The later causes all sorts of
bad and unexpected things as one might expect.
