### PR TITLE
Removed reference to obsolete variable 'hadtimes'

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -7868,7 +7868,7 @@ static SplineFont *SFD_GetFont( FILE *sfd,SplineFont *cidmaster,char *tok,
     int pushedbacktok = false;
     Encoding *enc = &custom;
     struct remap *remap = NULL;
-    int hadtimes=false, haddupenc;
+    int haddupenc;
     int old_style_order2 = false;
     int had_layer_cnt=false;
 
@@ -8384,7 +8384,7 @@ exit( 1 );
 	AltUniFigure(sf,sf->map,true);
     if ( sf->sfd_version<2 )
 	SFD_AssignLookups((SplineFont1 *) sf);
-    if ( !hadtimes )
+    if ( !d.hadtimes )
 	SFTimesFromFile(sf,sfd);
 
     SFDFixupUndoRefs(sf);


### PR DESCRIPTION
The function SFD_GetFont defines local variable 'hadtimes', set to true when CreationTime is read from an SFD file (else the file's mtime is used for the creation time).  However, this variable had migrated to a field of the same name in the SFD_GetFontMetaDataData structure when the SFD_GetFontMetaData function was created, and is now always false, meaning that CreationTime is _always_ overwritten with the file's mtime.

This patch restores the code's intended behavior, which is to preserve the value of CreationTime if it exists in the SFD file, and only use the file's mtime if it does not.  The obsolete local variable 'hadtimes' is also removed.
