### PR TITLE
Fix #1779 Native script tests never 'fail'

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -10398,8 +10398,10 @@ _Noreturn void ProcessNativeScript(int argc, char *argv[], FILE *script) {
 		// If the script is accessible, we start to parse it.
 		c.lineno = 1;
 		// Set the jump environment for returning from the error reporter.
-		while (setjmp(env));
-		c.err_env = &env;
+                if (c.interactive) {
+                    while (setjmp(env));
+                    c.err_env = &env;
+                }
 		// Parse and execute.
 		while ( c.script && !c.error && !c.returned && !c.broken && (tok = ff_NextToken(&c))!=tt_eof ) {
 			ff_backuptok(&c);


### PR DESCRIPTION
Change 66ff553a6f2044d382a0f78702886efe625a8fa6 wanted to allow interactive
executions to continue in spite of errors encountered in native scripts.
It set up the setjmp/longjmp information that `traceback()` could use to
return to the native script statement execution loop.

Unfortunately while other parts of that and other changes were well
directed towards the object interactive mode, the `setjmp()` would run
in all modes.  This caused _any_ `Error()` or other exception to always
return to the statement loop.  And that routine ended in an `exit(0)`,
forcing every native script execution to return a zero exit code.

This change simply makes the`setjmp()` also conditional on the interactive
flag.  With this change `Quit(N)` sets exit code N, `Error()` displays the
error message and then set exit code 1, and exceptions also display errors
and then set exit code 1.

Tested with `Quit()`, `Error()` and exceptions, in both main programs and
in subroutines.

Also see further descriptions in issue #1779.
