### PR TITLE
Library version values upgraded accordingly (2.0 or higher)

### DIFF
--- a/Unicode/Makefile.am
+++ b/Unicode/Makefile.am
@@ -27,16 +27,14 @@
 
 lib_LTLIBRARIES = libgunicode.la
 
-libgunicode_la_SOURCES = ArabicForms.c alphabet.c backtrns.c char.c		\
-	 cjk.c memory.c ucharmap.c unialt.c ustring.c utype.c usprintf.c	\
-	 gwwiconv.c combiners.h
+libgunicode_la_SOURCES = ArabicForms.c alphabet.c backtrns.c char.c	\
+	cjk.c memory.c ucharmap.c unialt.c ustring.c utype.c		\
+	usprintf.c gwwiconv.c combiners.h
 
 libgunicode_la_CPPFLAGS = "-I$(top_builddir)/inc"	\
 	"-I$(top_srcdir)/inc" $(MY_CFLAGS)
 
-# Using -release instead of -version-info seems appropriate in the
-# absence of a well defined ABI.
-libgunicode_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
-libgunicode_la_LIBADD = $(MY_LIBS) 
+libgunicode_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGUNICODE_VERSION)
+libgunicode_la_LIBADD = $(MY_LIBS)
 
 -include $(top_srcdir)/git.mk

--- a/collab/Makefile.am
+++ b/collab/Makefile.am
@@ -36,7 +36,7 @@ libzmqcollab_la_CPPFLAGS = \
  $(MY_CFLAGS) $(LIBZMQ_CFLAGS) $(GLIB_CFLAGS)
 
 libzmqcollab_la_LIBADD = $(MY_LIBS) $(GLIB_LIBS) $(LIBZMQ_LIBS)
-libzmqcollab_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
+libzmqcollab_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBZMQCOLLAB_VERSION)
 
 #--------------------------------------------------------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,16 +53,28 @@ m4_define([libfontforge_major_version], '2') dnl 20120731-b was 1.0
 m4_define([libfontforge_minor_version], '0')
 m4_define([libgdraw_major_version], '5') dnl 20120731-b was 4.10
 m4_define([libgdraw_minor_version], '0')
+m4_define([libgioftp_major_version], '2') dnl 20120731-b was 1.0
+m4_define([libgioftp_minor_version], '0')
+m4_define([libgunicode_major_version], '4') dnl 20120731-b was 3.2
+m4_define([libgunicode_minor_version], '0')
 m4_define([libgutils_major_version], '2') dnl 20120731-b was 1.3
 m4_define([libgutils_minor_version], '0')
-m4_define([libunicode_major_version], '4') dnl 20120731-b was 3.2
-m4_define([libunicode_minor_version], '0')
+m4_define([libzmqcollab_major_version], '2') dnl n/a
+m4_define([libzmqcollab_minor_version], '0')
 
+#--------------------------------------------------------------------------
+# Setup variables before running AC_INIT()
 m4_define([fontforge_version],
           [fontforge_major_version.fontforge_minor_version.fontforge_package_stamp])
 #m4_define([fontforge_info],
 #          [fontforge_major_version:fontforge_minor_version:0])
 #m4_define([fontforge_package_name], ["fontforge"])
+m4_define([libfontforge_info],[libfontforge_major_version:libfontforge_minor_version:0])
+m4_define([libgdraw_info],[libgdraw_major_version:libgdraw_minor_version:0])
+m4_define([libgioftp_info],[libgioftp_major_version:libgioftp_minor_version:0])
+m4_define([libgunicode_info],[libgunicode_major_version:libgunicode_minor_version:0])
+m4_define([libgutils_info],[libgutils_major_version:libgutils_minor_version:0])
+m4_define([libzmqcollab_info],[libzmqcollab_major_version:libzmqcollab_minor_version:0])
 
 #--------------------------------------------------------------------------
 AC_INIT([fontforge],[2.0.0_beta1],[fontforge-devel@lists.sourceforge.net])
