### PR TITLE
Implement initial support for XDG [1]

### DIFF
--- a/fontforge/autosave.c
+++ b/fontforge/autosave.c
@@ -82,7 +82,7 @@ return( editdir );
 }
 
 static char *getAutoDirName(char *buffer) {
-    char *dir=getPfaEditDir(buffer);
+    char *dir=getFontForgeUserDir(Config);
 
     if ( dir==NULL )
 return( NULL );

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -481,9 +481,9 @@ static char *getPfaEditEncodings(void) {
 
     if ( encfile!=NULL )
 return( encfile );
-    if ( getPfaEditDir(buffer)==NULL )
+    if ( getFontForgeUserDir(Config)==NULL )
 return( NULL );
-    sprintf(buffer,"%s/Encodings.ps", getPfaEditDir(buffer));
+    sprintf(buffer,"%s/Encodings.ps", getFontForgeUserDir(Config));
     encfile = copy(buffer);
 return( encfile );
 }

--- a/fontforge/fontforgevw.h
+++ b/fontforge/fontforgevw.h
@@ -28,6 +28,7 @@
 #define _FONTFORGEVW_H_
 
 #include "fontforge.h"
+#include "gfile.h"
 #include "gimage.h"
 #include "baseviews.h"
 

--- a/fontforge/fontview.c
+++ b/fontforge/fontview.c
@@ -4947,7 +4947,7 @@ static void FVMenuMakeNamelist(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent 
     char *filename, *temp;
     FILE *file;
 
-    snprintf(buffer, sizeof(buffer),"%s/%s.nam", getPfaEditDir(buffer), fv->b.sf->fontname );
+    snprintf(buffer, sizeof(buffer),"%s/%s.nam", getFontForgeUserDir(Config), fv->b.sf->fontname );
     temp = def2utf8_copy(buffer);
     filename = gwwv_save_filename(_("Make Namelist"), temp,"*.nam");
     free(temp);
@@ -4986,7 +4986,7 @@ return;				/* Cancelled */
 	pt = temp;
     else
 	++pt;
-    snprintf(buffer,sizeof(buffer),"%s/%s", getPfaEditDir(buffer), pt);
+    snprintf(buffer,sizeof(buffer),"%s/%s", getFontForgeUserDir(Config), pt);
     if ( access(buffer,F_OK)==0 ) {
 	buts[0] = _("_Replace");
 	buts[1] = _("_Cancel");

--- a/fontforge/groups.c
+++ b/fontforge/groups.c
@@ -76,9 +76,9 @@ static char *getPfaEditGroups(void) {
 
     if ( groupname!=NULL )
 return( groupname );
-    if ( getPfaEditDir(buffer)==NULL )
+    if ( getFontForgeUserDir(Config)==NULL )
 return( NULL );
-    sprintf(buffer,"%s/groups", getPfaEditDir(buffer));
+    sprintf(buffer,"%s/groups", getFontForgeUserDir(Config));
     groupname = copy(buffer);
 return( groupname );
 }

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -680,13 +680,12 @@ return( false );
 }
 
 void LoadNamelistDir(char *dir) {
-    char prefdir[1024];
     DIR *diro;
     struct dirent *ent;
     char buffer[1025];
 
     if ( dir == NULL )
-	dir = getPfaEditDir(prefdir);
+	dir = getFontForgeUserDir(Config);
     if ( dir == NULL )
 return;
 

--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -440,9 +440,9 @@ static char *getPfaEditPrefs(void) {
 
     if ( prefs!=NULL )
 return( prefs );
-    if ( getPfaEditDir(buffer)==NULL )
+    if ( getFontForgeUserDir(Config)==NULL )
 return( NULL );
-    sprintf(buffer,"%s/prefs", getPfaEditDir(buffer));
+    sprintf(buffer,"%s/prefs", getFontForgeUserDir(Config));
     prefs = copy(buffer);
 return( prefs );
 }

--- a/fontforge/oflib.c
+++ b/fontforge/oflib.c
@@ -544,9 +544,9 @@ static char *getOFLibDir(void) {
 
     if ( oflibdir!=NULL )
 return( oflibdir );
-    if ( getPfaEditDir(buffer)==NULL )
+    if ( getFontForgeUserDir(Config)==NULL )
 return( NULL );
-    sprintf(buffer,"%s/OFLib", getPfaEditDir(buffer));
+    sprintf(buffer,"%s/OFLib", getFontForgeUserDir(Config));
     if ( access(buffer,F_OK)==-1 )
 	if ( GFileMkDir(buffer)==-1 )
 return( NULL );

--- a/fontforge/prefs.c
+++ b/fontforge/prefs.c
@@ -781,9 +781,9 @@ static char *getPfaEditPrefs(void) {
 
     if ( prefs!=NULL )
 return( prefs );
-    if ( getPfaEditDir(buffer)==NULL )
+    if ( getFontForgeUserDir(Config)==NULL )
 return( NULL );
-    sprintf(buffer,"%s/prefs", getPfaEditDir(buffer));
+    sprintf(buffer,"%s/prefs", getFontForgeUserDir(Config));
     prefs = copy(buffer);
 return( prefs );
 }
@@ -2651,7 +2651,7 @@ void RecentFilesRemember(char *filename) {
 void LastFonts_Save(void) {
     FontView *fv, *next;
     char buffer[1024];
-    char *ffdir = getPfaEditDir(buffer);
+    char *ffdir = getFontForgeUserDir(Config);
     FILE *preserve = NULL;
 
     if ( ffdir ) {

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18711,7 +18711,7 @@ static struct string_list *default_pyinit_dirs(void) {
     snprintf(subdir, sizeof(subdir), "python%d", PY_MAJOR_VERSION);
 
     sharedir = getFontForgeShareDir();
-    userdir = getPfaEditDir(buffer);
+    userdir = getFontForgeUserDir(Config);
 
     if ( sharedir!=NULL ) {
 	snprintf(buffer,sizeof(buffer),"%s/%s",sharedir,subdir);

--- a/fontforge/start.c
+++ b/fontforge/start.c
@@ -85,8 +85,8 @@ static void initlibltdl(void) {
 
     if (!plugins_are_initialized()) {
         init_plugins();
-        if (getPfaEditDir(buffer)!=NULL ) {
-            strcpy(buffer,getPfaEditDir(buffer));
+        if (getFontForgeUserDir(Config)!=NULL ) {
+            strcpy(buffer,getFontForgeUserDir(Config));
             strcat(buffer,"/plugins");
             lt_dladdsearchdir(strdup(buffer));
         }

--- a/fontforge/startui.c
+++ b/fontforge/startui.c
@@ -657,7 +657,7 @@ static void  AddR(char *program_name, char *window_name, char *cmndline_val) {
 
 static int ReopenLastFonts(void) {
     char buffer[1024];
-    char *ffdir = getPfaEditDir(buffer);
+    char *ffdir = getFontForgeUserDir(Config);
     FILE *old;
     int any = 0;
 
@@ -777,12 +777,12 @@ static void ffensuredir( const char* basedir, const char* dirname, mode_t mode )
 }
 
 static void ensureDotFontForgeIsSetup() {
-    char *basedir = GFileGetHomeDir();
+    char *basedir = getFontForgeUserDir(Config);
     if ( !basedir ) {
 	return;
     }
-    ffensuredir( basedir, ".FontForge",        S_IRWXU );
-    ffensuredir( basedir, ".FontForge/python", S_IRWXU );
+    ffensuredir( basedir, "",       S_IRWXU );
+    ffensuredir( basedir, "python", S_IRWXU );
 }
 
 static void DoAutoRecoveryPostRecover_PromptUserGraphically(SplineFont *sf)

--- a/gdraw/hotkeys.c
+++ b/gdraw/hotkeys.c
@@ -41,8 +41,6 @@
 
 static int hotkeySystemCanUseMacCommand = 0;
 
-extern char *getPfaEditDir(char *buffer);
-
 struct dlistnode* hotkeys = 0;
 
 static char* hotkeyGetWindowTypeString( Hotkey* hk ) 
@@ -159,14 +157,14 @@ static char *getHotkeyFilename( char* extension ) {
     char *ret=NULL;
     char buffer[1025];
 
-    if ( getPfaEditDir(buffer)==NULL ) {
+    if ( getFontForgeUserDir(Config)==NULL ) {
 	fprintf(stderr,_("Can not work out where your hotkey definition file is!\n"));
 	return( NULL );
     }
     if( !extension )
 	extension = "";
     
-    sprintf(buffer,"%s/hotkeys%s", getPfaEditDir(buffer), extension);
+    sprintf(buffer,"%s/hotkeys%s", getFontForgeUserDir(Config), extension);
     ret = copy(buffer);
     return( ret );
 }

--- a/gtkui/fontview.c
+++ b/gtkui/fontview.c
@@ -2944,7 +2944,7 @@ void FontViewMenu_SaveNamelist(GtkMenuItem *menuitem, gpointer user_data) {
     SplineChar *sc;
     int i;
 
-    snprintf(buffer, sizeof(buffer),"%s/%s.nam", getPfaEditDir(buffer), fv->b.sf->fontname );
+    snprintf(buffer, sizeof(buffer),"%s/%s.nam", getFontForgeUserDir(Config), fv->b.sf->fontname );
     temp = g_filename_to_utf8(buffer,-1,&read,&written,NULL);
     filename = gwwv_saveas_filename(_("Save Namelist of font"), temp,"*.nam");
     free(temp);
@@ -2988,7 +2988,7 @@ return;				/* Cancelled */
 	pt = temp;
     else
 	++pt;
-    snprintf(buffer,sizeof(buffer),"%s/%s", getPfaEditDir(buffer), pt);
+    snprintf(buffer,sizeof(buffer),"%s/%s", getFontForgeUserDir(Config), pt);
     if ( access(buffer,F_OK)==0 ) {
 	buts[0] = _("_Replace");
 	buts[1] = GTK_STOCK_CANCEL;

--- a/gtkui/prefs.c
+++ b/gtkui/prefs.c
@@ -526,9 +526,9 @@ static char *getPfaEditPrefs(void) {
 
     if ( prefs!=NULL )
 return( prefs );
-    if ( getPfaEditDir(buffer)==NULL )
+    if ( getFontForgeUserDir(Config)==NULL )
 return( NULL );
-    sprintf(buffer,"%s/prefs", getPfaEditDir(buffer));
+    sprintf(buffer,"%s/prefs", getFontForgeUserDir(Config));
     prefs = copy(buffer);
 return( prefs );
 }

--- a/inc/gfile.h
+++ b/inc/gfile.h
@@ -27,6 +27,11 @@
 #ifndef _GFILE_H
 #define _GFILE_H
 
+/* home directories for fontforge */
+enum { Cache, Config, Data };
+
+char *smprintf(char *fmt, ...);
+
 extern char* GFileGetHomeDir(void);
 extern unichar_t* u_GFileGetHomeDir(void);
 
@@ -74,6 +79,8 @@ extern char *getLocaleDir(void);
 extern char *getPixmapDir(void);
 extern char *getHelpDir(void);
 extern char *getDotFontForgeDir(void);
+extern char *getUserHomeDir(void);
+extern char *getFontForgeUserDir(int dir);
 extern char *getTempDir(void);
 
 /**


### PR DESCRIPTION
I only used `Config` as I do not know what everything that calls PfaEditDir actually is, so I did not try to decide where each file belongs.  I replaced the HomeDir function and avoided using existing GFile functions, as they use `copy()` which leaks.

Also, the files will not be created if `XDG_CONFIG_HOME` or `~/.config` does not exist.  Something in `ffensuredir` would fix that.  Finally, because I have replaced getPfaEditDir completely, consideration for the `VMS` flag and renaming of `~/.PfaEdit` is gone.
#847
