### PR TITLE
Reveal partially hidden button in "FontInfo / Layers"

### DIFF
--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -8233,7 +8233,7 @@ return;
 
     LayersMatrixInit(&layersmi,d);
 
-    lgcd[k].gd.pos.width = 300; lgcd[k].gd.pos.height = 200;
+    lgcd[k].gd.pos.width = 300; lgcd[k].gd.pos.height = 180;
     lgcd[k].gd.flags = sf->multilayer ? gg_visible : (gg_enabled | gg_visible);
     lgcd[k].gd.cid = CID_Backgrounds;
     lgcd[k].gd.u.matrix = &layersmi;


### PR DESCRIPTION
On both Ubuntu and Cygwin, when the "Layers" pane of the "Font Info..."
dialog was displayed, the "Delete" button below the "Layers:" list box
was obscured or hidden.

Upon first seeing this, the thought was that the entire "Font Info..."
dialog window would have to be made taller to display the button.
(Another pane "Lookups" would also seem to need this)

Instead, this fix merely shortens the list box, allowing the button to
rise and be seen.  This still allows as many as 8 layer descriptions
to be displayed without scrolling.

Cygwin before; button top barely visible below list's bottom scrollbar
![fontinfo_dialog_layers_cygwin_1](https://cloud.githubusercontent.com/assets/842881/3712836/ba3fd4a2-1539-11e4-89a5-e69856bb1e51.png)
Ubuntu before; a bit more of the button visible 
![fontinfo_dialog_layers_ubuntu_1](https://cloud.githubusercontent.com/assets/842881/3712835/b2ff5d52-1539-11e4-987c-67b1c54b10b9.png)

Cygwin after; button visible below a somewhat shorter list box
![fontinfo_dialog_layers_cygwin_2](https://cloud.githubusercontent.com/assets/842881/3712837/c1f43530-1539-11e4-9eb2-f1fb26b017ee.png)
Ubuntu after
![fontinfo_dialog_layers_ubuntu_2](https://cloud.githubusercontent.com/assets/842881/3712839/c85b47b0-1539-11e4-8ec4-74d89b15350b.png)
