### PR TITLE
SVG font input empty chars not output to SFD or fonts

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2865,6 +2865,7 @@ static SplineChar *SVGParseGlyphArgs(xmlNodePtr glyph,int defh, int defv,
     name = xmlGetProp(glyph,(xmlChar *) "horiz-adv-x");
     if ( name!=NULL ) {
 	sc->width = strtod((char *) name,NULL);
+        sc->widthset = true;
 	xmlFree(name);
     } else
 	sc->width = defh;


### PR DESCRIPTION
Magic flag `widthset` was not being set for input glyphs upon parsing
from SVG font files.  This flag is used by `sfd.c` routine `SFDOmit()`
to judge whether a character was significant enough to be output.

Upon first input from SVG font file, empty glyphs (not containing any
drawing instructions / spline info) would appear in character view
(as X'd boxes).  But these would not be output to a new SFD file or
any generated fonts.  Restarting FF using the previous SFD file as
input would find none of the empty characters - they'd disappeared.

This would affect such glyphs as `'.null'`, `'space'`, and maybe
`'nomarkingreturn'`.

Fix adds one line to set flag into `svg.c` routine `SVGParseGlyphArgs()`.
