### PR TITLE
Remove string "fontview," from family name list

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -68,7 +68,7 @@ int compact_font_on_open=0;
 int navigation_mask = 0;		/* Initialized in startui.c */
 int prefs_ensure_correct_extension = 1;
 
-static char *fv_fontnames = "fontview," MONO_UI_FAMILIES;
+static char *fv_fontnames = MONO_UI_FAMILIES;
 
 #define	FV_LAB_HEIGHT	15
 


### PR DESCRIPTION
I don't think this string should be there.
