### PR TITLE
issue1573: make GFileDirName() handle the returned memory as documented.

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -1035,7 +1035,8 @@ void _FVMenuOpen(FontView *fv) {
 #if defined(__MINGW32__)
     OpenDir = GFileGetHomeDocumentsDir(); //Default value
     if (fv && fv->b.sf && fv->b.sf->filename) {
-        OpenDir = GFileDirName(fv->b.sf->filename);
+	free(OpenDir);
+        OpenDir = copy( GFileDirName( fv->b.sf->filename));
     }
 #endif
 
@@ -1060,7 +1061,7 @@ return;
 	for ( fvtest=0, test=fv_list; test!=NULL; ++fvtest, test=(FontView *) (test->b.next) );
     } while ( fvtest==fvcnt );	/* did the load fail for some reason? try again */
     
-    if (OpenDir != NULL) free(OpenDir);
+    free( OpenDir );
 }
 
 static void FVMenuOpen(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -1023,13 +1023,13 @@ unichar_t *u_GFileGetHomeDocumentsDir(void) {
 
 char *GFileDirName(const char *path)
 {
-    char ret[PATH_MAX+1];
+    static char ret[PATH_MAX+1];
     strncpy( ret, path, PATH_MAX );
     ret[PATH_MAX] = '\0';
     GFileNormalizePath( ret );
     char *pt = strrchr( ret, '/' );
     if ( pt )
 	*pt = '\0';
-    return strdup(ret);
+    return ret;
 }
 


### PR DESCRIPTION
gfiledirname is documented as returning a pointer to memory owned by the function.
This is again now the case.
