### PR TITLE
Add F/B speed keys for switching layers

### DIFF
--- a/fontforge/charview_private.h
+++ b/fontforge/charview_private.h
@@ -245,6 +245,7 @@
 extern void CVMenuPointType(GWindow gw, struct gmenuitem *mi, GEvent *e);
 extern void CVMerge(GWindow gw,struct gmenuitem *mi,GEvent *e);
 extern void CVMergeToLine(GWindow gw,struct gmenuitem *mi,GEvent *e);
+extern void CVLSelectLayer(CharView *cv, int layer);
 
 
 #endif

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -7697,6 +7697,9 @@ return;
     } else if ( event->u.chr.keysym=='\\' && (event->u.chr.state&ksm_control) ) {
 	/* European keyboards need a funky modifier to get \ */
 	CVDoTransform(cv,cvt_none);
+    } else if ( (event->u.chr.keysym=='F' || event->u.chr.keysym=='B') &&
+            !(event->u.chr.state&(ksm_control|ksm_meta)) ) {
+        CVLSelectLayer(cv, event->u.chr.keysym=='F' ? 1 : 0);
     } else if ( (event->u.chr.state&ksm_control) && (event->u.chr.keysym=='-' || event->u.chr.keysym==0xffad/*XK_KP_Subtract*/) ){
 	    _CVMenuScale(cv, MID_ZoomOut);
     } else if ( (event->u.chr.state&ksm_control) && (event->u.chr.keysym=='=' || event->u.chr.keysym==0xffab/*XK_KP_Add*/) ){

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -2499,7 +2499,7 @@ static int CVLScanForItem(int x, int y, int *col) {
 }
 
 /* Called in response to some event where we want to change the current layer. */
-static void CVLSelectLayer(CharView *cv, int layer) {
+void CVLSelectLayer(CharView *cv, int layer) {
     enum drawmode dm = cv->b.drawmode;
 
     if ( layer<-1 || layer>=cv->b.sc->layer_cnt )


### PR DESCRIPTION
Adds Shift-F and Shift-B speed keys in the charview to switch the active layer to Fore and Back respectively.
