### PR TITLE
Properly store bit-depth for bitmaps when generating ttc.

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -15487,10 +15487,7 @@ return(NULL);
 	    ret->sizes = malloc((cnt+1)*sizeof(int32));
 	    ret->sizes[cnt] = 0;
 	    for ( cnt=0, bdf=ret->sf->bitmaps; bdf!=NULL; bdf=bdf->next, ++cnt ) {
-		if ( bdf->clut==NULL )
-		    ret->sizes[cnt] = bdf->pixelsize;
-		else
-		    ret->sizes[cnt] = (BDFDepth(bdf)<<16) | bdf->pixelsize;
+		ret->sizes[cnt] = (BDFDepth(bdf)<<16) | bdf->pixelsize;
 	    }
 	}
     }


### PR DESCRIPTION
Before this change it is impossible to create a ttc with embedded
monochrome bitmaps from a python script, as the bit depth for such
bitmaps was set to 0. Before this scripts like

  font.bitmapSizes = ((12,),)
  font.regenBitmaps((12,))
  font.generateTtc("font.ttc", None, bitmap_type="ttf", layer=1)

would result in an error message like

  The font database does not contain a bitmap of size 12 and depth 0

PyFFFont_GenerateTTC is the only caller of makesflist and BDFDepth(bdf)
where bdf->clut == NULL already returns '1' as desired.
