### PR TITLE
Fix gdraw scrollbars

### DIFF
--- a/gdraw/ggadgetP.h
+++ b/gdraw/ggadgetP.h
@@ -232,6 +232,7 @@ typedef struct gscrollbar {		/* and slider */
     int8 repeatcmd;		/*  sb event to be generated on timer interupts (ie. upline)*/
     int8 thumbborder;		/* Size of the border of the thumbbox */
     int8 sbborder;		/* Size of the border of the main scrollbar */
+    int16 size_offset;		/* Thumb size offset when the thumb size gets clamped. */
     int16 thumboff;		/* Offset from where the thumb was pressed to top of thumb */
     int16 arrowsize;		
     int16 thumbsize;		/* Current thumb size, refigured after every call to setbounds */

--- a/gdraw/gscrollbar.c
+++ b/gdraw/gscrollbar.c
@@ -605,8 +605,8 @@ int32 GScrollBarSetPos(GGadget *g,int32 pos) {
 	gsb->thumbpos = 0;
     else
 	gsb->thumbpos =
-	    (gsb->g.vert?gsb->g.inner.height:gsb->g.inner.width)*(pos-gsb->sb_min)/
-		    (gsb->sb_max-gsb->sb_min);
+	    ((gsb->g.vert?gsb->g.inner.height:gsb->g.inner.width)-gsb->size_offset)
+	      *(pos-gsb->sb_min)/(gsb->sb_max-gsb->sb_min);
     _ggadget_redraw(g);
 return( pos );
 }
@@ -624,13 +624,17 @@ return;
     gsb->sb_max = sb_max;
     gsb->sb_pagesize = sb_pagesize;
     gsb->sb_mustshow = sb_mustshow;
+    gsb->size_offset = 0;
     gsb->thumbsize = (gsb->g.vert?gsb->g.inner.height:gsb->g.inner.width);
     if ( sb_max-sb_min > sb_pagesize )
 	gsb->thumbsize = (gsb->thumbsize*gsb->sb_pagesize)/(sb_max-sb_min);
     if ( gsb->thumbsize<2*gsb->thumbborder+10 ) {
+        gsb->size_offset = 2*gsb->thumbborder+10 - gsb->thumbsize;
 	gsb->thumbsize = 2*gsb->thumbborder+10;
-	if ( gsb->thumbsize>(gsb->g.vert?gsb->g.inner.height:gsb->g.inner.width) )
+	if ( gsb->thumbsize>(gsb->g.vert?gsb->g.inner.height:gsb->g.inner.width) ) {
+	    gsb->size_offset = 0;
 	    gsb->thumbsize = (gsb->g.vert?gsb->g.inner.height:gsb->g.inner.width);
+        }
     }
     GScrollBarSetPos(g,gsb->sb_pos);
 }


### PR DESCRIPTION
- Subtract the offset height of the thumb to the total height before calculating the thumb pos by ratio
- Highly decrease the minimum size for the scrollbar thumb &ndash; worked-around with a constant setting since the computation [happening here](https://github.com/fontforge/fontforge/blob/a7886343df283b2dbf33562e43835c9d0cf47a2f/gdraw/gscrollbar.c#L513) is quite obfuscated and warrants deeper research.

cc #1552 (for the first part), #1583, #1233.

r? @frank-trampe
