### PR TITLE
Use the suggested defaults for RadicalDisplayStyleVerticalGap and Radica...

### DIFF
--- a/fontforge/mathconstants.c
+++ b/fontforge/mathconstants.c
@@ -108,6 +108,7 @@ struct MATH *MathTableNew(SplineFont *sf) {
     math->ScriptScriptPercentScaleDown	= 60;
     math->DelimitedSubFormulaMinHeight	= emsize*1.5;
     /* No default given for math->DisplayOperatorMinHeight */
+    /* No default given for math->MathLeading */
     /* No default given for math->AxisHeight */
     sc = SFGetChar(sf,'x',NULL);
     if ( sc!=NULL ) {
@@ -131,17 +132,31 @@ struct MATH *MathTableNew(SplineFont *sf) {
     math->SubSuperscriptGapMin = 4*sf->uwidth;			/* 4* default rule thickness */
     math->SuperscriptBottomMaxWithSubscript = math->AccentBaseHeight;	/* X-height */
     math->SpaceAfterScript = emsize/24;				/* .5pt at 12pt */
+    /* No default given for math->UpperLimitGapMin */
+    /* No default given for math->UpperLimitBaselineRiseMin */
+    /* No default given for math->LowerLimitGapMin */
+    /* No default given for math->LowerLimitBaselineDropMin */
+    /* No default given for math->StackTopShiftUp */
+    /* No default given for math->StackTopDisplayStyleShiftUp */
+    /* No default given for math->StackBottomShiftDown */
+    /* No default given for math->StackBottomDisplayStyleShiftDown */
     math->StackGapMin = 3*sf->uwidth;				/* 3* default rule thickness */
     math->StackDisplayStyleGapMin = 7*sf->uwidth;
+    /* No default given for math->StretchStackTopShiftUp */
+    /* No default given for math->StretchStackBottomShiftDown */
     math->StretchStackGapAboveMin = math->UpperLimitGapMin;
     math->StretchStackGapBelowMin = math->LowerLimitGapMin;
+    /* No default given for math->FractionNumeratorShiftUp */
     math->FractionNumeratorDisplayStyleShiftUp = math->StackTopDisplayStyleShiftUp;
+    /* No default given for math->FractionDenominatorShiftDown */
     math->FractionDenominatorDisplayStyleShiftDown = math->StackBottomDisplayStyleShiftDown;
     math->FractionNumeratorGapMin = sf->uwidth;
     math->FractionNumeratorDisplayStyleGapMin = 3*sf->uwidth;
     math->FractionRuleThickness = sf->uwidth;
     math->FractionDenominatorGapMin = sf->uwidth;
     math->FractionDenominatorDisplayStyleGapMin = 3*sf->uwidth;
+    /* No default given for math->SkewedFractionHorizontalGap */
+    /* No default given for math->SkewedFractionVerticalGap */
     math->OverbarVerticalGap = 3*sf->uwidth;
     math->OverbarRuleThickness = sf->uwidth;
     math->OverbarExtraAscender = sf->uwidth;
@@ -149,6 +164,8 @@ struct MATH *MathTableNew(SplineFont *sf) {
     math->UnderbarRuleThickness = sf->uwidth;
     math->UnderbarExtraDescender = sf->uwidth;
     math->RadicalVerticalGap = sf->uwidth;
+    math->RadicalDisplayStyleVerticalGap = sf->uwidth+.25*math->AccentBaseHeight; /* rule thickness + 1/4 X-height */
+    math->RadicalRuleThickness = sf->uwidth;
     math->RadicalExtraAscender = sf->uwidth;
     math->RadicalKernBeforeDegree = 5*emsize/18;
     math->RadicalKernAfterDegree = -10*emsize/18;

--- a/tests/test1006.py
+++ b/tests/test1006.py
@@ -16,6 +16,35 @@ if not math.exists():
 if ( math.ScriptPercentScaleDown!=3 or math.SubscriptBaselineDropMin != 6) :
   raise ValueError("Assignment failed")
 
+# Test some default values for math constants
+math.clear()
+if ( math.ScriptPercentScaleDown != 80 or
+     math.ScriptScriptPercentScaleDown != 60 or
+     math.DelimitedSubFormulaMinHeight != font.em*1.5 or
+     math.SubSuperscriptGapMin != 4*font.uwidth or
+     math.SpaceAfterScript != font.em/24 or
+     math.StackGapMin != 3*font.uwidth or
+     math.StackDisplayStyleGapMin != 7*font.uwidth or
+     math.FractionNumeratorGapMin != font.uwidth or
+     math.FractionNumeratorDisplayStyleGapMin != 3*font.uwidth or
+     math.FractionRuleThickness != font.uwidth or
+     math.FractionDenominatorGapMin != font.uwidth or
+     math.OverbarVerticalGap != 3*font.uwidth or
+     math.OverbarRuleThickness != font.uwidth or
+     math.OverbarExtraAscender != font.uwidth or
+     math.UnderbarVerticalGap != 3*font.uwidth or
+     math.UnderbarRuleThickness != font.uwidth or
+     math.UnderbarExtraDescender != font.uwidth or
+     math.RadicalVerticalGap != font.uwidth or
+     math.RadicalDisplayStyleVerticalGap != font.uwidth or
+     math.RadicalRuleThickness != font.uwidth or
+     math.RadicalRuleThickness != font.uwidth or
+     math.RadicalExtraAscender != font.uwidth or
+     math.RadicalKernBeforeDegree != 5*font.em/18 or
+     math.RadicalKernAfterDegree != -int(10*font.em/18) or
+     math.RadicalDegreeBottomRaisePercent != 60 ):
+  raise ValueError("Unexpected default value for one math constant")
+
 math.clear()
 if math.exists():
   raise ValueError("Thinks there is a math table in an empty font")


### PR DESCRIPTION
RadicalDisplayStyleVerticalGap and RadicalRuleThickness math constants currently default to 0. This patch uses the values suggested in http://www.microsoft.com/typography/otspec/math.htm. It also adds comment for other constants to make explicit when no default is given.
