### PR TITLE
ufo: fix a flipped OS/2 descender value

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -1173,9 +1173,9 @@ static int UFOOutputFontInfo(const char *basedir, SplineFont *sf, int layer) {
 	else
 	    PListAddInteger(dictnode,"openTypeOS2WinAscent",sf->pfminfo.os2_winascent);
 	if ( sf->pfminfo.windescent_add )
-	    PListAddInteger(dictnode,"openTypeOS2WinDescent",bb.miny+sf->pfminfo.os2_windescent);
+	    PListAddInteger(dictnode,"openTypeOS2WinDescent",-(bb.miny+sf->pfminfo.os2_windescent));
 	else
-	    PListAddInteger(dictnode,"openTypeOS2WinDescent",sf->pfminfo.os2_windescent);
+	    PListAddInteger(dictnode,"openTypeOS2WinDescent",-sf->pfminfo.os2_windescent);
     }
     if ( sf->pfminfo.subsuper_set ) {
 	PListAddInteger(dictnode,"openTypeOS2SubscriptXSize",sf->pfminfo.os2_subxsize);


### PR DESCRIPTION
Commit f06cb470c77c8f5073ff146057de54ebaf938716 followup.

Fixes http://doc.robofont.com/forums/topic/bug-on-generating/.