### PR TITLE
Don't bundle uthash, its already packaged on most linux distributions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,6 @@ GITIGNOREFILES = \
 AM_CPPFLAGS =
 AM_LDFLAGS =
 
-BUILT_SOURCES = uthash/src
 EXTRA_DIST =
 CLEANFILES =
 MOSTLYCLEANFILES =
@@ -113,7 +112,6 @@ EXTRA_DIST += \
 	Packaging/FontForge-doc.spec \
 	Packaging/FontForge.spec \
 	Packaging/FontForge.static.spec \
-	uthash/src \
 	$(NULL)
 
 #--------------------------------------------------------------------------
@@ -129,11 +127,6 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-theme-2012 --enable-debug
 
 
 #--------------------------------------------------------------------------
-uthash/src:
-	if [ ! -e uthash/src ]; then \
-	if [ -e uthash ] ; then rm -r uthash ; fi ; \
-	git clone https://github.com/troydhanson/uthash ; \
-	fi ;
 
 # We import a selection of targets from Frank's standard packaging Makefile.
 


### PR DESCRIPTION
I don't think we need uthash to be pulled while building fontforge. I see its already packaged on most linux distributions like Ubuntu, Fedora.

cc #1725.
