### PR TITLE
Stop corrupting file position on a failed encoding string parse.

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -452,8 +452,10 @@ static char *_readencstring(FILE *ttf,int offset,int len,
 	free(cstr);
     } else {
 	enc = enc_from_platspec(platform,specific);
-	if ( enc==NULL )
-return( NULL );
+	if ( enc==NULL ) {
+	  fseek(ttf, pos, SEEK_SET);
+	  return( NULL );
+	}
 	if ( enc->is_unicodebmp ) {
 	    str = pt = malloc((sizeof(unichar_t)/2)*len+sizeof(unichar_t));
 	    for ( i=0; i<len/2; ++i ) {


### PR DESCRIPTION
 Fix a missing reset of the file position in _readencstring as reported by Norbert Janssen.

The function takes an offset from which to read and seeks there. It caches the original file position but fails to reset it on failure. This patch fixes that.
