### PR TITLE
The API for giflib changed slightly - added function check in m4 test

### DIFF
--- a/gutils/gimagereadgif.c
+++ b/gutils/gimagereadgif.c
@@ -159,20 +159,16 @@ GImage *GImageReadGif(char *filename) {
     // as at that time, I added a smoother macro here to allow v4 to
     // still work OK for the time being.
     // 
-#if GIFLIB_MAJOR == 4
-#define ffDGifOpenFileName(fn)               DGifOpenFileName(fn)
-#define ffDGifOpenFileNameWithError(fn,err)  DGifOpenFileName(fn)
+#if defined(GIFLIB_MAJOR) && GIFLIB_MAJOR >= 5 || defined(_GIFLIB_5PLUS)
+    if ( (gif=DGifOpenFileName(filename,NULL))==NULL ) {
 #else
-#define ffDGifOpenFileName(fn)               DGifOpenFileName(fn,NULL)
-#define ffDGifOpenFileNameWithError(fn,err)  DGifOpenFileName(fn,err)
+    if ( (gif=DGifOpenFileName(filename))==NULL ) {
 #endif
-    
-    if ( (gif=ffDGifOpenFileName(filename))==NULL ) {
 	fprintf( stderr,"Can't open \"%s\"\n",filename );
 	return( NULL );
     }
 
-    if ( DGifSlurp(gif)==GIF_ERROR ) {
+    if ( DGifSlurp(gif)!=GIF_OK ) {
 	fprintf(stderr,"Bad input file \"%s\"\n",filename );
 	DGifCloseFile(gif);
 	return( NULL );

--- a/m4/fontforge_arg_with.m4
+++ b/m4/fontforge_arg_with.m4
@@ -223,6 +223,10 @@ if test x"${i_do_have_giflib}" = xyes -a x"${GIFLIB_LIBS}" = x; then
                   [AC_SUBST([GIFLIB_LIBS],["${found_lib}"])],
                   [i_do_have_giflib=no])
 fi
+if test x"${i_do_have_giflib}" = xyes -a x"${GIFLIB_LIBS}" = x; then
+   FONTFORGE_SEARCH_LIBS([EGifGetGifVersion],[gif ungif],
+                  [AC_SUBST([GIFLIB_VER5P],["${found_lib}"])],[])
+fi
 if test x"${i_do_have_giflib}" = xyes -a x"${GIFLIB_CFLAGS}" = x; then
    AC_CHECK_HEADER(gif_lib.h,[AC_SUBST([GIFLIB_CFLAGS],[""])],[i_do_have_giflib=no])
    if test x"${i_do_have_giflib}" = xyes; then
@@ -241,7 +245,6 @@ if test x"${i_do_have_giflib}" != xyes; then
    AC_DEFINE([_NO_LIBUNGIF],1,[Define if not using giflib or libungif.)])
 fi
 ])
-
 
 dnl There is no pkg-config support for libjpeg, at least on Gentoo. (17 Jul 2012)
 dnl


### PR DESCRIPTION
FontForge developer list still indicates a problem with giflib.
See [Fontforge-devel] Bug report: Failing to build, Aug 18,2013
