### PR TITLE
Stop calling GDrawDrawText on zero-length text when drawing pop-up tips.

### DIFF
--- a/gdraw/ggadgets.c
+++ b/gdraw/ggadgets.c
@@ -627,7 +627,7 @@ return( true );
 		temp = -1;
 		if (( ept = u_strchr(pt,'\n'))!=NULL )
 		    temp = ept-pt;
-		GDrawDrawText(popup,x,y,pt,temp,popup_foreground);
+		if (temp > 0) GDrawDrawText(popup,x,y,pt,temp,popup_foreground);
 		y += fh;
 		pt = ept+1;
 	    } while ( ept!=NULL && *pt!='\0' );


### PR DESCRIPTION
GDrawDrawText behaves strangely (repeating lines) when given zero-length text input. So we try to avoid doing that.
