### PR TITLE
Fix incorrect type-casting of signed to unsigned.

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -1876,7 +1876,7 @@ return( NULL );
 	}
 	if ( !found ) {
 	    if ( sc->unicodeenc!=-1 &&
-                 (unsigned)sc->unicodeenc<unicode4_size &&
+                 sc->unicodeenc < (int)unicode4_size &&
 		     (j = EncFromUni(sc->unicodeenc,enc))!= -1 )
 		encoded[j] = i;
 	    else {

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -15689,7 +15689,7 @@ return (NULL);
     fv = self->fv;
     if ( !PyArg_ParseTuple(args,"i|s", &uni, &name ) )
 return( NULL );
-    if ( uni<-1 || (unsigned)uni>=unicode4_size ) {
+    if ( uni<-1 || uni >= (int)unicode4_size ) {
 	PyErr_Format(PyExc_ValueError, "Unicode codepoint, %d, out of range, must be either -1 or between 0 and 0x10ffff", uni );
 return( NULL );
     } else if ( uni==-1 && name==NULL ) {
@@ -15763,7 +15763,7 @@ return (NULL);
 	if ( !PyArg_ParseTuple(args,"i", &uni ) )
 return( NULL );
     }
-    if ( uni<-1 || (unsigned)uni>=unicode4_size ) {
+    if ( uni<-1 || uni >= (int)unicode4_size ) {
 	PyErr_Format(PyExc_ValueError, "Unicode codepoint, %d, out of range, must be either -1 or between 0 and 0x10ffff", uni );
 return( NULL );
     }
@@ -15793,7 +15793,7 @@ return( NULL );
 	    uni = -1;
 	} else if ( !PyArg_ParseTuple(args,"i|s", &uni, &name ) )
 return( NULL );
-	if ( uni<-1 || (unsigned)uni>=unicode4_size ) {
+	if ( uni<-1 || uni >= (int)unicode4_size ) {
 	    PyErr_Format(PyExc_ValueError, "Unicode codepoint, %d, out of range, must be either -1 or between 0 and 0x10ffff", uni );
 return( NULL );
 	} else if ( uni==-1 && name==NULL ) {

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -1429,7 +1429,7 @@ static void SFDDumpChar(FILE *sfd,SplineChar *sc,EncMap *map,int *newgids,int to
     }
     if ( sc->unicodeenc!=-1 &&
 	    ((map->enc->is_unicodebmp && sc->unicodeenc<0x10000) ||
-	     (map->enc->is_unicodefull && (unsigned)sc->unicodeenc<unicode4_size)) )
+	     (map->enc->is_unicodefull && sc->unicodeenc < (int)unicode4_size)) )
 	/* If we have altunis, then the backmap may not give the primary */
 	/*  unicode code point, which is what we need here */
 	fprintf(sfd, "Encoding: %d %d %d\n", sc->unicodeenc, sc->unicodeenc,

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -4691,7 +4691,7 @@ return( NULL );			/* No variation selectors */
 	any = 0;
 	for ( gid=mingid; gid<=maxgid; ++gid ) if ( (sc=sf->glyphs[gid])!=NULL ) {
 	    for ( altuni = sc->altuni; altuni!=NULL; altuni=altuni->next ) {
-		if ( altuni->unienc!=-1 && (unsigned)altuni->unienc<unicode4_size &&
+		if ( altuni->unienc!=-1 && altuni->unienc < (int)unicode4_size &&
 			altuni->vs==vses[i] && altuni->fid==0 ) {
 		    for ( au=sc->altuni; au!=NULL; au=au->next )
 			if ( au->unienc==altuni->unienc && au->vs==-1 && au->fid==0 )


### PR DESCRIPTION
These incorrect type-casts were introduced by 3cb817b8.
Blindly type-casting to please the compiler is bad!

This should fix this issue: https://sourceforge.net/p/fontforgebuilds/tickets/8/

~~I need to test whether that is so though.~~ Yep!