@@ -110,6 +122,14 @@ AC_SUBST([VERSION_MAJOR])
 AC_SUBST([VERSION_MINOR])
 AC_SUBST([VERSION_PATCH])
 
+#--------------------------------------------------------------------------
+# Pass library version variables to several MAKEFILE.AM
+AC_SUBST([LIBFONTFORGE_VERSION],[$libfontforge_info])
+AC_SUBST([LIBGDRAW_VERSION],[$libgdraw_info])
+AC_SUBST([LIBGIOFTP_VERSION],[$libgioftp_info])
+AC_SUBST([LIBGUNICODE_VERSION],[$libgunicode_info])
+AC_SUBST([LIBGUTILS_VERSION],[$libgutils_info])
+AC_SUBST([LIBZMQCOLLAB_VERSION],[$libzmqcollab_info])
 #--------------------------------------------------------------------------
 #
 # URLs for dependencies.

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -90,25 +90,26 @@ AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 
 #--------------------------------------------------------------------------
 
-libfontforge_la_SOURCES = asmfpst.c autohint.c autosave.c autotrace.c	\
-	autowidth.c bezctx_ff.c bitmapchar.c bitmapcontrol.c bvedit.c		\
-	clipnoui.c crctab.c cvexport.c cvimages.c cvundoes.c dumpbdf.c		\
-	dumppfa.c effects.c encoding.c featurefile.c fontviewbase.c			\
-	freetype.c fvcomposite.c fvfonts.c fvimportbdf.c fvmetrics.c		\
-	glyphcomp.c http.c ikarus.c lookups.c macbinary.c macenc.c			\
-	mathconstants.c mm.c namelist.c nonlineartrans.c noprefs.c			\
-	nouiutil.c nowakowskittfinstr.c ofl.c othersubrs.c palmfonts.c		\
-	parsepdf.c parsepfa.c parsettfatt.c parsettfbmf.c parsettf.c		\
-	parsettfvar.c plugins.c print.c psread.c pua.c python.c				\
-	savefont.c scripting.c scstyles.c search.c sfd1.c sfd.c				\
-	sflayout.c spiro.c splinechar.c splinefill.c splinefont.c			\
-	splineorder2.c splineoverlap.c splinesaveafm.c splinesave.c			\
-	splinestroke.c splineutil2.c splineutil.c start.c stemdb.c svg.c	\
-	tottfaat.c tottfgpos.c tottf.c tottfvar.c ttfinstrs.c				\
-	ttfspecial.c ufo.c unicoderange.c utils.c winfonts.c zapfnomen.c	\
-	groups.c langfreq.c ftdelta.c autowidth2.c woff.c stamp.c			\
-	activeinui.c pluginloading.c is_LIGATURE.c flaglist.c strlist.c \
-    sfundo.h collabclient.c collabclient.h collabclientpriv.h
+libfontforge_la_SOURCES = activeinui.c asmfpst.c autohint.c autosave.c	\
+	autotrace.c autowidth.c autowidth2.c bezctx_ff.c bitmapchar.c	\
+	bitmapcontrol.c bvedit.c collabclient.c collabclient.h		\
+	collabclientpriv.h clipnoui.c crctab.c cvexport.c cvimages.c	\
+	cvundoes.c dumpbdf.c dumppfa.c effects.c encoding.c		\
+	featurefile.c flaglist.c fontviewbase.c freetype.c		\
+	fvcomposite.c fvfonts.c fvimportbdf.c fvmetrics.c ftdelta.c	\
+	glyphcomp.c groups.c http.c ikarus.c is_LIGATURE.c langfreq.c	\
+	lookups.c macbinary.c macenc.c mathconstants.c mm.c namelist.c	\
+	nonlineartrans.c noprefs.c nouiutil.c nowakowskittfinstr.c	\
+	ofl.c othersubrs.c palmfonts.c parsepdf.c parsepfa.c		\
+	parsettfatt.c parsettfbmf.c parsettf.c parsettfvar.c plugins.c	\
+	pluginloading.c print.c psread.c pua.c python.c savefont.c	\
+	scripting.c scstyles.c search.c sfd1.c sfd.c sflayout.c		\
+	sfundo.h spiro.c splinechar.c splinefill.c splinefont.c		\
+	splineorder2.c splineoverlap.c splinesaveafm.c splinesave.c	\
+	splinestroke.c splineutil2.c splineutil.c stamp.c start.c	\
+	stemdb.c strlist.c svg.c tottfaat.c tottfgpos.c tottf.c		\
+	tottfvar.c ttfinstrs.c ttfspecial.c ufo.c unicoderange.c	\
+	utils.c winfonts.c woff.c zapfnomen.c
 
 nodist_libfontforge_la_SOURCES = libstamp.c
 EXTRA_libfontforge_la_SOURCES = splinerefigure.c
