### PR TITLE
psread.c: Remove (originally) unreached code that broke autotrace

### DIFF
--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -824,11 +824,6 @@ static int aload(unsigned sp, struct psstack *stack,size_t stacktop, struct garb
 		++sp;
 	    }
 	}
-	if ( sp<stacktop ) {
-	    stack[sp].type = ps_array;
-	    stack[sp].u.dict = dict;
-	    ++sp;
-	}
     }
 return( sp );
 }


### PR DESCRIPTION
This fixes a bug (autotrace is broken) that @JonathanMagus reported. Without this fix, attempting to use autotrace (at least on Windows; using potrace) creates a spurious/unusable trace, or it can crash FF.

I believe that this code was always unreached (since 2003 when it was written), so I removed it. I don't know what this code was meant to do, so if anybody does know what it is meant to do, that would help. Long explanation follows.

---

Commit b2a6cbb563d049a033508ec85fef583d14f38ac6 introduced the original code with check

```
if (sp < sizeof(stack)/sizeof(stack[0]))
```

But as `stack` is a pointer, the result was comparing `sp < 0`, which can never occur (sp >= 0). Hence this code block was never executed.

Commit a2c8bab1914abe2d6d1c012d8b57bf6444ce9e02 changed the code to be:

```
if (sp < stacktop)
```

Which I can only guess is what it should be, _if_ the code in the code block worked. Since the code in the block can now be executed, it causes the bug with autotrace.
