### PR TITLE
gc: on osx fontforge-config.h *must* be included before ffglib.h.

### DIFF
--- a/fontforge/fontforgeui.h
+++ b/fontforge/fontforgeui.h
@@ -27,6 +27,7 @@
 #ifndef _PFAEDITUI_H_
 #define _PFAEDITUI_H_
 
+#include <fontforge-config.h>
 #include "ffglib.h"
 #include "fontforgevw.h"
 #include <gprogress.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -24,6 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fontforge-config.h>
 
 #include "fontforgeui.h"
 #include "cvruler.h"

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -24,7 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+#include <fontforge-config.h>
 
 #include "fontforgeui.h"
 #include "groups.h"

--- a/fontforgeexe/windowmenu.c
+++ b/fontforgeexe/windowmenu.c
@@ -24,6 +24,8 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <fontforge-config.h>
+
 # include "fontforgeui.h"
 # include <gfile.h>
 # include "splinefont.h"


### PR DESCRIPTION
```
At any case, since calloc() is being tweaked then the fontforge-config.h
doesn't help to be explicitly the first include file just to be sure.
```
