### PR TITLE
Add reencode function in Python binding

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2003,6 +2003,42 @@ static void BCProtectUndoes( Undoes *undo,BDFChar *bc ) {
     }
 }
 
+int SFReencode(SplineFont *sf, const char *encname, int force) {
+    Encoding *new_enc;
+    FontViewBase *fv = sf->fv;
+
+    if ( strmatch(encname,"compacted")==0 ) {
+	fv->normal = EncMapCopy(fv->map);
+	CompactEncMap(fv->map,sf);
+    } else {
+	new_enc = FindOrMakeEncoding(encname);
+	if ( new_enc==NULL )
+return -1;
+	if ( force )
+	    SFForceEncoding(sf,fv->map,new_enc);
+	else if ( new_enc==&custom )
+	    fv->map->enc = &custom;
+	else {
+	    EncMap *map = EncMapFromEncoding(sf,new_enc);
+	    EncMapFree(fv->map);
+	    fv->map = map;
+	    if ( !no_windowing_ui )
+		FVSetTitle(fv);
+	}
+	if ( fv->normal!=NULL ) {
+	    EncMapFree(fv->normal);
+	    fv->normal = NULL;
+	}
+	SFReplaceEncodingBDFProps(sf,fv->map);
+    }
+    free(fv->selected);
+    fv->selected = calloc(fv->map->enccount,sizeof(char));
+    if ( !no_windowing_ui )
+	FontViewReformatAll(sf);
+
+return 0;
+}
+
 void SFRemoveGlyph( SplineFont *sf,SplineChar *sc ) {
     struct splinecharlist *dep, *dnext;
     struct bdfcharlist *bdep, *bdnext;

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -3134,6 +3134,7 @@ static void bSelectByColor(Context *c) {
 static void bReencode(Context *c) {
     Encoding *new_enc;
     int force = 0;
+    int ret;
 
     if ( c->a.argc!=2 && c->a.argc!=3 )
 	ScriptError( c, "Wrong number of arguments");
@@ -3141,39 +3142,9 @@ static void bReencode(Context *c) {
 	ScriptError(c,"Bad argument type");
     if ( c->a.argc==3 )
 	force = c->a.vals[2].u.ival;
-    if ( strmatch(c->a.vals[1].u.sval,"compacted")==0 ) {
-	c->curfv->normal = EncMapCopy(c->curfv->map);
-	CompactEncMap(c->curfv->map,c->curfv->sf);
-    } else {
-	new_enc = FindOrMakeEncoding(c->a.vals[1].u.sval);
-	if ( new_enc==NULL )
-	    ScriptErrorString(c,"Unknown encoding", c->a.vals[1].u.sval);
-	if ( force )
-	    SFForceEncoding(c->curfv->sf,c->curfv->map,new_enc);
-	else if ( new_enc==&custom )
-	    c->curfv->map->enc = &custom;
-	else {
-	    EncMap *map = EncMapFromEncoding(c->curfv->sf,new_enc);
-	    EncMapFree(c->curfv->map);
-	    c->curfv->map = map;
-	    if ( !no_windowing_ui )
-		FVSetTitles(c->curfv->sf);
-	}
-	if ( c->curfv->normal!=NULL ) {
-	    EncMapFree(c->curfv->normal);
-	    c->curfv->normal = NULL;
-	}
-	SFReplaceEncodingBDFProps(c->curfv->sf,c->curfv->map);
-    }
-    free(c->curfv->selected);
-    c->curfv->selected = calloc(c->curfv->map->enccount,sizeof(char));
-    if ( !no_windowing_ui )
-	FontViewReformatAll(c->curfv->sf);
-/*
-    c->curfv->sf->changed = true;
-    c->curfv->sf->changed_since_autosave = true;
-    c->curfv->sf->changed_since_xuidchanged = true;
-*/
+    ret = SFReencode(c->curfv->sf, c->a.vals[1].u.sval, force);
+    if ( ret==-1 )
+	ScriptErrorString(c,"Unknown encoding", c->a.vals[1].u.sval);
 }
 
 static void bRenameGlyphs(Context *c) {

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2121,6 +2121,7 @@ extern void SFFindNearTop(SplineFont *);
 extern void SFRestoreNearTop(SplineFont *);
 extern int SFForceEncoding(SplineFont *sf,EncMap *old,Encoding *new_map);
 extern int CountOfEncoding(Encoding *encoding_name);
+extern int SFReencode(SplineFont *sf, const char *encname, int force);
 extern void SFMatchGlyphs(SplineFont *sf,SplineFont *target,int addempties);
 extern void MMMatchGlyphs(MMSet *mm);
 extern const char *_GetModifiers(const char *fontname, const char *familyname, const char *weight);


### PR DESCRIPTION
This is a squashed commit for #1563 since GitHub currently cannot change PR branch.

**Copy-n-paste messages below:**
Now I implemented `reencode` method in Font object, and it passes two arguments: encoding and force encode (optional), similar to fontforge script.  The `encoding` setter is still available in order not to break the existing script.
