### PR TITLE
ufo: fix kerning pairs output

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -1009,7 +1009,7 @@ static void KerningPListAddGlyph(xmlNodePtr parent, const char *key, const KernP
     xmlNewChild(parent, NULL, BAD_CAST "key", BAD_CAST key); // "<key>%s</key>" key
     xmlNodePtr dictxml = xmlNewChild(parent, NULL, BAD_CAST "dict", NULL); // "<dict>"
     while ( kp!=NULL ) {
-      xmlNewChildInteger(dictxml, NULL, BAD_CAST kp->sc->name, kp->off); // "<key>%s</key><integer>%d</integer>" kp->sc->name kp->off
+      PListAddInteger(dictxml, kp->sc->name, kp->off); // "<key>%s</key><integer>%d</integer>" kp->sc->name kp->off
       kp = kp->next;
     }
 }


### PR DESCRIPTION
Output before this patch:

```
<plist>
  <dict>
    <key>space</key>
    <dict>
      <colon>-20</colon>
      <J>40</J>
    </dict>
    <key>f</key>
    <dict>
      <o>-10</o>
      <parenright>80</parenright>
    </dict>
  </dict>
</plist>
```

[Spec](http://unifiedfontobject.org/versions/ufo2/kerning.html):

```
<plist version="1.0">
<dict>
  <key>A</key>
  <dict>
    <key>B</key>
    <integer>-10</integer>
    <key>X</key>
    <integer>-10</integer>
    <key>Z</key>
    <integer>-15</integer>
  </dict>
  <key>X</key>
  <dict>
    <key>Q</key>
    <integer>-10</integer>
  </dict>
</dict>
</plist>
```

cc #1634.

r? @frank-trampe
