### PR TITLE
osx: fontview scroll speed is slowed down substantially when this system

### DIFF
--- a/osx/FontForge.app/Contents/Resources/opt/local/etc/fonts/fonts.conf
+++ b/osx/FontForge.app/Contents/Resources/opt/local/etc/fonts/fonts.conf
@@ -27,6 +27,8 @@
 <dir>/usr/X11/lib/X11/fonts/100dpi</dir>
 <dir>/usr/X11/lib/X11/fonts/misc</dir>
 
+<dir>/Library/Fonts</dir>
+
 <!--
 
 <dir>/usr/X11/lib/X11/fonts</dir> 

--- a/osx/create-osx-app-bundle.sh
+++ b/osx/create-osx-app-bundle.sh
@@ -272,7 +272,7 @@ NEWPREFIX=/Applications/FontForge.app/Contents/Resources/opt/local
 
 mkdir -p $bundle_etc
 #cp -av /opt/local/etc/fonts   $bundle_etc
-cp -av /opt/local/etc/fonts/conf.d   $bundle_etc/fonts/
+cp -avL /opt/local/etc/fonts/conf.d   $bundle_etc/fonts/
 cp -av /opt/local/etc/pango   $bundle_etc
 cd $bundle_etc/pango
 sed -i -e "s|$OLDPREFIX|$NEWPREFIX|g" pangorc


### PR DESCRIPTION
```
  font path is removed from the initial fontconfig scan.
```
