### PR TITLE
Fix crash #1671 gdraw/gresedit.c

### DIFF
--- a/gdraw/gprogress.c
+++ b/gdraw/gprogress.c
@@ -198,7 +198,7 @@ static GResInfo progress_ri = {
     NULL,
     progress_re,
     N_("Progress"),
-    N_("Popup windows"),
+    N_("Progress Bars"),
     "GProgress",
     "Gdraw",
     false,

--- a/gdraw/gresedit.c
+++ b/gdraw/gresedit.c
@@ -331,7 +331,7 @@ static int GRE_InheritFontChange(GGadget *g, GEvent *e) {
 		*res->font = ifd.font;
  
 		GGadgetSetTitle8(g,ifd.spec);
-		GRE_FigureInheritance(gre,res,cid_off,cid_off+2,false,
+		GRE_FigureInheritance(gre,res,cid_off,cid_off+2,true,
 			(void *) &ifd, inherit_font_change);
 		free( ifd.spec );
 	    }


### PR DESCRIPTION
`GResEditDlg()` has sections to set up the different kinds of controls as found in various panes in the X resources dialog.  In two panes clicking on the 'inherit' checkbox for the "Font:" item would crash FF ("Text" and "Button" panes).

`GRE_InheritFontChange()` runs to react to those user clicks.  It calls `GRE_FigureInheritance()` to figure out the inheritance issues (whether to inherit from the parent `GGadget` type).

A parameter to `GRE_FigureInheritance()` 'is_font' is used to flag that a more complicated font data item is being manipulated. That flag was not set on this call, even though a font item _was_ being manipulated, which then caused a crash in a deeper call to `inherit_font_change()`.

Tested and cures crash.  Inheritance appears to work correctly...

During investigation, noted that descriptive title in the "Progress" pane was wrong.  Changed this to "Progress Bars".
