### PR TITLE
Open file dialog file list: tighten cursor hit checking

### DIFF
--- a/fontforgeexe/openfontdlg.c
+++ b/fontforgeexe/openfontdlg.c
@@ -532,11 +532,8 @@ return( false );
     GFileChooserGetChildren(d->gfc,NULL, &list, NULL);
     if ( list==NULL )
 return( false );
-    GGadgetGetSize(list,&size);
-    if ( event->u.mouse.x < size.x || event->u.mouse.y <size.y ||
-	    event->u.mouse.x >= size.x+size.width ||
-	    event->u.mouse.y >= size.y+size.height )
-return( false );
+    if ( !GGadgetWithin(list,event->u.mouse.x,event->u.mouse.y) )
+        return( false );
     pos = GListIndexFromY(list,event->u.mouse.y);
     if ( pos == d->filename_popup_pos )
 return( pos!=-1 );


### PR DESCRIPTION
One difficulty with testing the recent issue with listing discovered
font names in popups taking a very long time with PDF files, was that
any near approach to the file list by the mouse cursor would trigger 
the font name lookup code.  It was impossible to use the vertical scroll 
bar, as that was included in the 'hit' checked area of the dialog.

The list area hit testing in `WithinList()` was asking for the 'size' of
the file list, then checking if the mouse coordinates were within that
area.  But the actual routine being used to determine list bounds,
`gdraw/glist.c` routine `glist_getsize()`, was explicitly adding the area
of the vertical scroll bar to the 'list' area.

A different method for hit testing is using `gdraw/ggadgets.c` routine
`GGadgetWithin()` which will use only the _real_ bounds of the list's
content area.

Without this change, font name list popups can be provoked when moving
the cursor within the vertical scroll bar.  With the change, that popup code 
is not invoked by mouse movements within the scroll bar, and which then 
avoids any possible slow downs due to the other issue.

I don't know how many other dialog lists might have this issue. It is
very confusing as all these gdraw routines were implemented at nearly
the same time. Why the better, more precise, hit check wasn't done here
when easily available... confuses.
