### PR TITLE
Shuffle code for starting and clearing Python in order to avoid crashes.

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18175,6 +18175,12 @@ _Noreturn void PyFF_Main(int argc,char **argv,int start) {
 
     no_windowing_ui = running_script = true;
 
+#ifndef _NO_PYTHON
+/*# ifndef GWW_TEST*/
+    FontForge_InitializeEmbeddedPython(); /* !!!!!! debug (valgrind doesn't like python) */
+/*# endif*/
+#endif
+
     PyFF_ProcessInitFiles();
 
     /* Skip '-script' option */
@@ -18189,6 +18195,11 @@ _Noreturn void PyFF_Main(int argc,char **argv,int start) {
 
     /* Run Python */
     exitcode = Py_Main( newargc, newargv );
+#ifndef _NO_PYTHON
+/*# ifndef GWW_TEST*/
+    FontForge_FinalizeEmbeddedPython(); /* !!!!!! debug (valgrind doesn't like python) */
+/*# endif*/
+#endif
     exit(exitcode);
 }
 
@@ -18306,6 +18317,12 @@ static void AddSpiroConstants( PyObject *module ) {
 _Noreturn void PyFF_Stdin(void) {
     no_windowing_ui = running_script = true;
 
+#ifndef _NO_PYTHON
+/*# ifndef GWW_TEST*/
+    FontForge_InitializeEmbeddedPython(); /* !!!!!! debug (valgrind doesn't like python) */
+/*# endif*/
+#endif
+
     PyFF_ProcessInitFiles();
 
     if ( isatty(fileno(stdin)))
@@ -18313,6 +18330,12 @@ _Noreturn void PyFF_Stdin(void) {
     else
 	PyRun_SimpleFile(stdin,"<stdin>");
     exit(0);
+#ifndef _NO_PYTHON
+/*# ifndef GWW_TEST*/
+    FontForge_FinalizeEmbeddedPython(); /* !!!!!! debug (valgrind doesn't like python) */
+/*# endif*/
+#endif
+
 }
 
 

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -10467,11 +10467,6 @@ static void _CheckIsScript(int argc, char *argv[]) {
     int i, is_python = DefaultLangPython();
     char *pt;
 
-#ifndef _NO_PYTHON
-/*# ifndef GWW_TEST*/
-    FontForge_InitializeEmbeddedPython(); /* !!!!!! debug (valgrind doesn't like python) */
-/*# endif*/
-#endif
     if ( argc==1 )
 return;
     for ( i=1; i<argc; ++i ) {
@@ -10538,9 +10533,6 @@ return;
 	    }
 	}
     }
-#ifndef _NO_PYTHON
-    FontForge_FinalizeEmbeddedPython();
-#endif
 }
 #endif
 

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1035,10 +1035,8 @@ int fontforge_main( int argc, char **argv ) {
     if ( default_encoding==NULL )
 	default_encoding=&custom;	/* In case iconv is broken */
 
-    // This check also starts the embedded python,
-    // we must call PythonUI_Init() before CheckIsScript()
-    // to allow GUI code to potentially add extra methods to the
-    // python objects.
+    // This no longer starts embedded Python unless control passes to the Python executors,
+    // which exit independently rather than returning here.
     CheckIsScript(argc,argv); /* Will run the script and exit if it is a script */
 					/* If there is no UI, there is always a script */
 			                /*  and we will never return from the above */
@@ -1172,6 +1170,12 @@ int fontforge_main( int argc, char **argv ) {
 	}
     }
     
+#ifndef _NO_PYTHON
+/*# ifndef GWW_TEST*/
+    FontForge_InitializeEmbeddedPython(); /* !!!!!! debug (valgrind doesn't like python) */
+/*# endif*/
+#endif
+
 #ifndef _NO_PYTHON
     if( ProcessPythonInitFiles )
 	PyFF_ProcessInitFiles();
@@ -1344,6 +1348,12 @@ exit( 0 );
 	_FVMenuOpen(NULL);
     GDrawEventLoop(NULL);
     GDrawDestroyDisplays();
+
+#ifndef _NO_PYTHON
+/*# ifndef GWW_TEST*/
+    FontForge_FinalizeEmbeddedPython(); /* !!!!!! debug (valgrind doesn't like python) */
+/*# endif*/
+#endif
 
     // These free menu translations, mostly.
     BitmapViewFinishNonStatic();


### PR DESCRIPTION
This addresses issue #1580 and issue #1585.

Since the _CheckIsScript execution path ends separately from the normal execution path in certain cases, it seemed easiest for now to initialize and finalize Python separately for those paths. Each of the two Python functions that can take over execution and terminate independently now initializes and finalizes Python. fontforge_main also initializes and finalizes Python after the _CheckIsScript call.
