### PR TITLE
osx: make zip contain symlinks now. Surprisingly trying to use a 'copy' ...

### DIFF
--- a/osx/create-osx-app-bundle.sh
+++ b/osx/create-osx-app-bundle.sh
@@ -313,7 +313,7 @@ cp -av /opt/local/share/X11/locale $bundle_share/X11
 cd $TEMPDIR
 find FontForge.app -exec touch {} \;
 rm -f  ~/FontForge.app.zip
-zip -9 -r ~/FontForge.app.zip FontForge.app
+zip -9 --symlinks -r ~/FontForge.app.zip FontForge.app
 cp -f  ~/FontForge.app.zip /tmp/
 chmod o+r /tmp/FontForge.app.zip
 

--- a/pycontrib/even.py
+++ b/pycontrib/even.py
@@ -17,7 +17,8 @@ evenpath = os.path.dirname(sys.modules[__name__].__file__) + "/Even"
 
 def runEvenShell(data = None, glyphOrFont = None):
     """Run even"""
-    subprocess.call([evenpath, ''])
+    subprocess.Popen([evenpath, ''])
+    #subprocess.call([evenpath, ''])
 
 if fontforge.hasUserInterface():
     fontforge.registerMenuItem(runEvenShell, None, None, ("Font","Glyph"),


### PR DESCRIPTION
...of a

```
 dylib will crash python. if its a symlink then its all good.
 also, spawn even in the bg so as not to block.
```
