### PR TITLE
multichar: only skip unqualified hotkeys on the input text box now. So

### DIFF
--- a/fontforge/charview.c
+++ b/fontforge/charview.c
@@ -7452,22 +7452,6 @@ return;
     {
 	/* All Done */;
     }
-    else if( cv->activeModifierControl
-	&& event->u.chr.keysym == ',' || event->u.chr.keysym == '.' )
-    {
-	GGadget *active = GWindowGetFocusGadgetOfWindow(cv->gw);
-	if( active == cv->charselector )
-	{
-	    if( event->u.chr.keysym == ',' )
-	    {
-		CVMoveInWordListByOffset( cv, -1 );
-	    }
-	    else if( event->u.chr.keysym == '.' )
-	    {
-		CVMoveInWordListByOffset( cv, 1 );
-	    }
-	}
-    }
     else if ( event->u.chr.keysym=='s' &&
 	    (event->u.chr.state&ksm_control) &&
 	    (event->u.chr.state&ksm_meta) )
@@ -12449,7 +12433,7 @@ CharView *CharViewCreateExtended(SplineChar *sc, FontView *fv,int enc, int show 
     gd.u.list = cv_charselector_init;
     cv->charselector = GListFieldCreate(cv->gw,&gd,cv);
     CVSetCharSelectorValueFromSC( cv, sc );
-    GGadgetSetSkipHotkeyProcessing( cv->charselector, 1 );
+    GGadgetSetSkipUnQualifiedHotkeyProcessing( cv->charselector, 1 );
 
     memset(aspects,0,sizeof(aspects));
     aspects[0].text = (unichar_t *) sc->name;

--- a/gdraw/ggadgetP.h
+++ b/gdraw/ggadgetP.h
@@ -99,6 +99,7 @@ struct ggadget {
     unsigned int prevlabel: 1;			/* For groupboxes */
     unsigned int contained: 1;			/* is part of a bigger ggadget (ie. a scrollbar is part of a listbox) */
     unsigned int gg_skip_hotkey_processing: 1;
+    unsigned int gg_skip_unqualified_hotkey_processing: 1;
     short cid;
     void *data;
     GBox *box;

--- a/gdraw/ggadgets.c
+++ b/gdraw/ggadgets.c
@@ -1463,3 +1463,18 @@ int GGadgetGetSkipHotkeyProcessing( GGadget *g )
     return (g->gg_skip_hotkey_processing);
 }
 
+void GGadgetSetSkipUnQualifiedHotkeyProcessing( GGadget *g, int v )
+{
+    if( !g )
+	return;
+    g->gg_skip_unqualified_hotkey_processing = v;
+}
+
+int GGadgetGetSkipUnQualifiedHotkeyProcessing( GGadget *g )
+{
+    if( !g )
+	return 0;
+
+    return (g->gg_skip_unqualified_hotkey_processing);
+}
+

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -2068,6 +2068,7 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 
 //    printf("GMenuBarCheckKey(top) keysym:%d upper:%d lower:%d\n",keysym,toupper(keysym),tolower(keysym));
 
+    int SkipUnQualifiedHotkeyProcessing = 0;
     // see if we should skip processing
     if( g )
     {
@@ -2075,6 +2076,7 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 	GGadget* focus = GWindowGetFocusGadgetOfWindow(w);
 	if( GGadgetGetSkipHotkeyProcessing(focus))
 	    return 0;
+	SkipUnQualifiedHotkeyProcessing = GGadgetGetSkipUnQualifiedHotkeyProcessing(focus);
     }
     
 
@@ -2169,6 +2171,13 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
     printf("     has ksm_control:%d\n", (event->u.chr.state & ksm_control ));
     printf("     has ksm_meta:%d\n",    (event->u.chr.state & ksm_meta ));
     printf("     has ksm_shift:%d\n",   (event->u.chr.state & ksm_shift ));
+
+    if( SkipUnQualifiedHotkeyProcessing && !event->u.chr.state )
+    {
+	printf("skipping unqualified hotkey for widget g:%p\n", g);
+	return 0;
+    }
+    
     
     struct dlistnodeExternal* node= hotkeyFindAllByEvent( top, event );
     struct dlistnode* hklist = (struct dlistnode*)node;

--- a/inc/ggadget.h
+++ b/inc/ggadget.h
@@ -629,5 +629,7 @@ extern void GVisibilityBoxSetToMinWH(GGadget *g);
 
 extern void GGadgetSetSkipHotkeyProcessing( GGadget *g, int v );
 extern int GGadgetGetSkipHotkeyProcessing( GGadget *g );
+extern void GGadgetSetSkipUnQualifiedHotkeyProcessing( GGadget *g, int v );
+extern int GGadgetGetSkipUnQualifiedHotkeyProcessing( GGadget *g );
 
 #endif


### PR DESCRIPTION
the user can freely set next line in wordlist to anything (as long as it
has at least one qualifier like control) and that will work within and without
of the text input box.

Kept the full hotkey clobber for widget feature for something else in the future.
