### PR TITLE
Allow the GWindow passed to GDrawGetUserData() to be null.

### DIFF
--- a/gdraw/gdraw.c
+++ b/gdraw/gdraw.c
@@ -295,6 +295,8 @@ void GDrawSetUserData(GWindow gw, void *ud) {
 }
 
 void *GDrawGetUserData(GWindow gw) {
+    if( !gw )
+	return 0;
 return( gw->user_data );
 }
 


### PR DESCRIPTION
If it is then don't crash, but instead just return null.
