### PR TITLE
Add a new named pipe to allow other processes to send python scripts to fontforge for execution.

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -727,6 +727,7 @@ extern void FVAutoWidth2(FontView *fv);
 extern void SC_MarkInstrDlgAsChanged(SplineChar *sc);
 
 extern void PythonUI_Init(void);
+extern void PythonUI_namedpipe_Init(void);
 
 extern void SCStroke(SplineChar *sc);
 
@@ -1390,6 +1391,8 @@ extern void SFDDumpUndo(FILE *sfd,SplineChar *sc,Undoes *u, const char* keyPrefi
 extern void Prefs_LoadDefaultPreferences( void );
 
 
+extern CharView* CharViewFindActive();
+extern FontViewBase* FontViewFindActive();
 extern FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* ), void* udata );
 extern int FontViewFind_byXUID(      FontViewBase* fv, void* udata );
 extern int FontViewFind_byXUIDConnected( FontViewBase* fv, void* udata );

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -6044,6 +6044,8 @@ static void CVAddGuide(CharView *cv,int is_v,int guide_pos) {
     }
 }
 
+static CharView* ActiveCharView = 0;
+
 static int cv_e_h(GWindow gw, GEvent *event) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
 
@@ -6197,6 +6199,7 @@ return( GGadgetDispatchEvent(cv->vsb,event));
       break;
       case et_focus:
 	if ( event->u.focus.gained_focus ) {
+	    ActiveCharView = cv;
 	    if ( cv->gic!=NULL )
 		GDrawSetGIC(gw,cv->gic,0,20);
 	}
@@ -6204,6 +6207,12 @@ return( GGadgetDispatchEvent(cv->vsb,event));
     }
 return( true );
 }
+
+CharView* CharViewFindActive()
+{
+    return ActiveCharView;
+}
+
 
 #define MID_Fit		2001
 #define MID_ZoomIn	2002

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -6926,6 +6926,7 @@ return( GGadgetDispatchEvent(fv->vsb,event));
 	FVTimer(fv,event);
       break;
       case et_focus:
+	  printf("fv.et_focus\n");
 	if ( event->u.focus.gained_focus )
 	    GDrawSetGIC(gw,fv->gic,0,20);
       break;
@@ -7015,6 +7016,8 @@ void FontViewRemove(FontView *fv) {
  */
 extern int osx_fontview_copy_cut_counter;
 
+static FontView* ActiveFontView = 0;
+
 static int fv_e_h(GWindow gw, GEvent *event) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
 
@@ -7024,6 +7027,16 @@ return( GGadgetDispatchEvent(fv->vsb,event));
     }
 
     switch ( event->type ) {
+      case et_focus:
+	  if ( event->u.focus.gained_focus )
+	  {
+	      printf("fv.et_focus fv_e_h\n");
+	      ActiveFontView = fv;
+	  }
+	  else
+	  {
+	  }
+	  break;
       case et_selclear:
 #ifdef __Mac
 	  // For some reason command + c and command + x wants
@@ -7967,6 +7980,22 @@ int FontViewFind_bySplineFont( FontViewBase* fv, void* udata )
 	return 0;
     return fv->sf == udata;
 }
+
+static int FontViewFind_ActiveWindow( FontViewBase* fvb, void* udata )
+{
+    FontView* fv = (FontView*)fvb;
+    return( fv->gw == udata || fv->v == udata );
+}
+
+FontViewBase* FontViewFindActive()
+{
+    return ActiveFontView;
+    /* GWindow w = GWindowGetCurrentFocusTopWindow(); */
+    /* FontViewBase* ret = FontViewFind( FontViewFind_ActiveWindow, w ); */
+    /* return ret; */
+}
+
+
 
 FontViewBase* FontViewFind( int (*testFunc)( FontViewBase*, void* udata ), void* udata )
 {

--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -786,6 +786,58 @@ copyUIMethodsToBaseTable( PyMethodDef* ui, PyMethodDef* md )
     return md;
 }
 
