### PR TITLE
gfilechooser.c: Really fix the realloc procedure for gfc->history

### DIFF
--- a/gdraw/gfilechooser.c
+++ b/gdraw/gfilechooser.c
@@ -491,7 +491,7 @@ static void GFileChooserScanDir(GFileChooser *gfc,unichar_t *dir) {
 	uc_strcat(freeme,"/");
 	dir = freeme;
     }
-    if ( gfc->hpos>=gfc->hmax ) {
+    if ( gfc->hpos+1>=gfc->hmax ) {
 	gfc->hmax = gfc->hmax+20;
 	gfc->history = realloc(gfc->history,(gfc->hmax)*sizeof(unichar_t *));
     }


### PR DESCRIPTION
`gfc->hpos` is the position of the current entry; new entry goes in
`gfc->hpos+1`, so there must be enough space for `gfc->hpos+1` entries.

Related issues: #1640, #1644 

Currently building it myself to see if issue is resolved.
