### PR TITLE
SFD unpickle usage outside of Python scripting crash

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -17852,8 +17852,10 @@ static module_definition module_def_psMat = {
 
 
 static void PyFF_PicklerInit(void) {
-    if ( pickler==NULL )
-	PyRun_SimpleString("import " PICKLE ";\nimport __FontForge_Internals___;\n__FontForge_Internals___.initPickles(" PICKLE ".dumps," PICKLE ".loads);");
+    if ( pickler==NULL ) {
+        FontForge_InitializeEmbeddedPython();
+        PyRun_SimpleString("import " PICKLE ";\nimport __FontForge_Internals___;\n__FontForge_Internals___.initPickles(" PICKLE ".dumps," PICKLE ".loads);");
+    }
 }
 
 static void PyFF_PickleTypesInit(void) {


### PR DESCRIPTION
This change fixes the issue #1756 "why this script failed to generate
ttf for oxygen-fonts?"

There are a number of ways that embedded Python is used from FontForge,
such as script files, source from STDIN, entered via UI dialog, and
even via a socket (!?).  And also it can be used as part of a convenient
way to encode/decode complex object data through SFD files, in font and
glyph `PickledData:` sections.

When native scripts were used with FontForge, the embedded Python was not
initialized for running, because it wasn't going to be used. :)  Except,
if the script was opening SFD files that happened to contain `PickledData:`
sections, fontforge/sfd.c `SFD_GetFont()` and `SFDGetChar()` routines
would call `SFDUnPickle()` and thence `PyFF_UnPickleMeToObjects()`.
Trying to use the Python pickle/unpickle APIs without having initialized
Python would then crash.

This change simply adds a call to `FontForge_InitializeEmbeddedPython()`
to the initialization of the FF pickle/unpickle routines.  It does not
address when the now needed Python cleanup at program end should happen.

This change should logically also address part of issue #1687, but it
seems that the problem there is not completely covered by this fix.

Tested with both Python 2 and 3, with native and Python scripts, and
using the UI.

Closes #1756.
