### PR TITLE
Avoid hiding strlen function needed by strcmp

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -1497,17 +1497,17 @@ return( ch1=='\0' );
 }
 
 static void TTFAddLangStr(FILE *ttf, struct ttfinfo *info, int id,
-	int strlen, int stroff,int plat,int spec,int language) {
+	int strlength, int stroff,int plat,int spec,int language) {
     struct ttflangname *cur, *prev;
     char *str;
 
     if ( plat==1 && id>=256 && (info->features!=NULL || info->fvar_start!=0)) {
-	MacFeatureAdd(ttf,info,id,strlen,stroff,spec,language);
+	MacFeatureAdd(ttf,info,id,strlength,stroff,spec,language);
 return;
     } else if ( id<0 || id>=ttf_namemax )
 return;
 
-    str = _readencstring(ttf,stroff,strlen,plat,spec,language);
+    str = _readencstring(ttf,stroff,strlength,plat,spec,language);
     if ( str==NULL )		/* we didn't understand the encoding */
 return;
     if ( id==ttf_postscriptname )


### PR DESCRIPTION
GCC 4.8 complains about unknown  function for stcmp in line 1537.

This patch tries to avoid such hiding.

Thanks for reviewing.
