### PR TITLE
Update osx/FontForge.app/Contents/MacOS/FontForge

### DIFF
--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -118,4 +118,4 @@ $scriptdir/fcprogress.pl >|/tmp/zz 2>&1
 
 export PATH="$PATH:$bundle_bin"
 echo $WRAPPER $bundle_bin/fontforge -new "$@" > /tmp/oo
-$WRAPPER $bundle_bin/fontforge -new "$@"
+$WRAPPER $bundle_bin/fontforge -new "$@" &


### PR DESCRIPTION
In https://github.com/fontforge/fontforge/issues/2055 I reported a dock bounce issue. This resolves this, by adding a `&` to the final command. The effect is that now when run the FF dock icon disappears after loading. This is helpful because the XQuartz icon is actually what users must click to bring FF windows to the foreground; and if they Force Quit XQuartz then FF will also exit. 

`/Applications/FontForge.app/Contents/MacOS/FontForge --debug` works with this change.