### PR TITLE
Fix a U. F. O. layering bug.

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -4046,8 +4046,8 @@ return( NULL );
 										if ( layerdest+1>sf->layer_cnt ) {
  										    sf->layers = realloc(sf->layers,(layerdest+1)*sizeof(LayerInfo));
 										    memset(sf->layers+sf->layer_cnt,0,((layerdest+1)-sf->layer_cnt)*sizeof(LayerInfo));
+										    sf->layer_cnt = layerdest+1;
 										}
-										sf->layer_cnt = layerdest+1;
 
 										// The check is redundant, but it allows us to copy from sfd.c.
 										if (( layerdest<sf->layer_cnt ) && sf->layers) {


### PR DESCRIPTION
Fix a problem that caused the U. F. O. driver to shrink the layer storage when reading a U. F. O. ordering layers in a fashion different from FontForge.
