### PR TITLE
issue1344: work on source tree clones from bootstrap.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -9,7 +9,7 @@
 
 # Source required external libraries:
 # Set a version string for this script.
-scriptversion=2012-10-21.11; # UTC
+scriptversion=2014-07-30.00; # UTC
 
 # General shell script boiler plate, and helper functions.
 # Written by Gary V. Vaughan, 2004
@@ -3462,6 +3462,14 @@ func_require_extra_locale_categories ()
 # require_git
 # -----------
 # Ignore git if it's not available, or we're not in a git checkout tree.
+#
+#
+# ***** WARNING ***** 
+#
+# This function is replaced by fontforge_require_git which is
+# contained in bootstrap.conf. If you expect func_require_git to
+# execute please look instead at fontforge_require_git for debugging.
+#
 require_git=func_require_git
 func_require_git ()
 {

--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -1,4 +1,4 @@
-# bootstrap.conf (fontforge) version 2014-04-14
+# bootstrap.conf (fontforge) version 2014-07-30
 # Written by Gary V. Vaughan, 2010
 
 # Copyright (C) 2010 Free Software Foundation, Inc.
@@ -76,10 +76,24 @@ fontforge_require_git ()
 
     $opt_skip_git && GIT=true
 
-    test true = "$GIT" || { # Test for .git directory as we auto-generate .gitignore
-      if test -d .git && ($GIT --version) >/dev/null 2>&1; then :; else
-      GIT=true
-      fi
+    test true = "$GIT" || { 
+        # Test for .git directory as we auto-generate .gitignore
+	#
+	# note that we *need* to have the .git directory here because
+	# submodules are used like gnulib. However, for OSX build
+	# environments we might be a temporary "copy" of the tree
+	# which doesn't include .git so we are best to assume that the
+	# user knows what they are doing, and create the .git if it
+	# doesn't exist
+	#
+	if test -d .git ; then :; else
+	    echo "WARNING: you do not have a .git directory in your build, so one is being created"
+            $GIT init;
+	fi
+
+        if ($GIT --version) >/dev/null 2>&1; then :; else
+            GIT=true
+        fi
     }
 
     func_verbose "GIT='$GIT'"


### PR DESCRIPTION
Some build environments clone the source tree before starting the
bootstrap/configure process. For example, homebrew on osx. That being
the case, some of these do not copy the .git tree in the clone
probably because it is not intended to be long lived. BUT if there is
no .git subdirectory then the old bootstrap would subtly fail by
forcing the GIT command to be out of bounds.

This update allows bootstrap to run in such .git'less clones and thus
removes one hurdle to FontForge building from homebrew.
