### PR TITLE
Add detection for Python library collisions.

### DIFF
--- a/pyhook/Makefile.am
+++ b/pyhook/Makefile.am
@@ -51,3 +51,7 @@ LIBADD = $(top_builddir)/Unicode/libgunicode.la	\
 	$(top_builddir)/fontforge/libfontforge.la
 
 -include $(top_srcdir)/git.mk
+
+install-exec-local:
+	@ sfff=`(pyff_count=0 ; for item in \`echo -e "import sys\nfor file in sys.path:\n\tprint \"%s\" %file\n" | python\` ; do if [ -e "$$item"/fontforge.so ] ; then echo "$$item"/fontforge.so ; pyff_count=\`expr $$pyff_count + 1\`; fi ; done ;) | grep -v '^$(DESTDIR)$(pyexecdir)' | grep -v '^$(pyexecdir)'`; if [ "$$sfff" != "" ]; then echo "There may be another FontForge Python library on this system."; echo "$$sfff"; fi;
+


### PR DESCRIPTION
This outputs a message when installing the Python library if the Python environment detects another FontForge Python library in another location. It is not an error or a warning since there are contexts (such as packaging) in which the presence of another FontForge Python library in another location is not incorrect.
