### PR TITLE
Make menus only as wide as they need to be. Fixes #853

### DIFF
--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1395,7 +1395,7 @@ static GMenu *_GMenu_Create( GMenuBar* toplevel,
     GRect pos;
     GDisplay *disp = GDrawGetDisplayOfWindow(owner);
     GWindowAttrs pattrs;
-    int i, width, keywidth;
+    int i, width, max_iwidth = 0, max_hkwidth = 0;
     unichar_t buffer[300];
     extern int _GScrollBar_Width;
     int ds, ld, temp, lh;
@@ -1429,13 +1429,13 @@ static GMenu *_GMenu_Create( GMenuBar* toplevel,
     lh = m->fh;
 
     GDrawSetFont(m->w,m->font);
-    m->hasticks = false; width = 0; keywidth = 0;
+    m->hasticks = false;
     for ( i=0; mi[i].ti.text!=NULL || mi[i].ti.image!=NULL || mi[i].ti.line; ++i ) {
 	if ( mi[i].ti.checkable )
 	    m->hasticks = true;
 	temp = GTextInfoGetWidth(m->w,&mi[i].ti,m->font);
-	if ( temp>width )
-	    width = temp;
+	if (temp > max_iwidth)
+	    max_iwidth = temp;
 
 	uc_strcpy(buffer,"");
 	uint16 short_mask = 0;
@@ -1474,14 +1474,13 @@ static GMenu *_GMenu_Create( GMenuBar* toplevel,
 	    uc_strcpy( buffer, keydesc );
 
 	    temp = GDrawGetTextWidth(m->w,buffer,-1);
+	    if (temp > max_hkwidth)
+	        max_hkwidth = temp;
 	    /* if( short_mask && mac_menu_icons ) { */
 	    /* 	temp += GMenuMacIconsWidth( m, short_mask ); */
 	    /* } */
 	}
 
-	if ( temp>keywidth ) keywidth=temp;
-	if ( mi[i].sub!=NULL && 3*m->as>keywidth )
-	    keywidth = 3*m->as;
 	temp = GTextInfoGetHeight(m->w,&mi[i].ti,m->font);
 	if ( temp>lh ) {
 	    if ( temp>3*m->fh/2 )
@@ -1491,7 +1490,9 @@ static GMenu *_GMenu_Create( GMenuBar* toplevel,
     }
     m->fh = lh;
     m->mcnt = m->lcnt = i;
-    if ( keywidth!=0 ) width += keywidth + GDrawPointsToPixels(m->w,8);
+
+    //Width: Max item length + max length of hotkey text + padding
+    width = max_iwidth + max_hkwidth + GDrawPointsToPixels(m->w, 10);
     if ( m->hasticks ) {
 	int ticklen = m->as + GDrawPointsToPixels(m->w,5);
 	width += ticklen;


### PR DESCRIPTION
This stops menus from being annoyingly wide by calculating the menu width to be:

```
max_item_text_width + max_hotkey_text_width + padding
```

Where `padding` is the minimum separation between item and hotkey text. ~~This is currently fixed at 12 units.~~ Oh I should use `GDrawPointsToPixels`

~~P.S: I have no idea what the original intention of `keywidth` was - maybe width was different before pango was used or something.~~

But in debugging, `keywidth` was always equal to `width`, meaning that the menu width was always more than double the minimum width required.

Edit: Looking at the 2012 version, `keywidth` had something to do with calculating the bidirectional text width (which I presume Pango now does), which has since been removed. As `temp` is reused for all width calculations, and that step was removed, `keywidth` was being compared against the item width, which was wrong.
