### PR TITLE
Update default kerning type.

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -1337,7 +1337,7 @@ return( true );		/* No change, don't bother user */
 	    struct subtable_data sd;
 	    memset(&sd,0,sizeof(sd));
 	    sd.flags = (mv->vertical ? sdf_verticalkern : sdf_horizontalkern ) |
-		    sdf_kernpair;
+		    sdf_kernclass;
 	    sub = SFNewLookupSubtableOfType(psc->parent,gpos_pair,&sd,mv->layer);
 	    if ( sub==NULL )
 return( false );


### PR DESCRIPTION
When creating a new kerning lookup from the metrics view, default to class kerning. @davelab6 advises that this reflects current best practices.

This relates to #1583.
