### PR TITLE
Fix crash in "MM" -> "Blend to New Font".

### DIFF
--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -767,7 +767,7 @@ return;
 	gcd[k++].creator = GGroupCreate;
 
 	GGadgetsCreate(gw,gcd);
-	for ( i=0; i<4; ++i )
+	for ( i=0; i<mm->axis_count; ++i )
 	    free(axisnames[i]);
 	GTextInfoListFree(gcd[k-4].gd.u.list);
 	GWidgetIndicateFocusGadget(gcd[1].ret);


### PR DESCRIPTION
Selecting "Blend to New Font" in the "MM" menu currently crashes due to
detection of an invalid free. The issue is that MMChangeBlend calls
GCDFillupMacWeights which fills 'axisnames' with strings, but only the
first 'axis_count' should be freed (the rest are set to static
strings). The other caller of GCDFillupMacWeights (EditStyleName)
already does the right thing in this situation, which is to only free
the first 'axis_count' strings in 'axisnames'. This changes the cleanup
code in MMChangeBlend to do the same.

After this change, "Blend to New Font" appears to work as expected, at least so far as I've used it.