@@ -124,54 +125,8 @@ if LIBZMQ
 libfontforge_la_LIBADD += $(top_builddir)/collab/libzmqcollab.la $(LIBZMQ_LIBS)
 endif LIBZMQ
 
-# Using -release instead of -version-info seems appropriate in the
-# absence of a well defined ABI.
-libfontforge_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
+libfontforge_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGE_VERSION)
 libfontforge_la_LIBADD += $(MY_LIBS) $(LIBZMQ_LIBS)
-
-if GRAPHICAL_USER_INTERFACE
-
-libfontforgeexe_la_SOURCES = alignment.c anchorsaway.c   \
-	autowidth2dlg.c basedlg.c bdfinfo.c bitmapdlg.c bitmapview.c	\
-	charinfo.c charview.c clipui.c combinations.c contextchain.c	\
-	cursors.c cvaddpoints.c cvdebug.c cvdgloss.c cvexportdlg.c		\
-	cvfreehand.c cvgetinfo.c cvgridfit.c cvhand.c cvhints.c			\
-	cvimportdlg.c cvknife.c cvpalettes.c cvpointer.c cvruler.c 		\
-	cvshapes.c cvstroke.c cvtranstools.c displayfonts.c effectsui.c	\
-	encodingui.c fontinfo.c fontview.c freetypeui.c fvfontsdlg.c	\
-	fvmetricsdlg.c gotodlg.c groupsdlg.c histograms.c images.c		\
-	kernclass.c layer2layer.c lookupui.c macencui.c math.c			\
-	metricsview.c mmdlg.c nonlineartransui.c oflib.c openfontdlg.c	        \
-	prefs.c problems.c pythonui.c savefontdlg.c scriptingdlg.c		\
-	scstylesui.c searchview.c sftextfield.c showatt.c simplifydlg.c	        \
-	splashimage.c startui.c statemachine.c tilepath.c transform.c	        \
-	ttfinstrsui.c uiutil.c windowmenu.c justifydlg.c deltaui.c		\
-	usermenu.c collabclientui.c collabclientui.h                    \
-	sfundo.c wordlistparser.c wordlistparser.h
-
-else !GRAPHICAL_USER_INTERFACE
-
-libfontforgeexe_la_SOURCES = startnoui.c
-
-endif !GRAPHICAL_USER_INTERFACE
-
-nodist_libfontforgeexe_la_SOURCES = exelibstamp.c
-
-if MACINTOSH
-libfontforgeexe_la_SOURCES += macobjective.h
-MACFFEXE_LIBADD=macobjective.o
-endif MACINTOSH
-
-libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZMQ_CFLAGS)
-libfontforgeexe_la_LIBADD = libfontforge.la $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD)
-
-# Using -release instead of -version-info seems appropriate in the
-# absence of a well defined ABI.
-libfontforgeexe_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
-libfontforgeexe_la_LIBADD += $(MY_LIBS) $(LIBZMQ_LIBS) 
-if LIBZMQ
-libfontforgeexe_la_LIBADD += $(top_srcdir)/collab/libzmqcollab.la
-endif
 
 #--------------------------------------------------------------------------
 

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -145,21 +145,21 @@ MACFFEXE_LIBADD=macobjective.o
 endif MACINTOSH
 
 libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZMQ_CFLAGS)
