### PR TITLE
Fix a crash from CVResize when character selection widgets are missing.

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -5948,7 +5948,7 @@ return;
 		    cv->dv->ii.vheight/cv->dv->ii.fh);
 	}
 
-	{
+	if (cv->charselector != NULL && cv->charselectorPrev != NULL && cv->charselectorNext != NULL) {
 	  GRect charselector_size;
 	  GRect charselectorNext_size;
 	  GRect charselectorPrev_size;


### PR DESCRIPTION
It is apparently possible for the relevant data structures to be null, so we must be more careful. See 48d8d85be5e366a9f5c06826f087abb8474a5726 and #1781.
