### PR TITLE
Add force encoding to python binding

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2003,7 +2003,7 @@ static void BCProtectUndoes( Undoes *undo,BDFChar *bc ) {
     }
 }
 
-int SFFontReencode(SplineFont *sf, const char *encname, int force) {
+int SFReencode(SplineFont *sf, const char *encname, int force) {
     Encoding *new_enc;
     FontViewBase *fv = sf->fv;
 

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -12357,7 +12357,7 @@ return( -1 );
 	ENDPYGETSTR();
 return( -1 );
     }
-    ret = SFFontReencode(self->fv->sf, encname, 0);
+    ret = SFReencode(self->fv->sf, encname, 0);
     if ( ret==-1 )
 	PyErr_Format(PyExc_NameError, "Unknown encoding %s", encname);
     ENDPYGETSTR();
@@ -16769,7 +16769,7 @@ return ( NULL );
     if ( !PyArg_ParseTuple(args, "s|i", &encname, &force) )
 return ( NULL );
 
-    if ( SFFontReencode(self->fv->sf, encname, force) != 0 ) {
+    if ( SFReencode(self->fv->sf, encname, force) != 0 ) {
 	PyErr_Format(PyExc_NameError, "Unknown encoding %s", encname);
 return ( NULL );
     }

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -3142,7 +3142,7 @@ static void bReencode(Context *c) {
 	ScriptError(c,"Bad argument type");
     if ( c->a.argc==3 )
 	force = c->a.vals[2].u.ival;
-    ret = SFFontReencode(c->curfv->sf, c->a.vals[1].u.sval, force);
+    ret = SFReencode(c->curfv->sf, c->a.vals[1].u.sval, force);
     if ( ret==-1 )
 	ScriptErrorString(c,"Unknown encoding", c->a.vals[1].u.sval);
 }

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2121,7 +2121,7 @@ extern void SFFindNearTop(SplineFont *);
 extern void SFRestoreNearTop(SplineFont *);
 extern int SFForceEncoding(SplineFont *sf,EncMap *old,Encoding *new_map);
 extern int CountOfEncoding(Encoding *encoding_name);
-extern int SFFontReencode(SplineFont *sf, const char *encname, int force);
+extern int SFReencode(SplineFont *sf, const char *encname, int force);
 extern void SFMatchGlyphs(SplineFont *sf,SplineFont *target,int addempties);
 extern void MMMatchGlyphs(MMSet *mm);
 extern const char *_GetModifiers(const char *fontname, const char *familyname, const char *weight);


### PR DESCRIPTION
I need to use force encoding in my python script.

**CHANGED**
Now I implemented `reencode` method in Font object, and it passes two arguments: encoding and force encode (optional), similar to fontforge script.  The `encoding` setter is still available in order not to break the existing script.
