### PR TITLE
Fix bad allocation in ParseComponentTuple

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -6870,6 +6870,7 @@ return( NULL );
     for ( i=0; i<cnt; ++i ) {
 	PyObject *obj = PySequence_GetItem(tuple,i);
 	int extender=0, start=0, end=0, full=0;
+	char *glyphName;
 	if ( PyType_IsSubtype(&PyFF_GlyphType, Py_TYPE(obj)) ) {
 	    parts[i].component = copy( ((PyFF_Glyph *) obj)->sc->name );
 	} else if ( ANYSTRING_CHECK(obj) ) {
@@ -6883,8 +6884,10 @@ return( NULL );
 return( NULL );
 	    }
 	    parts[i].component = copy(((PyFF_Glyph *) g)->sc->name);
-	} else if ( !PyArg_ParseTuple(obj,"s|iiii", &parts[i].component,
+	} else if ( PyArg_ParseTuple(obj,"s|iiii", &glyphName,
 		&extender, &start, &end, &full )) {
+	    parts[i].component = copy(glyphName);
+	} else {
             free(parts);
 return( NULL );
         }

--- a/tests/test1006.py
+++ b/tests/test1006.py
@@ -35,6 +35,10 @@ if a.horizontalVariants != "B C D" or a.horizontalComponentItalicCorrection!=10:
 if a.verticalVariants != "B.v C.v D.v" or a.verticalComponentItalicCorrection!=20:
   raise ValueError("Failed to set some glyph vertical variant/component")
 
+# non-regression test for a bad allocation in ParseComponentTuple
+font[65].horizontalComponents = (('a',))
+font[65].verticalComponents = (('a',))
+
 #print a.verticalComponents
 #print a.mathKern.topLeft
 


### PR DESCRIPTION
With the modification in this patch, tests/test1006.py should demonstrate the error:
*** Error in `python': munmap_chunk(): invalid pointer: 0x00007f1ae263a444 ***

With a similar testcase I also obtained
*** Error in `/usr/bin/python': free(): invalid pointer: 0x00007ffff7e5b684 ***

The issue seems to be that PyArg_ParseTuple does not allocate a new string for parts[i].component. This patch make my testcases work as expected.