### PR TITLE
Fix crashes occurring when XDestroyImage() tries to free image data.

### DIFF
--- a/gdraw/gimagexdraw.c
+++ b/gdraw/gimagexdraw.c
@@ -1722,6 +1722,14 @@ static void check_image_buffers(GXDisplay *gdisp, int neww, int newh, int is_bit
 return;
 
     if ( gdisp->gg.img!=NULL ) {
+	/* If gdisp->gg.img->data was allocated by GC_malloc rather
+	   than standard libc malloc then it must be set to NULL so
+	   that XDestroyImage() does not try to free it and crash.
+	   
+	   If we no longer use libgc then the following conditional
+	   block can be removed, but in case it isn't, the enclosed
+	   free() will prevent a memory leak.
+	*/
 	if (gdisp->gg.img->data) {
 	    free(gdisp->gg.img->data);
 	    gdisp->gg.img->data = NULL;
@@ -1729,6 +1737,14 @@ return;
 	XDestroyImage(gdisp->gg.img);
     }
     if ( gdisp->gg.mask!=NULL ) {
+	/* If gdisp->gg.mask->data was allocated by GC_malloc rather
+	   than standard libc malloc then it must be set to NULL so
+	   that XDestroyImage() does not try to free it and crash.
+	   
+	   If we no longer use libgc then the following conditional
+	   block can be removed, but in case it isn't, the enclosed
+	   free() will prevent a memory leak.
+	*/
 	if (gdisp->gg.mask->data) {
 	    free(gdisp->gg.mask->data);
 	    gdisp->gg.mask->data = NULL;


### PR DESCRIPTION
XDestroyImage() assumes that it can call free() on the data pointed to
by the XImage structure it is passed.  However, the data may have come
from the strange malloc(), in which case calling free() on it is a
guaranteed crash.  Unfortunately, we have no way of knowing here if
this is the case or not, so we must always set gdisp->gg.img->data and
gdisp->gg.mask->data to NULL and live with the resulting memory leak
when we are wrong.
