### PR TITLE
issue527: width in metrics view can now be changed many times.

### DIFF
--- a/fontforge/collabclient.c
+++ b/fontforge/collabclient.c
@@ -32,6 +32,9 @@ int pref_collab_roundTripTimerMS = 2000;
 #include "collabclientpriv.h"
 #include "inc/basics.h"
 
+int DEBUG_SHOW_SFD_CHUNKS = 0;
+
+
 void collabclient_CVPreserveStateCalled( CharViewBase *cv )
 {
 #ifdef BUILD_COLLAB

--- a/fontforge/collabclientpriv.h
+++ b/fontforge/collabclientpriv.h
@@ -52,7 +52,7 @@
 // Set to true if you want to see the raw SFD undo fragments which
 // are moving to/from the server.
 //
-#define DEBUG_SHOW_SFD_CHUNKS 0
+extern int DEBUG_SHOW_SFD_CHUNKS; // defined in collabclient.c
 
 
 

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -686,6 +686,7 @@ return(NULL);
     undo = chunkalloc(sizeof(Undoes));
 
     undo->undotype = ut_state;
+    undo->layer = dm_fore;
     undo->was_modified = sc->changed;
     undo->was_order2 = sc->layers[layer].order2;
     undo->u.state.width = sc->width;
@@ -843,6 +844,7 @@ return(NULL);
     undo->was_modified = sc->changed;
     undo->was_order2 = sc->layers[ly_fore].order2;
     undo->u.state.width = sc->width;
+    undo->layer = dm_fore;
 
     Undoes* ret = AddUndo(undo,&sc->layers[ly_fore].undoes,&sc->layers[ly_fore].redoes);
 
@@ -930,11 +932,18 @@ static void SCUndoAct(SplineChar *sc,int layer, Undoes *undo) {
 	Layer *head = layer==ly_grid ? &sc->parent->grid : &sc->layers[layer];
 	SplinePointList *spl = head->splines;
 
+	printf("SCUndoAct() ut_state case, layer:%d sc:%p scn:%s scw:%d uw:%d\n",
+	       layer, sc, sc->name, sc->width, undo->u.state.width );
+	
 	if ( layer==ly_fore ) {
 	    int width = sc->width;
 	    int vwidth = sc->vwidth;
 	    if ( sc->width!=undo->u.state.width )
+	    {
+		printf("SCUndoAct() sc:%p scn:%s scw:%d uw:%d\n",
+		       sc, sc->name, sc->width, undo->u.state.width );
 		SCSynchronizeWidth(sc,undo->u.state.width,width,NULL);
+	    }
 	    sc->vwidth = undo->u.state.vwidth;
 	    undo->u.state.width = width;
 	    undo->u.state.vwidth = vwidth;


### PR DESCRIPTION
No CPU lock or crashes. Width can now also be changed by dragging the
chars in the metricsview. Maybe my config is different to what it was
before but drags now work here on F20.

Also tested manually changing the width, lbearing, rbearing using the
up/down arrow keys in the grid at the bottom of the metricsview
window.

See point 3 of https://github.com/fontforge/fontforge/issues/527
