### PR TITLE
bootstrapped tarball should not link files from where tarball is generated

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -2635,7 +2635,7 @@ func_gnulib_tool ()
             ;;
       esac
 
-      $opt_copy || func_append_uniq gnulib_tool_options " --symlink"
+      $opt_copy && func_append_uniq gnulib_tool_options " --symlink"
 
       func_append_uniq gnulib_tool_options " $gnulib_mode"
       func_append gnulib_tool_options " $gnulib_modules"


### PR DESCRIPTION
While trying to build rpm package I faced 2 issues. 

First one after I generated tarball I see that fontforge-20140813.214.g6173e80/config/ diretory linking some files (e.g. install-sh) to /home/parag/fontforge/gnulib/build-aux/

Second is same m4 macro files in fontforge-20140813.214.g6173e80/m4/ linking in /home/parag/fontforge/gnulib/m4

and both places build is failed as that path is not available in build server. This pull request have fixed issues for me.
