### PR TITLE
Add application category for OS X

### DIFF
--- a/osx/FontForge.app/Contents/Info.plist
+++ b/osx/FontForge.app/Contents/Info.plist
@@ -159,5 +159,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.graphics-design</string>
 </dict>
 </plist>


### PR DESCRIPTION
Because OS X apps generally don't like apps being subfoldered (updates miss their targets), as of Lion the Finder has had an Applications-specific View by Application Category view. It sorts by a piece of metadata called LSApplicationCategoryType which if missing, dumps the application in the "Others" section at the bottom. This commit adds the correct application category for FontForge, "Graphics & Design".
