### PR TITLE
Fix bad ref count dec in Python APIs font index/contains

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -16927,46 +16927,33 @@ static PyObject *PyFF_FontIndex( PyObject *object, PyObject *index ) {
     FontViewBase *fv;
     SplineFont *sf;
     SplineChar *sc = NULL;
-#if PY_MAJOR_VERSION >= 3
-    int index_is_bytes = false;
-#endif
 
     if ( CheckIfFontClosed(self) )
-return (NULL);
+        return (NULL);
     fv = self->fv;
     sf = fv->sf;
     if ( STRING_CHECK(index)) {
 	char *name;
 	PYGETSTR(index, name, NULL);
-#if PY_MAJOR_VERSION >= 3
-	index_is_bytes = true;
-#endif
 	sc = SFGetChar(sf,-1,name);
+        ENDPYGETSTR();
     } else if ( PyInt_Check(index)) {
 	int pos = PyInt_AsLong(index), gid;
 	if ( pos<0 || pos>=fv->map->enccount ) {
 	    PyErr_Format(PyExc_TypeError, "Index out of bounds");
-return( NULL );
+            return( NULL );
 	}
 	gid = fv->map->map[pos];
 	sc = gid==-1 ? NULL : sf->glyphs[gid];
     } else {
 	PyErr_Format(PyExc_TypeError, "Index must be an integer or a string" );
-return( NULL );
+        return( NULL );
     }
     if ( sc==NULL ) {
-#if PY_MAJOR_VERSION >= 3
-        if (index_is_bytes)
-            Py_DECREF(index);
-#endif
 	PyErr_Format(PyExc_TypeError, "No such glyph" );
-return( NULL );
+        return( NULL );
     }
-#if PY_MAJOR_VERSION >= 3
-    if (index_is_bytes)
-        Py_DECREF(index);
-#endif
-return( PySC_From_SC_I(sc));
+    return( PySC_From_SC_I(sc));
 }
 
 static int PyFF_FontContains( PyObject *object, PyObject *index ) {
@@ -16974,41 +16961,28 @@ static int PyFF_FontContains( PyObject *object, PyObject *index ) {
     FontViewBase *fv;
     SplineFont *sf;
     SplineChar *sc = NULL;
-#if PY_MAJOR_VERSION >= 3
-    int index_is_bytes = false;
-#endif
 
     if ( CheckIfFontClosed(self) )
-return (-1);
+        return (-1);
     fv = self->fv;
     sf = fv->sf;
     if ( STRING_CHECK(index)) {
 	char *name;
         PYGETSTR(index, name, 0);
-#if PY_MAJOR_VERSION >= 3
-	index_is_bytes = true;
-#endif
 	sc = SFGetChar(sf,-1,name);
+        ENDPYGETSTR();
     } else if ( PyInt_Check(index)) {
 	int pos = PyInt_AsLong(index), gid;
 	if ( pos<0 || pos>=fv->map->enccount ) {
-return( 0 );
+            return( 0 );
 	}
 	gid = fv->map->map[pos];
 	sc = gid==-1 ? NULL : sf->glyphs[gid];
     } else {
-#if PY_MAJOR_VERSION >= 3
-    if (index_is_bytes)
-        Py_DECREF(index);
-#endif
 	PyErr_Format(PyExc_TypeError, "Index must be an integer or a string" );
-return( -1 );
+        return( -1 );
     }
-#if PY_MAJOR_VERSION >= 3
-    if (index_is_bytes)
-        Py_DECREF(index);
-#endif
-return( sc!=NULL );
+    return( sc!=NULL );
 }
 
 static PySequenceMethods PyFF_FontSequence = {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -127,7 +127,7 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
 	test1001.py test1001a.py test1001b.py test1001c.py	\
 	test1002.py test1003.py test1004.py test1005.py		\
-	test1006.py test1007.py
+	test1006.py test1007.py test1008.py
 
 EXTRA_DIST += link_test.c randomtest.c build-aux/missing
 

--- a/tests/test1008.py
+++ b/tests/test1008.py
@@ -1,0 +1,171 @@
+# Test various Python APIs to examine all glyphs in a font
+#
+# Checking these API operations from python.c:
+#
+#   if integer in f:          - font has a glyph for this encoding value?
+#   glyph = f[integer]        - get glyph object for encoding value index
+#   for name in f:            - iterate through glyph names in font
+#   glyph = f[name]           - get glyph object for glyph name key
+#   for glyph in f.glyphs()   
+#                             - iterate thru glyphs in GID order
+#   for glyph in f.glyphs('encoding') 
+#                             - iterate thru glyphs in encoding order
+#   if name in f:             - font has a glyph for this glyph name?
+
+import sys, fontforge
+
+dontFailTest  = False
+
+problemsSeen = 0
+
+inputFilepath = sys.argv[1]
+print("Opening input file '" + inputFilepath + "'")
+font1 = fontforge.open(inputFilepath)
+
+print("  Font '%s'  from  %s" % (font1.fontname, font1.path))
+print("")
+
+# We can get names in two different orderings, by encoding value order
+# and by 'GID' order.  They can differ, as in OverlapBugs.sfd
+
+glyphNamesInGIDOrder = []
+glyphNamesInEncOrder = []
+
+
+# This loops over a range of possible GID's, testing to each to see
+#   if it is for a valid glyph.  Thus the tested operations are:
+#         if enc in font1:          - 'contains' test
+#           glyph = font1[enc]      - index by number
+
+if True:
+  print("Listing glyph names over range of encoding values:")
+
+  # XXX use an API to get actual count?  then check that API? :)
+  for enc in range(1024):
+    if enc in font1:
+      glyph = font1[enc]
+      glyphName = glyph.glyphname 
+      print("  {:3d} glyphName:   '{}'".format(enc, glyphName))
+      glyphNamesInEncOrder.append(glyphName)
+      # XXX check that 'enc' matches glyph.encoding ?
+
+  print("")
+
+# This loops using an iterator running over all glyphs in a font, 
+#   in GID order, and returning the glyph name.
+#   Here the tested operations are:
+#         for glyphName in font1:     - font iterator for names
+#           glyph = font1[glyphName]  - index by string key
+
+# Allow testing against either a known list of glyph names, or 
+#   using the iterator from the font object.
+
+iterGlyph = font1
+#iterGlyph = ( '.notdef', 'C12341', 'C12357', 'C12360', 'C12592', 'C12860' )
+
+
+if True:
+  print("Listing glyph names using \"for glyphName in font:\" iterator:")
+
+  for glyphName in iterGlyph:
+    glyph = font1[glyphName]
+    enc   = glyph.encoding
+    print("  {:3d} glyphName:   '{}'".format(enc, glyphName))
+    glyphNamesInGIDOrder.append(glyphName)
+
+  # While the order of names may differ between encoding and GID ordering,
+  # these two lists should at least have the same count of names
+  if len(glyphNamesInEncOrder) != len(glyphNamesInGIDOrder):
+    print("*Error: the list of glyph names saved from using font iterator does not match the lists from other API usage")
+    print("  Previous list count: {:d}".format(len(glyphNamesInEncOrder)))
+    print("     this list count:  {:d}".format(len(glyphNamesInGIDOrder)))
+    print("  Previous list:       {}".format(glyphNamesInEncOrder))
+    print("     this list:        {}".format(glyphNamesInGIDOrder))
+    problemsSeen += 1
+
+  print("")
+
+
+
+if True:
+  print("Listing glyph names using font.glyphs() iterator:")
+
+  glyphNames = []
+
+  for glyph in font1.glyphs():
+    glyphName = glyph.glyphname 
+    enc   = glyph.encoding
+    print("  {:3d} glyphName:   '{}'".format(enc, glyphName))
+    glyphNames.append(glyphName)
+
+
+  if glyphNamesInGIDOrder != glyphNames:
+    print("*Error: the list of glyph names saved from using iterator font.glyphs() does not match the lists from other API usage")
+    print("  Previous list count: {:d}".format(len(glyphNamesInGIDOrder)))
+    print("     this list count:  {:d}".format(len(glyphNames)))
+    print("  Previous list:       {}".format(glyphNamesInGIDOrder))
+    print("     this list:        {}".format(glyphNames))
+    problemsSeen += 1
+
+  print("")
+
+  print("Listing glyph names using font.glyphs('encoding') iterator:")
+
+  glyphNames = []
+
+  for glyph in font1.glyphs('encoding'):
+    glyphName = glyph.glyphname 
+    enc = glyph.encoding
+    print("  {:3d} glyphName:   '{}'".format(enc, glyphName))
+    glyphNames.append(glyphName)
+
+
+  if glyphNamesInEncOrder != glyphNames:
+    print("*Error: the list of glyph names saved from using iterator font.glyphs('encoding') does not match the lists from other API usage")
+    print("  Previous list count: {:d}".format(len(glyphNamesInEncOrder)))
+    print("     this list count:  {:d}".format(len(glyphNames)))
+    print("  Previous list:       {}".format(glyphNamesInEncOrder))
+    print("     this list:        {}".format(glyphNames))
+    problemsSeen += 1
+
+  print("")
+
+
+if True:
+  print("Listing glyph names in list and checking with \"glyphName in font\":")
+
+  glyphNames = []
+
+  for glyphName in glyphNamesInEncOrder:
+    if glyphName in font1:
+      glyph = font1[glyphName]
+      enc   = glyph.encoding
+      print("  {:3d} glyphName:   '{}'".format(enc, glyphName))
+      glyphNames.append(glyphName)
+    else:
+      print("*Warning: known glyph name '{:s}' not found using test \"'{:s}' in font\"".format(glyphName, glyphName))
+
+  if glyphNamesInEncOrder != glyphNames:
+    print("*Error: the list of glyph names found using \"glyphName in font\" does not match the lists from other API usage")
+    print("  Previous list count: {:d}".format(len(glyphNamesInEncOrder)))
+    print("     this list count:  {:d}".format(len(glyphNames)))
+    print("  Previous list:       {}".format(glyphNamesInEncOrder))
+    print("     this list:        {}".format(glyphNames))
+    problemsSeen += 1
+      
+  print("")
+
+
+if problemsSeen:
+  if dontFailTest:
+    print("  %d problem results were detected - would fail this test..." % (problemsSeen))
+    print("      but 'no fail' flag set.")
+    sys.exit(0)
+  else:
+    print("  %d problem results were detected - failing this test!" % (problemsSeen))
+    sys.exit("  %d failing glyphs were detected - failing this test!" % (problemsSeen))
+else:
+  print("  No problems found - test successful")
+  sys.exit(0)
+
+# vim:ft=python:ts=2:sw=2:et:is:hls:ss=10:tw=222:

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -97,6 +97,7 @@ check_python([Clockwise direction test],[test1004.py],[DirectionTest.sfd])
 check_python([Generate duplicate fonts test],[test1005.py],[AddExtremaTest2.sfd])
 check_python([Math table test],[test1006.py])
 check_python([Check for splinestroke 0 len fail],[test1007.py],[ayn+meem.init.svg])
+check_python([PythonAPI: font glyph iteration],[test1008.py],[OverlapBugs.sfd])
 #check_python([find overlap bug],[findoverlapbugs.py])
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
`fontforge/python.c` had a few places where `PYGETSTR()`/`ENDPYGETSTR()` defines were not used correctly, and worse, a couple places where `Py_DECREF()` was used on the wrong object rather than correctly using `ENDPYGETSTR()`.

When building FontForge with Python3 and running Python scripts, this could result in active variables being garbage-collected out from under running code.  Oh, and leaking memory.  And FF crashes.  This only happened with Python3, not Python2.

Test failures and FF crashes could be demonstrated when using the construct

```
    glyph = font1[glyphName]
```

as the problems in `PyFF_FontIndex()` were a bit worse.

Failures couldn't be demonstrated as easily when using the construct

```
    if glyphName in font1:
```

though the code in `PyFF_FontContains()` was similarly wrong.

It would seem as though this code was done before the PYGETSTR/ENDPYGETSTR ideas were fully worked out?  As part of enabling the code for Python3 compatibility.  Certainly fully using those defines makes the code shorter.

This change has been tested under Python 2.7.6 and Python 3.4.0 (Ubuntu):
- with Python2 w/o fix - tests succeed
- with Python3 w/o fix - gross failures and "Segmentation fault (core dumped)"
- with Python3 w/fix   - success
- with Python2 w/fix   - success

A test script is also added, `test1008.py`, that tests a number of interrelated APIs for scanning all glyphs in a font:

```
  # Checking these API operations from python.c:
  #
  #   if integer in f:          - font has a glyph for this encoding value?
  #   glyph = f[integer]        - get glyph object for encoding value index
  #   for name in f:            - iterate through glyph names in font
  #   glyph = f[name]           - get glyph object for glyph name key
  #   for glyph in f.glyphs()
  #                             - iterate thru glyphs in GID order
  #   for glyph in f.glyphs('encoding')
  #                             - iterate thru glyphs in encoding order
  #   if name in f:             - font has a glyph for this glyph name?
```

I haven't fully checked out all usages of `PYGETSTR`/`ENDPYGETSTR` in python.c, and routines `GlyphsFromTuple()` and maybe `PyFF_PrivateIndexAssign()` look needy.  Nor have I checked on all uses of `Py_DECREF()`, just enough to say not misused a lot.
