### PR TITLE
Fix webcollab.py to be more Python3 compatible

### DIFF
--- a/pycontrib/webcollab.py
+++ b/pycontrib/webcollab.py
@@ -36,7 +36,7 @@ def ensureChildClosed():
     childNodejs = None
 
 def WebServerInCollabModeGoodbye():
-    print 'webcollab closing...'
+    print('webcollab closing...')
     ensureChildClosed()
 
 def startWebServerInCollabMode(data = None, glyphOrFont = None):
@@ -44,8 +44,8 @@ def startWebServerInCollabMode(data = None, glyphOrFont = None):
     global child
     global childNodejs
     ensureChildClosed()
-    print "FONTFORGE:" + FONTFORGE
-    print "script path:" + collabpath + "web-test-collab.py"
+    print("FONTFORGE:" + FONTFORGE)
+    print("script path:" + collabpath + "web-test-collab.py")
     child = subprocess.Popen( [ FONTFORGE, "-forceuihidden", "-script", collabpath + "web-test-collab.py" ] )
     #
     # start the nodejs server
@@ -61,7 +61,7 @@ def stopWebServerInCollabMode(data = None, glyphOrFont = None):
     ensureChildClosed()
 
 if fontforge.hasUserInterface():
-    print "fontforge.hasUserInterface!"
+    print("fontforge.hasUserInterface!")
     fontforge.onAppClosing( WebServerInCollabModeGoodbye )
     fontforge.registerMenuItem(startWebServerInCollabMode, None, None, ("Font","Glyph"),
                                 None, "Start Web server in Collab mode");


### PR DESCRIPTION
Change c3770c88b50 in #1636 introduced a new python source file, `webcollab.py`, containing some print statements, a well-known incompatibility at the source level between Python 2 and Python 3.

Starting an updated fontforge built with Python 3 produces this error:

```
  File "/home/tom/local/share/fontforge/python/webcollab.py", line 39
    print 'webcollab closing...'
                               ^
SyntaxError: invalid syntax
```

This fix merely changes to the Python 3 function call format for print.  It seems to satisfy both Python3 and Python2...
