### PR TITLE
Write 'kern' subtable header correctly even if some kern pairs were dropped

### DIFF
--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -179,6 +179,7 @@ static void ttf_dumpsfkerns(struct alltabs *at, SplineFont *sf, int tupleIndex, 
     int b, bmax;
     int *breaks;
     int winfail=0;
+    int subtableBeginPos,subtableEndPos;
 
     if ( CountKerns(at,sf,&kcnt)==0 )
 return;
@@ -196,25 +197,11 @@ return;
 	    gid = 0;
 	    for ( b=0; b<bmax; ++b ) {
 		c = bmax==1 ? c : breaks[b];
-		if ( version==0 ) {
-		    putshort(at->kern,0);		/* subtable version */
-		    if ( c>10920 )
-			ff_post_error(_("Too many kern pairs"),_("The 'kern' table supports at most 10920 kern pairs in a subtable"));
-		    putshort(at->kern,(7+3*c)*sizeof(uint16)); /* subtable length */
-		    putshort(at->kern,!isv);	/* coverage, flags=hor/vert&format=0 */
-		} else {
-		    putlong(at->kern,(8+3*c)*sizeof(uint16)); /* subtable length */
-		    /* Apple's new format has a completely different coverage format */
-		    putshort(at->kern,(isv?0x8000:0)| /* format 0, horizontal/vertical flags (coverage) */
-				    tupleMask);
-		    putshort(at->kern,tupleIndex);
-		}
-		putshort(at->kern,c);
-		for ( i=1,j=0; i<=c; i<<=1, ++j );
-		i>>=1; --j;
-		putshort(at->kern,i*6);		/* binary search headers */
-		putshort(at->kern,j);
-		putshort(at->kern,6*(c-i));
+
+		// skip subtable header because we don't know the number of kern pairs yet
+		subtableBeginPos=ftell(at->kern);
+		if(version==0) fseek(at->kern,7*sizeof(uint16),SEEK_CUR);
+		else fseek(at->kern,8*sizeof(uint16),SEEK_CUR);
 
 		for ( tot = 0; gid<at->gi.gcnt && tot<c; ++gid ) if ( at->gi.bygid[gid]!=-1 ) {
 		    SplineChar *sc = sf->glyphs[at->gi.bygid[gid]];
@@ -254,6 +241,31 @@ return;
 		    }
 		    tot += m;
 		}
+
+		// now we can fill the subtable header
+		c=tot;
+		subtableEndPos=ftell(at->kern);
+		fseek(at->kern,subtableBeginPos,SEEK_SET);
+		if ( version==0 ) {
+		    putshort(at->kern,0);		/* subtable version */
+		    if ( c>10920 )
+			ff_post_error(_("Too many kern pairs"),_("The 'kern' table supports at most 10920 kern pairs in a subtable"));
+		    putshort(at->kern,(7+3*c)*sizeof(uint16)); /* subtable length */
+		    putshort(at->kern,!isv);	/* coverage, flags=hor/vert&format=0 */
+		} else {
+		    putlong(at->kern,(8+3*c)*sizeof(uint16)); /* subtable length */
+		    /* Apple's new format has a completely different coverage format */
+		    putshort(at->kern,(isv?0x8000:0)| /* format 0, horizontal/vertical flags (coverage) */
+				    tupleMask);
+		    putshort(at->kern,tupleIndex);
+		}
+		putshort(at->kern,c);
+		for ( i=1,j=0; i<=c; i<<=1, ++j );
+		i>>=1; --j;
+		putshort(at->kern,i*6);		/* binary search headers */
+		putshort(at->kern,j);
+		putshort(at->kern,6*(c-i));
+		fseek(at->kern,subtableEndPos,SEEK_SET);
 	    }
 	    free(offsets);
 	    free(glnum);


### PR DESCRIPTION
My previous changeset contains a bug: if some kern pairs are omitted, _kern_ subtable header contains incorrect information about its size and number of kern pairs. The issue is now fixed by building _kern_ subtable header after writing kern pairs, when information about number of kern pairs is already available. It can be tested on Roboto-Regular.ttf.
