### PR TITLE
SVG circle/ellipse elements constructed correctly

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1796,30 +1796,37 @@ return( NULL );
     if ( rx<0 ) rx = -rx;
     if ( ry<0 ) ry = -ry;
 
+    /* a magic number to make cubic beziers approximate ellipses    */
+    /*            4/3 * ( sqrt(2) - 1 ) = 0.55228...                */
+    /*   also     4/3 * tan(t/4)   where t = 90 b/c we do 4 curves  */
+    double magic = 0.5522847498307933984022516322796;
+    /* offset from on-curve point to control points                 */
+    double drx = rx * magic;
+    double dry = ry * magic;
     cur = chunkalloc(sizeof(SplineSet));
     cur->first = SplinePointCreate(cx-rx,cy);
-    cur->last = SplinePointCreate(cx,cy+ry);
-    cur->first->nextcp.x = cx-rx; cur->first->nextcp.y = cy+ry;
-    cur->last->prevcp = cur->first->nextcp;
+    cur->first->nextcp.x = cx-rx; cur->first->nextcp.y = cy+dry;
+    cur->first->prevcp.x = cx-rx; cur->first->prevcp.y = cy-dry;
     cur->first->noprevcp = cur->first->nonextcp = false;
+    cur->last = SplinePointCreate(cx,cy+ry);
+    cur->last->prevcp.x = cx-drx; cur->last->prevcp.y = cy+ry;
+    cur->last->nextcp.x = cx+drx; cur->last->nextcp.y = cy+ry;
     cur->last->noprevcp = cur->last->nonextcp = false;
-    SplineMake(cur->first,cur->last,true);
+    SplineMake(cur->first,cur->last,false);
     sp = SplinePointCreate(cx+rx,cy);
-    sp->prevcp.x = cx+rx; sp->prevcp.y = cy+ry;
-    sp->nextcp.x = cx+rx; sp->nextcp.y = cy-ry;
+    sp->prevcp.x = cx+rx; sp->prevcp.y = cy+dry;
+    sp->nextcp.x = cx+rx; sp->nextcp.y = cy-dry;
     sp->nonextcp = sp->noprevcp = false;
-    cur->last->nextcp = sp->prevcp;
-    SplineMake(cur->last,sp,true);
+    SplineMake(cur->last,sp,false);
     cur->last = sp;
     sp = SplinePointCreate(cx,cy-ry);
-    sp->prevcp = cur->last->nextcp;
-    sp->nextcp.x = cx-rx; sp->nextcp.y = cy-ry;
+    sp->prevcp.x = cx+drx; sp->prevcp.y = cy-ry;
+    sp->nextcp.x = cx-drx; sp->nextcp.y = cy-ry;
     sp->nonextcp = sp->noprevcp = false;
-    cur->first->prevcp = sp->nextcp;
-    SplineMake(cur->last,sp,true);
-    SplineMake(sp,cur->first,true);
+    SplineMake(cur->last,sp,false);
+    SplineMake(sp,cur->first,false);
     cur->last = cur->first;
-return( cur );
+    return( cur );
 }
 
 static SplineSet *SVGParsePoly(xmlNodePtr poly, int isgon) {


### PR DESCRIPTION
See #1702 "SVG import: Fontforge adds a ton of extra points whenever
circles are involved" for additional discussions and illustrations.

Imported SVG circle and ellipse elements were being implemented using
quadratic bezier splines, which is known to be incorrect, as cubic
beziers are needed to even approximate these curves.  As part of using
quadratics, the control points were spaced too widely apart and thus
were flattening sections of the curves.

`fontforge/svg.c` routine `SVGParseEllipse()` is changed to use cubic splines.
Additionally the control point distances are determined using a magic
constant from formulas described on the web that give a very good
approximation to the desired curves when using only 4 splines.

Investigation finds that the existing UI circle curve drawing feature
within FF already uses cubics (and showing that quadratics were rejected
as inadequate) and use of a number near to the ideal magic constant.
(`fontforgeexe/cvshapes.c` :: `CVMouseDownShape()` and `struct ellipse3`)

And strangely, this fix using cubics and corrected control points makes the 
other problems noted in #1702 disappear.  Noted without obvious explanation.

Closes #1702
