### PR TITLE
Correct generation of ghost hints for references

### DIFF
--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -1842,6 +1842,7 @@ static StemInfo *RefHintsMerge(StemInfo *into, StemInfo *rh, real mul, real offs
 	if ( h==NULL || start!=h->start || width!=h->width ) {
 	    n = chunkalloc(sizeof(StemInfo));
 	    n->start = start; n->width = width;
+	    n->ghost = rh->ghost;
 	    n->next = h;
 	    if ( prev==NULL )
 		into = n;


### PR DESCRIPTION
When FontForge autohints a glyph that is a reference to some other glyph, ghost hints in the original glyph become ordinary hints in the reference. As a result, during OpenType/CFF font export these hints are written with positive stem widths. The problem is that in OpenType/CFF ghost hints should have negative stem widths ("The Type 2 Charstring Format", page 6).

This patch fixes this behavior.
