### PR TITLE
osx debug: go the other way from live and let live and try to force

### DIFF
--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -80,6 +80,15 @@ if [ x"$1" == "x--debug" -o x"$1" == "x--debug-clearenv" ]; then
     fi
 
     if command -v lldb 2>/dev/null; then
+
+        export PYTHONPATH="/Applications/FontForge.app/Contents/MacOS/Even.app/Contents/Resources/lib/"
+        export PATH="$PATH:$bundle_bin"
+        export PYTHON="$bundle_bin/Python.framework.*/bin/python"
+        export PYTHONHOME="$bundle_bin/Python.framework.2.7"
+
+        echo "have set up python stuff... PYTHONHOME: $PYTHONHOME "
+        echo "have set up python stuff... PYTHON:     $PYTHON "
+
         WRAPPER="gdb --args"
         WRAPPER="script $HOME/FontForge-Debug-Output.txt lldb --debug --source /Applications/FontForge.app/Contents/MacOS/debug-script -- "
         $WRAPPER

--- a/osx/FontForge.app/Contents/MacOS/debug-script
+++ b/osx/FontForge.app/Contents/MacOS/debug-script
@@ -1,4 +1,5 @@
 version
+script print sys.version
 settings set frame-format "frame #${frame.index}: ${frame.pc}{ ${module.file.basename}`${function.name-with-args}{${function.pc-offset}}}{ at ${line.file.basename}:${line.number}}\n"
 target create /Applications/FontForge.app/Contents/Resources/opt/local/bin/fontforge
 target select 0


### PR DESCRIPTION
```
       selection of the embedded python for fontforge use during a
       debug session.
```

I will test this branch with a build to see how it works out on other machines with custom python setups. If it works out then I'll come back and merge.
