### PR TITLE
Allow grabbing a spline between two curve points to respect the curve point types.

### DIFF
--- a/fontforge/cvpointer.c
+++ b/fontforge/cvpointer.c
@@ -999,9 +999,15 @@ return;
     // dont go changing pt_curve points into pt_corner without explicit consent.
     //
     if( oldfrompointtype == pt_curve )
+    {
 	old->from->pointtype = oldfrompointtype;
+	SPTouchControl( old->from, &old->from->nextcp, cv->b.layerheads[cv->b.drawmode]->order2 );
+    }
     if( oldtopointtype == pt_curve )
+    {
 	old->to->pointtype = oldtopointtype;
+	SPTouchControl( old->to, &old->to->prevcp, cv->b.layerheads[cv->b.drawmode]->order2 );
+    }
 
     old->from->nextcpdef = old->to->prevcpdef = false;
     SplineFree(old);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2563,6 +2563,15 @@ extern void SplineCharDefaultPrevCP(SplinePoint *base);
 extern void SplineCharDefaultNextCP(SplinePoint *base);
 extern void SplineCharTangentNextCP(SplinePoint *sp);
 extern void SplineCharTangentPrevCP(SplinePoint *sp);
+/**
+ * This is like SPAdjustControl but you have not wanting to move the
+ * BCP at all, but you would like the current location of the passed
+ * BCP to reshape the spline through the splinepoint. For example, if
+ * you drag the spline between two points then you might like to touch
+ * the inside BCP between the two splinepoints to reshape the whole
+ * curve through a curve point.
+ */
+extern void SPTouchControl(SplinePoint *sp,BasePoint *which, int order2);
 extern void SPAdjustControl(SplinePoint *sp,BasePoint *cp, BasePoint *to,int order2);
 extern void SPHVCurveForce(SplinePoint *sp);
 extern void SPSmoothJoint(SplinePoint *sp);

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -4631,6 +4631,13 @@ return;
     }
 }
 
+void SPTouchControl(SplinePoint *sp,BasePoint *which, int order2)
+{
+    BasePoint to = *which;
+    SPAdjustControl( sp, which, &to, order2 );
+}
+
+
 void SPAdjustControl(SplinePoint *sp,BasePoint *cp, BasePoint *to,int order2) {
     BasePoint *othercp = cp==&sp->nextcp?&sp->prevcp:&sp->nextcp;
     int refig = false, otherchanged = false;


### PR DESCRIPTION
This means that the BCP of the splinepoints on either side of the
spline we are moving are going to be touched so that they effect the
other corresponding BCP for the corner point and will force the
adjacent splines to update themselves properly in response to your
mouse movement.

Dave's video comment a few down on the below issue shows the desired
adjacent spline movement:
https://github.com/fontforge/fontforge/issues/533
