### PR TITLE
Fix range boundary parsing encoding for CFF font with custom encoding 1

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3341,8 +3341,10 @@ return;						/* Use cids instead */
 	    pos = 1;
             /* Parse format 1 code ranges */
 	    for ( i=0; i<cnt ; ++i ) {
+                /* next byte is code of first character in range */
 		first = getc(ttf);
-		last = first + getc(ttf)-1;
+                /* next byte is the number of additional characters in range */
+		last = first + getc(ttf);
 		while ( first<=last && first<256 ) {
 		    if ( pos<info->glyph_cnt )
 			map->map[first] = pos;


### PR DESCRIPTION
from CFF format specification, format 1 has the following makeup:
card8: first character in range
card8: number of additional characters (excluding the first)

This change corrects the calculation of the code of the last character in range
to respect the fact that the additional character specification excludes the
first character in the range.
