### PR TITLE
Fix NULL pointer crash in PSTKD_Ok().

### DIFF
--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -4007,7 +4007,7 @@ return( true );
 	    sf = pstkd->sf;
 	    oldsfd = SFDCreateUndoForLookup( sf, lookup_type );
 
-	    if( DEBUG )
+	    if( DEBUG && oldsfd )
 		GFileWriteAll( "/tmp/old-lookup-table.sfd", oldsfd );
 	}
 


### PR DESCRIPTION
SFDCreateUndoForLookup() returns NULL if an error occurs when reading the file to a string.  We should not call GFileWriteAll() in that case.
