### PR TITLE
If File/Open is chosen on a font in the fontview, by default

### DIFF
--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -987,16 +987,25 @@ static void FVMenuMergeKern(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UN
     MergeKernInfo(fv->b.sf,fv->b.map);
 }
 
-void MenuOpen(GWindow UNUSED(base), struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
+void MenuOpen(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e))
+{
+    FontView *fv = (FontView *) GDrawGetUserData(gw);
     char *temp;
     char *eod, *fpt, *file, *full;
     FontView *test; int fvcnt, fvtest;
 
-    char* defaultOpenDir = GFileGetHomeDocumentsDir();
+    char* OpenDir = GFileGetHomeDocumentsDir();
+    if( fv && fv->b.sf && fv->b.sf->filename )
+    {
+	printf("existing name:%s\n", fv->b.sf->filename );
+	char* dname = GFileDirName( fv->b.sf->filename );
+	OpenDir = dname;
+    }
+    
     
     for ( fvcnt=0, test=fv_list; test!=NULL; ++fvcnt, test=(FontView *) (test->b.next) );
     do {
-	temp = GetPostScriptFontName(defaultOpenDir,true);
+	temp = GetPostScriptFontName(OpenDir,true);
 	if ( temp==NULL )
 return;
 	eod = strrchr(temp,'/');

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -820,3 +820,18 @@ char *GFileGetHomeDocumentsDir(void)
     return ret;
 }
 
+char *GFileDirName(const char *path)
+{
+    char ret[PATH_MAX+1];
+    char splitchar = '/';
+#if defined(__MINGW32__)
+    splitchar = '\\';
+#endif
+
+    strncpy( ret, path, PATH_MAX );
+    char *pt = strrchr( ret, splitchar );
+    if ( pt )
+	*pt = '\0';
+    return ret;
+}
+

--- a/inc/gfile.h
+++ b/inc/gfile.h
@@ -82,4 +82,15 @@ extern char *getTempDir(void);
  */
 extern char *GFileGetHomeDocumentsDir(void);
 
+/**
+ * Return the directory name for the full path 'path'.
+ * This is like the shell "dirname" command, for example:
+ * GFileDirName("/a/b/c/foo.sfd") returns "/a/b/c".
+ * This will also handle mingw paths as expected.
+ *
+ * The return value is owned by the function which is not reenterant.
+ * Do not try to free the return value.
+ */
+extern char *GFileDirName(const char *path );
+
 #endif


### PR DESCRIPTION
load the directory that contains that font in the open dialog box.

If its a new font, then load ~/Documents on Linux and osx and the My Documents
folder on win32.
