### PR TITLE
Remove an unnecessary check as identified by coverity.

### DIFF
--- a/fontforge/parsettfatt.c
+++ b/fontforge/parsettfatt.c
@@ -1984,7 +1984,7 @@ return;
 			if ( *pt!='\0' && pt[strlen(pt)-1]==' ' )
 			pt[strlen(pt)-1] = '\0';
 		}
-		if (glyphs[i] < 0 || glyphs[i] > info->glyph_cnt) {
+		if (glyphs[i] > info->glyph_cnt) {
 		        fprintf(stderr, "This glyph is out of bounds.\n");
 		} else if (info->chars[glyphs[i]] == NULL || info->chars[glyphs[i]]->possub == NULL) {
 		        if (justinuse != git_justinuse) fprintf( stderr , "This glyph isn't loaded yet.\n" );


### PR DESCRIPTION
I introduced it in a3a31070daae1b341c7101aa6f2a84213d0f92a7.
