### PR TITLE
zlib check for lib, check for header, otherwise hard-stop if not found.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -314,8 +314,8 @@ dnl AC_SEARCH_LIBS([dlopen], [dl dld])
 FONTFORGE_CONFIG_X_LIBRARIES
 
 # zlib is a requirement. It is too commonly available to bother leaving out.
-AC_CHECK_LIB([z],[deflateEnd],[AC_CHECK_HEADER([zlib.h],[have_libz=yes])],
-      [AC_CHECK_LIB([zlib],[deflate],[AC_CHECK_HEADER([zlib.h],[have_libz=yes])])])
+AC_CHECK_LIB([zlib],[deflateEnd],[AC_CHECK_HEADER([zlib.h],[have_libz=yes])],
+      [AC_CHECK_LIB([z],[deflateEnd],[AC_CHECK_HEADER([zlib.h],[have_libz=yes])])])
 if test x"${have_libz}" != xyes; then
    AC_MSG_FAILURE([ERROR: Please install the Developer version of zlib],[1])
 fi


### PR DESCRIPTION
Converted test from PKG_CHECK_MODULES() to a lib and header check since
some operating systems don't have pkg-config setup as well as with linux
(see issue #176 where user runs into install problem zlib not found).
Most users won't run into issues since zlib is very common, but we need
to verify zlib.h file is there for compiling Fontforge from source.
