### PR TITLE
Fix Python extension naming on Windows.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -472,6 +472,15 @@ case $host in
 esac
 AC_SUBST([MY_LIB_LDFLAGS], [${my_lib_ldflags}])
 
+# Native Windows Python modules have a '.pyd' extension and not '.dll'
+pyhook_file_extension=""
+case $host in
+    *mingw*)
+        pyhook_file_extension="${pyhook_file_extension} -shrext \".pyd\""
+    ;;
+esac
+AC_SUBST([PYHOOK_FILE_EXTENSION], [${pyhook_file_extension}])
+
 AC_LANG_POP
 
 #--------------------------------------------------------------------------

--- a/pyhook/Makefile.am
+++ b/pyhook/Makefile.am
@@ -29,11 +29,13 @@ pyexec_LTLIBRARIES = psMat.la fontforge.la
 
 psMat_la_SOURCES = psMatpyhook.c
 psMat_la_LIBADD = $(LIBADD)
-psMat_la_LDFLAGS = $(MY_LIB_LDFLAGS) -module
+psMat_la_LDFLAGS = $(MY_LIB_LDFLAGS) -module -shared -avoid-version \
+                   $(PYHOOK_FILE_EXTENSION)
 
 fontforge_la_SOURCES = fontforgepyhook.c
 fontforge_la_LIBADD = $(LIBADD)
-fontforge_la_LDFLAGS = $(MY_LIB_LDFLAGS) -module
+fontforge_la_LDFLAGS = $(MY_LIB_LDFLAGS) -module -shared -avoid-version \
+                       $(PYHOOK_FILE_EXTENSION)
 
 AM_CFLAGS = $(WARN_CFLAGS)
 
@@ -42,7 +44,6 @@ AM_CPPFLAGS = -DLIBDIR='"$(libdir)"' $(PYTHON_CFLAGS)			\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
 	"-I$(top_builddir)/fontforge" "-I$(top_srcdir)/fontforge"	\
 	$(MY_CFLAGS)
-AM_LDFLAGS = -module -shared -avoid-version
 
 LIBADD = $(top_builddir)/Unicode/libgunicode.la	\
 	$(top_builddir)/gutils/libgutils.la			\


### PR DESCRIPTION
The extensions should not be versioned (`-avoid-version`), and for native Windows Python modules, they should have a '.pyd' extension. `AM_LDFLAGS` can't be used because this gets overridden by the library-specific `LDFLAGS` (`MY_LIB_LDFLAGS` must be specified for each library so the `-no-undefined` flag works, as `-no-undefined` cannot be specified in `AM_LDFLAGS`).

I'm not very experienced with writing autoconf configurations so I can't say if I've done a particularly good job of what I want it to do. The `.pyd` change of extension should affect native Windows builds only and not Cygwin builds.
