### PR TITLE
Fix small one-time leaks in start.c :: initlibltdl()

### DIFF
--- a/fontforge/start.c
+++ b/fontforge/start.c
@@ -83,13 +83,16 @@ static void initlibrarysearchpath(void) {
 
 static void initlibltdl(void) {
     char buffer[2000];
+    char *userConfigDir;
 
     if (!plugins_are_initialized()) {
         init_plugins();
-        if (getFontForgeUserDir(Config)!=NULL ) {
-            strcpy(buffer,getFontForgeUserDir(Config));
+        userConfigDir = getFontForgeUserDir(Config);
+        if ( userConfigDir != NULL ) {
+            strcpy(buffer,userConfigDir);
             strcat(buffer,"/plugins");
-            lt_dladdsearchdir(strdup(buffer));
+            free(userConfigDir);
+            lt_dladdsearchdir(buffer);
         }
     }
 }


### PR DESCRIPTION
Library routine `lt_dladdsearchdir()` takes a string argument, but always
copies it before use.  It did not need to be `strdup()`ed.  This was _very_
defensive coding... ;)

`gutils/fsys.c` :: `getFontForgeUserDir()` always newly allocates the returned
string value.  This must be freed when no longer needed.  @adrientetar has recently 
fixed a couple of the several uses of this routine.  All the rest need to be fixed.

The former routine `getPfaEditDir()` would generate the requested string once,
the first time, and retain that for further usages.  E.g.

```
      char *getPfaEditDir(char *buffer) {
          static char *editdir = NULL;
          :   :    :   :    :   :    :   :    :   :
          editdir = copy(buffer);
          return( editdir );
```

Thus strings would leak at most once, and even code like the two consecutive
calls replaced by the fix would still only leak once.  Now that we allocate new strings
each time, we need to `free()` after each use.
