### PR TITLE
Fix leak in "Open Font" dialog file filter list

### DIFF
--- a/fontforgeexe/openfontdlg.c
+++ b/fontforgeexe/openfontdlg.c
@@ -155,6 +155,12 @@ static GTextInfo **StandardFilters(void) {
     int k, cnt, i;
     GTextInfo **ti;
 
+    /* Make two passes thru outer loop. The first pass determines the
+     * interim count of how many entries will be generated and then
+     * allocates an array with 3 entries more than that. The second 
+     * pass ( if(k) ) accumulates the data values, then adds a trailer,
+     * to return in the GTextInfo** structure 'ti'.
+     */
     for ( k=0; k<2; ++k ) {
 	cnt = 0;
 	for ( i=0; def_font_filters[i].name!=NULL; ++i ) {
@@ -776,7 +782,8 @@ unichar_t *FVOpenFont(char *title, const char *defaultfile, int mult) {
     d.gfc = gcd[0].ret;
     d.rename = gcd[renamei].ret;
 
-    GGadgetSetList(harray1[2]->ret,(filts = StandardFilters()),true);
+    filts = StandardFilters();
+    GGadgetSetList(harray1[2]->ret,filts,true);
     GHVBoxSetExpandableRow(boxes[0].ret,0);
     GHVBoxSetExpandableCol(boxes[2].ret,gb_expandglue);
     GHVBoxSetExpandableCol(boxes[3].ret,gb_expandglue);
@@ -804,6 +811,7 @@ unichar_t *FVOpenFont(char *title, const char *defaultfile, int mult) {
     GDrawSync(NULL);
     GDrawProcessPendingEvents(NULL);		/* Give the window a chance to vanish... */
     free( d.lastpopupfontname );
+    GTextInfoArrayFree(filts);
     for ( cnt=0; nlnames[cnt]!=NULL; ++cnt) {
 	free(nlnames[cnt]);
     }

--- a/gdraw/gtextinfo.c
+++ b/gdraw/gtextinfo.c
@@ -678,6 +678,9 @@ return;
     free(ti);
 }
 
+/* The list is terminated with an empty entry. Not a NULL pointer, but 
+ * rather an empty entry terminates lists of GTextInfo entries.  (!)
+ */
 void GTextInfoArrayFree(GTextInfo **ti) {
     int i;
 


### PR DESCRIPTION
Each time the "Open Font" dialog is displayed, `fontforgeexe/openfontdlg.c` :: `FVOpenFont()` fetches a list of file filter types from `StandardFilters()`.  The list 'filts' is later used in setting up the dialog, but is nowhere free()d.  About 2K bytes leaks on each dialog use.

This fix free()s the list using the magic routine `GTextInfoArrayFree()`.
