### PR TITLE
Remove unused no_windowing_ui code fontforge/parsettfbmf.c

### DIFF
--- a/fontforge/parsettfbmf.c
+++ b/fontforge/parsettfbmf.c
@@ -554,11 +554,6 @@ return;
 	    for ( i=0; i<cnt; ++i )
 		sel[i] = true;
 	}
-    } else if ( no_windowing_ui ) {
-	if ( onlyone ) {
-	    if ( biggest!=-1 ) sel[biggest] = true;
-	} else
-	    biggest = -2;
     } else if ( onlyone ) {
 	biggest=ff_choose(_("Load Bitmap Fonts"), choices,cnt,biggest,
 		_("Do you want to load the bitmap fonts embedded in this true/open type file?\n(And if so, which)"));


### PR DESCRIPTION
Two consecutive `else if()` statements test the same condition.  The
second true clause is never executed (since 2007!).  Reviewing the
blame listing for chain of changes did not reveal intent behind the
code in the second unused clause.

Testing with and without scripting confirms the second clause is never executed.

This change removes the second clause, for five unused lines of code.
