### PR TITLE
Allow points, BCP et al to have an alpha mask applied to them

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -825,8 +825,10 @@ extern void FVDelay(FontView *fv,void (*func)(FontView *));
 extern void GFI_FinishContextNew(struct gfi_data *d,FPST *fpst, int success);
 extern void SCPreparePopup(GWindow gw,SplineChar *sc, struct remap *remap, int enc, int actualuni);
 enum outlinesfm_flags { sfm_stroke=0x1, sfm_fill=0x2, sfm_nothing=0x4, sfm_stroke_trans = (0x1|0x8) };
-extern void CVDrawSplineSetSpecialized(CharView *cv, GWindow pixmap, SplinePointList *set,
-	Color fg, int dopoints, DRect *clip, enum outlinesfm_flags strokeFillMode );
+extern void CVDrawSplineSetSpecialized( CharView *cv, GWindow pixmap, SplinePointList *set,
+					Color fg, int dopoints, DRect *clip,
+					enum outlinesfm_flags strokeFillMode,
+					Color AlphaChannelOverride );
 extern void CVDrawSplineSet(CharView *cv, GWindow pixmap, SplinePointList *set,
 	Color fg, int dopoints, DRect *clip );
 extern void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *set,


### PR DESCRIPTION
in the dragging shadow when that mode is active.

This is DraggingComparisonAlphaChannelOverride with a default of
0x88 which is roughly 52%.
