### PR TITLE
Fix swapped arguments to SplineCharAntiAlias in EpsGeneratePreview.

### DIFF
--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -54,7 +54,7 @@ return;
     depth = 4;
     bdfc = SplineCharFreeTypeRasterizeNoHints(sc,layer,pixelsize,72,4);
     if ( bdfc==NULL )
-	bdfc = SplineCharAntiAlias(sc,pixelsize,layer,4);
+	bdfc = SplineCharAntiAlias(sc,layer,pixelsize,4);
     if ( bdfc==NULL )
 return;
 


### PR DESCRIPTION
This addresses a crash from attempting to export a glyph from a typeface supplied by Georg Heeg on the fontforge-devel list on March 6, 2015.
