### PR TITLE
Fix linking of libggc_veener.la, and add more needed gnulib modules

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,4 +1,4 @@
-# bootstrap.conf (fontforge) version 2014-03-02
+# bootstrap.conf (fontforge) version 2014-03-03
 # Written by Gary V. Vaughan, 2010
 
 # Copyright (C) 2010 Free Software Foundation, Inc.
@@ -41,8 +41,10 @@ gnulib_tool_options='
 gnulib_modules='
 	warnings
 	manywarnings
+	gethostname
 	getline
 	iconv
+	inet_ntop
 	progname
 	strcase
 	strndup

--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -50,6 +50,8 @@ libggc_veneer_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc" $(LIBG
 
 libggc_veneer_la_LIBADD = $(LIBGC_LIBS)
 
+libggc_veneer_la_LDFLAGS = $(MY_LIB_LDFLAGS)
+
 #--------------------------------------------------------------------------
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
This is aimed at fixing problems caused by #1251.
