### PR TITLE
improve-python-script-mainloop-integration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -565,6 +565,8 @@ fi
 AM_CONDITIONAL([HAVE_IPYTHON],[test x"${have_ipython}" = xyes])
 
 #--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
 
 AC_ARG_ENABLE([python-even],
         [AS_HELP_STRING([--enable-python-even],
@@ -572,6 +574,31 @@ AC_ARG_ENABLE([python-even],
         [have_python_even=yes])
 AM_CONDITIONAL([HAVE_PYTHON_EVEN],[test x"${have_python_even}" = xyes])
 
+#--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
+# We do not use GTK2 unless explicitly told it is OK to try to do that
+#
+AC_ARG_ENABLE([gtk2-use],
+        [AS_HELP_STRING([--enable-gtk2-use],
+                [Try to detect and use gtk2])],
+        [have_gtk2_use=yes])
+if test x$have_gtk2_use = xyes ; then
+    PKG_CHECK_MODULES([GTK2],[gtk+-2.0],
+	[
+		fontforge_can_use_gtk=yes
+		AC_DEFINE(FONTFORGE_CAN_USE_GTK,[],[FontForge is able to use some GTK2 functions if it wants])
+		echo "building functionality that relies on gtk2..."
+	],
+	[
+		fontforge_can_use_gtk=no
+		echo "NOT building functionality that relies on gtk2..."
+	])
+fi
+AM_CONDITIONAL([FONTFORGE_CAN_USE_GTK],[test x"${fontforge_can_use_gtk}" = xyes])
+
+#--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
 #--------------------------------------------------------------------------
 # Output commands - Create FontForge Portable Makefiles
 

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -137,8 +137,8 @@ if MACINTOSH
 MACFFEXE_LIBADD=macobjective.o
 endif MACINTOSH
 
-libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZMQ_CFLAGS)
-libfontforgeexe_la_LIBADD = $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD) $(MY_LIBS)
+libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZMQ_CFLAGS) $(GTK2_CFLAGS)
+libfontforgeexe_la_LIBADD = $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD) $(MY_LIBS) $(GTK2_LIBS)
 
 libfontforgeexe_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGEEXE_VERSION) \
 	${MY_LIB_LDFLAGS}

