### PR TITLE
Small leak and ineffective code GIOGetMimeType()

### DIFF
--- a/gutils/g_giomime.c
+++ b/gutils/g_giomime.c
@@ -133,7 +133,9 @@ char* GIOGetMimeType(const char *path) {
 	    // file name
 	    content_type=g_content_type_guess(NULL,sniff_buffer,res,&uncertain);
 	    if (uncertain) {
-		g_content_type_guess(path,sniff_buffer,res,NULL);
+	        if (content_type!=NULL)
+                    g_free(content_type);
+		content_type=g_content_type_guess(path,sniff_buffer,res,NULL);
             }
         }
     }


### PR DESCRIPTION
Interesting result from valgrind revealed that
- a line of code _was_ being executed,
- but that that line's work was being _ignored_

Fix changes the line to be an assignment, and then adds the required intermediate g_free().

This typo didn't alter the final result, as the third (!) call to routine g_content_type_guess() gave the correct final result.  (I checked)

Still, @khaledhosny might want to check the original code to see if this typo exists there also.
