### PR TITLE
osx: the build is now not liking g_hash_table_new_full() on osx with a GC error. 

### DIFF
--- a/fontforgeexe/collabclientui.c
+++ b/fontforgeexe/collabclientui.c
@@ -333,7 +333,7 @@ static void zeromq_beacon_fd_callback(int zeromq_fd, void* datas )
 		    printf("user:%s\n", ba->username );
 		    printf("mach:%s\n", ba->machinename );
 
-		    beacon_announce_t* copy = malloc( sizeof(beacon_announce_t));
+		    beacon_announce_t* copy = g_malloc( sizeof(beacon_announce_t));
 		    memcpy( copy, ba, sizeof(beacon_announce_t));
 		    copy->last_msg_from_peer_time = time(0);
 		    copy->port = ntohs( copy->port );
@@ -427,7 +427,7 @@ collabclient_ensureClientBeacon(void)
     if( client_beacon )
 	return;
     
-    peers = g_hash_table_new_full( g_str_hash, g_str_equal, 0, free );
+    peers = g_hash_table_new_full( g_str_hash, g_str_equal, 0, g_free );
     client_beacon_timerID = 0;
     
     
@@ -716,7 +716,7 @@ collabclient_sendRedo_Internal( FontViewBase *fv, SplineChar *sc, Undoes *undo, 
 static void
 collabclient_sendRedo_Internal_CV( CharViewBase *cv, Undoes *undo, int isLocalUndo )
 {
-    printf("collabclient_sendRedo_Internal_CV() cv:%p\h", cv );
+    printf("collabclient_sendRedo_Internal_CV() cv:%p\n", cv );
     collabclient_sendRedo_Internal( cv->fv, cv->sc, undo, isLocalUndo );
 }
 


### PR DESCRIPTION
Move     to glib explicit memory alloc for the hash table values.
