### PR TITLE
several errors created fixing other stuff, now corrected

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -14220,7 +14220,7 @@ return( NULL );
     for ( i=0 ; i<cnt1*cnt2; ++i ) {
 	offs[i] = PyInt_AsLong(PySequence_GetItem(offsets,i));
 	if ( PyErr_Occurred()) {
-	    free(offs); free(class2_strs); free(class2_strs);
+	    free(offs); free(class2_strs); free(class1_strs);
 return( NULL );
 	}
     }
@@ -18451,7 +18451,7 @@ void PyFF_Main(int argc,char **argv,int start) {
 #if !defined(__MINGW32__)
 //    signal( 15, HandleSigTerm );
 #endif
-    
+
     PyFF_ProcessInitFiles();
 
     /* Skip '-script' option */

--- a/fontforge/spiro.c
+++ b/fontforge/spiro.c
@@ -95,6 +95,7 @@ SplineSet *SpiroCP2SplineSet(spiro_cp *spiros) {
 	    spiro_cp *nspiros;
 	    if ( (nspiros=malloc((n+1)*sizeof(spiro_cp)))==NULL ) {
 		if ( lastty ) spiros[n-1].ty = lastty;
+		free(bc);
 		return( NULL );
 	    }
 	    memcpy(nspiros,spiros,(n+1)*sizeof(spiro_cp));
@@ -104,6 +105,7 @@ SplineSet *SpiroCP2SplineSet(spiro_cp *spiros) {
 	    if ( TaggedSpiroCPsToBezier0(nspiros,bc)==0 ) {
 		if ( lastty ) spiros[n-1].ty = lastty;
 		free(nspiros);
+		free(bc);
 		return( NULL );
 	    }
 #else

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1403,7 +1403,6 @@ static SplinePointList *SplinePointListCopySpiroSelected1(SplinePointList *spl) 
 	for ( j=i; j<spl->spiro_cnt-1 && SPIRO_SELECTED(&list[j]); ++j );
 	temp = galloc((j-i+2)*sizeof(spiro_cp));
 	memcpy(temp,list+i,(j-i)*sizeof(spiro_cp));
-	if ( freeme!=NULL ) free(list);
 	temp[0].ty = SPIRO_OPEN_CONTOUR;
 	memset(temp+(j-i),0,sizeof(spiro_cp));
 	temp[j-i].ty = SPIRO_END;

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -800,9 +800,8 @@ int GFileWriteAll(char *filepath, char *data) {
 
     if ( (fp = fopen( filepath, "wb" )) != NULL ) {
 	if ( (fwrite( data, 1, bwrite, fp ) == bwrite) && \
-	     (fflush(fp) == 0) && \
-	     (fclose(fp) == 0) )
-	    return 0;
+	     (fflush(fp) == 0) )
+	    return( (fclose(fp) == 0 ? 0: -1) );
 	fclose(fp);
     }
     return -1;


### PR DESCRIPTION
As the saying goes "old bugs out, new bugs in" fixed these accidental errs
python.c = typo while copying from working copy to local git master copy.
spiro.c = resource leaks - release mem if error happens, forgot bc too.
splineutil.c = entire routine needs a good look, remove this quick fix.
fsys.c = subtle bug if fclose()!=0 means you try to fclose() twice!
