### PR TITLE
Export initial first font kern class to SVG

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -872,17 +872,21 @@ static void svg_dumpkerns(FILE *file,SplineFont *sf,int isv) {
     }
 
     for ( kc=isv ? sf->vkerns : sf->kerns; kc!=NULL; kc=kc->next ) {
-	for ( i=1; i<kc->first_cnt; ++i ) for ( j=1; j<kc->second_cnt; ++j ) {
-	    if ( kc->offsets[i*kc->second_cnt+j]!=0 &&
-		    *kc->firsts[i]!='\0' && *kc->seconds[j]!='\0' ) {
-		fprintf( file, isv ? "    <vkern g1=\"" : "    <hkern g1=\"" );
-		fputkerns( file, kc->firsts[i]);
-		fprintf( file, "\"\n\tg2=\"" );
-		fputkerns( file, kc->seconds[j]);
-		fprintf( file, "\"\n\tk=\"%d\" />\n",
-			-kc->offsets[i*kc->second_cnt+j]);
-	    }
-	}
+        for ( i=0; i<kc->first_cnt; ++i ) {
+            if ( kc->firsts[i] && *kc->firsts[i]!='\0' ) {
+                for ( j=0; j<kc->second_cnt; ++j ) {
+                    if ( kc->seconds[j] && *kc->seconds[j]!='\0' &&
+                         kc->offsets[i*kc->second_cnt+j]!=0 ) {
+                        fprintf( file, isv ? "    <vkern g1=\"" : "    <hkern g1=\"" );
+                        fputkerns( file, kc->firsts[i]);
+                        fprintf( file, "\"\n\tg2=\"" );
+                        fputkerns( file, kc->seconds[j]);
+                        fprintf( file, "\"\n\tk=\"%d\" />\n",
+                                -kc->offsets[i*kc->second_cnt+j]);
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Issue #1811 reported that kerning information was lost when generating
an SVG file from a TTF from Google.  The first item displayed within
the Element / Font Info / Lookups / GPOS / 'kern' lookup class 2
dialog was not seen in the generated SVG file, while all other shown
kerning classes could be found represented in SVG `<hkern>` lines.

`fontforge/svg.c` routine `svg_dumpkerns()` first outputs char kern pairs
and then outputs font-based GPOS lookup kern information.  It would skip
the first entries in the font `sf->firsts[]` and `sf->seconds[]` lists.
This was reasonable for `sf->seconds[]` as this is a placeholder entry for
the "{Everything Else}" list entry seen in the kerning dialog display.
But the initial entry in the `sf->firsts[]` list _[might](https://github.com/fontforge/fontforge/blob/c53b96929d8878a3dfcac2279c400a34b629bb08/fontforge/parsettfatt.c#L628-L631) [not](https://github.com/fontforge/fontforge/blob/c53b96929d8878a3dfcac2279c400a34b629bb08/fontforge/parsettfatt.c#L105-L106)_ be a dummy
entry.

This change has `svg_dumpkerns()` dump the initial entry in `sf->firsts[]`
if it is 'significant', containing information.  This has the side-effect
of being a little more careful, checking for non-NULL before using the
pointers.

After this change the generated SVG file contained the desired additional
information, with that being the only change to the SVG output.

This change addresses and should close issue #1811, as class-based kerning
information is now correctly exported to the SVG file.

However there may be other issues with character-based kerning information
export.  It is hard to follow the logic, understand the input or output,
and the broken TTF from Google doesn't help...
