### PR TITLE
Add .dir-locals.el to set up Emacs c-mode appropriately (thanks, monkeyiq)

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+((nil . ((show-trailing-whitespace . nil)))
+ (c-mode . ((c-style-alist . '("stroustrup"
+                               (indent-tabs-mode . t)
+                               (tab-width . 8))))))


### PR DESCRIPTION
This supercedes the (now removed) advice on use with Emacs; instead it's automatic!
