### PR TITLE
Skip through unrecognized tags in an S. F. D..

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -562,6 +562,28 @@ return( NULL );
 return( pt );
 }
 
+static void read_unknown_tag(FILE *sfd) {
+  // In the event that we encounter an unknown tag,
+  // we will read until we reach the end of the file
+  // or a new line outside of a quoted string.
+  int tmpc = getc(sfd);
+  while (tmpc != EOF && tmpc != '\n' && tmpc != '\r') {
+    while (tmpc != EOF && tmpc != '\n' && tmpc != '\r' && tmpc != '"') {
+      tmpc = getc(sfd);
+    }
+    if (tmpc == '"') {
+      ungetc(tmpc, sfd);
+      char *tmpstring = SFDReadUTF7Str(sfd);
+      free(tmpstring);
+      tmpstring = NULL;
+      tmpc = getc(sfd);
+    }
+  }
+  if (tmpc != EOF) {
+    ungetc(tmpc, sfd);
+  }
+}
+
 struct enc85 {
     FILE *sfd;
     unsigned char sofar[4];
@@ -8219,7 +8241,9 @@ bool SFD_GetFontMetaData( FILE *sfd,
         //
         // We didn't have a match ourselves.
         //
-        return false;
+        // return false;
+        // Try to read through it anyway.
+        read_unknown_tag(sfd);
     }
     return true;
 }

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -8244,6 +8244,7 @@ bool SFD_GetFontMetaData( FILE *sfd,
         // return false;
         // Try to read through it anyway.
         read_unknown_tag(sfd);
+        LogError(_("Unknown tag %s."), tok);
     }
     return true;
 }


### PR DESCRIPTION
This will enhance the ability of present FontForge to parse files from future versions that add one-line tags to S. F. D..

cc #1934.