### PR TITLE
revert change to default open/save path handling in dialogs

### DIFF
--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -633,18 +633,21 @@ int _FVMenuSaveAs(FontView *fv) {
 	FilenameFunc = GFileChooserSaveAsInputFilenameFunc;
     }
 
+#if defined(__MINGW32__)
     //
     // If they are "saving as" but there is no path, lets help
     // the poor user by starting someplace sane rather than in `pwd`
     //
     if( !GFileIsAbsolute(temp) )
     {
-	char* defaultSaveDir = GFileGetHomeDocumentsDir();
-	char* temp2 = GFileAppendFile( defaultSaveDir, temp, 0 );
-	gfree(temp);
-	temp = temp2;
+    	char* defaultSaveDir = GFileGetHomeDocumentsDir();
+	printf("save-as:%s\n", temp );
+    	char* temp2 = GFileAppendFile( defaultSaveDir, temp, 0 );
+    	gfree(temp);
+    	temp = temp2;
     }
-
+#endif
+    
     ret = GWidgetSaveAsFileWithGadget8(_("Save as..."),temp,0,NULL,
 				       _FVSaveAsFilterFunc, FilenameFunc,
 				       &gcd );
@@ -994,14 +997,16 @@ void MenuOpen(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e))
     char *eod, *fpt, *file, *full;
     FontView *test; int fvcnt, fvtest;
 
-    char* OpenDir = GFileGetHomeDocumentsDir();
+    char* OpenDir = NULL;
+#if defined(__MINGW32__)
+    OpenDir = GFileGetHomeDocumentsDir();
     if( fv && fv->b.sf && fv->b.sf->filename )
     {
 	printf("existing name:%s\n", fv->b.sf->filename );
 	char* dname = GFileDirName( fv->b.sf->filename );
 	OpenDir = dname;
     }
-    
+#endif
     
     for ( fvcnt=0, test=fv_list; test!=NULL; ++fvcnt, test=(FontView *) (test->b.next) );
     do {

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -816,7 +816,11 @@ char *GFileGetHomeDocumentsDir(void)
     ret = copy( my_documents );
     return ret;
 #endif
-    ret = GFileAppendFile( GFileGetHomeDir(), "/Documents", 1 );
+
+    // For Linux and OSX it was decided that this should be just the
+    // home directory itself.
+//    ret = GFileAppendFile( GFileGetHomeDir(), "/Documents", 1 );
+    ret = GFileGetHomeDir();
     return ret;
 }
 

--- a/inc/gfile.h
+++ b/inc/gfile.h
@@ -77,7 +77,7 @@ extern char *getDotFontForgeDir(void);
 extern char *getTempDir(void);
 
 /**
- * This is the full path of ~/Documents on OSX and Linux
+ * This is the full path of ~ on OSX and Linux
  * and something like c:\Users\foo\Documents on windows
  */
 extern char *GFileGetHomeDocumentsDir(void);


### PR DESCRIPTION
Leave it in place for win32 as that binary will likely be started from a forced path instead of pwd anyway.
