### PR TITLE
Add WARN_CFLAGS to Makefiles

### DIFF
--- a/Unicode/Makefile.am
+++ b/Unicode/Makefile.am
@@ -68,6 +68,7 @@ libgunicode_la_SOURCES =	\
 
 #	usprintf.c
 
+libgunicode_la_CFLAGS = $(WARN_CFLAGS)
 libgunicode_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
 	$(MY_CFLAGS)

--- a/collab/Makefile.am
+++ b/collab/Makefile.am
@@ -30,6 +30,8 @@ lib_LTLIBRARIES = libzmqcollab.la
 
 libzmqcollab_la_SOURCES = zmq_kvmsg.c zmq_kvmsg.h
 
+libzmqcollab_la_CFLAGS = $(WARN_CFLAGS)
+
 libzmqcollab_la_CPPFLAGS = \
  "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc" \
  "-I$(top_builddir)/lib" "-I$(top_srcdir)/lib" \

--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,9 @@ if test "$gl_gcc_warnings" = yes; then
   nw="$nw -Wsystem-headers"   # glibc headers fail as of glibc 2.17, gcc 4.8
   nw="$nw -Wsuggest-attribute=format" # glibc headers fail as of glibc 2.17, gcc 4.8
   nw="$nw -Wstrict-aliasing"  # -Sep2012, There's a bug in <py3 with Py_True/False that will propagate with GCC's "strict-aliasing" rules.
+  nw="$nw -Wunused"           # FIXME: we need to turn this off in order to deactivate -Wunused-result below
+  nw="$nw -Wunused-result"    # FIXME: We should have this, but currently it makes too much noise
+  nw="$nw -Wsuggest-attribute=pure" # FIXME: Maybe later?
   nw="$nw -Wall"
   nw="$nw -Wunused-macros"    # those macros might come in handy later
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -52,6 +52,7 @@ LIBADD = $(top_builddir)/Unicode/libgunicode.la	\
 	$(top_builddir)/gutils/libgioftp.la	\
 	$(top_builddir)/lib/libgnu.la
 
+AM_CFLAGS = $(WARN_CFLAGS)
 
 AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -86,6 +86,8 @@ endif GRAPHICAL_USER_INTERFACE
 
 LDADD = $(LIBADD) $(GUILIBADD)
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
               "-I$(top_srcdir)/fontforge" \

--- a/fontforgeexe/collab/Makefile.am
+++ b/fontforgeexe/collab/Makefile.am
@@ -41,6 +41,7 @@ if LIBZMQ
 internal_bin_PROGRAMS = fontforge-internal-collab-server
 
 fontforge_internal_collab_server_SOURCES = fontforge-internal-collab-server.c
+fontforge_internal_collab_server_CFLAGS = $(AM_CFLAGS) $(WARN_CFLAGS)
 fontforge_internal_collab_server_CPPFLAGS = $(AM_CPPFLAGS) \
   "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc" \
   "-I$(top_builddir)/lib" "-I$(top_srcdir)/lib" \

--- a/gdraw/Makefile.am
+++ b/gdraw/Makefile.am
@@ -42,6 +42,8 @@ libgdraw_la_SOURCES = choosericons.c ctlvalues.c drawboxborder.c	\
 	gimagebmpP.h gresourceP.h gxcdrawP.h fontP.h ggadgetP.h		\
 	gpsdrawP.h gwidgetP.h gxdrawP.h hotkeys.c hotkeys.h
 
+libgdraw_la_CFLAGS = $(WARN_CFLAGS)
+
 libgdraw_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
 	"-I$(top_srcdir)/fontforge" "-DSHAREDIR=\"${MY_SHAREDIR}\"" $(MY_CFLAGS)

--- a/gutils/Makefile.am
+++ b/gutils/Makefile.am
@@ -39,6 +39,8 @@ libgutils_la_SOURCES = divisors.c dlist.c fsys.c gcol.c gimage.c	\
 	giothread.c giotrans.c giofuncP.h gioP.h gnetwork.c gutils.c	\
 	gwwintl.c prefs.c prefs.h unicodelibinfo.c unicodelibinfo.h
 
+libgutils_la_CFLAGS = $(WARN_CFLAGS)
+
 libgutils_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
 	$(MY_CFLAGS)

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -27,6 +27,8 @@
 
 plugindir = ${pkglibdir}/plugins
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
 	"-I$(top_builddir)/fontforge" "-I$(top_srcdir)/fontforge"	\

--- a/pyhook/Makefile.am
+++ b/pyhook/Makefile.am
@@ -33,6 +33,8 @@ psMat_la_LIBADD = $(LIBADD)
 fontforge_la_SOURCES = fontforgepyhook.c
 fontforge_la_LIBADD = $(LIBADD)
 
+AM_CFLAGS = $(WARN_CFLAGS)
+
 AM_CPPFLAGS = -DLIBDIR='"$(libdir)"' $(PYTHON_CFLAGS)			\
 	"-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"			\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\


### PR DESCRIPTION
Now we actually get the GCC warnings.

Turn off a couple of warnings that make too much noise and won't
easily be fixed.
