### PR TITLE
Disable AT_TESTED in testsuite

### DIFF
--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -48,7 +48,8 @@ AT_CLEANUP
 #--------------------------------------------------------------------------
 
 AT_COLOR_TESTS
-AT_TESTED([fontforge])
+dnl it only checks for pre-installed fontforge
+dnl AT_TESTED([fontforge])
 
 AT_BANNER([FontForge Native Scripting Tests])
 


### PR DESCRIPTION
AT_TESTED only checks for fontforge in existing path. Not only is this unuseful in test suite, it actually causes the whole test suite fail to run under clean environments (such as chroot and inside fresh virtual machines)
