### PR TITLE
Rearrange check for blank tooltips

### DIFF
--- a/gdraw/ggadgets.c
+++ b/gdraw/ggadgets.c
@@ -610,7 +610,7 @@ static int msgpopup_eh(GWindow popup,GEvent *event) {
 
 	popup_visible = true;
 	pt = msg = (unichar_t *) popup_info.msg;
-	if ( pt==NULL && popup_info.img==NULL ) {
+	if ( (pt==NULL || *pt=='\0') && popup_info.img==NULL ) {
 	    GGadgetEndPopup();
 return( true );
 	}
@@ -623,14 +623,18 @@ return( true );
 	    GDrawWindowFontMetrics(popup,popup_font,&as, &ds, &ld);
 	    fh = as+ds;
 	    y += as;
-	    do {
-		temp = -1;
+	    while ( *pt!='\0' ) {
+                /* Find end of this line, if multiline text */
 		if (( ept = u_strchr(pt,'\n'))!=NULL )
-		    temp = ept-pt;
-		if (temp > 0) GDrawDrawText(popup,x,y,pt,temp,popup_foreground);
+		    temp = ept-pt;  /* display next segment of multiline text */
+                else
+                    temp = -1;     /* last line, so display remainder of text */
+		GDrawDrawText(popup,x,y,pt,temp,popup_foreground);
 		y += fh;
 		pt = ept+1;
-	    } while ( ept!=NULL && *pt!='\0' );
+                if ( ept==NULL )
+                    break;
+	    }
 	}
     } else if ( event->type == et_timer && event->u.timer.timer==popup_timer ) {
 	GGadgetPopupTest(event);


### PR DESCRIPTION
As reported in #1807, for many tooltips, single line tooltips were blank
and the last line of multi-line tooltips were blank.

In an attempt to curb empty tooltips, a change misinterpreted how a
character count was being used.  The value was actually trying to flag
leading lines of a multi-line tooltips.

This change makes that leading/last line flagging a tiny bit more
explicit, and adding comments.

Trying to implement the original desire to omit tooltips with empty texts,
this change alters when the loop checks for end-of-string. (do-while
changed to while)  Also, a much earlier check for empty string will
simply exit and not display an empty tooltip text.

In addition to testing normal tooltips (easiest check is hovering over
the checkbox labels in the Generate Fonts dialog; these show two line,
single line, and 11 line tooltips), a series of empty and partially
empty texts were exercised.

```
fontforgeexe/savefontdlg.c
  2611         gcd[k].gd.popup_msg = (unichar_t *) _("Check the glyph outlines for standard errors before saving\nThis can be slow.");

      popup_msg = _("Check the glyph outlines for standard errors before saving\n");
  Shows as correct first line, but then no second line at all - a
    one line tooltip.
  Did GDrawWindowFontMetrics() determine line height to be only one?

      popup_msg = _("\nThis can be slow.");
  Shows as first line blank, second line "This can be slow."

      popup_msg = _("\n");
  A one line, one character, blank tooltip is displayed.
    Well, a "\n" sure does say "give me a blank line", so displaying
    *something* seems the correct thing to do.

      popup_msg = _("");
  Nothing is displayed.
```

These special conditions seem to give reasonable results.

This change should close #1807
