### PR TITLE
wordlistparser: restore unencoded glyphs decoding

### DIFF
--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -260,7 +260,7 @@ u_WordlistEscapedInputStringToRealString_readGlyphName(
 	    unichar_t* endptr = 0;
 	    long unicodepoint = u_strtoul( glyphname+1, &endptr, 16 );
 	    TRACE("AAA glyphname:%s\n", u_to_c(glyphname+1) );
-	    TRACE("AAA unicodepoint:%d\n", unicodepoint );
+	    TRACE("AAA unicodepoint:%ld\n", unicodepoint );
 	    sc = SFGetChar( sf, unicodepoint, 0 );
 	    if( sc && endptr )
 	    {
@@ -482,6 +482,7 @@ WordListLine WordlistEscapedInputStringToParsedDataComplex(
 		out->sc = sc;
 		out->isSelected = isSelected;
 		out->currentGlyphIndex = currentGlyphIndex;
+                out->n = n;
 		out++;
 		/* out = utf8_idpb( out, n, 0 ); */
 		/* if( !out ) */
@@ -921,6 +922,7 @@ unichar_t* WordListLine_toustr( WordListLine wll )
     unichar_t* p = ret;
     for( ; wll->sc; wll++, p++ ) {
 	*p = wll->sc->unicodeenc;
+        if (*p == -1) *p = wll->n;
     }
     return ret;
 }

--- a/fontforgeexe/wordlistparser.h
+++ b/fontforgeexe/wordlistparser.h
@@ -83,6 +83,7 @@ typedef struct wordlistchar {
     SplineChar* sc;
     int isSelected;
     int currentGlyphIndex;
+    int n;
 } WordListChar;
 
 typedef WordListChar* WordListLine;


### PR DESCRIPTION
This allows calling unencoded glyphs in the metrics window via their entity name again.

cc #1622.

r? @frank-trampe
