### PR TITLE
Documented change to script search behavior.

### DIFF
--- a/htdocs/scripting.html
+++ b/htdocs/scripting.html
@@ -210,7 +210,9 @@ $ fontforge -lang={ff|py} -c "script-string"
   can contain characters not legal in name tokens it is important to allow
   general strings to specify filenames). If the procedure name does not contain
   a directory then it is assumed to be in the same directory as the current
-  script file. At most 25 arguments can be passed to a procedure.
+  script file.  As a convenience, it is not necessary to include the
+  script's extension if it is either ".ff" or ".pe".  At most 25 arguments can be
+  passed to a procedure.
   <P>
   Arrays are passed by reference, strings and integers are passed by value.
   <P>


### PR DESCRIPTION
Fontforge will now automatically find a script that ends in .ff or .pe
without needing to include that in the name of the call to the script.
