### PR TITLE
Fix buffer overrun on multi-char SVG hkern u1="..."

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -3044,7 +3044,7 @@ static char *SVGGetNames(SplineFont *sf,xmlChar *g,xmlChar *utf8,SplineChar **sc
 	    temp = SFGetChar(sf,u[i],NULL);
 	    if ( temp!=NULL ) {
 		if ( *sc==NULL ) *sc = temp;
-		len = strlen(temp->name)+1;
+		len += strlen(temp->name)+1;
 	    }
 	}
     }


### PR DESCRIPTION
`fontforge/svg.c` routine `SVGGetNames()` scans the argument variable `utf8` (from hkern `u1="..."` or `u2="..."` attribute values) for contained characters, finding the glyph name for each character, and accumulating the total string length needed to copy all of these glyph names into one string.  Only it doesn't manage to, having missed the '+' in

```
                len += strlen(temp->name)+1;
```

This fix corrects the typo, correctly accumulating the needed string length for use with the following `malloc()`.  Tested as not crashing after this fix with one, four, and 28 characters.

Without the fix an hkern element like:

```
    <hkern u1="&#xE124;,&#xE125;,&#xE126;,&#xE127;,&#xE128;,&#xE129;,&#xE12A;,&#xE12B;,&#xE12C;,&#xE12D;,&#xE12E;,&#xE12F;,&#xE130;,&#xE131;,&#xE132;,&#xE133;,&#xE134;,&#xE135;,&#xE136;,&#xE137;,&#xE138;,&#xE139;,&#xE13A;,&#xE13B;,&#xE13C;,&#xE13D;,&#xE13E;,&#xE13F;"
           u2="&#xE110;"  k="375"   />
```

will cause errors such as:
      `Segmentation fault (core dumped)`
As few as three or four characters in one u1="..." will crash FontForge.
