### PR TITLE
Make compilable on Cygwin

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -646,7 +646,7 @@ int _FVMenuSaveAs(FontView *fv) {
 	FilenameFunc = GFileChooserSaveAsInputFilenameFunc;
     }
 
-#if defined(__MINGW32__)||defined(__CYGWIN__)
+#if defined(__MINGW32__)
     //
     // If they are "saving as" but there is no path, lets help
     // the poor user by starting someplace sane rather than in `pwd`
@@ -1024,7 +1024,7 @@ void MenuOpen(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e))
     FontView *test; int fvcnt, fvtest;
 
     char* OpenDir = NULL;
-#if defined(__MINGW32__)||defined(__CYGWIN__)
+#if defined(__MINGW32__)
     FontView *fv = (FontView *) GDrawGetUserData(gw);
     OpenDir = GFileGetHomeDocumentsDir();
     if( fv && fv->b.sf && fv->b.sf->filename )


### PR DESCRIPTION
Once patched for Cygwin, but the recent commit d27b15a2cafda33b4c7f4133828e1b743d2fbeeb doesn't compile.

This patch fixes this regression.

Note: On Cygwin, unlike MinGW, POSIX API is preferred to that of Windows.
