### PR TITLE
collab: Send the font name in the beacon to allow clients to use

### DIFF
--- a/fontforge/collabclientpriv.h
+++ b/fontforge/collabclientpriv.h
@@ -59,7 +59,7 @@
 #define beacon_announce_username_sz     50
 #define beacon_announce_machinename_sz  50
 #define beacon_announce_ip_sz           20
-
+#define beacon_announce_fontname_sz     40
 
 
 #include "ffglib.h"
@@ -86,6 +86,7 @@ typedef struct {
     // are only used in the local hash version of this data structure.
     time_t last_msg_from_peer_time;
     uint8_t ip[beacon_announce_ip_sz];
+    uint8_t fontname[beacon_announce_fontname_sz];
 } beacon_announce_t;
 
 /**

--- a/fontforge/collabclientui.c
+++ b/fontforge/collabclientui.c
@@ -534,7 +534,7 @@ void collabclient_free( void** ccvp )
 
 #ifdef BUILD_COLLAB
 
-static void collabclient_sendSFD( void* ccvp, char* sfd )
+static void collabclient_sendSFD( void* ccvp, char* sfd, char* fontname )
 {
     cloneclient_t* cc = (cloneclient_t*)ccvp;
 
@@ -542,6 +542,7 @@ static void collabclient_sendSFD( void* ccvp, char* sfd )
     kvmsg_fmt_key  (kvmsg, "%s%d", SUBTREE, cc->publisher_sendseq++);
     kvmsg_set_body (kvmsg, sfd, strlen(sfd));
     kvmsg_set_prop (kvmsg, "type", MSG_TYPE_SFD );
+    kvmsg_set_prop (kvmsg, "fontname", fontname );
 //    kvmsg_set_prop (kvmsg, "ttl", "%d", randof (30));
     kvmsg_send     (kvmsg, cc->publisher);
     kvmsg_destroy (&kvmsg);
@@ -739,7 +740,7 @@ void collabclient_sessionStart( void* ccvp, FontView *fv )
     {
 	char* sfd = GFileReadAll( filename );
 	printf("connecting to server...4 sfd:%p\n", sfd );
-	collabclient_sendSFD( cc, sfd );
+	collabclient_sendSFD( cc, sfd, fv->b.sf->fontname );
     }
     GFileUnlink(filename);
     printf("connecting to server...sent the sfd for session start.\n");

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -5686,11 +5686,11 @@ static void FVMenuCollabConnect(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent
 	    printf("user:%s\n", ba->username );
 	    printf("mach:%s\n", ba->machinename );
 
-	    char format[20];
-	    sprintf( format, "%%%d", maxUserNameLength );
+	    char format[50];
+	    sprintf( format, "%s %%%d", "%s", maxUserNameLength );
 	    strcat( format, "s %s");
 	    char buf[101];
-	    snprintf( buf, 100, format, ba->username, ba->machinename );
+	    snprintf( buf, 100, format, ba->fontname, ba->username, ba->machinename );
 	    choices[i] = copy( buf );
 	    if( i >= max )
 		break;


### PR DESCRIPTION
```
    that when selecting where to connect.
```
