### PR TITLE
osx build: a few things coming together to make the build stop.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -431,6 +431,8 @@ case $host in
    dnl this way.
    *-freebsd* | *-openbsd*)
       ;;
+   *-apple-darwin*)
+      ;;
    *) saved_LDFLAGS=$LDFLAGS
       AC_MSG_CHECKING([whether the linker supports --no-undefined])
       LDFLAGS="$saved_LDFLAGS -Wl,--no-undefined"

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -120,7 +120,7 @@ AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 # optimization turns out to have disastrous effects. Compile it
 # without optimization.
 splinerefigure.lo: $(srcdir)/splinerefigure.c $(srcdir)/splinefont.h
-	$(LIBTOOL) --mode=compile $(CC) -g -c -o		\
+	$(LIBTOOL) --mode=compile $(CC) $(RAW_COMPILE_PLATFORM_CFLAGS) -g -c -o \
 		splinerefigure.lo $(AM_CPPFLAGS) $(srcdir)/splinerefigure.c
 
 #--------------------------------------------------------------------------

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -7371,7 +7371,7 @@ void FontViewRemove(FontView *fv) {
  * and paste on the OSX. So this guard lets us quietly ignore that
  * event when we have just done command+c or command+x.
  */
-int osx_fontview_copy_cut_counter = 0;
+extern int osx_fontview_copy_cut_counter;
 
 static int fv_e_h(GWindow gw, GEvent *event) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -2055,7 +2055,7 @@ static int osx_handle_keysyms( int st, int k )
     return k;
 }
 
-extern int osx_fontview_copy_cut_counter;
+int osx_fontview_copy_cut_counter = 0;
 
 
 

--- a/m4/fontforge_platform_specifics.m4
+++ b/m4/fontforge_platform_specifics.m4
@@ -23,6 +23,9 @@ AS_CASE([$host],
        MACAPP=""
       fi
 
+      RAW_COMPILE_PLATFORM_CFLAGS=" $CFLAGS -arch x86_64 -arch i386 "
+      AC_SUBST([RAW_COMPILE_PLATFORM_CFLAGS])
+
       dnl fink puts stuff under /sw
       dnl macports puts stuff under /opt/local
       dnl but when macport/fink overwrite a standard lib, I still want the standard


### PR DESCRIPTION
Main outstanding issue is that linking with the undefined = error setup
causes a stop at RunApplicationEventLoop() not being found.
