### PR TITLE
Removed unnecessary duplicated calls to GDrawGetUserData.

### DIFF
--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -3051,22 +3051,18 @@ static void CVPopupSelectInvoked(GWindow v, GMenuItem *mi, GEvent *e) {
 	CVMakeClipPath(cv);
       break;
     case MID_MakeLine: {
-	CharView *cv = (CharView *) GDrawGetUserData(v);
 	_CVMenuMakeLine((CharViewBase *) cv,mi->mid==MID_MakeArc, e!=NULL && (e->u.mouse.state&ksm_meta));
 	break;
     }
     case MID_MakeArc: {
-	CharView *cv = (CharView *) GDrawGetUserData(v);
 	_CVMenuMakeLine((CharViewBase *) cv,mi->mid==MID_MakeArc, e!=NULL && (e->u.mouse.state&ksm_meta));
 	break;
     }
     case MID_InsertPtOnSplineAt: {
-	CharView *cv = (CharView *) GDrawGetUserData(v);
 	_CVMenuInsertPt( cv );
 	break;
     }
     case MID_NameContour: {
-	CharView *cv = (CharView *) GDrawGetUserData(v);
 	_CVMenuNameContour( cv );
 	break;
     }


### PR DESCRIPTION
GDrawGetUserData is called at the beginning of CVPopupSelectInvoked; it isn't necessary to call it again inside every case of the switch.
