### PR TITLE
Fixed failure to set had_layer_cnt in SFD_GetFont()

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -8059,6 +8059,7 @@ static SplineFont *SFD_GetFont( FILE *sfd,SplineFont *cidmaster,char *tok,
 
 
 	SFD_GetFontMetaData( sfd, tok, sf, &d );
+	had_layer_cnt = d.had_layer_cnt;
 
 	if ( strmatch(tok,"DisplaySize:")==0 )
 	{


### PR DESCRIPTION
SFD_GetFont() maintains a flag called had_layer_cnt which must be set true when a "LayerCount:" directive is processed.  This flag is then passed to functions such as SFD_GetChar() as a backward-compatibility measure.  Many, many things will break horribly if this flag is false in a font which uses more than the default layers.

Unfortunately, SFD_GetFont() appears to have been refactored recently to perform some of its work in another function, SFD_GetFontMetaData(), which maintains its own copy of the had_layer_cnt flag, whose value was not getting propagated back to the one SFD_GetFont() uses.  This was causing multilayer fonts to become corrupted, and in some cases to crash fontforge.

For the purpose of transparently fixing the bug, I have included a statement which simply copies the flag after the call to SFD_GetFontMetaData().  As a later improvement, we should also consider doing away with SFD_GetFont()'s local variable altogether if possible, and maintain this flag in only one place.
