### PR TITLE
Trailing blanks and buffer overflows

### DIFF
--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -263,7 +263,7 @@ struct macbinaryheader {
     uint32 type;
     uint32 creator;
 };
-	    
+
 static struct resource *PSToResources(FILE *res,FILE *pfbfile) {
     /* split the font up into as many small resources as we need and return */
     /*  an array pointing to the start of each */
@@ -314,7 +314,7 @@ return( NULL );
     resstarts[cnt].pos = 0;
 return( resstarts );
 }
-	    
+
 static uint32 TTFToResource(FILE *res,FILE *ttffile) {
     /* A truetype font just gets dropped into a resource */
     struct stat statb;
@@ -1041,7 +1041,7 @@ static uint32 SFsToFOND(FILE *res,struct sflist *sfs,uint32 id,int format,int bf
 	    psfaces[psstyle] = sfi;
     }
     sf = faces[0]->sf;
-    
+
     putlong(res,0);			/* Fill in length later */
     putshort(res,IsMacMonospaced(sf,faces[0]->map)?0x9000:0x1000);
     putshort(res,id);
@@ -1352,15 +1352,12 @@ static void DumpResourceMap(FILE *res,struct resourcetype *rtypes,enum fontforma
 
 long mactime(void) {
     time_t now;
-    int i;
 
     time(&now);
     /* convert from 1970 based time to 1904 based time */
-    now += (1970-1904)*365L*24*60*60;
-    for ( i=1904; i<1970; i+=4 )
-	now += 24*60*60;
+    now += (1970-1904)*365L*24*60*60+((1970-1904)>>2)*24*60*60;
     /* Ignore any leap seconds -- Sorry Steve */
-return( now );
+    return( now );
 }
 
 static int DumpMacBinaryHeader(FILE *res,struct macbinaryheader *mb) {
@@ -1374,7 +1371,7 @@ static int DumpMacBinaryHeader(FILE *res,struct macbinaryheader *mb) {
 	char *pt = strrchr(mb->binfilename,'/');
 	if ( pt==NULL ) pt = mb->binfilename;
 	else ++pt;
-	strcpy(buffer,pt);
+	strncpy(buffer,pt,sizeof(buffer)-1);
 	dpt = strrchr(buffer,'.');
 	if ( dpt==NULL ) {
 	    buffer[0] = '_';

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -169,7 +169,7 @@ static char *toknames[] = { "moveto", "rmoveto", "curveto", "rcurveto",
 	"abs", "round", "ceiling", "floor", "truncate", "max", "min",
 	"ne", "eq", "gt", "ge", "lt", "le", "and", "or", "xor", "not",
 	"exp", "sqrt", "ln", "log", "atan", "sin", "cos",
-	"true", "false", 
+	"true", "false",
 	"if", "ifelse", "for", "loop", "repeat", "exit",
 	"stopped", "stop",
 	"def", "bind", "load",
@@ -1155,7 +1155,7 @@ return( sp-5 );
 return( sp-5 );
     }
     polarity = stack[sp-3].u.tf;
-    
+
     if ( stack[sp-4].type!=ps_num || stack[sp-5].type!=ps_num ) {
 	LogError( _("First and second arguments of imagemask must be integers.\n" ));
 return( sp-5 );
@@ -1277,7 +1277,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
     DashType dashes[DASH_MAX];
     int dash_offset = 0;
     Entity *ent;
-    char oldloc[24];
+    char oldloc[25];
     int warned = 0;
     struct garbage tofrees;
     SplineSet *clippath = NULL;
@@ -1286,7 +1286,8 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 
     tokbuf = galloc(tokbufsize);
 
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
 
     memset(&gb,'\0',sizeof(GrowBuf));
@@ -1438,7 +1439,7 @@ printf( "-%s-\n", toknames[tok]);
 	    } else if ( strcmp(tokbuf,"togNS_")==0 ) {
 		wrapper->top->fogns = !wrapper->top->fogns;
     continue;
-	    } 
+	    }
 	}
 	switch ( tok ) {
 	  case pt_number:
@@ -3284,7 +3285,7 @@ static void SCInterpretPS(FILE *ps,SplineChar *sc, int *flags) {
     sc->layers[ly_fore].refs = revrefs(ec.refs);
     free(wrapper.top);
 }
-    
+
 void PSFontInterpretPS(FILE *ps,struct charprocs *cp,char **encoding) {
     char tokbuf[100];
     int tok,i, j;

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -8183,7 +8183,7 @@ return( dval );
 
 static SplineFont *SFD_Read(char *filename,FILE *sfd, int fromdir) {
     SplineFont *sf=NULL;
-    char oldloc[24], tok[2000];
+    char oldloc[25], tok[2000];
     double version;
 
     if ( sfd==NULL ) {
@@ -8195,7 +8195,8 @@ static SplineFont *SFD_Read(char *filename,FILE *sfd, int fromdir) {
     }
     if ( sfd==NULL )
 return( NULL );
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
     ff_progress_change_stages(2);
     if ( (version = SFDStartsCorrectly(sfd,tok))!=-1 )
@@ -8524,7 +8525,7 @@ return( true );
 SplineFont *SFRecoverFile(char *autosavename,int inquire,int *state) {
     FILE *asfd = fopen( autosavename,"r");
     SplineFont *ret;
-    char oldloc[24], tok[1025];
+    char oldloc[25], tok[1025];
 
     if ( asfd==NULL )
 return(NULL);
@@ -8532,7 +8533,8 @@ return(NULL);
 	fclose( asfd );
 return( NULL );
     }
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
     ret = SlurpRecovery(asfd,tok,sizeof(tok));
     if ( ret==NULL ) {

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -1018,7 +1018,7 @@ return( true );
 
 return( false );
 }
-		
+
 int SCSetMetaData(SplineChar *sc,char *name,int unienc,const char *comment) {
     SplineFont *sf = sc->parent;
     int i, mv=0;
@@ -1174,9 +1174,10 @@ static int CheckBluePair(char *blues, char *others, int bluefuzz,
     int bluevals[10+14], cnt, pos=0, maxzoneheight;
     int err = 0;
     char *end;
-    char oldloc[24];
+    char oldloc[25];
 
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
     if ( others!=NULL ) {
 	while ( *others==' ' ) ++others;
@@ -1250,7 +1251,7 @@ return( err );
 
 static int CheckStdW(struct psdict *dict,char *key ) {
     char *str_val, *end;
-    char oldloc[24];
+    char oldloc[25];
     bigreal val;
 
     if ( (str_val = PSDictHasEntry(dict,key))==NULL )
@@ -1260,7 +1261,8 @@ return( true );
 return( false );
     ++str_val;
 
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
     val = strtod(str_val,&end);
     setlocale(LC_NUMERIC,oldloc);
@@ -1277,7 +1279,7 @@ return( true );
 
 static int CheckStemSnap(struct psdict *dict,char *snapkey, char *stdkey ) {
     char *str_val, *end;
-    char oldloc[24];
+    char oldloc[25];
     bigreal std_val = -1;
     bigreal stems[12], temp;
     int cnt, found;
@@ -1286,7 +1288,8 @@ static int CheckStemSnap(struct psdict *dict,char *snapkey, char *stdkey ) {
     if ( (str_val = PSDictHasEntry(dict,stdkey))!=NULL ) {
 	while ( *str_val==' ' ) ++str_val;
 	if ( *str_val=='[' && *str_val!='{' ) ++str_val;
-	strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+	strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+	oldloc[24]=0;
 	setlocale(LC_NUMERIC,"C");
 	std_val = strtod(str_val,&end);
 	setlocale(LC_NUMERIC,oldloc);
@@ -1304,7 +1307,8 @@ return( false );
 	while ( *str_val==' ' ) ++str_val;
 	if ( *str_val==']' && *str_val!='}' )
     break;
-	strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+	strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+	oldloc[24]=0;
 	setlocale(LC_NUMERIC,"C");
        temp = strtod(str_val,&end);
 	setlocale(LC_NUMERIC,oldloc);
@@ -1328,7 +1332,7 @@ return( true );
 int ValidatePrivate(SplineFont *sf) {
     int errs = 0;
     char *blues, *bf, *test, *end;
-    char oldloc[24];
+    char oldloc[25];
     int fuzz = 1;
     bigreal bluescale = .039625;
     int magicpointsize;
@@ -1343,7 +1347,8 @@ return( pds_missingblue );
     }
 
     if ( (test=PSDictHasEntry(sf->private,"BlueScale"))!=NULL ) {
-	strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+	strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+	oldloc[24]=0;
 	setlocale(LC_NUMERIC,"C");
         bluescale = strtod(test,&end);
 	setlocale(LC_NUMERIC,oldloc);
@@ -1788,7 +1793,7 @@ int SCValidate(SplineChar *sc, int layer, int force) {
 	}
 	++k;
     } while ( k<cid->subfontcnt );
-		
+
   end:;
     /* This test is intentionally here and should be done even if the glyph */
     /*  hasn't changed. If the lookup changed it could make the glyph invalid */
@@ -1801,7 +1806,7 @@ return( sc->layers[layer].validation_state&~(vs_known|vs_selfintersects) );
 
 return( sc->layers[layer].validation_state&~vs_known );
 }
-    
+
 int SFValidate(SplineFont *sf, int layer, int force) {
     int k, gid;
     SplineFont *sub;
@@ -1840,7 +1845,7 @@ int SFValidate(SplineFont *sf, int layer, int force) {
 return( -1 );
 	    } else if ( SCValidateAnchors(sc)!=NULL )
 		sc->layers[layer].validation_state |= vs_missinganchor;
-	    
+
 	    if ( sc->unlink_rm_ovrlp_save_undo )
 		any |= sc->layers[layer].validation_state&~vs_selfintersects;
 	    else

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -1384,7 +1384,7 @@ char *_GetModifiers(char *fontname, char *familyname,char *weight) {
     if ( fpt!=NULL ) {
 	for ( i=0; mods[i]!=NULL; ++i ) for ( j=0; mods[i][j]!=NULL; ++j ) {
 	    if ( strcmp(fpt,mods[i][j])==0 ) {
-		strcpy(space,fullmods[i][j]);
+		strncpy(space,fullmods[i][j],sizeof(space)-1);
 return(space);
 	    }
 	}

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -244,7 +244,7 @@ void SplinePointFree(SplinePoint *sp) {
 
 void SplinePointMDFree(SplineChar *sc, SplinePoint *sp) {
     MinimumDistance *md, *prev, *next;
-    
+
     if ( sc!=NULL ) {
 	prev = NULL;
 	for ( md = sc->md; md!=NULL; md = next ) {
@@ -290,7 +290,7 @@ void SplineSetBeziersClear(SplinePointList *spl) {
 
     if ( spl==NULL )
 return;
-    
+
     if ( spl->first!=NULL ) {
 	nonext = spl->first->next==NULL;
 	first = NULL;
@@ -312,7 +312,7 @@ void SplinePointListFree(SplinePointList *spl) {
 
     if ( spl==NULL )
 return;
-    
+
     if ( spl->first!=NULL ) {
 	nonext = spl->first->next==NULL;
 	first = NULL;
@@ -431,7 +431,7 @@ void RefCharsFree(RefChar *ref) {
 
 /* Remove line segments which are just one point long */
 /* Merge colinear line segments */
-/* Merge two segments each of which involves a single pixel change in one dimension (cut corners) */ 
+/* Merge two segments each of which involves a single pixel change in one dimension (cut corners) */
 static void SimplifyLineList(LineList *prev) {
     LineList *next, *lines;
 
@@ -1020,7 +1020,7 @@ return;
     bounds->maxx = bounds->maxy = -1e10;
 
     SplineSetQuickBounds(sc->layers[layer].splines,bounds);
-    
+
     for ( ref = sc->layers[layer].refs; ref!=NULL; ref = ref->next ) {
 	SplineSetQuickBounds(ref->layers[0].splines,&temp);
 	if ( bounds->minx==0 && bounds->maxx==0 && bounds->miny==0 && bounds->maxy == 0 )
@@ -1767,7 +1767,7 @@ static void TransformPointExtended(SplinePoint *sp, real transform[6], enum tran
 	{
 	    sp->nextcp = sp->me;
 	}
-    
+
 	if ( !sp->noprevcp )
 	{
 	    BpTransform(&sp->prevcp,&sp->prevcp,transform);
@@ -1779,10 +1779,10 @@ static void TransformPointExtended(SplinePoint *sp, real transform[6], enum tran
     }
 
 
-    
+
     if ( sp->pointtype == pt_hvcurve )
     {
-	if( 
+	if(
 	    ((sp->nextcp.x==sp->me.x && sp->prevcp.x==sp->me.x && sp->nextcp.y!=sp->me.y) ||
 	     (sp->nextcp.y==sp->me.y && sp->prevcp.y==sp->me.y && sp->nextcp.x!=sp->me.x)))
 	{
@@ -1928,7 +1928,7 @@ SplinePointList *SplinePointListTransformExtended(SplinePointList *base, real tr
 		for ( spt = spl->first ; spt!=pfirst; spt = spt->next->to )
 		{
 		    if ( pfirst==NULL ) pfirst = spt;
-		    if ( spt->selected && spt->prev!=NULL && !spt->prev->from->selected && 
+		    if ( spt->selected && spt->prev!=NULL && !spt->prev->from->selected &&
 			 spt->prev->from->pointtype == pt_tangent )
 			SplineCharTangentPrevCP(spt->prev->from);
 		    if ( spt->selected && spt->next!=NULL && !spt->next->to->selected &&
@@ -1964,7 +1964,7 @@ SplinePointList *SplinePointListSpiroTransform(SplinePointList *base, real trans
     int allsel, anysel;
     int i;
 
-    
+
     if ( allpoints )
 return( SplinePointListTransform(base,transform,tpt_AllPoints));
 
@@ -2636,7 +2636,7 @@ static void SplineFontFromType1(SplineFont *sf, FontDict *fd, struct pscontext *
 
 static SplineFont *SplineFontFromMMType1(SplineFont *sf, FontDict *fd, struct pscontext *pscontext) {
     char *pt, *end, *origweight;
-    char oldloc[24];
+    char oldloc[25];
     MMSet *mm;
     int ipos, apos, ppos, item, i;
     real blends[12];	/* At most twelve points/axis in a blenddesignmap */
@@ -2653,7 +2653,8 @@ return( NULL );
     mm = chunkalloc(sizeof(MMSet));
 
     pt = fd->weightvector;
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
     while ( *pt==' ' || *pt=='[' ) ++pt;
     while ( *pt!=']' && *pt!='\0' ) {
@@ -2730,7 +2731,7 @@ return( NULL );
 	} else
 	    ++pt;
     }
-    
+
     mm->axismaps = gcalloc(mm->axis_count,sizeof(struct axismap));
     pt = fd->fontinfo->blenddesignmap;
     while ( *pt==' ' ) ++pt;
@@ -3056,7 +3057,7 @@ return;
 	    for ( subref=rsc->layers[i].refs; subref!=NULL; subref=subref->next )
 		cnt += subref->layer_cnt;
 	}
-    
+
 	rf->layer_cnt = cnt;
 	rf->layers = gcalloc(cnt,sizeof(struct reflayer));
 	cnt = 0;
@@ -3159,7 +3160,7 @@ static void _SFReinstanciateRefs(SplineFont *sf) {
 	++cnt;
     }
 }
-	    
+
 void SFReinstanciateRefs(SplineFont *sf) {
     int i;
 
@@ -3775,7 +3776,7 @@ return(tmin);
 return(tmax);
     if (( low<0 && high>0 ) ||
 	    ( low>0 && high<0 )) {
-	
+
 	forever {
 	    t = (tmax+tmin)/2;
 	    if ( t==tmax || t==tmin )
@@ -4562,7 +4563,7 @@ return( false );
 
 return( true );
 }
-    
+
 /* returns 0=>no intersection, 1=>at least one, location in pts, t1s, t2s */
 /*  -1 => We couldn't figure it out in a closed form, have to do a numerical */
 /*  approximation */
@@ -5303,7 +5304,7 @@ int SSPointWithin(SplineSet *spl,BasePoint *pt) {
 	}
 	spl = spl->next;
     }
-return( cnt!=0 );	
+return( cnt!=0 );
 }
 
 void StemInfoFree(StemInfo *h) {
@@ -6387,7 +6388,7 @@ void OtfFeatNameListFree(struct otffeatname *fn) {
 
 EncMap *EncMapNew(int enccount,int backmax,Encoding *enc) {
     EncMap *map = chunkalloc(sizeof(EncMap));
-    
+
     map->enccount = map->encmax = enccount;
     map->backmax = backmax;
     map->map = galloc(enccount*sizeof(int));
@@ -6402,7 +6403,7 @@ EncMap *EncMap1to1(int enccount) {
     EncMap *map = chunkalloc(sizeof(EncMap));
     /* Used for CID fonts where CID is same as orig_pos */
     int i;
-    
+
     map->enccount = map->encmax = map->backmax = enccount;
     map->map = galloc(enccount*sizeof(int));
     map->backmap = galloc(enccount*sizeof(int));
@@ -6519,7 +6520,7 @@ void BaseScriptFree(struct basescript *bs) {
 	bs = next;
     }
 }
-	
+
 void BaseFree(struct Base *base) {
     if ( base==NULL )
 return;
@@ -6542,7 +6543,7 @@ return( NULL );
     ret[i] = NULL;
 return( ret );
 }
-    
+
 struct jstf_lang *JstfLangsCopy(struct jstf_lang *jl) {
     struct jstf_lang *head=NULL, *last=NULL, *cur;
     int i;
@@ -6766,7 +6767,7 @@ static void countcluster(SplinePoint **ptspace, struct cluster *cspace,
     break;
     }
 }
-	
+
 static int _SplineCharRoundToCluster(SplineChar *sc,SplinePoint **ptspace,
 	struct cluster *cspace,int ptcnt,int is_y,int dohints,
 	int layer, int changed,

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -922,10 +922,11 @@ return( uni==-1 || uni>=0x10000 ||
 
 static void svg_sfdump(FILE *file,SplineFont *sf,int layer) {
     int defwid, i, formeduni;
-    char oldloc[24];
+    char oldloc[25];
     struct altuni *altuni;
 
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
 
     for ( i=0; i<sf->glyphcnt; ++i ) if ( sf->glyphs[i]!=NULL )

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -57,7 +57,7 @@ char *TTFFoundry=NULL;
 	name		various names associated with the font
 	post		postscript names and other stuff
 Required by windows but not mac
-	OS/2		bleah. 
+	OS/2		bleah.
 Required for TrueType
 	loca		pointers to the glyphs
 	glyf		character shapes
@@ -359,7 +359,7 @@ const char *ttfstandardnames[258] = {
 "ccaron",
 "dcroat"
 };
-/* Relates Unicode blocks as in 
+/* Relates Unicode blocks as in
  	http://unicode.org/Public/UNIDATA/Blocks.txt
    to bit positions in the OpenType standard Unicode Character Range
    field 'ulUnicodeRange'.
@@ -841,7 +841,7 @@ static void dumppointarrays(struct glyphinfo *gi,BasePoint *bp, char *fs, int pc
 	else if ( bp[i].y-last.y>-256 && bp[i].y-last.y<255 ) {
 	    flags |= _Y_Short;
 	    if ( bp[i].y>=last.y )
-		flags |= _Y_Same;		/* In this context it means positive */	
+		flags |= _Y_Same;		/* In this context it means positive */
 	}
 	last = bp[i];
 	if ( lastflag==-1 ) {
@@ -1298,7 +1298,7 @@ return;
     gi->pointcounts[gi->next_glyph++] = ptcnt;
 
     dumpinstrs(gi,isc->ttf_instrs,isc->ttf_instrs_len);
-	
+
     dumppointarrays(gi,bp,fs,ptcnt);
     SplinePointListsFree(ttfss);
     free(bp);
@@ -1392,7 +1392,7 @@ static int AssignTTFGlyph(struct glyphinfo *gi,SplineFont *sf,EncMap *map,int is
 
     for ( i=0; i<sf->glyphcnt; ++i ) if ( sf->glyphs[i]!=NULL ) {
 	SplineChar *sc = sf->glyphs[i];
-	if ( SCWorthOutputting(sc) && sc->ttf_glyph==-1 
+	if ( SCWorthOutputting(sc) && sc->ttf_glyph==-1
 #if HANYANG
 		&& (!iscff || !sc->compositionunit)
 #endif
@@ -3052,7 +3052,7 @@ void SFDefaultOS2Simple(struct pfminfo *pfminfo,SplineFont *sf) {
     pfminfo->os2_winascent = pfminfo->os2_windescent = 0;
 
     if ( sf->subfonts!=NULL ) sf = sf->subfonts[0];
-    pfminfo->linegap = pfminfo->vlinegap = pfminfo->os2_typolinegap = 
+    pfminfo->linegap = pfminfo->vlinegap = pfminfo->os2_typolinegap =
 	    rint(.09*(sf->ascent+sf->descent));
 }
 
@@ -3427,14 +3427,14 @@ static void setos2(struct os2 *os2,struct alltabs *at, SplineFont *sf,
 	    os2->fsSel |= 256;
     }
 /* David Lemon @Adobe.COM
-1)  The sTypoAscender and sTypoDescender values should sum to 2048 in 
-a 2048-unit font. They indicate the position of the em square 
+1)  The sTypoAscender and sTypoDescender values should sum to 2048 in
+a 2048-unit font. They indicate the position of the em square
 relative to the baseline.
 GWW: Almost, sTypoAscender-sTypoDescender == EmSize
 
-2)  The usWinAscent and usWinDescent values represent the maximum 
-height and depth of specific glyphs within the font, and some 
-applications will treat them as the top and bottom of the font 
+2)  The usWinAscent and usWinDescent values represent the maximum
+height and depth of specific glyphs within the font, and some
+applications will treat them as the top and bottom of the font
 bounding box. (the "ANSI" glyphs)
 GWW: That's what's documented. But it means non-ANSI glyphs get clipped. So the
 docs are wrong.
@@ -4188,7 +4188,7 @@ static void dumpnames(struct alltabs *at, SplineFont *sf,enum fontformat format)
 		    "This font has a name table which is %d bytes and is bigger than this limit.\n"),
 		    at->namelen);
 #endif
-    
+
 }
 
 static void dumppost(struct alltabs *at, SplineFont *sf, enum fontformat format) {
@@ -4402,7 +4402,7 @@ return( NULL );		/* Doesn't have the single byte entries */
 	if ( map->map[i]!=-1 && sf->glyphs[map->map[i]]!=NULL &&
 		sf->glyphs[map->map[i]]->ttf_glyph!=-1 )
 	    glyphs[i] = sf->glyphs[map->map[i]]->ttf_glyph;
-    
+
     pos = 1;
 
     complained = false;
@@ -5141,7 +5141,7 @@ int32 filechecksum(FILE *file) {
     }
 return( sum );
 }
-    
+
 static void AbortTTF(struct alltabs *at, SplineFont *sf) {
     int i;
 
@@ -5741,7 +5741,7 @@ static void buildtablestructures(struct alltabs *at, SplineFont *sf,
     }
     if ( tab!=NULL )
 	IError("Some user supplied tables omitted. Up sizeof tabs array in struct tabdir in ttf.h" );
-    
+
     at->tabdir.numtab = i;
     at->tabdir.searchRange = (i<16?8:i<32?16:i<64?32:64)*16;
     at->tabdir.entrySel = (i<16?3:i<32?4:i<64?5:6);
@@ -5803,7 +5803,7 @@ return( false );
 	AbortTTF(at,sf);
 return( false );
     }
-	
+
 
     ATmaxpInit(at,sf,format);
     if ( format==ff_otf )
@@ -6175,13 +6175,14 @@ static void ATinit(struct alltabs *at,SplineFont *sf,EncMap *map,int flags, int 
 int _WriteTTFFont(FILE *ttf,SplineFont *sf,enum fontformat format,
 	int32 *bsizes, enum bitmapformat bf,int flags,EncMap *map, int layer) {
     struct alltabs at;
-    char oldloc[24];
+    char oldloc[25];
     int i, anyglyphs;
 
     /* TrueType probably doesn't need this, but OpenType does for floats in dictionaries */
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
-    
+
     if ( format==ff_otfcid || format== ff_cffcid ) {
 	if ( sf->cidmaster ) sf = sf->cidmaster;
     } else {
@@ -6311,7 +6312,7 @@ static void dumphex(struct hexout *hexout,FILE *temp,int length) {
     }
     fprintf( hexout->type42, "\n  00\n >\n" );
 }
-    
+
 static void dumptype42(FILE *type42,struct alltabs *at, enum fontformat format) {
     FILE *temp = tmpfile();
     struct hexout hexout;
@@ -6358,11 +6359,12 @@ static void dumptype42(FILE *type42,struct alltabs *at, enum fontformat format) 
 int _WriteType42SFNTS(FILE *type42,SplineFont *sf,enum fontformat format,
 	int flags,EncMap *map,int layer) {
     struct alltabs at;
-    char oldloc[24];
+    char oldloc[25];
     int i;
 
     /* TrueType probably doesn't need this, but OpenType does for floats in dictionaries */
-    strcpy( oldloc,setlocale(LC_NUMERIC,NULL) );
+    strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
+    oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
 
     if ( sf->subfontcnt!=0 ) sf = sf->subfonts[0];
@@ -6892,7 +6894,7 @@ static void ttc_dump(FILE *ttc,struct alltabs *all, enum fontformat format,
 		all[i].tabdir.tabs[j].length = dup;
 	    }
 	}
-	
+
 	/* And now dump those tables into the file. I don't see how I could */
 	/*  order them meaningfully */
 	for ( j=0 ; j<all[i].tabdir.numtab; ++j ) {


### PR DESCRIPTION
Coverity scan check caught several places where possible buffer overflows
may happen. Also cleaned-up and removed a bunch of trailing spaces.
