### PR TITLE
Don't call g_type_init for glib versions >= 2.35

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -809,7 +809,9 @@ int fontforge_main( int argc, char **argv ) {
     int openflags=0;
     int doopen=0, quit_request=0;
 
+#if !(GLIB_CHECK_VERSION(2, 35, 0))
     g_type_init();
+#endif
 
     /* Must be done before we cache the current directory */
     /* Change to HOME dir if specified on the commandline */


### PR DESCRIPTION
It's been deprecated for versions >= 2.35
