### PR TITLE
Fix crash on GPOS kern classes select class text field

### DIFF
--- a/fontforgeexe/kernclass.c
+++ b/fontforgeexe/kernclass.c
@@ -1276,14 +1276,18 @@ static int KCD_TextSelect(GGadget *g, GEvent *e) {
 	char *start, *pt, *name;
 	int i;
 
-	for ( upt=uname; *upt!='(' && *upt!=' '; ++upt );
+        /* length of initial text contents up until blank, '(' or end-of-string */
+        for ( upt=uname; *upt!='\0' && *upt!='(' && *upt!=' '; ++upt );
 	name = u2utf8_copyn(uname,upt-uname);
+        /* if string empty or invalid for any reason, quit processing text */
+        if ( name==NULL )
+            return( false );
 	nlen = strlen(name);
 
 	for ( i=0; i<rows; ++i ) {
 	    for ( start = classes[i].u.md_str; start!=NULL && *start!='\0'; ) {
 		while ( *start==' ' ) ++start;
-		for ( pt=start; *pt!='\0' && *pt!=' ' && *pt!='(' && *pt!='\0'; ++pt );
+                for ( pt=start; *pt!='\0' && *pt!=' ' && *pt!='('; ++pt );
 		if ( pt-start == nlen && strncmp(name,start,nlen)==0 ) {
 		    GMatrixEditScrollToRowCol(list,i,0);
 		    GMatrixEditActivateRowCol(list,i,0);
@@ -1291,11 +1295,11 @@ static int KCD_TextSelect(GGadget *g, GEvent *e) {
 			KCD_VShow(kcd,i);
 		    else
 			KCD_HShow(kcd,i);
-return( true );
+                    return( true );
 		}
 		if ( *pt=='(' ) {
 		    while ( *pt!=')' && *pt!='\0' ) ++pt;
-		    ++pt;
+		    if ( *pt==')' ) ++pt;
 		}
 		start = pt;
 	    }


### PR DESCRIPTION
`fontforgeexe/kernclass.c` :: `KCD_TextSelect()` had several problems handling text strings found in the "Select Class Containing:" incremental match text field.  One could carefully tab into the field, but mouse clicking into the field would instantly crash.

Code initially scanning string was missing check for end-of-string, which was a problem when the field was empty.  Code was not checking the return from `u2utf8_copyn()` which could return NULL on various errors.  The two of these flaws caused the crash.

Additionally further in the code there was a duplicated check for end-of-string and then a missing check that could walk off the end of the string.

Tested as fixed against both such text fields and with various input and match strings.

```
  Ubuntu-Medium.sfd
        Element / Font Info... / Lookups / GPOS
            "'kern' Horizontal Kerning lookup 1"
            "'kern' Horizontal Kerning lookup 1 subtable"
    clicked into text field "Select Class Containing:" under "First Char"
```
