### PR TITLE
Restore ability to build without collab.

### DIFF
--- a/fontforgeexe/collabclientui.c
+++ b/fontforgeexe/collabclientui.c
@@ -418,7 +418,7 @@ static void collabclient_roundTripTimer( void* ccvp )
 	collabclient_sessionReconnect( cc );
     }
 }
-#endif
+
 
 
 typedef struct _CollabSessionCallbacks CollabSessionCallbacks;
@@ -514,6 +514,7 @@ void collabclient_sessionDisconnect( FontViewBase* fv )
 #endif
 }
 
+#endif
 
 #ifdef BUILD_COLLAB
 

--- a/fontforgeexe/collabclientui.h
+++ b/fontforgeexe/collabclientui.h
@@ -165,9 +165,10 @@ extern int Collab_getLastChangedPos( void );
 extern int Collab_getLastChangedCodePoint( void );
 
 
-
+#ifdef BUILD_COLLAB
 typedef void (*collabclient_notification_cb)( FontViewBase* fv );
 extern void collabclient_addSessionJoiningCallback( collabclient_notification_cb func );
 extern void collabclient_addSessionLeavingCallback( collabclient_notification_cb func );
+#endif // BUILD_COLLAB
 
 #endif

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -203,8 +203,10 @@ static GWindow CreatePalette(GWindow w, GRect *pos, int (*eh)(GWindow,GEvent *),
     if ( palettes_docked )
 	ReparentFixup(gw,v,0,pos->y,pos->width,pos->height);
 
+#ifdef BUILD_COLLAB
     collabclient_addSessionJoiningCallback( onCollabSessionStateChanged );
     collabclient_addSessionLeavingCallback( onCollabSessionStateChanged );
+#endif
     
 return( gw );
 }

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -5742,10 +5742,12 @@ static void AskAndMaybeCloseLocalCollabServers()
 	    if( sel[i] )
 	    {
 		FontViewBase* fv = FontViewFind( FontViewFind_byCollabBasePort, (void*)(intptr_t)port );
+#ifdef BUILD_COLLAB
 		if( fv )
 		    collabclient_sessionDisconnect( fv );
 		printf("CLOSING port:%d fv:%p\n", port, fv );
 		collabclient_closeLocalServer( port );
+#endif // BUILD_COLLAB
 	    }
 	}
 	else


### PR DESCRIPTION
This addresses issue #1683. This is a quick fix and probably isn't the best approach, but we need FontForge to build for people without collab.

Closes #1683.