-libfontforgeexe_la_LIBADD = $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD) $(MY_LIBS) 
+libfontforgeexe_la_LIBADD = $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD) $(MY_LIBS)
 
 # Using -release instead of -version-info seems appropriate in the
 # absence of a well defined ABI.
 libfontforgeexe_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
 if LIBZMQ
-libfontforgeexe_la_LIBADD += $(top_builddir)/collab/libzmqcollab.la $(LIBZMQ_LIBS) 
+libfontforgeexe_la_LIBADD += $(top_builddir)/collab/libzmqcollab.la $(LIBZMQ_LIBS)
 endif
 
 #--------------------------------------------------------------------------
 
 EXTRA_DIST = fontimage.pe fontlint.pe sfddiff.pe \
-	exelibstamp.pre fontimage.1 fontlint.1 sfddiff.1			\
+	exelibstamp.pre fontimage.1 fontlint.1 sfddiff.1		\
 	darwinsetup.in macobjective.m
-# MacFontForgeApp.zip 
+# MacFontForgeApp.zip
 MOSTLYCLEANFILES = fontimage fontlint sfddiff exelibstamp.c
 
 #--------------------------------------------------------------------------

--- a/gdraw/Makefile.am
+++ b/gdraw/Makefile.am
@@ -29,21 +29,21 @@ include $(top_srcdir)/mk/layout.am
 
 lib_LTLIBRARIES = libgdraw.la
 
-libgdraw_la_SOURCES = choosericons.c ctlvalues.c drawboxborder.c		\
-	gaskdlg.c gbuttons.c gcolor.c gchardlg.c gcontainer.c gdraw.c		\
-	gdrawbuildchars.c gdrawerror.c gdrawtxt.c gdrawtxtinit.c			\
-	gfilechooser.c gfiledlg.c ggadgets.c ggroupbox.c gimageclut.c		\
-	gimagecvt.c gimagepsdraw.c gimagewriteeps.c gdrawgimage.c			\
-	gimagexdraw.c gkeysym.c glist.c gmenu.c gprogress.c gpsdraw.c		\
-	gpstxtinit.c gradio.c gresource.c gresourceimage.c gresedit.c		\
-	gsavefiledlg.c gscrollbar.c gtabset.c gtextfield.c gtextinfo.c		\
-	gwidgets.c gxdraw.c gxcdraw.c ghvbox.c gmatrixedit.c gdrawable.c	\
-	gspacer.c xkeysyms_unicode.c colorP.h gdrawP.h gimagebmpP.h			\
-	gresourceP.h gxcdrawP.h fontP.h ggadgetP.h gpsdrawP.h gwidgetP.h	\
-	gxdrawP.h hotkeys.c hotkeys.h
+libgdraw_la_SOURCES = choosericons.c ctlvalues.c drawboxborder.c	\
+	gaskdlg.c gbuttons.c gcolor.c gchardlg.c gcontainer.c gdraw.c	\
+	gdrawbuildchars.c gdrawerror.c gdrawtxt.c gdrawtxtinit.c	\
+	gfilechooser.c gfiledlg.c ggadgets.c ggroupbox.c gimageclut.c	\
+	gimagecvt.c gimagepsdraw.c gimagewriteeps.c gdrawgimage.c	\
+	gimagexdraw.c gkeysym.c glist.c gmenu.c gprogress.c gpsdraw.c	\
+	gpstxtinit.c gradio.c gresource.c gresourceimage.c gresedit.c	\
+	gsavefiledlg.c gscrollbar.c gtabset.c gtextfield.c gtextinfo.c	\
+	gwidgets.c gxdraw.c gxcdraw.c ghvbox.c gmatrixedit.c		\
+	gdrawable.c gspacer.c xkeysyms_unicode.c colorP.h gdrawP.h	\
+	gimagebmpP.h gresourceP.h gxcdrawP.h fontP.h ggadgetP.h		\
+	gpsdrawP.h gwidgetP.h gxdrawP.h hotkeys.c hotkeys.h
 
 libgdraw_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
