### PR TITLE
multichar: stop crashes when clicking around bearing lines, and also

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -4410,7 +4410,7 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
 	}
     }
     
-    
+    cv->changedActiveGlyph = 1;
     printf("CVSwitchActiveSC(b) activeidx:%d newidx:%d\n", cv->additionalCharsToShowActiveIndex, idx );
     for( i=0; i < additionalCharsToShowLimit; i++ )
 	if( cv->additionalCharsToShow[i] )
@@ -4584,6 +4584,7 @@ return;
 	    fsadjusted.xh += 2*fsadjusted.fudge;
 	    SplineChar* xc = 0;
 	    int xcidx = -1;
+	    int borderFudge = 20;
 	    
 	    {
 		int offset = cv->b.sc->width;
@@ -4597,6 +4598,12 @@ return;
 		    xc = cv->additionalCharsToShow[i];
 		    if( !xc )
 			break;
+		    int OffsetForDoingCharNextToActive = 0;
+		    if( i == ridx )
+		    {
+			OffsetForDoingCharNextToActive = borderFudge;
+		    }
+		    
 
 		    cumulativeLeftSideBearing += offset;
 		    /* printf("1 adj. x:%f %f\n",fsadjusted.xl,fsadjusted.xh); */
@@ -4615,9 +4622,10 @@ return;
 		    printf("A:%d\n", cumulativeLeftSideBearing );
 		    printf("B:%f\n", fsadjusted.p->cx );
 		    printf("C:%d\n", cumulativeLeftSideBearing+xc->width );
-		    int found = IS_IN_ORDER3( cumulativeLeftSideBearing,
-					      fsadjusted.p->cx,
-					      cumulativeLeftSideBearing+xc->width );
+		    int found = IS_IN_ORDER3(
+			cumulativeLeftSideBearing + OffsetForDoingCharNextToActive,
+			fsadjusted.p->cx,
+			cumulativeLeftSideBearing+xc->width );
 		    printf("CVMOUSEDOWN i:%d found:%d\n", i, found );
 		    if( found )
 		    {
@@ -4653,6 +4661,11 @@ return;
 		    if( !xc )
 			break;
 		    cumulativeLeftSideBearing -= xc->width;
+		    int OffsetForDoingCharNextToActive = 0;
+		    if( i == lidx )
+		    {
+			OffsetForDoingCharNextToActive = borderFudge;
+		    }
 
 		    /* printf("1 adj. x:%f %f\n",fsadjusted.xl,fsadjusted.xh); */
 		    /* printf("1 adj.cx:%f %f\n",fsadjusted.c_xl,fsadjusted.c_xh); */
@@ -4670,9 +4683,10 @@ return;
 		    printf("A:%d\n", cumulativeLeftSideBearing );
 		    printf("B:%f\n", fsadjusted.p->cx );
 		    printf("C:%d\n", cumulativeLeftSideBearing+xc->width );
-		    int found = IS_IN_ORDER3( cumulativeLeftSideBearing,
-					      fsadjusted.p->cx,
-					      cumulativeLeftSideBearing+xc->width );
+		    int found = IS_IN_ORDER3(
+			cumulativeLeftSideBearing,
+			fsadjusted.p->cx,
+			cumulativeLeftSideBearing + xc->width - OffsetForDoingCharNextToActive );
 		    
 		    printf("cvmousedown i:%d found:%d\n", i, found );
 		    if( found )

--- a/fontforge/cvpointer.c
+++ b/fontforge/cvpointer.c
@@ -1441,7 +1441,12 @@ return( false );
     /*  done by move selection */
     if ( cv->expandedge!=ee_none && !cv->widthsel && !cv->vwidthsel && !cv->lbearingsel
 	 && cv->nearcaret==-1 && !cv->icsel && !cv->tah_sel )
-	needsupdate = CVExpandEdge(cv);
+    {
+	if( !cv->changedActiveGlyph )
+	{
+	    needsupdate = CVExpandEdge(cv);
+	}
+    }
     else if ( cv->nearcaret!=-1 && cv->lcarets!=NULL ) {
 	if ( cv->info.x!=cv->last_c.x ) {
 	    if ( !cv->recentchange ) SCPreserveLayer(cv->b.sc,CVLayer((CharViewBase *) cv),2);
@@ -1601,17 +1606,24 @@ void CVMouseUpPointer(CharView *cv ) {
 	cv->lcarets = NULL;
 	GDrawSetCursor(cv->v,ct_mypointer);
     }
-    if ( cv->expandedge!=ee_none )
+    if( cv->changedActiveGlyph )
     {
-	CVUndoCleanup(cv);
-	cv->expandedge = ee_none;
-	GDrawSetCursor(cv->v,ct_mypointer);
+	cv->changedActiveGlyph = 0;
     }
-    else if ( CVAllSelected(cv) && cv->b.drawmode==dm_fore && cv->p.spline==NULL
-	      && !cv->p.prevcp && !cv->p.nextcp && cv->info.y==cv->p.cy )
+    else
     {
-	SCUndoSetLBearingChange(cv->b.sc,(int) rint(cv->info.x-cv->p.cx));
-	SCSynchronizeLBearing(cv->b.sc,cv->info.x-cv->p.cx,CVLayer((CharViewBase *) cv));
+	if ( cv->expandedge!=ee_none )
+	{
+	    CVUndoCleanup(cv);
+	    cv->expandedge = ee_none;
+	    GDrawSetCursor(cv->v,ct_mypointer);
+	}
+	else if ( CVAllSelected(cv) && cv->b.drawmode==dm_fore && cv->p.spline==NULL
+		  && !cv->p.prevcp && !cv->p.nextcp && cv->info.y==cv->p.cy )
+	{
+	    SCUndoSetLBearingChange(cv->b.sc,(int) rint(cv->info.x-cv->p.cx));
+	    SCSynchronizeLBearing(cv->b.sc,cv->info.x-cv->p.cx,CVLayer((CharViewBase *) cv));
+	}
     }
     CPEndInfo(cv);
 }

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -201,6 +201,7 @@ typedef struct charview {
     unsigned int inDraggingComparisonOutline: 1;
     unsigned int activeModifierControl: 1; //< Is control being held right now?
     unsigned int activeModifierAlt: 1;     //< Is alt being held right now?
+    unsigned int changedActiveGlyph: 1;    //< Set in CVSwitchActiveSC() cleared in cvmouseup()
     
     int hvoffset;		/* for showalmosthvlines */
     int layers_off_top;


### PR DESCRIPTION
add a fudge near them so that you don't switch chars by for example
clicking on the right side bearing line + 1 pixel.
