### PR TITLE
splinesaveafm: more guards against NULL splinechar

### DIFF
--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -1097,6 +1097,7 @@ int LayerWorthOutputting(SplineFont *sf, int layer) {
 }
 
 int SCLWorthOutputtingOrHasData(SplineChar *sc, int layer) {
+  if (sc == NULL) return 0;
   if (layer >= sc->layer_cnt) return 0;
   if (SCDrawsSomethingOnLayer(sc, layer)) return 1;
   if (sc->layers[layer].python_persistent) return 1;


### PR DESCRIPTION
Cure for the following:

~~~
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff58f6bb9 in SCLWorthOutputtingOrHasData (sc=0x0, layer=1)
    at splinesaveafm.c:1100
1100	  if (layer >= sc->layer_cnt) return 0;

(gdb) where
#0  0x00007ffff58f6bb9 in SCLWorthOutputtingOrHasData (sc=0x0, layer=1)
    at splinesaveafm.c:1100
#1  0x00007ffff59ec51e in WriteUFOLayer (
    glyphdir=0x1c6bf20 "/home/adrien/cn_release/Roman/Regular/font.ufo/glyphs", sf=0x90aa20, layer=1) at ufo.c:1843
#2  0x00007ffff59ed07e in WriteUFOFontFlex (
    basedir=0x24efe50 "/home/adrien/cn_release/Roman/Regular/font.ufo/", 
    sf=0x90aa20, ff=ff_ufo, flags=4, map=0x911be0, layer=1, all_layers=0)
    at ufo.c:1997
#3  0x00007ffff59ed1c1 in WriteUFOFont (
    basedir=0x24efe50 "/home/adrien/cn_release/Roman/Regular/font.ufo/", 
    sf=0x90aa20, ff=ff_ufo, flags=4, map=0x911be0, layer=1) at ufo.c:2018
#4  0x00007ffff5827fdf in _DoSave (sf=0x90aa20, 
    newname=0x24efe50 "/home/adrien/cn_release/Roman/Regular/font.ufo/", 
    sizes=0x0, res=-1, map=0x911be0, subfontdefinition=0x0, layer=1)
    at savefont.c:844
#5  0x00007ffff7a0b560 in DoSave (d=0x7fffffff5cf0, path=0x45adcc0)
    at savefontdlg.c:1627
#6  0x00007ffff7a0b9a1 in GFD_exists (gio=0x240f690) at savefontdlg.c:1684
#7  0x00007ffff6b27ec9 in _gio_file_statfile (gc=0x240f690, 
    path=0x45add90 "/home/adrien/cn_release/Roman/Regular/font.ufo/")
    at giofile.c:187
#8  0x00007ffff6b280e3 in _GIO_localDispatch (gc=0x240f690) at giofile.c:240
#9  0x00007ffff6b27283 in GIOdispatch (gc=0x240f690, gf=gf_statfile)
    at gio.c:176
#10 0x00007ffff6b272e7 in GIOfileExists (gc=0x240f690) at gio.c:190
#11 0x00007ffff7a0bc69 in _GFD_SaveOk (d=0x7fffffff5cf0) at savefontdlg.c:1721
#12 0x00007ffff7a0bcf1 in GFD_SaveOk (g=0x37e23d0, e=0x7fffffff54a0)
    at savefontdlg.c:1732
#13 0x00007ffff6828847 in GButtonInvoked (b=0x37e23d0, ev=0x7fffffff5740)
    at gbuttons.c:255
#14 0x00007ffff6829722 in gbutton_mouse (g=0x37e23d0, event=0x7fffffff5740)
    at gbuttons.c:483
#15 0x00007ffff68336d8 in _GWidget_Container_eh (gw=0x45adf30, 
    event=0x7fffffff5740) at gcontainer.c:302
#16 0x00007ffff6835419 in _GWidget_TopLevel_eh (gw=0x45adf30, 
    event=0x7fffffff5740) at gcontainer.c:745
#17 0x00007ffff68b1705 in dispatchEvent (gdisp=0x69db70, event=0x7fffffff58f0)
    at gxdraw.c:3478
#18 0x00007ffff68b18a1 in GXDrawProcessOneEvent (gdisp=0x69db70)
    at gxdraw.c:3510
#19 0x00007ffff68386ec in GDrawProcessOneEvent (gdisp=0x69db70) at gdraw.c:771
#20 0x00007ffff7a15a73 in SFGenerateFont (sf=0x90aa20, layer=1, family=0, 
    map=0x911be0) at savefontdlg.c:3197
#21 0x00007ffff792e58e in _FVMenuGenerate (fv=0x909ca0, family=0)
    at fontview.c:525
#22 0x00007ffff792e5c5 in FVMenuGenerate (gw=0xcc3d60, UNUSED_mi=0xcc4ef0, 
    UNUSED_e=0x7fffffffb750) at fontview.c:531
#23 0x00007ffff68641b7 in gmenu_mouse (m=0x240f690, event=0x7fffffffb750)
    at gmenu.c:901
#24 0x00007ffff6865c6b in gmenu_eh (w=0x240f7a0, ge=0x7fffffffb750)
    at gmenu.c:1336
#25 0x00007ffff68b1705 in dispatchEvent (gdisp=0x69db70, event=0x7fffffffb900)
    at gxdraw.c:3478
#26 0x00007ffff68b1c9d in GXDrawEventLoop (gd=0x69db70) at gxdraw.c:3586
#27 0x00007ffff68387cb in GDrawEventLoop (gdisp=0x69db70) at gdraw.c:791
#28 0x00007ffff7a58432 in fontforge_main (argc=1, argv=0x7fffffffdc38)
    at startui.c:1367
#29 0x00000000004007dd in main (argc=1, argv=0x7fffffffdc38) at main.c:39
~~~

Commit f6b8f1afdaac16c33c2819d45819c89cd9753057 followup. Note that `SCHasData()` already had the check.