### PR TITLE
Update fontforge-common.dirs

### DIFF
--- a/Packaging/debian/cp-src/fontforge-common.dirs
+++ b/Packaging/debian/cp-src/fontforge-common.dirs
@@ -1,1 +1,1 @@
-usr/share/pixmaps
+usr/share/fontforge


### PR DESCRIPTION
fix path to restore access to shortcuts and theme