--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -560,6 +560,111 @@ static PyObject *PyFFFont_CollabSessionSetUpdatedCallback(PyFF_Font *self, PyObj
     return result;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+#ifdef FONTFORGE_CAN_USE_GTK
+
+#define GMenuItem GMenuItem_Glib
+#define GTimer GTimer_GTK
+#define GList  GList_Glib
+#include <gdk/gdkx.h>
+#undef GTimer
+#undef GList
+#undef GMenuItem
+
+static void GtkWindowToMainEventLoop_fd_callback( int fd, void* datas )
+{
+    printf("GtkWindowToMainEventLoop_fd_callback()\n");
+    gboolean may_block = false;
+    g_main_context_iteration( g_main_context_default(), may_block );
+}
+
+
+static PyObject *PyFFFont_addGtkWindowToMainEventLoop(PyFF_Font *self, PyObject *args)
+{
+    PyObject *result = NULL;
+    PyObject *temp;
+    int v = 0;
+
+    if ( !PyArg_ParseTuple( args, "i", &v ))
+        return( NULL );
+
+    printf("***************** xid: %d\n", v );
+    gpointer gdkwindow = gdk_xid_table_lookup( v );
+    printf("***************** obj: %p\n", gdkwindow );
+
+    if( gdkwindow )
+    {
+        Display* d = GDK_WINDOW_XDISPLAY(gdkwindow);
+        int fd = XConnectionNumber(d);
+        printf("***************** fd: %d\n", fd );
+        if( fd )
+        {
+            gpointer udata = 0;
+            GDrawAddReadFD( 0, fd, udata, GtkWindowToMainEventLoop_fd_callback );
+        }
+    }
+    
+    /* Boilerplate to return "None" */
+    Py_INCREF(Py_None);
+    result = Py_None;
+    return result;
+}
+
+static PyObject *PyFFFont_removeGtkWindowToMainEventLoop(PyFF_Font *self, PyObject *args)
+{
+    PyObject *result = NULL;
+    PyObject *temp;
+    int v = 0;
+
+    if ( !PyArg_ParseTuple( args, "i", &v ))
+        return( NULL );
+
+    printf("rem ***************** xid: %d\n", v );
+    gpointer gdkwindow = gdk_xid_table_lookup( v );
+    printf("rem ***************** obj: %p\n", gdkwindow );
+
+    if( gdkwindow )
+    {
+        Display* d = GDK_WINDOW_XDISPLAY(gdkwindow);
+        int fd = XConnectionNumber(d);
+        printf("REMOVE ***************** fd: %d\n", fd );
+        if( fd )
+        {
+            gpointer udata = 0;
+            GDrawRemoveReadFD( 0, fd, udata );
+        }
+    }
+    
+    /* Boilerplate to return "None" */
+    Py_INCREF(Py_None);
+    result = Py_None;
+    return result;
+}
+
+#else
+
+#define EMPTY_METHOD				\
+    {						\
+    PyObject *result = NULL;			\
+    /* Boilerplate to return "None" */		\
+    Py_INCREF(Py_None);				\
+    result = Py_None;				\
+    return result;				\
+}
+    									\
+static PyObject *PyFFFont_addGtkWindowToMainEventLoop(PyFF_Font *self, PyObject *args)
+{ EMPTY_METHOD; }
+static PyObject *PyFFFont_removeGtkWindowToMainEventLoop(PyFF_Font *self, PyObject *args)
+{ EMPTY_METHOD; }
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
 
 
@@ -603,6 +708,11 @@ PyMethodDef PyFF_FontUI_methods[] = {
    { "CollabLastChangedPos", (PyCFunction) PyFF_getLastChangedPos, METH_VARARGS, "" },
    { "CollabLastChangedCodePoint", (PyCFunction) PyFF_getLastChangedCodePoint, METH_VARARGS, "" },
    { "CollabLastSeq", (PyCFunction) PyFF_getLastSeq, METH_VARARGS, "" },
+
+   // allow python code to expose it's gtk mainloop to fontforge
+   { "addGtkWindowToMainEventLoop", (PyCFunction) PyFFFont_addGtkWindowToMainEventLoop, METH_VARARGS, "fixme." },
+   { "removeGtkWindowToMainEventLoop", (PyCFunction) PyFFFont_removeGtkWindowToMainEventLoop, METH_VARARGS, "fixme." },
+
    
    PYMETHODDEF_EMPTY /* Sentinel */
 };

--- a/gdraw/gxdraw.c
+++ b/gdraw/gxdraw.c
@@ -2980,6 +2980,7 @@ return;
 	    timeout = &offset;
 	}
 	fd = XConnectionNumber(display);
+//    printf("gxdraw.... x connection number:%d\n", fd );
 	FD_ZERO(&read); FD_ZERO(&write); FD_ZERO(&except);
 	FD_SET(fd,&read);
 	FD_SET(fd,&except);

--- a/pycontrib/graphicore/shell.py
+++ b/pycontrib/graphicore/shell.py
@@ -33,6 +33,7 @@ if len(sys.argv) == 0:
     sys.argv.append('')
 
 from ipython_view import *
+import gdraw
 
 def runShell(data = None, glyphOrFont = None):
     """Run an ipython shell in a gtk-widget with the current fontforge module in the namespace"""
@@ -52,7 +53,10 @@ def runShell(data = None, glyphOrFont = None):
     W.show_all()
     W.connect('delete_event',lambda x,y:False)
     W.connect('destroy',lambda x:gtk.main_quit())
-    gtk.main()
+
+    # Start gtk loop here!
+    gdraw.gtkrunner.sniffwindow(W)
+    gdraw.gtkrunner.start()
 if fontforge.hasUserInterface():
     fontforge.registerMenuItem(runShell, None, None, ("Font","Glyph"),
                                 None, "Interactive Python Shell");


### PR DESCRIPTION
Instead of the IPython shell using gtk.main() it now tells fontforge
about it's X Connection and is more closely integrated into the fontforge
main loop. The reason for doing this is so that events are sent to the
python UI as soon as they happen (fontforge is watching the X connection
for the gtk windows too) and the python script does not block the main
fontforge UI. That is, both the python and fontforge C created windows
are all responsive to user interaction at the same time.
