### PR TITLE
fontforge_package_name is used for defining the datadir path.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ m4_define([fontforge_version],
           [fontforge_major_version.fontforge_minor_version.fontforge_package_stamp])
 #m4_define([fontforge_info],
 #          [fontforge_major_version:fontforge_minor_version:0])
-#m4_define([fontforge_package_name], ["fontforge"])
+m4_define([fontforge_package_name], ["fontforge"])
 m4_define([libfontforgeexe_info],[libfontforgeexe_major_version:libfontforgeexe_minor_version:0])
 m4_define([libfontforge_info],[libfontforge_major_version:libfontforge_minor_version:0])
 m4_define([libgdraw_info],[libgdraw_major_version:libgdraw_minor_version:0])


### PR DESCRIPTION
If you do not define it in the configure.ac then you will end up with
/usr/local/share/fontforge_package_name
instead of
/usr/local/share/fontforge

As there are locale, doc etc that are at the parent level to share/fontforge
I'm not 100% sure that having a version number in there would help.

If you have two versions of fontforge you wanted to parallel install then you
would still get conflicting files for
/usr/local/share/doc/fontforge/index.html

If on the other hand you use
./configure --prefix=/usr/local/fontforge-2014jan
then all would be installed into that subtree and you can have as many fontforges
as you like installed without using /usr/local/share/fontforge_package_name.

I'm not entirely sure about the change I'm reverting here. I imagine
that having a proper version in there instead of
fontforge_package_name might be what was intended?
