### PR TITLE
Lookups/GPOS/AddSubtable dialog bigger, reveal controls

### DIFF
--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -2287,8 +2287,8 @@ static void AnchorClassD(SplineFont *sf, struct lookup_subtable *sub, int def_la
     wattrs.utf8_window_title = buffer;
     wattrs.is_dlg = true;
     pos.x = pos.y = 0;
-    pos.width = GGadgetScale(GDrawPointsToPixels(NULL,300));
-    pos.height = GDrawPointsToPixels(NULL,200);
+    pos.width = GGadgetScale(GDrawPointsToPixels(NULL,325));
+    pos.height = GDrawPointsToPixels(NULL,250);
     acd.gw = gw = GDrawCreateTopWindow(NULL,&pos,acd_e_h,&acd,&wattrs);
 
     i = 0;


### PR DESCRIPTION
Make the Lookups/GPOS/Add Subtable dialog slightly bigger to expose some previously hidden controls.

Making the dialog taller exposes the "OK" and "Cancel" buttons that were previously hidden down below the dialog window's bottom border.  Making the dialog a bit wider exposes the rest of the vertical scrollbar
which was only half visible. 

This has been tested as needed and fixing problem under cygwin and Ubuntu.  Steps to reproduce are in issue #1446, "GPOS Anchor classes "Add Subtable" dialog too short"

Before under Cygwin
![fontinfo_lookups_gpos_addsubtable1](https://cloud.githubusercontent.com/assets/842881/3694943/1d4b32da-1378-11e4-9117-d8bfa1772fb0.png)  

After under Cygwin
![fontinfo_lookups_gpos_addsubtable5](https://cloud.githubusercontent.com/assets/842881/3694927/f2725020-1377-11e4-8d33-e99bd390e1c7.png)

Before under Ubuntu
![fontinfo_lookups_gpos_addsubtable1_ubuntu](https://cloud.githubusercontent.com/assets/842881/3694969/6ca0a810-1378-11e4-9a4a-171ee3ffa5e6.png)

After under Ubuntu
![fontinfo_lookups_gpos_addsubtable5_ubuntu](https://cloud.githubusercontent.com/assets/842881/3694932/0d062bc8-1378-11e4-9b94-9a17ff25dc32.png)
