### PR TITLE
Add experimental support for fine point adjustment.

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1018,6 +1018,7 @@ extern Undoes *CVPreserveMaybeState(CharView *cv, int isTState );
 extern void CVRestoreTOriginalState(CharView *cv);
 extern void CVUndoCleanup(CharView *cv);
 
+extern void AdjustControls(SplinePoint *sp);
 extern void CVAdjustPoint(CharView *cv, SplinePoint *sp);
 extern void CVMergeSplineSets(CharView *cv, SplinePoint *active, SplineSet *activess,
 	SplinePoint *merge, SplineSet *mergess);

--- a/fontforgeexe/cvaddpoints.c
+++ b/fontforgeexe/cvaddpoints.c
@@ -577,7 +577,7 @@ return;			/* We clicked on the active point, that's a no-op */
 	cv->p.constrain = sp->me;
 }
 
-static void AdjustControls(SplinePoint *sp) {
+void AdjustControls(SplinePoint *sp) {
     if ( sp->next!=NULL ) {
 	SplineCharDefaultNextCP(sp);	/* also fixes up tangents */
 	SplineCharDefaultPrevCP(sp->next->to);


### PR DESCRIPTION
Allow for moving of points on their control point lines without moving the control points (by holding down the control key).

This is in response to #2050.

We also need to settle on a key combination. Alt is not available for drag operations because some window managers use that for moving the window. Shift is not available since that would cause the click beginning the drag operation to deselect the point to be moved.
