### PR TITLE
Add coverity +kill annotation to scripting.c traceback()

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -224,6 +224,7 @@ static void calldatafree(Context *c) {
 	}
 }
 
+/* coverity[+kill] */
 static void traceback(Context *c) {
     int cnt = 0;
     while ( c!=NULL ) {


### PR DESCRIPTION
Coverity was showing a number of false positives because it did not
understand that in the context of `scripting.c` calling `ScriptError()`
effectively terminated the calling routine, just like a return statement
or an `abort()`.

Coverity would report uninitialized variables or out-of-bounds reads
or writes and the like, as it analysed code following a call to
`ScriptError()`.  For example, in `fontforge/scripting.c` :: [`bSqrt()`](https://github.com/fontforge/fontforge/blob/master/fontforge/scripting.c#L1431-L1444) 
it would report that variable `val` could be uninitialized in the call
to `sqrt()`.

There is a mechanism to instruct Coverity that a routine should be
considered as terminating processing.  Adding a "function annotation"
in the form of a comment before the function gives it the information 
that should prevent the scanner from being so confused.

This change adds such an annotation to routine `traceback()`, which is
the actual routine that uses the quite rude `longjmp()` to terminate
normal processing.

> ```
>     /* coverity[+kill] */
>     static void traceback(Context *c) {
> ```

We should inspect the _next_ Coverity report and see if this clears
up a number of the false reports.  If not it may be that this same
function annotation needs to be added to all the _using_ routines,
such as `ScriptError()`.
