### PR TITLE
Leaks when mouse moving over "Open Font" file list

### DIFF
--- a/fontforgeexe/openfontdlg.c
+++ b/fontforgeexe/openfontdlg.c
@@ -542,6 +542,7 @@ return( pos!=-1 );
     if ( ufile==NULL )
 return( true );
     file = u2def_copy(ufile);
+    free(ufile);
 
     fontnames = GetFontNames(file);
     if ( fontnames==NULL || fontnames[0]==NULL )
@@ -560,6 +561,12 @@ return( true );
 	msg[len-1] = '\0';
     }
     GGadgetPreparePopup(GGadgetGetWindow(d->gfc),msg);
+    if ( fontnames!=NULL ) {
+        for ( cnt=0; fontnames[cnt]!=NULL; ++cnt ) {
+            free(fontnames[cnt]);
+        }
+        free(fontnames);
+    }
     free(file);
     free(d->lastpopupfontname);
     d->lastpopupfontname = msg;


### PR DESCRIPTION
The "Open Font" dialog was tracking mouse movements over the list of
possible filenames.  The desire was to always have the font name(s)
of files available for the balloon popup over the filename, if the
mouse paused long enough over the same filename.

For each mouse movement the filename under the cursor would be
identified and that file path generated in a newly allocated string.
That string was not free()d after use.

Once the file path was identified the font file would be opened to
discover the font name(s) in that file.  These were returned in a
list of strings, with list and strings newly allocated.  These were
not being free()d.

Depending on how much mouse movement occurred over the file list (and
apparently including movement over the file list scrollbar?) 10's to
100's of KB were leaked.

Both the found file path names and the font names are free()d by this fix.

(Wow, if I'd'a known all these leaks were in this one area I'd'a created one big PR ... ?!?)
