### PR TITLE
Focus fc-cache better on the Macintosh in order to cut start time.

### DIFF
--- a/osx/FontForge.app/Contents/MacOS/fcprogress.pl
+++ b/osx/FontForge.app/Contents/MacOS/fcprogress.pl
@@ -13,7 +13,7 @@ my $forcecache = "";
 if ( ! -d "/Applications/FontForge.app/Contents/Resources/opt/local/var/cache/fontconfig" ) {
     $forcecache = "-f";
 } 
-my $fcproc = IO::File->new("$dirname/fc/fc-cache $forcecache  -v|");
+my $fcproc = IO::File->new("$dirname/fc/fc-cache $forcecache  -v /Applications/FontForge.app/Contents/Resources/opt/local/share/fontforge/pixmaps |");
 
 my $bodypreamble = "This setup is only run once...";
 my $args = '--title "FontForge is scanning for fonts" --text "This setup is only run once..."';


### PR DESCRIPTION
This addresses part of #2055.

I was unable to test this effectively since I have yet to locate the fontconfig cache on Macintosh. I would welcome any advice on this. I have already looked at /usr/local/var/cache/fontconfig, ~/Library/Caches/org.freedesktop.something (which was not present), /Applications/FontForge.app/Contents/Resources/opt/stuff, and /var/caches/stuff (which was not present), and I found nothing.

It is sort of puzzling that there is no fontconfig utility that reports the cache path.

@adrientetar?
