### PR TITLE
Come to a hard-stop if user wants libreadline, but it's not available.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -760,7 +760,7 @@ Optional Library	UseIt?	HaveIt?	WebsiteURL
   libtiff			${i_do_have_libtiff}	${libtiff_url}
   libuninameslist	${with_libuninameslist}	${i_do_have_libuninameslist}	${libuninameslist_url}
   zeromq (libzmq)		${i_do_have_libzmq}	${libzmq_url}
-  libreadline			${i_do_have_libreadline}	${libreadline_url}
+  libreadline		${with_libreadline}	${i_do_have_libreadline}	${libreadline_url}
   X Window System		${i_do_have_x}
 ])
 

--- a/m4/fontforge_arg_with.m4
+++ b/m4/fontforge_arg_with.m4
@@ -173,13 +173,20 @@ AC_DEFUN([FONTFORGE_ARG_WITH_LIBTIFF_fallback],
 
 
 dnl FONTFORGE_ARG_WITH_LIBREADLINE
-dnl --------------------------
+dnl ------------------------------
+dnl Add with libreadline support by default, only if libreadline library exists
+dnl AND readline/readline.h header file exist.
+dnl If user defines --without-libreadline, then do not include libreadline.
+dnl If user defines --with-libreadline, then fail with error if there is no
+dnl libreadline library OR no readline/readline.h header file.
 AC_DEFUN([FONTFORGE_ARG_WITH_LIBREADLINE],
 [
 AC_ARG_VAR([LIBREADLINE_CFLAGS],[C compiler flags for LIBREADLINE, overriding the automatic detection])
 AC_ARG_VAR([LIBREADLINE_LIBS],[linker flags for LIBREADLINE, overriding the automatic detection])
 AC_ARG_WITH([libreadline],[AS_HELP_STRING([--without-libreadline],[build without READLINE support])],
-            [i_do_have_libreadline="${withval}"],[i_do_have_libreadline=yes])
+            [i_do_have_libreadline="${withval}"; with_libreadline="${withval}"],
+            [i_do_have_libreadline=yes; with_libreadline=check])
+
 if test x"${i_do_have_libreadline}" = xyes -a x"${LIBREADLINE_LIBS}" = x; then
    FONTFORGE_SEARCH_LIBS([rl_readline_version],[readline],
 		  [LIBREADLINE_LIBS="${LIBREADLINE_LIBS} ${found_lib}"],
@@ -194,17 +201,30 @@ if test x"${i_do_have_libreadline}" = xyes -a x"${LIBREADLINE_LIBS}" = x; then
    fi
 fi
 if test x"${i_do_have_libreadline}" = xyes -a x"${LIBREADLINE_CFLAGS}" = x; then
-   AC_CHECK_HEADER([readline/readline.h],[AC_SUBST([LIBREADLINE_CFLAGS],[""])],[i_do_have_libreadline=no])
+   AC_CHECK_HEADER([readline/readline.h],[$LIBREADLINE_CFLAGS=""],[i_do_have_libreadline=no])
 fi
-if test x"${i_do_have_libreadline}" = xyes; then
-   if test x"${LIBREADLINE_LIBS}" != x; then
-      AC_SUBST([LIBREADLINE_LIBS],["${LIBREADLINE_LIBS}"])
+
+AC_MSG_CHECKING([Build with LibReadLine support?])
+if test x"${with_libreadline}" = xyes; then
+   if test x"${i_do_have_libreadline}" != xno; then
+      AC_MSG_RESULT([yes])
+   else
+      AC_MSG_FAILURE([ERROR: Please install the Developer version of libreadline],[1])
    fi
 else
-   FONTFORGE_WARN_PKG_NOT_FOUND([LIBREADLINE])
-   AC_DEFINE([_NO_LIBREADLINE],1,[Define if not using libreadline.])
+   if test x"${i_do_have_libreadline}" = xno || test x"${with_libreadline}" = xno; then
+      AC_MSG_RESULT([no])
+      AC_DEFINE([_NO_LIBREADLINE],1,[Define if not using libreadline.])
+      LIBREADLINE_CFLAGS=""
+      LIBREADLINE_LIBS=""
+   else
+      AC_MSG_RESULT([yes])
+   fi
 fi
+AC_SUBST([LIBREADLINE_CFLAGS])
+AC_SUBST([LIBREADLINE_LIBS])
 ])
+
 
 dnl FONTFORGE_ARG_WITH_LIBSPIRO
 dnl ---------------------------

--- a/m4/fontforge_create_pkg-config_files.m4
+++ b/m4/fontforge_create_pkg-config_files.m4
@@ -34,6 +34,7 @@ test x"${i_do_have_libjpeg}" = xyes && __private_deps="${__private_deps} ${LIBJP
 test x"${i_do_have_libspiro}" = xyes && test x"${with_libspiro}" != xno && __private_deps="${__private_deps} ${LIBSPIRO_LIBS}"
 test x"${i_do_have_libuninameslist}" = xyes && test x"${with_libuninameslist}" && __private_deps="${__private_deps} ${LIBUNINAMESLIST_LIBS}"
 test x"${i_do_have_libunicodenames}" = xyes && __private_deps="${__private_deps} ${LIBUNICODENAMES_LIBS}"
+test x"${i_do_have_libreadline}" = xyes && test x"${with_libreadline}" != xno && __private_deps="${__private_deps} ${LIBREADLINE_LIBS}"
 test x"${i_do_have_x}" = xyes && __private_deps="${__private_deps} ${X_PRE_LIBS} ${X_LIBS} ${X_EXTRA_LIBS}"
 __private_deps="${__private_deps} ${PTHREAD_LIBS}"
 __private_deps="${__private_deps} ${LIBLTDL}"


### PR DESCRIPTION
Default is to check and include, or not include if not available, but
if user option is "--with-libreadline" then the library and header files
must be available, otherwise ./configure comes to a hard-stop.
