### PR TITLE
Fix ufo.c compilation on Windows and in Python-free environments.

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -195,7 +195,7 @@ xmlNodePtr PythonLibToXML(void *python_persistent,SplineChar *sc) {
     dictnode = xmlNewNode(NULL, BAD_CAST "dict"); //     "  <dict>"
     if ( has_hints 
 #ifndef _NO_PYTHON
-         || (python_persistent!=NULL && PyMapping_Check(dict) && sc!=NULL)
+         || (python_persistent!=NULL && PyMapping_Check((PyObject *)python_persistent) && sc!=NULL)
 #endif
        ) {
 


### PR DESCRIPTION
This addresses #1463.
