### PR TITLE
Stop doubling keyboard actions in the Metrics View.

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5007,7 +5007,7 @@ static int mv_e_h(GWindow gw, GEvent *event) {
 	  // For now, we just return 0 so that the default event handler takes care.
 	  return 0;
 	}
-	MVChar(mv,event);
+	// MVChar(mv,event);
       break;
       case et_charup:
 	if ((event->u.chr.keysym == GK_Tab || event->u.chr.keysym == GK_BackTab) && (!(event->u.chr.state&ksm_meta))) {


### PR DESCRIPTION
Stop triggering MVChar from the keyboard down events since we now trigger it on the keyboard up event and want to avoid duplication.

This addresses a problem from #2018.
