### PR TITLE
allow scale tool to work on 1+ BCP if they are selected.

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -8296,7 +8296,7 @@ void CVTransFuncLayer(CharView *cv,Layer *ly,real transform[6], enum fvtrans_fla
     else
     {
 	if( cv->active_tool==cvt_scale )
-	    tpmask |= tpmask_operateOnBCP;
+	    tpmask |= tpmask_operateOnSelectedBCP;
 	
 	SplinePointListTransformExtended(
 	    ly->splines, transform,

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2345,7 +2345,7 @@ enum transformPointType { tpt_OnlySelected, tpt_AllPoints, tpt_OnlySelectedInter
  */ 
 enum transformPointMask {
     tpmask_dontFixControlPoints = 1 << 1,
-    tpmask_operateOnBCP         = 1 << 2
+    tpmask_operateOnSelectedBCP = 1 << 2
 };
 extern SplinePointList *SplinePointListTransform(SplinePointList *base, real transform[6], enum transformPointType allpoints );
 extern SplinePointList *SplinePointListTransformExtended(SplinePointList *base, real transform[6],

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1736,7 +1736,7 @@ static void TransformPointExtended(SplinePoint *sp, real transform[6], enum tran
      * If we are to transform selected BCP instead of their base splinepoint
      * then lets do that.
      */
-    if( tpmask & tpmask_operateOnBCP
+    if( tpmask & tpmask_operateOnSelectedBCP
 	&& (sp->nextcpselected || sp->prevcpselected ))
     {
 	if( sp->nextcpselected )


### PR DESCRIPTION
Otherwise the base splinepoints are operated on as before.

If there is a selected BCP for a splinepoint then that BCP is operated
on and the base splinepoint is left as it was. If there is no selected
BCP then the base splinepoint is operated on as it was before the
commit. This can be mixed, for example 2 splinepoint without either of
their BCP selected and three splinepoints one with its next BCP
selected and the other two with their prev BCPs selected.
