### PR TITLE
Fixed crashes and data corruption in PyFFContour_GetSplineAfterPoint()

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -2849,7 +2849,7 @@ return( Py_BuildValue("((dddd)(dddd))", 0,end.x-start.x-cx,cx,start.x,
 	if ( ++pnum>=self->pt_cnt ) pnum = 0;
 	if ( self->points[pnum]->on_curve ) {
 	    end.x = self->points[pnum]->x; end.y = self->points[pnum]->y;
-return( Py_BuildValue("((dddd)(dddd))", 0,0,end.x-start.x,start.x, 0,0,end.y-start.y,start.y ));
+	    return( Py_BuildValue("((dddd)(dddd))", 0.0,0.0,end.x-start.x,start.x, 0.0,0.0,end.y-start.y,start.y ));
 	}
 	ncp.x = self->points[pnum]->x; ncp.y = self->points[pnum]->y;
 	if ( ++pnum>=self->pt_cnt ) pnum = 0;


### PR DESCRIPTION
Three bug fixes in the Python function contour.getSplineAfterPoint().  The first bug is serious (it is a guaranteed crash at least on OS X), the other two cause this function to produce garbage data but not crash.
1.  When contour.getSplineAfterPoint(0) is called and contour.is_quadratic is false, it causes the array self->points[] to be accessed with an negative index, resulting in a crash or invalid data being used.  The original code attempted to handle this condition but did so incorrectly.  Now fixed.
2.  When contour.getSplineAfterPoint() is called and contour.is_quadratic() is false, the point corresponding to the given point number is examined and if point.on_curve is true, the point number is decremented, and if point.on_curve is still true, decremented again.  The author presumably intended to handle the situation in which the given point was actually a control point, in which case both of those tests need to be reversed, testing point.on_curve for false.  Fixed.
3.  Py_BuildValue() takes a variable-length list of arguments whose types are determined by a format string.  This means that the compiler cannot perform the usual type checking and size conversions that it would normally do.  In this case, an integer zero was being passed as an argument for which the format specifier was "d", meaning that a C double was expected.  On machines where int and double are not the same width, this guarantees corruption of arguments on the stack. The fix is to substitute 0.0 for 0 in these arguments, which C treats as constant of type double.
