### PR TITLE
Fix names handling for TTC files. This fixes issue #1351.

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -505,14 +505,15 @@ char *TTFGetFontName(FILE *ttf,int32 offset,int32 off2) {
     /* esel = */ getushort(ttf);
     /* rshift = */ getushort(ttf);
     for ( i=0; i<num; ++i ) {
-	tag = getlong(ttf);
-	/* checksum = */ getlong(ttf);
-	nameoffset = off2+getlong(ttf);
-	if ( tag==CHR('n','a','m','e'))
-    break;
+        tag = getlong(ttf);
+        /* checksum = */ getlong(ttf);
+        nameoffset = off2+getlong(ttf);
+        /* length = */ getlong(ttf);
+        if ( tag==CHR('n','a','m','e'))
+            break;
     }
     if ( i==num )
-return( NULL );
+        return( NULL );
 
     fseek(ttf,nameoffset,SEEK_SET);
     /* format = */ getushort(ttf);
@@ -520,60 +521,60 @@ return( NULL );
     stringoffset = nameoffset+getushort(ttf);
     fullval = famval = 0;
     for ( i=0; i<num; ++i ) {
-	plat = getushort(ttf);
-	spec = getushort(ttf);
-	lang = getushort(ttf);
-	name = getushort(ttf);
-	len = getushort(ttf);
-	off = getushort(ttf);
-	enc = enc_from_platspec(plat,spec);
-	if ( enc==NULL )
-    continue;
-	val = 0;
-	if ( plat==3 && !enc->is_custom && lang==locale )
-	    val = 15;
-	else if ( plat==3 && !enc->is_custom && (lang&0xff)==(locale&0xff) )
-	    val = 14;
-	else if ( (plat==0 || plat==1) && !enc->is_custom && lang==maclang )
-	    val = 13;
-    /* Ok, that didn't work, how about an english name? */
-	else if ( plat==3 && !enc->is_custom && lang==0x409 )
-	    val = 12;
-	else if ( plat==3 && !enc->is_custom && (lang&0xff)==0x09 )
-	    val = 11;
-	else if ( (plat==0 || plat==1) && !enc->is_custom && lang==0 )
-	    val = 10;
-    /* failing that I'll take what I can get */
-	else if ( !enc->is_custom )
-	    val = 1;
-	if ( name==4 && val>fullval ) {
-	    fullval = val;
-	    fullstr = off;
-	    fulllen = len;
-	    fullplat = plat;
-	    fullspec = spec;
-	    fulllang = lang;
-	    if ( val==12 )
-    break;
-	} else if ( name==1 && val>famval ) {
-	    famval = val;
-	    famstr = off;
-	    famlen = len;
-	    famplat = plat;
-	    famspec = spec;
-	    famlang = lang;
-	}
+        plat = getushort(ttf);
+        spec = getushort(ttf);
+        lang = getushort(ttf);
+        name = getushort(ttf);
+        len = getushort(ttf);
+        off = getushort(ttf);
+        enc = enc_from_platspec(plat,spec);
+        if ( enc==NULL )
+            continue;
+        val = 0;
+        if ( plat==3 && !enc->is_custom && lang==locale )
+            val = 15;
+        else if ( plat==3 && !enc->is_custom && (lang&0xff)==(locale&0xff) )
+            val = 14;
+        else if ( (plat==0 || plat==1) && !enc->is_custom && lang==maclang )
+            val = 13;
+        /* Ok, that didn't work, how about an english name? */
+        else if ( plat==3 && !enc->is_custom && lang==0x409 )
+            val = 12;
+        else if ( plat==3 && !enc->is_custom && (lang&0xff)==0x09 )
+            val = 11;
+        else if ( (plat==0 || plat==1) && !enc->is_custom && lang==0 )
+            val = 10;
+        /* failing that I'll take what I can get */
+        else if ( !enc->is_custom )
+            val = 1;
+        if ( name==4 && val>fullval ) {
+            fullval = val;
+            fullstr = off;
+            fulllen = len;
+            fullplat = plat;
+            fullspec = spec;
+            fulllang = lang;
+            if ( val==12 )
+                break;
+        } else if ( name==1 && val>famval ) {
+            famval = val;
+            famstr = off;
+            famlen = len;
+            famplat = plat;
+            famspec = spec;
+            famlang = lang;
+        }
     }
     if ( fullval==0 ) {
-	if ( famval==0 )
-return( NULL );
-	fullstr = famstr;
-	fulllen = famlen;
-	fullplat = famplat;
-	fullspec = famspec;
-	fulllang = famlang;
+        if ( famval==0 )
+            return( NULL );
+        fullstr = famstr;
+        fulllen = famlen;
+        fullplat = famplat;
+        fullspec = famspec;
+        fulllang = famlang;
     }
-return( _readencstring(ttf,stringoffset+fullstr,fulllen,fullplat,fullspec,fulllang));
+    return( _readencstring(ttf,stringoffset+fullstr,fulllen,fullplat,fullspec,fulllang));
 }
 
 static int PickTTFFont(FILE *ttf,char *filename,char **chosenname) {


### PR DESCRIPTION
Commit 3cb817b81abedf1b37b958b6a1d32f9079a7147b introduced the issue.

Most of the changes in this is just indentation, the line that fixes the issue is adding back this:

```
/* length = */ getlong(ttf);
```
