### PR TITLE
Fix share folder logic to be relative to current program dir

### DIFF
--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -784,7 +784,8 @@ char *getShareDir(void) {
 
     set = true;
 
-    pt = strstr(GResourceProgramDir,"/bin");
+    //Assume share folder is one directory up
+    pt = strrchr(GResourceProgramDir, '/');
     if ( pt==NULL ) {
 #ifdef SHAREDIR
 	return( sharedir = SHAREDIR );


### PR DESCRIPTION
Previous logic searched for first instance of "/bin". This could give the
wrong result if there is more than one bin folder in the path, e.g.:
"Y:/bin/FontForge/bin" gives a share folder of "Y:/share"

With the new scheme, the share folder is relative to the current path, e.g.:
"Y:/bin/FontForge/bin" gives "Y:/bin/FontForge/share"

See also #2095.