### PR TITLE
Follow ICCCM spec when hiding windows

### DIFF
--- a/gdraw/gxdraw.c
+++ b/gdraw/gxdraw.c
@@ -1467,7 +1467,10 @@ static void GXDrawSetVisible(GWindow w, int visible) {
 	    s_h.y = gw->pos.y + gdisp->off_y;
 	    XSetNormalHints(gdisp->display,gw->w,&s_h);
 	}
-	XUnmapWindow(gdisp->display,gw->w);
+	if (gw->is_toplevel)
+		XWithdrawWindow(gdisp->display,gw->w,gdisp->screen);
+	else
+		XUnmapWindow(gdisp->display,gw->w);
 	_GXDraw_RemoveRedirects(gdisp,gw);
     }
 }


### PR DESCRIPTION
In some non-reparenting window managers such as Awesome 3.4, FontForge
dialogs behave incorrectly. The symptoms are the following:
- on first use, the dialogs are visible
- when closed and reopened, they are not visible anymore
- switching to a different tag/workspace and then back makes all
  previously opened dialogs visible again (even the ones that were not
  reopened).

This is caused by the WM not noticing the withdrawal of the dialogs by
FontForge, which in turn is caused by FontForge not complying with the
ICCCM specification, section 4.1.4[1](http://tronche.com/gui/x/icccm/sec-4.html#s-4.1.4), which recommends sending a
synthetic UnmapNotify event to the root screen when unmapping a window.

Since this behavior is needed often, Xlib provides the XWithdrawWindow()
to unmap and send the event with a single call.

This patch fixes the issue with FontForge in Awesome 3.4 by replacing
calls to XUnmapWindow() with XWithdrawWindow() for top-level windows.
