### PR TITLE
Fix small leak in autosave.c getAutoDirName()

### DIFF
--- a/fontforge/autosave.c
+++ b/fontforge/autosave.c
@@ -47,14 +47,15 @@ int AutoSaveFrequency=5;
 static char *getAutoDirName(char *buffer) {
     char *dir=getFontForgeUserDir(Config);
 
-    if ( dir==NULL )
-return( NULL );
-    sprintf(buffer,"%s/autosave", dir);
-    if ( access(buffer,F_OK)==-1 )
-	if ( GFileMkDir(buffer)==-1 )
-return( NULL );
-    dir = copy(buffer);
-return( dir );
+    if ( dir!=NULL ) {
+        sprintf(buffer,"%s/autosave", dir);
+        free(dir);
+        if ( access(buffer,F_OK)==-1 )
+            if ( GFileMkDir(buffer)==-1 )
+                return( NULL );
+        dir = copy(buffer);
+    }
+    return( dir );
 }
 
 static void MakeAutoSaveName(SplineFont *sf) {


### PR DESCRIPTION
Another use of the recent routine `gutils/fsys.c` :: `getFontForgeUserDir()`
that requires a `free()` of the newly allocated string after use.

Tested and leak has disappeared from `valgrind` reports.
