### PR TITLE
Cleaned up pointer and memory usage in SplineCharFreeTypeRasterizeNoHints

### DIFF
--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -1161,8 +1161,10 @@ return( NULL );
 	    if (clipmask != NULL)
 		free(clipmask);
 	}
-	free(temp.buffer);
     }
+
+    if (temp.buffer != NULL)
+	free(temp.buffer);
 
     free(outline.points);
     free(outline.tags);


### PR DESCRIPTION
Please see individual commits for details.
