### PR TITLE
portable compositor SFD script

### DIFF
--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -1187,8 +1187,10 @@ void FontImage(SplineFont *sf,char *filename,Array *arr,int width,int height) {
     li->ps = -1;
     SFMapOfSF(li,sf);
 
+#ifndef _NO_FFSCRIPT
     if ( arr==NULL || arr->argc<2 )
 	arr = freeme = SFDefaultScriptsLines(arr,sf);
+#endif /* _NO_FFSCRIPT */
 
     cnt = arr->argc/2;
     len = 1;
@@ -1275,8 +1277,10 @@ void FontImage(SplineFont *sf,char *filename,Array *arr,int width,int height) {
     GImageDestroy(image);
 
     LayoutInfo_Destroy(li);
+#ifndef _NO_FFSCRIPT
     if ( freeme!=NULL )
 	arrayfree(freeme);
+#endif /* _NO_FFSCRIPT */
 }
 
 #include <stdlib.h>


### PR DESCRIPTION
Soo I have this script (https://github.com/Kelvinsong/portable-compositor) that like writes opentype .fea files and adds necessary glyphs to SFD files. The result is a font in which you can access opentype features like old style numerals and small caps in any app that supports opentype rendering through the use of “magic words” like “<onum>1989</onum>”. @davelab6 suggested that this be incorporated somehow into fontforge itself…

Don’t know what tf is going on below with “sflayout” but it’s all in one file in my portable-compositor repository thing