### PR TITLE
Add SVG xmlns attributes. Fixes #626.

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -77,7 +77,7 @@ static int svg_outfontheader(FILE *file, SplineFont *sf,int layer) {
 	latin1ToUtf8Out(file,sf->comments);
 	fprintf( file, "\n-->\n" );
     }
-    fprintf( file, "<svg>\n" );
+    fprintf( file, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\">\n" );
     time(&now);
     fprintf( file, "<metadata>\nCreated by FontForge %d at %s",
 	    FONTFORGE_VERSIONDATE_RAW, ctime(&now) );
@@ -1042,7 +1042,7 @@ int _ExportSVG(FILE *svg,SplineChar *sc,int layer) {
     setlocale(LC_NUMERIC,"C");
     fprintf(svg, "<?xml version=\"1.0\" standalone=\"no\"?>\n" );
     fprintf(svg, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" >\n" );
-    fprintf(svg, "<svg viewBox=\"%d %d %d %d\">\n",
+    fprintf(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"%d %d %d %d\">\n",
 	    (int) floor(b.minx), (int) floor(b.miny),
 	    (int) ceil(b.maxx), (int) ceil(b.maxy));
     fprintf(svg, "  <g transform=\"matrix(1 0 0 -1 0 %d)\">\n",


### PR DESCRIPTION
Apparently Chrome doesn't treat it as a webfont if it's not there. Firefox also won't display the individual glyph svg exports unless it's there too.
