### PR TITLE
Unloop ft context

### DIFF
--- a/fontforge/bitmapcontrol.c
+++ b/fontforge/bitmapcontrol.c
@@ -234,10 +234,10 @@ return( false );
 	if ( bdfsf->subfontcnt!=0 && bd->which==bd_all ) {
 	    for ( j=0 ; j<bdfsf->subfontcnt; ++j ) {
 		subsf = bdfsf->subfonts[j];
+	        if ( usefreetype && freetypecontext==NULL )
+		    freetypecontext = FreeTypeFontContext(subsf,NULL, selfv, bd->layer);
 		for ( i=0; i<subsf->glyphcnt; ++i ) {
 		    if ( SCWorthOutputting(subsf->glyphs[i])) {
-			if ( usefreetype && freetypecontext==NULL )
-			    freetypecontext = FreeTypeFontContext(subsf,NULL, selfv, bd->layer);
 			ReplaceBDFC(subsf,sizes,i,freetypecontext,usefreetype, bd->layer);
 		    }
 		}
@@ -246,10 +246,10 @@ return( false );
 		freetypecontext = NULL;
 	    }
 	} else {
+	    if ( usefreetype && freetypecontext==NULL )
+	        freetypecontext = FreeTypeFontContext(sf,NULL, selfv, bd->layer);
 	    for ( i=0; i<fv->map->enccount; ++i ) {
 		if ( fv->selected[i] || bd->which == bd_all ) {
-		    if ( usefreetype && freetypecontext==NULL )
-			freetypecontext = FreeTypeFontContext(sf,NULL, selfv, bd->layer);
 		    ReplaceBDFC(sf,sizes,fv->map->map[i],freetypecontext,usefreetype, bd->layer);
 		}
 	    }


### PR DESCRIPTION
Calling FreeTypeFontContext can be an expensive operation.  If it fails consistently, then existing code will call it on *every single glyph*, which can cause a simple rasterization operation to take several hours on a large font.  The only reason to put the call inside the per-glyph loop is to handle the case of no glyphs being worth "outputting"; better to do the operation unconditionally outside the loop, which wastes it harmlessly once in the rare case instead of hundreds of thousands of times in what turned out to be for me a common case.

Patch backported from FontAnvil.