### PR TITLE
 IPython expects at least one item in sys.argv

### DIFF
--- a/pycontrib/graphicore/shell.py
+++ b/pycontrib/graphicore/shell.py
@@ -28,6 +28,10 @@ import fontforge;
 import pango
 import platform
 
+if len(sys.argv) == 0:
+    # some versions of IPython need content in sys.argv
+    sys.argv.append('')
+
 from ipython_view import *
 
 def runShell(data = None, glyphOrFont = None):


### PR DESCRIPTION
I wanted to see the python console, that I wrote back then and that is now included in fontforge.  What is fantastic by the way, thanks!

So I built fontforge on my Xubuntu 13.10 and executet it. A python warning regarding the python
console appeared. The traceback was not complete so I made my own by manipulating the python
files in /usr/local/share/fontforge/python/graphicore

This is not the traceback from then, but it shows the relevant part and the same error message:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "shell.py", line 31, in <module>
    from ipython_view import *
  File "ipython_view.py", line 23, in <module>
    import IPython
  File "/usr/lib/python2.7/dist-packages/IPython/**init**.py", line 43, in <module>
    from .config.loader import Config
  File "/usr/lib/python2.7/dist-packages/IPython/config/**init**.py", line 16, in <module>
    from .application import *
  File "/usr/lib/python2.7/dist-packages/IPython/config/application.py", line 67, in <module>
    """.strip().format(app=os.path.basename(sys.argv[0]))
IndexError: list index out of range

Then I executed a line of python from the "Execute Script..." dialogue in fontforge:

import sys
print sys.argv
# output> []

Fontforge starts Python without items in the sys.argv list but IPython expects
at least one item there.

A workaround for is adding an empty string to sys.argv when it is empty.

Before importing ipython_view I added in shell.py:

if len(sys.argv) == 0:
    # some versions of IPython need content in sys.argv
    sys.argv.append('')

Solved the problem for me :-)
