### PR TITLE
Fixed corruption caused by incorrect dumping of named point to SFD file.

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -680,7 +680,11 @@ static void SFDDumpSplineSet(FILE *sfd,SplineSet *spl) {
 		}
 	    }
 	    putc('\n',sfd);
-		if (sp->name != NULL) fprintf(sfd, "NamedP: %s\n", sp->name);
+	    if (sp->name != NULL) {
+		fputs("NamedP: ", sfd);
+		SFDDumpUTF7Str(sfd, sp->name);
+		putc('\n', sfd);
+	    }
 	    if ( sp==first )
 	break;
 	    if ( first==NULL ) first = sp;


### PR DESCRIPTION
Point's name is read by SFDReadUTF7Str(), which requires the name to be inside double quotes or it will fail, with the added consequence that any subsequent points in the containing spline to be lost.

Fixed by changing the printf() call to SFDDumpUTF7Str().
