### PR TITLE
Correct Font Info pane when creating an anchor point.

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -10443,7 +10443,7 @@ void CVAddAnchor(CharView *cv) {
 
     if ( AnchorClassUnused(cv->b.sc,&waslig)==NULL ) {
 	ff_post_notice(_("Make a new anchor class"),_("I cannot find an unused anchor class\nto assign a new point to. If you\nwish a new anchor point you must\ndefine a new anchor class with\nElement->Font Info"));
-	FontInfo(cv->b.sc->parent,CVLayer((CharViewBase *) cv),13,true);		/* Lookups */
+	FontInfo(cv->b.sc->parent,CVLayer((CharViewBase *) cv),15,true);		/* Lookups */
 	if ( AnchorClassUnused(cv->b.sc,&waslig)==NULL )
 return;
     }


### PR DESCRIPTION
When creating an anchor point, go to the correct pane in the Font Info box.

This partially addresses #700.
