### PR TITLE
Guard against crashes when "Guide" layer active

### DIFF
--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -1948,6 +1948,9 @@ static void _SCClearHintMasks(SplineChar *sc,int layer, int counterstoo) {
     SplinePoint *sp;
     RefChar *ref;
 
+    if ( layer<0 || layer>=sc->layer_cnt )
+        return;
+
     if ( counterstoo ) {
 	free(sc->countermasks);
 	sc->countermasks = NULL; sc->countermask_cnt = 0;
@@ -2002,6 +2005,10 @@ void SCModifyHintMasksAdd(SplineChar *sc,int layer, StemInfo *new) {
     int index;
     StemInfo *h;
     int i;
+
+    if ( layer<0 || layer>=sc->layer_cnt )
+        return;
+
     /* We've added a new stem. Figure out where it goes and modify the */
     /*  hintmasks accordingly */
 

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -657,6 +657,9 @@ return( undo );
 Undoes *SCPreserveHints(SplineChar *sc,int layer) {
     Undoes *undo;
 
+    if ( layer<0 || layer>=sc->layer_cnt )
+        return( NULL );
+
     if ( no_windowing_ui || maxundoes==0 )		/* No use for undoes in scripting */
 return(NULL);
     if ( !preserve_hint_undoes )

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -5049,10 +5049,10 @@ static PyObject *PyFF_Glyph_get_a_layer(PyFF_Glyph *self,int layeri) {
     Layer *layer;
     PyFF_Layer *ly;
 
-    if ( layeri<-1 || layeri>=sc->layer_cnt ) {
-	PyErr_Format(PyExc_ValueError, "Bad layer" );
+    if ( layeri<ly_grid || layeri>=sc->layer_cnt ) {
+	PyErr_Format(PyExc_ValueError, "Layer is out of range" );
 return( NULL );
-    } else if ( layeri==-1 )
+    } else if ( layeri==ly_grid )
 	layer = &sc->parent->grid;
     else
 	layer = &sc->layers[layeri];
@@ -5109,10 +5109,10 @@ static int PyFF_Glyph_set_a_layer(PyFF_Glyph *self,PyObject *value, void *UNUSED
     SplineSet *ss, *newss;
     int isquad;
 
-    if ( layeri<-1 || layeri>=sc->layer_cnt ) {
-	PyErr_Format(PyExc_ValueError, "Bad layer" );
+    if ( layeri<ly_grid || layeri>=sc->layer_cnt ) {
+	PyErr_Format(PyExc_ValueError, "Layer is out of range" );
 return( -1 );
-    } else if ( layeri==-1 )
+    } else if ( layeri==ly_grid )
 	layer = &sc->parent->grid;
     else
 	layer = &sc->layers[layeri];
@@ -8489,9 +8489,14 @@ Py_RETURN( self );
 
 static PyObject *PyFFGlyph_preserveLayer(PyFF_Glyph *self, PyObject *args) {
     int layer = self->layer, dohints=false;
+    SplineChar *sc = self->sc;
 
     if ( !PyArg_ParseTuple(args,"|ii", &layer, &dohints ) )
-return( NULL );
+        return( NULL );
+    if ( layer<0 || layer>=sc->layer_cnt ) {
+        PyErr_Format(PyExc_ValueError, "Layer is out of range" );
+        return( NULL );
+    }
     _SCPreserveLayer(self->sc,layer,dohints);
 Py_RETURN( self );
 }
@@ -9686,7 +9691,7 @@ return( -1 );
 return( -1 );
     }
     if ( value==NULL ) {
-	if ( layer>=2 )
+	if ( layer>ly_fore )
 	    SFRemoveLayer(sf,layer);
 	else {
 	    PyErr_Format(PyExc_ValueError, "You may not delete the background or foreground layers" );

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -334,6 +334,9 @@ int SCNumberPoints(SplineChar *sc,int layer) {
     SplinePoint *sp;
     RefChar *ref;
 
+    if ( layer<0 || layer>=sc->layer_cnt )
+        return( pnum );
+
     if ( sc->layers[layer].order2 ) {		/* TrueType and its complexities. I ignore svg here */
 	if ( sc->layers[layer].refs!=NULL ) {
 	    /* if there are references there can't be splines. So if we've got*/

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -6565,7 +6565,7 @@ return( changed );
 	if ( !changed ) {
 	    if ( layer==ly_all )
 		SCPreserveState(sc,dohints);
-	    else if ( layer!=-1 )
+	    else if ( layer!=ly_grid )
 		SCPreserveLayer(sc,layer,dohints);
 	    changed = true;
 	}
@@ -6627,8 +6627,8 @@ int SCRoundToCluster(SplineChar *sc,int layer,int sel,bigreal within,bigreal max
     /* point in it */
     /* if "sel" is true then we are only interested in selected points */
     /* (if there are no selected points then all points in the current layer) */
-    /* if "layer"==-1 then use sf->grid. if layer==-2 then all foreground layers*/
-    /* if "layer"==ly_fore or -2 then round hints that fall in our clusters too*/
+    /* if "layer"==ly_grid then use sf->grid. if layer==ly_all then all foreground layers*/
+    /* if "layer"==ly_fore or ly_all then round hints that fall in our clusters too*/
     int ptcnt, selcnt;
     int l,k,changed;
     SplineSet *spl;
@@ -6659,7 +6659,7 @@ int SCRoundToCluster(SplineChar *sc,int layer,int sel,bigreal within,bigreal max
 		}
 	    }
 	} else {
-	    if ( layer==-1 )
+	    if ( layer==ly_grid )
 		spl = sc->parent->grid.splines;
 	    else
 		spl = sc->layers[layer].splines;
@@ -6695,17 +6695,17 @@ return(false);				/* Can't be any clusters */
 
     qsort(ptspace,ptcnt,sizeof(SplinePoint *),xcmp);
     changed = _SplineCharRoundToCluster(sc,ptspace,cspace,ptcnt,false,
-	    (layer==-2 || layer==ly_fore) && !sel,layer,false,within,max);
+	    (layer==ly_all || layer==ly_fore) && !sel,layer,false,within,max);
 
     qsort(ptspace,ptcnt,sizeof(SplinePoint *),ycmp);
     changed = _SplineCharRoundToCluster(sc,ptspace,cspace,ptcnt,true,
-	    (layer==-2 || layer==ly_fore) && !sel,layer,changed,within,max);
+	    (layer==ly_all || layer==ly_fore) && !sel,layer,changed,within,max);
 
     free(ptspace);
     free(cspace);
 
     if ( changed ) {
-	if ( layer==-2 ) {
+	if ( layer==ly_all ) {
 	    for ( l=ly_fore; l<sc->layer_cnt; ++l ) {
 		for ( spl = sc->layers[l].splines; spl!=NULL; spl=spl->next ) {
 		    first = NULL;
@@ -6717,7 +6717,7 @@ return(false);				/* Can't be any clusters */
 		}
 	    }
 	} else {
-	    if ( layer==-1 )
+	    if ( layer==ly_grid )
 		spl = sc->parent->grid.splines;
 	    else
 		spl = sc->layers[layer].splines;

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -5746,6 +5746,9 @@ struct glyphdata *GlyphDataInit( SplineChar *sc,int layer,double em_size,int onl
     int cnt;
     double iangle;
 
+    if ( layer<0 || layer>=sc->layer_cnt )
+        return( NULL );
+
     /* We only hint one layer at a time */
     /* We shan't try to hint references yet */
     if ( sc->layers[layer].splines==NULL )

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -3088,7 +3088,7 @@ void CVRegenFill(CharView *cv) {
 	int size = cv->scale*(cv->b.fv->sf->ascent+cv->b.fv->sf->descent);
 	int clut_len= 2;
 
-        if ( layer==-1 ) layer=ly_fore; /* otherwise crashes when using guides layer! */
+        if ( layer==ly_grid ) layer=ly_fore; /* otherwise crashes when using guides layer! */
 
 	/* Generally I don't think there's much point in doing an anti-aliased*/
 	/*  fill. But on the "M" (and "W") glyph of extravigant caps, ft won't*/
@@ -6591,7 +6591,7 @@ static void CVInkscapeAdjust(CharView *cv) {
     DBounds b;
     int layer = CVLayer((CharViewBase *) cv);
 
-    if (layer != -1) SplineCharLayerQuickBounds(cv->b.sc,layer,&b);
+    if (layer != ly_grid) SplineCharLayerQuickBounds(cv->b.sc,layer,&b);
     else {
         b.minx = b.miny = 1e10;
         b.maxx = b.maxy = -1e10;
@@ -9628,8 +9628,8 @@ static void CVMenuRound2Hundredths(GWindow gw, struct gmenuitem *UNUSED(mi), GEv
 
 static void CVMenuCluster(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
-    int layer = cv->b.drawmode == dm_grid ? -1 :
-		cv->b.drawmode == dm_back ? 0
+    int layer = cv->b.drawmode == dm_grid ? ly_grid :
+		cv->b.drawmode == dm_back ? ly_back
 					: cv->b.layerheads[dm_fore] - cv->b.sc->layers;
     SCRoundToCluster(cv->b.sc,layer,true,.1,.5);
 }
@@ -9654,8 +9654,8 @@ static void CVMenuPatternTile(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *
 static void _CVMenuOverlap(CharView *cv,enum overlap_type ot) {
     /* We know it's more likely that we'll find a problem in the overlap code */
     /*  than anywhere else, so let's save the current state against a crash */
-    int layer = cv->b.drawmode == dm_grid ? -1 :
-		cv->b.drawmode == dm_back ? 0
+    int layer = cv->b.drawmode == dm_grid ? ly_grid :
+		cv->b.drawmode == dm_back ? ly_back
 					: cv->b.layerheads[dm_fore] - cv->b.sc->layers;
 
     DoAutoSaves();


### PR DESCRIPTION
This change implements checks against crashes in some vulnerable routines that can fail when the current displayed layer in CharView is the "Guide" aka 'grid' layer.

This addresses the internal code aspects of issue #1750 "Crash when clearing stem hints from Guide layer".  In conjunction with PR #1754 this **should be good enough to close that issue**.

Testing of various UI actions revealed that the below routines would crash when using the layer index value -1, which is the 'grid' layer index:

```
   fontforge/cvundoes.c    SCPreserveHints()
   fontforge/splinechar.c  SCNumberPoints()
   fontforge/autohint.c    _SCClearHintMasks()
   fontforge/stemdb.c      GlyphDataInit()
   fontforge/cvhints.c     SCModifyHintMasksAdd()
```

Code was added to these routines to simply return if the layer value was outside the valid index range for the layers array.

During testing using Python scripts a further set of routines sensitive to layer values were identified in python.c and fixes applied.

Finally, the original source investigation found a number of places where code was using "magic numbers" that were equivalent to the `enum layer_type` values defined in splinefont.h.  This obscured the intent of such code and enum definitions were used to replace those numbers (-1, -2, etc.)

Tested with debug printf()'s to demonstrate usefulness, with all these added checks being hit and preventing crashes.

 &nbsp; 
"Doctor Doctor when I touch my head it hurts. When I touch my arm it hurts. When I touch my knees it hurts." The doctor replied, "You have a broken finger."
