### PR TITLE
PeekMatch: Don't rewind by calling ungetc more than once (undefined behaviour)

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -148,9 +148,9 @@ static int PeekMatch(FILE *stream, const char * target) {
   while (target[pos1] != '\0' && lastread != EOF && lastread == target[pos1]) {
     pos1 ++; lastread = getc(stream);
   }
-  if (lastread != EOF) ungetc(lastread, stream);
-  int pos2 = pos1;
-  while (pos2 > 0) { ungetc(target[--pos2], stream); }
+  
+  int rewind_amount = pos1 + ((lastread == EOF) ? 0 : 1);
+  fseek(stream, -rewind_amount, SEEK_CUR);
   return (target[pos1] == '\0');
 }
 


### PR DESCRIPTION
Related issues: #1918

I don't know if this is an issue anywhere else. Someone needs to check all uses of `ungetc` to see if it is called to rewind by more than one character at a time. @frank-trampe? 

Not extensively tested. What I did:

    fontforge -lang=py -c "f=fontforge.open('descret-roman.sfd');f.save('out.sfd')"
    diff descret-roman.sfd out.sfd