+static void python_ui_fd_callback( int fd, void* udata );
+static void python_ui_setup_callback( bool makefifo )
+{
+    int fd = 0;
+    int err = 0;
+    char path[ PATH_MAX + 1 ];
+    snprintf( path, PATH_MAX, "%s/python-socket", getFontForgeUserDir(Cache));
+    
+    if( makefifo )
+    {
+	err = mkfifo( path, 0600 );
+    }
+    
+    void* udata = 0;
+    printf("PythonUI_Init(0)\n");
+    fd = open( path, O_RDONLY | O_NDELAY );
+    printf("PythonUI_Init(1) fd:%d\n", fd);
+    GDrawAddReadFD( 0, fd, udata, python_ui_fd_callback );
+    printf("PythonUI_Init(2)\n");
+    
+}
+
+static void python_ui_fd_callback( int fd, void* udata )
+{
+    fprintf( stderr, "python_ui_fd_callback(top) fd:%d\n", fd );
+    char data[ 1024*100 + 1 ];
+    memset(data, '\0', 1024*100 );
+//    sleep( 1 );
+    int sz = read( fd, data, 1024*100 );
+    fprintf( stderr, "python_ui_fd_callback() sz:%d d:%s\n", sz, data );
+
+    CharView* cv = CharViewFindActive();
+    if( cv )
+    {
+	fprintf( stderr, "python_ui_fd_callback() cv:%p\n", cv );
+	fprintf( stderr, "python_ui_fd_callback() fv:%p\n", cv->b.fv );
+	fprintf( stderr, "python_ui_fd_callback() sc:%p\n", cv->b.sc );
+	
+	int layer = 0;
+	PyFF_ScriptString( cv->b.fv, cv->b.sc, layer, data );
+    }
+    
+    GDrawRemoveReadFD( 0, fd, udata );
+    python_ui_setup_callback( 0 );
+    
+}
+
+void PythonUI_namedpipe_Init(void) {
+    python_ui_setup_callback( 1 );
+    
+}
+
 void PythonUI_Init(void) {
     TRACE("PythonUI_Init()\n"); 
     FfPy_Replace_MenuItemStub(PyFF_registerMenuItem);
@@ -794,5 +846,7 @@ void PythonUI_Init(void) {
 
     copyUIMethodsToBaseTable( PyFF_FontUI_methods,         PyFF_Font_methods );
     copyUIMethodsToBaseTable( module_fontforge_ui_methods, module_fontforge_methods );
+
+    
 }
 

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1203,6 +1203,9 @@ exit( 0 );
     collabclient_ensureClientBeacon();
     collabclient_sniffForLocalServer();
 
+    PythonUI_namedpipe_Init();
+    
+
 #if defined(__Mac)
     if ( listen_to_apple_events ) {
 	install_apple_event_handlers();

--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -617,6 +617,8 @@ return( true );
 
     GGadgetPopupExternalEvent(event);
     if ( event->type==et_focus ) {
+	printf("GWidget_TopLevel_eh() focus\n");
+	
 	if ( event->u.focus.gained_focus ) {
 	    if ( gw->is_toplevel && !gw->is_popup && !gw->is_dying ) {
 		if ( last_input_window!=gw )

--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -36,16 +36,14 @@ export FONTCONFIG_FILE="$bundle_etc/fonts/fonts.conf"
 export LANG=en_US.UTF-8
 export XLOCALEDIR="$bundle_share/X11/locale"
 
-export PYTHONHOME="$bundle_bin/Python.framework.2.7"
-# This line allows python to find the compiled libraries so for example the gdraw
-# module can use _libraries['libgdraw.so.5'] = CDLL('libgdraw.so.5')
-export LD_LIBRARY_PATH="$bundle_lib"
 
 WRAPPER=
 
 if [ x"$1" == "x--debug" ]; then
-    unset PYTHONHOME
-    unset LD_LIBRARY_PATH
+
+#    do not change these here, maybe the system has something it already needs
+#    unset PYTHONHOME
+#    unset LD_LIBRARY_PATH
 
     if command -v lldb 2>/dev/null; then
         WRAPPER="gdb --args"
@@ -61,6 +59,16 @@ if [ x"$1" == "x--debug" ]; then
         exit
     fi
 fi
+
+#
+# only change these here to the local bundle ones so the scripts
+# can run.
+export PYTHONHOME="$bundle_bin/Python.framework.2.7"
+export PYTHONPATH="/Applications/FontForge.app/Contents/MacOS/Even.app/Contents/Resources/lib/"
+# This line allows python to find the compiled libraries so for example the gdraw
+# module can use _libraries['libgdraw.so.5'] = CDLL('libgdraw.so.5')
+export LD_LIBRARY_PATH="$bundle_lib"
+
 
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f FontForge.app
 $scriptdir/fcprogress.pl >|/tmp/zz 2>&1

--- a/osx/create-osx-app-bundle.sh
+++ b/osx/create-osx-app-bundle.sh
@@ -64,6 +64,8 @@ sed -i -e "s/CFBundleGetInfoStringChangeMe/$CFBundleGetInfoString/g" $TEMPDIR/Fo
 sed -i -e "s/CFBundleVersionChangeMe/$FONTFORGE_VERSIONDATE_RAW/g" $TEMPDIR/FontForge.app/Contents/Info.plist
 
 
+
+
 #
 # Now to fix the binaries to have shared library paths that are all inside
 # the distrubtion instead of off into /opt/local or where macports puts things.
@@ -73,6 +75,15 @@ dylibbundler --overwrite-dir --bundle-deps --fix-file \
   ./fontforge \
   --install-path @executable_path/../lib \
   --dest-dir ../lib
+
+# # dylibbundler wants to do overwrite-dir in order to fix the shared libraries too
+# # but we want to preserve any existing subdirs, so we do the dylibundle to another
+# # dir and then move the nice generated output to ./lib before moving on.
+# cd ../lib-bundle
+# cp -av . ../lib
+# cd ..
+# rm -rf ./lib-bundle
+# cd ./bin
 dylibbundler --overwrite-dir --bundle-deps --fix-file \
   ./FontForgeInternal/fontforge-internal-collab-server \
   --install-path @executable_path/collablib \
@@ -87,6 +98,25 @@ do
     cp -av /opt/local/lib/$if $bundle_lib/
     library-paths-opt-local-to-absolute.sh $bundle_lib/$if 
 done
+
+# cd $bundle_lib
+# cd ./python2.7/site-packages/fontforge.so
+# for if in $(find . -name "*so")
+# do
+#     echo $if
+#     library-paths-opt-local-to-absolute.sh $if
+
+#     install_name_tool -change /opt/local/home/ben/bdwgc/lib/libgc.1.dylib /Applications/FontForge.app/Contents/Resources/opt/local/lib/libgc.1.dylib $if
+#     install_name_tool -change /usr/lib/libedit.3.dylib /Applications/FontForge.app/Contents/Resources/opt/local/lib/libedit.3.dylib $if
+#     install_name_tool -change /opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python \
+#        /Applications/FontForge.app/Contents/Resources//opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python \
+#        $if
+
+# done
+
+
+
+
 cd $bundle_bin
 
 


### PR DESCRIPTION
This file is owned by and only writable by
the user. Also some new code to track the last active fontview and
charview to help code that needs context but does not explicitly track
it, for example, the code that runs a python script from the named
pipe wants to pass the active char to that script so it can perform
something on that char.
