### PR TITLE
Native script SetGasp() extended to version 1 tables

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -3448,8 +3448,10 @@ static void bSetGasp(Context *c) {
 	    ScriptError(c,"'gasp' Pixel size out of range");
 	if ( i!=base && arr->vals[i].u.ival<=arr->vals[i-2].u.ival )
 	    ScriptError(c,"'gasp' Pixel size out of order");
-	if ( arr->vals[i+1].u.ival<0 || arr->vals[i+1].u.ival>3 )
+	if ( arr->vals[i+1].u.ival<0 || arr->vals[i+1].u.ival>15 )
 	    ScriptError(c,"'gasp' flag out of range");
+        if ( arr->vals[i+1].u.ival>3 )
+            sf->gasp_version=1;
     }
     if ( arr->argc>=2 && arr->vals[arr->argc-2].u.ival!=65535 )
 	ScriptError(c,"'gasp' Final pixel size must be 65535");


### PR DESCRIPTION
@MichinariNukazawa [reported](https://mail.google.com/mail/u/0/#inbox/148ad5832ecbf196) that they were not able to set values 
for TTF 'gasp' table.  It was discovered that the native scripting function 
`SetGasp()` had not yet been updated to support `'gasp'` version 1 additional flags.

@mskala [reported](https://mail.google.com/mail/u/0/#inbox/148af2d5160f1639) he had [updated](https://github.com/mskala/Tsukurimashou/commit/c225dabd5dd5fda56358ece93755cf14be6e26ac) FontAnvil to allow SetGasp() to apply version 1 flags.

Testing that change in FontForge revealed a small needed modification to his change
(four bit flags gives upper limit for mask of 15, as seen in MS docs).

Tested before and after change, and @mskala's change automatically sets
the table version number as needed, as there is no native scripting method
to do so.

As noted by @mskala, this does nothing for 'correcting' `'gasp'` table version numbers
as passed through from input font to output font.

Apple documents version 0 flags:
 &nbsp;  https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6gasp.html
Microsoft documents version 1 flags:
 &nbsp;  http://www.microsoft.com/typography/otspec/gasp.htm
