### PR TITLE
Pretty message on TTC open with missing/bad font names

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -642,7 +642,7 @@ static int PickTTFFont(FILE *ttf,char *filename,char **chosenname) {
     for ( i=0; i<cnt; ++i ) {
 	names[i] = TTFGetFontName(ttf,offsets[i],0);
         if ( names[i]==NULL ) 
-            names[i] = copy("<no name>");
+            asprintf(&names[i], "<Unknown font name %d>", i+1);
     }
     pt = strrchr(filename,'/');
     if ( pt==NULL ) pt = filename;


### PR DESCRIPTION
Very minor change to make font selection a bit more understandable,
when opening a TTC file where some/all font names in the TTC are
missing or bad.  User is slightly reassured to see there _are_ multiple
separate fonts within the TTC.

For each missing font name, a line of "Unknown font name NN" is
substituted in the list presented by the dialog "There are multiple
fonts in this file, pick one".  If user want to examine them one by
one they are at least assured they are picking different fonts.

Tested against broken downloaded font /tests/fonts/mingliu.ttc and
against the correct mingliy.ttc file from Windows.

This should close issue #1820
