### PR TITLE
View/Combinations/KernPairs mistakenly right-to-left

### DIFF
--- a/fontforgeexe/combinations.c
+++ b/fontforgeexe/combinations.c
@@ -230,6 +230,8 @@ static void CheckLeftRight(struct kerns *k) {
     /*  we don't recognize as right-to-left (ie. not in unicode) */
     if ( SCRightToLeft(k->first) || SCRightToLeft(k->second) )
 	k->r2l = true;
+    else 
+        k->r2l = false;
 }
 
 static void KPBuildKernList(KPData *kpd) {
@@ -271,7 +273,7 @@ static void KPBuildKernList(KPData *kpd) {
 	break;
 	    if ( cnt==0 )
 return;
-	    kpd->kerns = malloc((cnt+1)*sizeof(struct kerns));
+	    kpd->kerns = calloc(cnt+1, sizeof(struct kerns));
 	    kpd->kcnt = cnt;
 	}
     } else {
@@ -294,7 +296,7 @@ return;
 	break;
 	    if ( cnt==0 )
 return;
-	    kpd->kerns = malloc((cnt+1)*sizeof(struct kerns));
+	    kpd->kerns = calloc(cnt+1, sizeof(struct kerns));
 	    kpd->kcnt = cnt;
 	}
     }


### PR DESCRIPTION
Issue #1811 mentioned trying to understand kern pairs by consulting the
View / Combinations / Kern Pairs UI dialog, in addition to the other
dialogs that can display kern pairs.  While tracing reporter's steps with
their cited TTF I noticed something odd.  For just 'some' kern pairs,
the character pair would be displayed in reversed order and
right-justified.  Very much as though FF thought right-to-left display
was required.

I verified this behavior with the ./tests/fonts/Caliban.sfd file, where
for example 'sometimes' "Lv" would be displayed right-justified as "vL",
"Fo" would be "oF", etc.  This would happen for a small random assortment
of kerned pairs.

Disabling setting of the `r2l` flag within `fontforgeexe/combinations.c`
routine `CheckLeftRight()` did not stop the problem, as breakpoints on
the right-to-left display code in `KP_ExposeKerns()` found some pairs
had the flag set anyway.

Checking further found that when the `r2l` flag was added in 2002, no
additional initialization code was put into `KPBuildKernList()` or
`void KPBuildAnchorList()`.  Uninitialized allocated memory would
occasionally 'set' the flag `r2l`.

This change uses `calloc()` vs. `malloc()`, and has `CheckLeftRight()`
always set the flag to either true or false.  This guarantees flag is
defaulted to false, and is always left set correctly after each call.

Tested before and after against the Caliban.sfd file.  All pairs now
consistently displayed correctly.
