### PR TITLE
Fix bug in utf82u_strlen(). Count more in utf8_strlen() and utf82u_strle...

### DIFF
--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -818,26 +818,23 @@ char *utf8_db(char *utf8_text) {
     return( (char *) pt );
 }
 
-int utf8_strlen(const char *utf8_str) {
-    /* how many characters in the string NOT bytes */
-    int len = 0;
+long utf8_strlen(const char *utf8_str) {
+/* Count how many characters in the string NOT bytes */
+    long len = 0;
 
-    while ( utf8_ildb(&utf8_str)>0 )
-	++len;
-return( len );
+    while ( utf8_ildb(&utf8_str)>0 && ++len>0 );
+    return( len );
 }
 
-int utf82u_strlen(const char *utf8_str) {
-    /* how many shorts needed to represent it in UCS2 */
-    int ch;
-    int len = 0;
+long utf82u_strlen(const char *utf8_str) {
+/* Count how many shorts needed to represent in UCS2 */
+    int32 ch;
+    long len = 0;
 
-    while ( (ch = utf8_ildb(&utf8_str))>0 )
-	if ( ch>0x10000 )
-	    len += 2;
-	else
+    while ( (ch = utf8_ildb(&utf8_str))>0 && ++len>0 )
+	if ( ch>=0x10000 )
 	    ++len;
-return( len );
+    return( len );
 }
 
 void utf8_strncpy(register char *to, const char *from, int len) {

--- a/inc/ustring.h
+++ b/inc/ustring.h
@@ -112,8 +112,8 @@ extern void utf8_truncatevalid(char *str);
 extern char *latin1_2_utf8_strcpy(char *utf8buf,const char *lbuf);
 extern char *latin1_2_utf8_copy(const char *lbuf);
 extern char *utf8_2_latin1_copy(const char *utf8buf);
-extern int utf8_strlen(const char *utf8_str); /* how many characters in the string */
-extern int utf82u_strlen(const char *utf8_str); /* how many long would this be in shorts (UCS2) */
+extern long utf8_strlen(const char *utf8_str);	 /* Count how many characters in the string NOT bytes */
+extern long utf82u_strlen(const char *utf8_str); /* Count how many shorts needed to represent in UCS2 */
 extern void utf8_strncpy(register char *to, const char *from, int len); /* copy n characters NOT bytes */
 extern char *def2utf8_copy(const char *from);
 extern char *utf82def_copy(const char *ufrom);


### PR DESCRIPTION
...n()

short is only {0..0xffff}. Unlikely to encounter large strings but if yes,
then count further, however stop counting if len overflows into -ve value.
