### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
   - ./autogen.sh
   - ./configure --prefix=/usr
   - make
+  - tests/link_test
   - sudo make install
   - fontforge -version
 branches:


### PR DESCRIPTION
Travis CI is a de facto service used by many repos on GitHub, one of the benefits is that we can easily track building (possible with different libraries, compilers) for each commit and even pull requests.

I implemented the configuration file `.travis.yml`, in the future we can add more rules if necessary:
- test with more compilers
- run `make test`

To activate the service, we should follow the steps on http://about.travis-ci.org/docs/user/getting-started/  which can only be done by the repo owner.

We can also embed a status icon in REAME: http://about.travis-ci.org/docs/user/status-images/
