### PR TITLE
Fix build for glib < 2.28

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -4474,7 +4474,8 @@ void CVFreePreTransformSPL( CharView* cv )
 {
     if( cv->p.pretransform_spl )
     {
-	g_list_free_full( cv->p.pretransform_spl, SplinePointListFree );
+	g_list_foreach( cv->p.pretransform_spl, (GFunc)SplinePointListFree, NULL );
+	g_list_free( cv->p.pretransform_spl );
     }
     cv->p.pretransform_spl = 0;
 }


### PR DESCRIPTION
This fixes issues/995 where building fontforge with glib < 2.28 would fail due to the one-liner. I'd recommend making fontforge available on more platforms instead of always requiring the newest and most shiny libraries.
