### PR TITLE
Rename the native kerning option.

### DIFF
--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -851,7 +851,7 @@ static void SaveOptionsDlg(struct gfc_data *d,int which,int iscid) {
 
     gcd[k].gd.pos.y = gcd[k-1].gd.pos.y; gcd[k].gd.pos.x = gcd[k-2].gd.pos.x;
     gcd[k].gd.flags = gg_visible | gg_enabled | gg_utf8_popup;
-    label[k].text = (unichar_t *) _("Force native kerning");
+    label[k].text = (unichar_t *) _("Prefer native kerning");
     label[k].text_is_1byte = true;
     gcd[k].gd.popup_msg = (unichar_t *) _(
 	"Use native kerning structures (instead of a feature file) even when this might lose information.\n");


### PR DESCRIPTION
Rename the native kerning option in the Generate dialogue in order better to reflect its function.

It previously referred to forcing native kerning, which is incorrect since FontForge would still defer to existing kerning alignment if present. So it is more accurate to say that FontForge would prefer the native kerning.
