### PR TITLE
osx 10.9 --debug update, part 1.

### DIFF
--- a/osx/FontForge.app/Contents/MacOS/debug-script
+++ b/osx/FontForge.app/Contents/MacOS/debug-script
@@ -2,5 +2,9 @@ version
 settings set frame-format "frame #${frame.index}: ${frame.pc}{ ${module.file.basename}`${function.name-with-args}{${function.pc-offset}}}{ at ${line.file.basename}:${line.number}}\n"
 target create /Applications/FontForge.app/Contents/Resources/opt/local/bin/fontforge
 target select 0
-run -SkipPythonInitFiles 
+#run -SkipPythonInitFiles 
 
+# please type the run command to start FontForge
+#
+# run
+#


### PR DESCRIPTION
for osx 10.9 I haven't figured out how to perform the "run" operation
from lldb and have it execute as one would expect. Ironically, setting
up the whole show and falling off the end of the script allowing the
user to type run (or just r) actually works. So to allow for debug I
have temporarily moved to not starting the process in the script, but
allowing the user to do that.

It's unfortunate. I've tried many ways to "run" the process and
passing the binary on the command line etc. I tried passing the env
variable DISPLAY just in case that was it. There is something causing
FontForge to silently not start when the run is issued from the lldb
--script itself.
