### PR TITLE
Make sure fcntl.h is included.

### DIFF
--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -49,6 +49,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <stdarg.h>
+#include <fcntl.h>
 #include "ffpython.h"
 
 #include "gnetwork.h"


### PR DESCRIPTION
Needed for declaration of open(), plus definitions for O_RDONLY and O_NDELAY.
