### PR TITLE
Remove C99 style code so -std=c89 of clang works

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -8775,7 +8775,8 @@ void CVTransFunc(CharView *cv,real transform[6], enum fvtrans_flags flags)
 
 void CVTransFuncAllLayers(CharView *cv,real transform[6], enum fvtrans_flags flags)
 {
-    for( int idx = 0; idx < cv->b.sc->layer_cnt; ++idx )
+    int idx;
+    for( idx = 0; idx < cv->b.sc->layer_cnt; ++idx )
     {
 	Layer *ly = &cv->b.sc->layers[ idx ];
 	CVTransFuncLayer( cv, ly, transform, flags );

--- a/fontforge/metricsview.c
+++ b/fontforge/metricsview.c
@@ -1406,7 +1406,8 @@ return( false );
 			// still all fit as expected.
 			//
 			mv->perchar[i-1].kernafter = newkernafter;
-			for ( int j=i; j<mv->glyphcnt; ++j ) {
+			int j;
+			for ( j=i; j<mv->glyphcnt; ++j ) {
 			    mv->perchar[j].dx = mv->perchar[j-1].dx + mv->perchar[j-1].dwidth +
 				mv->perchar[j-1].kernafter;
 			}

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2765,7 +2765,7 @@ extern void SFD_GetFontMetaData( FILE *sfd,
 				 char *tok,
 				 SplineFont *sf,
 				 SFD_GetFontMetaDataData* d );
-typedef (*visitSFDFragmentFunc)( FILE *sfd, char *tokbuf, SplineFont *sf, void* udata );
+typedef void (*visitSFDFragmentFunc)( FILE *sfd, char *tokbuf, SplineFont *sf, void* udata );
 extern void visitSFDFragment( FILE *sfd, SplineFont *sf, visitSFDFragmentFunc ufunc, void* udata );
 extern char* DumpSplineFontMetadata( SplineFont *sf );
 


### PR DESCRIPTION
Patch to make clang scan-build run through as mentioned in issue #891.