-	"-DSHAREDIR=\"${MY_SHAREDIR}\"" $(MY_CFLAGS) 
+	"-DSHAREDIR=\"${MY_SHAREDIR}\"" $(MY_CFLAGS)
 
 libgdraw_la_LIBADD = $(MY_LIBS) $(top_builddir)/Unicode/libgunicode.la	\
 	$(top_builddir)/gutils/libgutils.la \
@@ -53,9 +53,7 @@ if GRAPHICAL_USER_INTERFACE
 libgdraw_la_LIBADD += $(XINPUT_LIBS)
 endif GRAPHICAL_USER_INTERFACE
 
-# Using -release instead of -version-info seems appropriate in the
-# absence of a well defined ABI.
-libgdraw_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
+libgdraw_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGDRAW_VERSION)
 
 
 -include $(top_srcdir)/git.mk

--- a/gutils/Makefile.am
+++ b/gutils/Makefile.am
@@ -29,15 +29,15 @@ lib_LTLIBRARIES = libgutils.la libgioftp.la
 
 #--------------------------------------------------------------------------
 
-libgutils_la_SOURCES = divisors.c fsys.c gcol.c gimage.c				\
-	gimagereadbmp.c gimageread.c gimagereadgif.c gimagereadjpeg.c		\
-	gimagereadpng.c gimagereadras.c gimagereadrgb.c gimagereadtiff.c	\
-	gimagereadxbm.c gimagereadxpm.c gimagewritebmp.c					\
-	gimagewritegimage.c gimagewritejpeg.c gimagewritepng.c				\
-	gimagewritexbm.c gimagewritexpm.c gwwintl.c gio.c giofile.c			\
-	giohosts.c giomime.c giothread.c giotrans.c gimagebmpP.h			\
-	giofuncP.h gioP.h dlist.c prefs.c prefs.h gnetwork.c                            \
-        unicodelibinfo.c unicodelibinfo.h gutils.c
+libgutils_la_SOURCES = divisors.c dlist.c fsys.c gcol.c gimage.c	\
+	gimagebmpP.h gimageread.c gimagereadbmp.c gimagereadgif.c	\
+	gimagereadjpeg.c gimagereadpng.c gimagereadras.c		\
+	gimagereadrgb.c gimagereadtiff.c gimagereadxbm.c		\
+	gimagereadxpm.c gimagewritebmp.c gimagewritegimage.c		\
+	gimagewritejpeg.c gimagewritepng.c gimagewritexbm.c		\
+	gimagewritexpm.c gio.c giofile.c giohosts.c giomime.c		\
+	giothread.c giotrans.c giofuncP.h gioP.h gnetwork.c gutils.c	\
+	gwwintl.c prefs.c prefs.h unicodelibinfo.c unicodelibinfo.h
 
 libgutils_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 	$(MY_CFLAGS)
@@ -47,20 +47,18 @@ if LIBZMQ
 libgutils_la_LIBADD += $(LIBZMQ_LIBS)
 endif
 
-# Using -release instead of -version-info seems appropriate in the
-# absence of a well defined ABI.
-libgutils_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
+libgutils_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGUTILS_VERSION)
 
 #--------------------------------------------------------------------------
 
 libgioftp_la_SOURCES = gioftp.c gioftpP.h
+
 libgioftp_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 	$(MY_CFLAGS)
 
 libgioftp_la_LIBADD = $(MY_LIBS) $(top_builddir)/Unicode/libgunicode.la
-# Using -release instead of -version-info seems appropriate in the
-# absence of a well defined ABI.
-libgioftp_la_LDFLAGS = $(MY_CFLAGS) -release $(VERSION)
+
+libgioftp_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGIOFTP_VERSION)
 
 #--------------------------------------------------------------------------
 


### PR DESCRIPTION
If you have an older copy of FontForge installed and then attempt to
install the newer version of FontForge, people have reported trouble. This
is due to some of the older libraries from 20120731-b having a higher value
than 2.0. This fix corrects it so that each library is higher than the old
previous values. Also re-aligned a couple of lists to be at default TAB=8.
