### PR TITLE
win build: its probably simpler in the long run to rename PrintDlg() in FF

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,4 +1,4 @@
-# bootstrap.conf (fontforge) version 2014-04-14
+# bootstrap.conf (fontforge) version 2014-05-19
 # Written by Gary V. Vaughan, 2010
 
 # Copyright (C) 2010 Free Software Foundation, Inc.
@@ -49,6 +49,7 @@ gnulib_modules='
 	strndup
 	xalloc
 	xvasprintf
+	gethostname
 '
 
 # Extra gnulib files that are not in modules, which override files of

--- a/collab/Makefile.am
+++ b/collab/Makefile.am
@@ -37,7 +37,7 @@ libzmqcollab_la_CPPFLAGS = \
  "-I$(top_builddir)/lib" "-I$(top_srcdir)/lib" \
  $(MY_CFLAGS) $(LIBZMQ_CFLAGS) $(GLIB_CFLAGS)
 
-libzmqcollab_la_LIBADD = $(MY_LIBS) $(GLIB_LIBS) $(LIBZMQ_LIBS)
+libzmqcollab_la_LIBADD = $(MY_LIBS) $(GLIB_LIBS) $(LIBZMQ_LIBS) $(top_builddir)/lib/libgnu.la $(top_builddir)/inc/libggc_veneer.la
 libzmqcollab_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBZMQCOLLAB_VERSION) \
 	${MY_LIB_LDFLAGS} $(LIBGC_LIBS) $(top_builddir)/inc/libggc_veneer.la
 

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -754,7 +754,7 @@ extern uint8 *DebuggerGetWatchCvts(struct debugger_context *dc, int *n);
 extern int DebuggingFpgm(struct debugger_context *dc);
 
 
-extern void PrintDlg(FontView *fv,SplineChar *sc,MetricsView *mv);
+extern void PrintFFDlg(FontView *fv,SplineChar *sc,MetricsView *mv);
 extern void PrintWindowClose(void);
 extern void InsertTextDlg(CharView *cv);
 

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -6657,7 +6657,7 @@ static void CVAddWordList(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUS
 static void CVMenuPrint(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
 
-    PrintDlg(NULL,cv->b.sc,NULL);
+    PrintFFDlg(NULL,cv->b.sc,NULL);
 }
 
 static void CVMenuExecute(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {

--- a/fontforgeexe/displayfonts.c
+++ b/fontforgeexe/displayfonts.c
@@ -41,7 +41,7 @@
 #include <gkeysym.h>
 #include "print.h"
 
-typedef struct printdlg {
+typedef struct printffdlg {
     struct printinfo pi;
     GWindow gw;
     GWindow setup;
@@ -1544,7 +1544,7 @@ return( false );
 return( true );
 }
     
-static void _PrintDlg(FontView *fv,SplineChar *sc,MetricsView *mv,
+static void _PrintFFDlg(FontView *fv,SplineChar *sc,MetricsView *mv,
 	int isprint,CharView *cv,SplineSet *fit_to_path) {
     GRect pos;
     GWindowAttrs wattrs;
@@ -2259,8 +2259,8 @@ return;
     }
 }
 
-void PrintDlg(FontView *fv,SplineChar *sc,MetricsView *mv) {
-    _PrintDlg(fv,sc,mv,true,NULL,NULL);
+void PrintFFDlg(FontView *fv,SplineChar *sc,MetricsView *mv) {
+    _PrintFFDlg(fv,sc,mv,true,NULL,NULL);
 }
 
 static SplineSet *OnePathSelected(CharView *cv) {
@@ -2294,7 +2294,7 @@ return( sel );
 }
 
 void InsertTextDlg(CharView *cv) {
-    _PrintDlg(NULL,cv->b.sc,NULL,false,cv,OnePathSelected(cv));
+    _PrintFFDlg(NULL,cv->b.sc,NULL,false,cv,OnePathSelected(cv));
 }
 
 void PrintWindowClose(void) {

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -52,10 +52,6 @@
 #include <windows.h>
 #endif
 
-// Clash on windows for a define to PrintDlgA
-#ifdef PrintDlg
-#undef PrintDlg
-#endif
 
 int OpenCharsInNewWindow = 0;
 char *RecentFiles[RECENT_MAX] = { NULL };
@@ -1146,7 +1142,7 @@ static void FVMenuPrint(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED
 
     if ( fv->b.container!=NULL && fv->b.container->funcs->is_modal )
 return;
-    PrintDlg(fv,NULL,NULL);
+    PrintFFDlg(fv,NULL,NULL);
 }
 
 static void FVMenuExecute(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -2283,7 +2283,7 @@ static void MVMenuGenerateTTC(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *
 
 static void MVMenuPrint(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
     MetricsView *mv = (MetricsView *) GDrawGetUserData(gw);
-    PrintDlg(NULL, NULL, mv);
+    PrintFFDlg(NULL, NULL, mv);
 }
 
 static void MVUndo(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {

--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -58,6 +58,14 @@
 #endif
 #include "collabclientui.h"
 
+
+#if defined(__MINGW32__)
+#ifndef O_NDELAY
+#define O_NDELAY 0
+#endif
+#endif // __MINGW32__
+
+
 /**
  * Use this to track if the script has joined a collab session.
  * if not then we get to very quickly avoid the collab code path :)

--- a/gtkui/fontview.c
+++ b/gtkui/fontview.c
@@ -1061,7 +1061,7 @@ void FontViewMenu_OpenMetrics(GtkMenuItem *menuitem, gpointer user_data) {
 void FontViewMenu_Print(GtkMenuItem *menuitem, gpointer user_data) {
     FontView *fv = FV_From_MI(menuitem);
 
-    PrintDlg(fv,NULL,NULL);
+    PrintFFDlg(fv,NULL,NULL);
 }
 
 void FontViewMenu_ExecScript(GtkMenuItem *menuitem, gpointer user_data) {

--- a/gtkui/stubs.c
+++ b/gtkui/stubs.c
@@ -20,7 +20,7 @@ void MetricsViewCreate(void) {
     gwwv_post_notice("NYI","Metrics View  not yet implemented");
 }
 
-void PrintDlg(void) {
+void PrintFFDlg(void) {
     gwwv_post_notice("NYI","Print  not yet implemented");
 }
 

--- a/gtkui/viewsgtk.h
+++ b/gtkui/viewsgtk.h
@@ -549,7 +549,7 @@ extern uint8 *DebuggerGetWatchCvts(struct debugger_context *dc, int *n);
 extern int DebuggingFpgm(struct debugger_context *dc);
 
 
-extern void PrintDlg(FontView *fv,SplineChar *sc,MetricsView *mv);
+extern void PrintFFDlg(FontView *fv,SplineChar *sc,MetricsView *mv);
 extern void PrintWindowClose(void);
 
 extern char *Kern2Text(SplineChar *other,KernPair *kp,int isv);


### PR DESCRIPTION
to something that doesn't clash with a global symbol on windows. There are
also some other changes that shouldn't effect other platforms but which will
help the code to compile on a mingw32 environment.
