### PR TITLE
If a stroked font somehow has zero strokewidth, do not rasterize.

### DIFF
--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -1039,7 +1039,8 @@ BDFChar *SplineCharFreeTypeRasterizeNoHints(SplineChar *sc,int layer,
 
     if ( !hasFreeType())
 return( NULL );
-    if ( sc->layers[layer].order2 && sc->parent->strokedfont )
+    if ( sc->parent->strokedfont &&
+	( sc->layers[layer].order2 || (int)sc->parent->strokewidth == 0 ) )
 return( NULL );
     if ( sc->layers[layer].order2 && sc->parent->multilayer ) {
 	/* I don't support stroking of order2 splines */


### PR DESCRIPTION
Otherwise, division by zero occurs and FontForge will probably crash.
