### PR TITLE
Fix small leak in startui.c ensureDotFontForgeIsSetup()

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -783,6 +783,7 @@ static void ensureDotFontForgeIsSetup() {
     }
     ffensuredir( basedir, "",       S_IRWXU );
     ffensuredir( basedir, "python", S_IRWXU );
+    free(basedir);
 }
 
 static void DoAutoRecoveryPostRecover_PromptUserGraphically(SplineFont *sf)


### PR DESCRIPTION
Another use of the recent routine `gutils/fsys.c` :: `getFontForgeUserDir()`
that requires a `free()` of the newly allocated string after use.

Tested and leak now gone from `valgrind` reports.
