### PR TITLE
Remove Win32 byte-order swapping in UniFromEnc

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2394,22 +2394,7 @@ return( -1 );
 return( -1 );
 	}
 	if ( tpt-(char *) to == sizeof(unichar_t) )
-	{
-#if defined(__MINGW32__)
-	    {
-		printf("UniFromEnc(original ret) enc:%d initial result:%ld\n", enc, to[0] );
-		// For whatever reason the mingw32 build seems to always produce
-		// a result in byte swapped order.
-		unichar_t t = to[0];
-		printf("UniFromEnc(ret1) %ld\n",t );
-		unichar_t low16  = t & 0xFFFF;
-		unichar_t high16 = t >> 16;
-		t = (low16<<16) | high16;
-		printf("UniFromEnc(ret2) enc:%d final result:%ld\n", enc, t );
-		to[0] = t;
-	    }
-	    printf("UniFromEnc(final ret) %ld\n",to[0] );
-#endif	    
+	{	    
 	    return( to[0] );
 	}
     } else if ( encname->tounicode_func!=NULL ) {


### PR DESCRIPTION
Reference: 513d4f79ed811dc44b8611aabfa9113276fd44a9
It seems that iconv has been updated since then, or something has changed so
that the correct value is returned without byte-order swapping.
