### PR TITLE
Fix libtool warnings when compiling for Windows

### DIFF
--- a/Unicode/Makefile.am
+++ b/Unicode/Makefile.am
@@ -34,7 +34,9 @@ libgunicode_la_SOURCES = ArabicForms.c alphabet.c backtrns.c char.c	\
 libgunicode_la_CPPFLAGS = "-I$(top_builddir)/inc"	\
 	"-I$(top_srcdir)/inc" $(MY_CFLAGS)
 
-libgunicode_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGUNICODE_VERSION)
+libgunicode_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGUNICODE_VERSION) \
+	${MY_LIB_LDFLAGS}
+
 libgunicode_la_LIBADD = $(MY_LIBS)
 
 #--------------------------------------------------------------------------

--- a/collab/Makefile.am
+++ b/collab/Makefile.am
@@ -36,7 +36,8 @@ libzmqcollab_la_CPPFLAGS = \
  $(MY_CFLAGS) $(LIBZMQ_CFLAGS) $(GLIB_CFLAGS)
 
 libzmqcollab_la_LIBADD = $(MY_LIBS) $(GLIB_LIBS) $(LIBZMQ_LIBS)
-libzmqcollab_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBZMQCOLLAB_VERSION)
+libzmqcollab_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBZMQCOLLAB_VERSION) \
+	${MY_LIB_LDFLAGS}
 
 #--------------------------------------------------------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -417,6 +417,8 @@ for arg in ${FFW_FLAGS}; do
    AX_CHECK_COMPILE_FLAG([$arg],[WARNING_CFLAGS+=" $arg"])
 done
 
+# Create LDFLAGS for libraries. Currently used to pass '-no-undefined' to libtool.
+my_lib_ldflags=""
 dnl add --no-undefined if supported. Based on information seen here:
 dnl https://mail.gnome.org/archives/commits-list/2011-October/msg10575.html
 dnl http://femass.com.br/Net-SNMP/configure.d/config_os_progs
@@ -435,8 +437,10 @@ case $host in
           AX_CHECK_COMPILE_FLAG([-Wl,--no-undefined],[WARNING_CFLAGS+=" -Wl,--no-undefined"])],
          [AC_MSG_RESULT([no])])
       LDFLAGS="$saved_LDFLAGS"
+	  my_lib_ldflags="${my_lib_ldflags} -no-undefined"
       ;;
 esac
+AC_SUBST([MY_LIB_LDFLAGS], [${my_lib_ldflags}])
 
 AC_LANG_POP
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -92,7 +92,9 @@ if LIBZMQ
 libfontforge_la_LIBADD += $(top_builddir)/collab/libzmqcollab.la $(LIBZMQ_LIBS)
 endif LIBZMQ
 
-libfontforge_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGE_VERSION)
+libfontforge_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGE_VERSION) \
+	${MY_LIB_LDFLAGS}
+
 libfontforge_la_LIBADD += $(MY_LIBS) $(LIBZMQ_LIBS)
 
 #--------------------------------------------------------------------------

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -140,7 +140,9 @@ endif MACINTOSH
 libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZMQ_CFLAGS)
 libfontforgeexe_la_LIBADD = $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD) $(MY_LIBS)
 
-libfontforgeexe_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGEEXE_VERSION)
+libfontforgeexe_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGEEXE_VERSION) \
+	${MY_LIB_LDFLAGS}
+
 if LIBZMQ
 libfontforgeexe_la_LIBADD += $(top_builddir)/collab/libzmqcollab.la $(LIBZMQ_LIBS)
 endif

--- a/gdraw/Makefile.am
+++ b/gdraw/Makefile.am
@@ -53,7 +53,7 @@ if GRAPHICAL_USER_INTERFACE
 libgdraw_la_LIBADD += $(XINPUT_LIBS)
 endif GRAPHICAL_USER_INTERFACE
 
-libgdraw_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGDRAW_VERSION)
-
+libgdraw_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGDRAW_VERSION) \
+	${MY_LIB_LDFLAGS}
 
 -include $(top_srcdir)/git.mk

--- a/gutils/Makefile.am
+++ b/gutils/Makefile.am
@@ -47,7 +47,8 @@ if LIBZMQ
 libgutils_la_LIBADD += $(LIBZMQ_LIBS)
 endif
 
-libgutils_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGUTILS_VERSION)
+libgutils_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGUTILS_VERSION) \
+	${MY_LIB_LDFLAGS}
 
 #--------------------------------------------------------------------------
 
@@ -58,7 +59,8 @@ libgioftp_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 
 libgioftp_la_LIBADD = $(MY_LIBS) $(top_builddir)/Unicode/libgunicode.la
 
-libgioftp_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGIOFTP_VERSION)
+libgioftp_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBGIOFTP_VERSION) \
+	${MY_LIB_LDFLAGS}
 
 #--------------------------------------------------------------------------
 

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -36,7 +36,7 @@ plugin_LTLIBRARIES =
 if PLUGIN_GB12345
 plugin_LTLIBRARIES += gb12345.la
 gb12345_la_SOURCES = gb12345.c
-gb12345_la_LDFLAGS = -module -avoid-version
+gb12345_la_LDFLAGS = -module -avoid-version ${MY_LIB_LDFLAGS}
 endif PLUGIN_GB12345
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
This fixes warnings by passing -no-undefined to libtool (not the linker) for any libraries that are built.
Edit: For reference - http://cygwin.com/ml/cygwin/2013-07/msg00421.html

On a side note, I noticed that MY_CFLAGS is passed to the LDFLAGS field in the Makefiles - should this be the case?
