### PR TITLE
lookupui: show feature code in the selection dropdown

### DIFF
--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -1499,7 +1499,9 @@ static GTextInfo *FeatureListFromLookupType(int lookup_type) {
 	cnt = 0;
 	for ( i=0; friendlies[i].tag!=0; ++i ) if ( friendlies[i].masks&mask ) {
 	    if ( k ) {
-		ti[cnt].text = (unichar_t *) copy( friendlies[i].friendlyname );
+		char buf[128];
+		snprintf(buf, sizeof buf, "%s %s", friendlies[i].tagstr, friendlies[i].friendlyname);
+		ti[cnt].text = (unichar_t *) copy( buf );
 		ti[cnt].text_is_1byte = true;
 		ti[cnt].userdata = friendlies[i].tagstr;
 	    }


### PR DESCRIPTION
It will show e.g. `smcp Small capitals` instead of just `Small capitals` in the selection dropdown. Very useful because one usually look up the feature names by their code, not by a verbose description.

r? @frank-trampe