### PR TITLE
Moving FontforgeInternal

### DIFF
--- a/mk/layout.am
+++ b/mk/layout.am
@@ -45,7 +45,7 @@ pixmapsdir = ${pkgdatadir}/pixmaps
 # Where to put binaries which are really only interesting to fontforge itself.
 # For example, processes that are created to help with real time collaboration
 # but which are really not so interesting for the user to ever directly create.
-internal_bindir = ${bindir}/FontForgeInternal
+internal_bindir = ${libexecdir}/bin/FontForgeInternal
 
 # Where the FontForge help system goes.
 HTDOCS_SUBDIR =

--- a/osx/create-osx-app-bundle.sh
+++ b/osx/create-osx-app-bundle.sh
@@ -11,6 +11,7 @@ scriptdir=$TEMPDIR/FontForge.app/Contents/MacOS
 bundle_res=$TEMPDIR/FontForge.app/Contents/Resources
 bundle_bin="$bundle_res/opt/local/bin"
 bundle_lib="$bundle_res/opt/local/lib"
+bundle_libexec="$bundle_res/opt/local/libexec"
 bundle_etc="$bundle_res/opt/local/etc"
 bundle_share="$bundle_res/opt/local/share"
 export PATH="$PATH:$scriptdir"
@@ -90,7 +91,7 @@ dylibbundler --overwrite-dir --bundle-deps --fix-file \
   --dest-dir ./FontForgeInternal/collablib
 
 cp -av /usr/lib/libedit* $bundle_lib/
-cp -av /usr/lib/libedit* $bundle_bin/FontForgeInternal/collablib/
+cp -av /usr/lib/libedit* $bundle_libexec/bin/FontForgeInternal/collablib/
 
 cd $bundle_lib
 for if in libXcomposite.1.dylib libXcursor.1.dylib libXdamage.1.dylib libXfixes.3.dylib libXinerama.1.dylib libXrandr.2.dylib libatk-1.0.0.dylib libgdk-x11-2.0.0.dylib libgdk_pixbuf-2.0.0.dylib libgtk-x11-2.0.0.dylib libtest-1.0.0.dylib
@@ -145,7 +146,7 @@ do
   otool -L  $if | grep libedit
   install_name_tool -change /usr/lib/libedit.3.dylib @executable_path/../lib/libedit.3.dylib $if
 done
-cd $bundle_bin/FontForgeInternal/collablib/
+cd $bundle_libexec/bin/FontForgeInternal/collablib/
 for if in *dylib 
 do 
   echo $if 

--- a/travis-scripts/create-osx-app-bundle-homebrew.sh
+++ b/travis-scripts/create-osx-app-bundle-homebrew.sh
@@ -19,6 +19,7 @@ scriptdir=$TEMPDIR/FontForge.app/Contents/MacOS
 bundle_res=$TEMPDIR/FontForge.app/Contents/Resources
 bundle_bin="$bundle_res/opt/local/bin"
 bundle_lib="$bundle_res/opt/local/lib"
+bundle_libexec="$bundle_res/opt/local/libexec"
 bundle_etc="$bundle_res/opt/local/etc"
 bundle_share="$bundle_res/opt/local/share"
 export PATH="$PATH:$scriptdir:/usr/local/bin"
@@ -135,7 +136,7 @@ dylibbundler --overwrite-dir --bundle-deps --fix-file \
 echo "... dylibbunder on collab server is complete ..."
 
 cp -av /usr/lib/libedit* $bundle_lib/
-cp -av /usr/lib/libedit* $bundle_bin/FontForgeInternal/collablib/
+cp -av /usr/lib/libedit* $bundle_libexec/bin/FontForgeInternal/collablib/
 
 cd $bundle_lib
 for if in libXcomposite.1.dylib libXcursor.1.dylib libXdamage.1.dylib libXfixes.3.dylib libXinerama.1.dylib libXrandr.2.dylib 
@@ -206,7 +207,7 @@ do
   otool -L  $if | grep libedit
   install_name_tool -change /usr/lib/libedit.3.dylib @executable_path/../lib/libedit.3.dylib $if
 done
-cd $bundle_bin/FontForgeInternal/collablib/
+cd $bundle_libexec/bin/FontForgeInternal/collablib/
 for if in *dylib 
 do 
   echo $if 


### PR DESCRIPTION
Having a directory inside the bin is generally frowned upon, and causes issues with Homebrew due to our audit red-flagging that behaviour. This (theoretically) changes that by moving that internal directory to libexec/bin. This should work okay, theoretically. Let me know what you all think.
