### PR TITLE
Don't resize hvbox smaller than minwidth/minheight

### DIFF
--- a/gdraw/ghvbox.c
+++ b/gdraw/ghvbox.c
@@ -299,6 +299,9 @@ static void GHVBoxResize(GGadget *g, int32 width, int32 height) {
 	g->inner.y += si.label_height;
     }
 
+    if(width < si.minwidth) width = si.minwidth;
+    if(height < si.minheight) height = si.minheight;
+
     if ( si.width!=width ) {
 	int vcols=0;
 	for ( i=0; i<gb->cols; ++i )


### PR DESCRIPTION
The old code does not respect minwidth/minheight, such that a box can be smaller than its min size.
This should fix #418, please check the new behaviour, see if it is ok.
