### PR TITLE
osx: the debugger itself wants to use python. 

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -98,6 +98,7 @@ int splash = 1;
 static int localsplash;
 static int unique = 0;
 static int listen_to_apple_events = false;
+static bool ProcessPythonInitFiles = 1;
 
 static void _dousage(void) {
     printf( "fontforge [options] [fontfiles]\n" );
@@ -1080,8 +1081,23 @@ int fontforge_main( int argc, char **argv ) {
     InitToolIconClut(default_background);
     InitToolIcons();
     InitCursors();
+
+    /**
+     * we have to do a quick sniff of argv[] here to see if the user
+     * wanted to skip loading these python init files.
+     */
+    for ( i=1; i<argc; ++i ) {
+	char buffer[1025];
+	char *pt = argv[i];
+
+	if ( !strcmp(pt,"-SkipPythonInitFiles")) {
+	    ProcessPythonInitFiles = 0;
+	}
+    }
+    
 #ifndef _NO_PYTHON
-    PyFF_ProcessInitFiles();
+    if( ProcessPythonInitFiles )
+	PyFF_ProcessInitFiles();
 #endif
 
     /* Wait until the UI has started, otherwise people who don't have consoles*/
@@ -1175,6 +1191,8 @@ exit( 0 );
 	    MenuNewComposition(NULL,NULL,NULL);
 	    any = 1;
 #  endif
+	} else if ( !strcmp(pt,"-SkipPythonInitFiles")) {
+	    // already handled above.
 	} else if ( strcmp(pt,"-last")==0 ) {
 	    if ( next_recent<RECENT_MAX && RecentFiles[next_recent]!=NULL )
 		if ( ViewPostScriptFont(RecentFiles[next_recent++],openflags))

--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -44,6 +44,9 @@ export LD_LIBRARY_PATH="$bundle_lib"
 WRAPPER=
 
 if [ x"$1" == "x--debug" ]; then
+    unset PYTHONHOME
+    unset LD_LIBRARY_PATH
+
     if command -v lldb 2>/dev/null; then
         WRAPPER="gdb --args"
         WRAPPER="script $HOME/FontForge-Debug-Output.txt lldb --debug --source /Applications/FontForge.app/Contents/MacOS/debug-script -- "

--- a/osx/FontForge.app/Contents/MacOS/debug-script
+++ b/osx/FontForge.app/Contents/MacOS/debug-script
@@ -2,5 +2,5 @@ version
 settings set frame-format "frame #${frame.index}: ${frame.pc}{ ${module.file.basename}`${function.name-with-args}{${function.pc-offset}}}{ at ${line.file.basename}:${line.number}}\n"
 target create /Applications/FontForge.app/Contents/Resources/opt/local/bin/fontforge
 target select 0
-run
+run -SkipPythonInitFiles 
 


### PR DESCRIPTION
```
This gets interesting when fontforge comes with it's own python. So this removes the local
 python and forces off loading python init files (the tools menu)
 so the main fontforge.c app runs ok. If we want to do debugging
 of python stuff too then this will be much more complicated.
```
