### PR TITLE
Tag imported TrueType layers correctly.

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -2169,6 +2169,8 @@ static SplineChar *readttfglyph(FILE *ttf,struct ttfinfo *info,uint32 start, uin
     SplineChar *sc = SplineCharCreate(2);
     int gbb[4];
 
+    sc->layers[ly_fore].background = 0;
+    sc->layers[ly_back].background = 1;
     sc->unicodeenc = -1;
     sc->vwidth = info->emsize;
     sc->orig_pos = gid;

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -3824,10 +3824,10 @@ SplineFont *SplineFontEmpty(void) {
 
     sf->layer_cnt = 2;
     sf->layers = calloc(2,sizeof(LayerInfo));
-    sf->layers[0].name = copy(_("Back"));
-    sf->layers[0].background = true;
-    sf->layers[1].name = copy(_("Fore"));
-    sf->layers[1].background = false;
+    sf->layers[ly_back].name = copy(_("Back"));
+    sf->layers[ly_back].background = true;
+    sf->layers[ly_fore].name = copy(_("Fore"));
+    sf->layers[ly_fore].background = false;
     sf->grid.background = true;
 
 return( sf );


### PR DESCRIPTION
As noted in #1552, TrueType files were importing with the background layer incorrectly tagged as a foreground layer.
