### PR TITLE
Win32: Find GResourceProgramDir before InitSimpleStuff in scripting main

### DIFF
--- a/fontforge/start.c
+++ b/fontforge/start.c
@@ -118,6 +118,9 @@ void doinitFontForgeMain(void) {
 
     if ( inited )
 return;
+#ifdef __MINGW32__
+    FindProgDir(NULL);
+#endif
     InitSimpleStuff();
     if ( default_encoding==NULL )
 	default_encoding=FindOrMakeEncoding("ISO8859-1");


### PR DESCRIPTION
In some cases, `GResourceProgramDir` is needed when running FontForge from the scripting main.
