### PR TITLE
Python font.save SFD CID Font crash on filename

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -15209,37 +15209,25 @@ return( fontiter_New( self,index,NULL) );
 
 
 static PyObject *PyFFFont_Save(PyFF_Font *self, PyObject *args) {
-    char *filename;
+    char *filename = NULL;
+    int localRevisionsToRetain = -1;
     char *locfilename = NULL;
     char *pt;
     FontViewBase *fv;
     int s2d=false;
-    int localRevisionsToRetain = -1;
 
     if ( CheckIfFontClosed(self) )
 	return(NULL);
     fv = self->fv;
 
-    int haveFilename = 0;
-    if ( PySequence_Size(args) == 2 )
-    {
-	haveFilename = 1;
-	if ( !PyArg_ParseTuple(args,"es|i", "UTF-8", &filename, &localRevisionsToRetain ))
-	    return( NULL );
-    }
-    if ( PySequence_Size(args) == 1 )
-    {
-	haveFilename = 1;
-	if ( !PyArg_ParseTuple(args,"es","UTF-8",&filename) )
-	    return( NULL );
-    }
+    if ( !PyArg_ParseTuple(args,"|esi", "UTF-8", &filename, &localRevisionsToRetain ))
+        return( NULL );
 
-
-    if ( haveFilename )
+    if ( filename!=NULL )
     {
 	/* Save As - Filename was provided */
 	locfilename = utf82def_copy(filename);
-	free(filename);
+	PyMem_Free(filename);
 
 	pt = strrchr(locfilename,'.');
 	if ( pt!=NULL && strmatch(pt,".sfdir")==0 )

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -3037,9 +3037,7 @@ int SFDWriteBakExtended(char* locfilename,
 
 
     int cacheRevisionsToRetain = prefRevisionsToRetain;
-    char* cacheSFFilename = sf->filename;
 
-    sf->filename = locfilename;
     sf->save_to_dir = s2d;
 
     if( localRevisionsToRetain < 0 )
@@ -3053,32 +3051,31 @@ int SFDWriteBakExtended(char* locfilename,
 	prefRevisionsToRetain = localRevisionsToRetain;
     }
 
-    rc = SFDWriteBak( sf, map, normal );
+    rc = SFDWriteBak( locfilename, sf, map, normal );
 
-    sf->filename = cacheSFFilename;
     prefRevisionsToRetain = cacheRevisionsToRetain;
 
     return rc;
 }
 
 
-int SFDWriteBak(SplineFont *sf,EncMap *map,EncMap *normal) {
+int SFDWriteBak(char *filename,SplineFont *sf,EncMap *map,EncMap *normal) {
     char *buf=0, *buf2=NULL;
     int ret;
 
     if ( sf->save_to_dir )
     {
-	ret = SFDWrite(sf->filename,sf,map,normal,true);
+	ret = SFDWrite(filename,sf,map,normal,true);
 	return(ret);
     }
 
     if ( sf->cidmaster!=NULL )
 	sf=sf->cidmaster;
-    buf = malloc(strlen(sf->filename)+10);
+    buf = malloc(strlen(filename)+10);
     if ( sf->compression!=0 )
     {
-	buf2 = malloc(strlen(sf->filename)+10);
-	strcpy(buf2,sf->filename);
+	buf2 = malloc(strlen(filename)+10);
+	strcpy(buf2,filename);
 	strcat(buf2,compressors[sf->compression-1].ext);
 	strcpy(buf,buf2);
 	strcat(buf,"~");
@@ -3095,32 +3092,32 @@ int SFDWriteBak(SplineFont *sf,EncMap *map,EncMap *normal) {
 	    char pathnew[PATH_MAX];
 	    int idx = 0;
 
-	    snprintf( path,    PATH_MAX, "%s", sf->filename );
-	    snprintf( pathnew, PATH_MAX, "%s-%02d", sf->filename, idx );
+	    snprintf( path,    PATH_MAX, "%s", filename );
+	    snprintf( pathnew, PATH_MAX, "%s-%02d", filename, idx );
 	    (void)rename( path, pathnew );
 
 	    for( idx=prefRevisionsToRetain; idx > 0; idx-- )
 	    {
-		snprintf( path, PATH_MAX, "%s-%02d", sf->filename, idx-1 );
-		snprintf( pathnew, PATH_MAX, "%s-%02d", sf->filename, idx );
+		snprintf( path, PATH_MAX, "%s-%02d", filename, idx-1 );
+		snprintf( pathnew, PATH_MAX, "%s-%02d", filename, idx );
 
 		int rc = rename( path, pathnew );
 		if( !idx && !rc )
 		    sf->backedup = bs_backedup;
 	    }
 	    idx = prefRevisionsToRetain+1;
-	    snprintf( path, PATH_MAX, "%s-%02d", sf->filename, idx );
+	    snprintf( path, PATH_MAX, "%s-%02d", filename, idx );
 	    unlink(path);
 	}
 
     }
     free(buf);
 
-    ret = SFDWrite(sf->filename,sf,map,normal,false);
+    ret = SFDWrite(filename,sf,map,normal,false);
     if ( ret && sf->compression!=0 ) {
 	unlink(buf2);
-	buf = malloc(strlen(sf->filename)+40);
-	sprintf( buf, "%s %s", compressors[sf->compression-1].recomp, sf->filename );
+	buf = malloc(strlen(filename)+40);
+	sprintf( buf, "%s %s", compressors[sf->compression-1].recomp, filename );
 	if ( system( buf )!=0 )
 	    sf->compression = 0;
 	free(buf);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2767,7 +2767,7 @@ extern void SFDDumpMacFeat(FILE *sfd,MacFeat *mf);
 extern MacFeat *SFDParseMacFeatures(FILE *sfd, char *tok);
 extern int SFDDoesAnyBackupExist(char* filename);
 extern int SFDWrite(char *filename,SplineFont *sf,EncMap *map,EncMap *normal, int todir);
-extern int SFDWriteBak(SplineFont *sf,EncMap *map,EncMap *normal);
+extern int SFDWriteBak(char *filename,SplineFont *sf,EncMap *map,EncMap *normal);
 extern int SFDWriteBakExtended(char* locfilename,
 			       SplineFont *sf,EncMap *map,EncMap *normal,
 			       int s2d,

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -723,7 +723,7 @@ int _FVMenuSave(FontView *fv) {
 	ret = _FVMenuSaveAs(fv);
     else {
 	FVFlattenAllBitmapSelections(fv);
-	if ( !SFDWriteBak(sf,fv->b.map,fv->b.normal) )
+	if ( !SFDWriteBak(sf->filename,sf,fv->b.map,fv->b.normal) )
 	    ff_post_error(_("Save Failed"),_("Save Failed"));
 	else {
 	    SplineFontSetUnChanged(sf);


### PR DESCRIPTION
`fontforge/sfd.c` routine `SFDWriteBakExtended()` tried to save the next
filename to be written to within the current `SplineFont` structure.
This because `SFDWriteBak()` took only a `SplineFont` argument.  Unfortunately
`SFDWriteBak()` might immediately switch which `SplineFont` structure was
active when a CID font was being saved.  The filename might be undefined
and use of `sf->filename` would crash.

Changed `SFDWriteBak()` to take a `char* filename` argument, like the other
two associated routines `SFDWriteBakExtended()` and `SFDWrite()`.  One other
use of `SFDWriteBak()` needed to be changed in `fontforge/fontview.c`

Also changed the python.c routine `PyFFFont_Save()` to better utilize the
features of `PyArg_ParseTuple()` (shorter code) along with fixing a
small gotcha related to `free()` vs. `PyMem_Free()`.

Tested with both the sample CID font from the original issue #1715 and
with a plain TTF file, with and without a filename and/or a specified
revisions desired count.  Also tested the UI File / Save function.

Closes #1715

There are at least three residual concerns.  One is that the continued
use of `sf->save_to_dir` in `SFDWriteBakExtended()` is likely also going
to encounter problems.  Somewhat similarly, the use of the global variable
`prefRevisionsToRetain` seems inopportune.

Second, there continues to be severe confusion as to which `SplineFont` is
the reference `SplineFont`.  There are lines equivalent to

```
    SplineFont *sf = fv->cidmaster?fv->cidmaster:fv->sf->mm!=NULL?fv->sf->mm->normal:fv->sf;
```

distributed over several files.  As it is, the Python APIs `font.path`,
`font.sfd_path`, and `font.default_base_filename` don't seem to know which
`SplineFont` to report from.  Below, first a CID font, then a TTF font:

```
      Opening input file 'fontex.cid.cff'
        Font 'AdobeSongStd-Light-Hanzi'  from  None
      Saving to output file 'a.sfd' with versioning 2
      At end,
        font.path                    'None'
        font.sfd_path                'None'
        font.default_base_filename   'None'

      Opening input file 'lklug.ttf'
        Font 'LKLUG'  from  /home/tom/study/fonts/FF/lklug.ttf
      Saving to output file 'a.sfd' with versioning 2
      At end,
        font.path                    'a.sfd'
        font.sfd_path                'a.sfd'
        font.default_base_filename   'None'
```

Third, a minor finding, it appears that changing the revisions count can
accidentally delete more than the intended backup files.

```
        -rw-rw-r--  1     23469 Sep  4 14:26 a.sfd-04
        -rw-rw-r--  1     23469 Sep  4 14:27 a.sfd-03
        -rw-rw-r--  1     23469 Sep  4 14:27 a.sfd-02
        -rw-rw-r--  1     23469 Sep  4 14:29 a.sfd-01
        -rw-rw-r--  1   2070471 Sep  4 14:32 a.sfd
    fontforge -quiet -script zhzhzoo2.py lklug.ttf      a.sfd 1
    Opening input file 'lklug.ttf'
      Font 'LKLUG'  from  /home/tom/study/fonts/FF/lklug.ttf
    Saving to output file 'a.sfd' with versioning 1
        -rw-rw-r--  1     23469 Sep  4 14:26 a.sfd-04
        -rw-rw-r--  1     23469 Sep  4 14:27 a.sfd-03
        -rw-rw-r--  1   2070471 Sep  4 14:32 a.sfd-01
        -rw-rw-r--  1   2070471 Sep  4 14:32 a.sfd
                 ? Where did a.sfd-02 go?
```
