### PR TITLE
Python font.em chgd to match UI em size computations

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -12629,7 +12629,7 @@ return( -1 );
     }
     sf = self->fv->sf;
     if ( (oldem = sf->ascent+sf->descent)<=0 ) oldem = 1;
-    ds = newem * sf->descent /oldem;
+    ds = rint( (double) newem * sf->descent / oldem );
     as = newem - ds;
     SFScaleToEm(sf,as,ds);
 return( 0 );


### PR DESCRIPTION
While investigating issue #1741 I noticed that the computed answers for
`.sfd` values `Ascent:` and `Descent:` were not matching those when
changed via the UI versus changed using the Python scripting setter
`font.em`.  The UI code was using floating-point computations and then
rounding-to-nearest, while the Python code was all integer multiply and
divide.

This change copies the UI operations and so resulting values match
using either UI or Python scripting.
