### PR TITLE
Handle an extant extensionless file without crashing in LoadSplineFont.

### DIFF
--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -1313,7 +1313,7 @@ return( NULL );
 		free(tobefreed1);
 		fname = tobefreed1 = copy(filename);
 	    }
-	}
+	} else fname = tobefreed1 = copy(filename);
     } else fname = tobefreed1 = copy(filename);
 
     sf = NULL;


### PR DESCRIPTION
This addresses issue #1528.
