### PR TITLE
fontforge.rb: resync with homebrew

### DIFF
--- a/travis-scripts/before_install_osx.sh
+++ b/travis-scripts/before_install_osx.sh
@@ -37,7 +37,8 @@ brew update
 brew config
 
 sed -i -e "s|{TRAVIS_PULL_REQUEST}|${TRAVIS_PULL_REQUEST}|g" ./travis-scripts/fontforge.rb
-sudo cp ./travis-scripts/fontforge.rb /usr/local/Library/Formula/fontforge.rb
+rm /usr/local/Library/Formula/fontforge.rb
+cp ./travis-scripts/fontforge.rb /usr/local/Library/Formula/fontforge.rb
 echo "*****"
 echo "*****"
 echo "***** using homebrew formula fontforge.rb:"
@@ -54,21 +55,19 @@ sudo installer -pkg /Volumes/XQuartz-*/XQuartz.pkg -target /
 popd 
 
 echo "doing an OSX before install step."
-# python may require a little force to install. In October 2014
-# there were issues with easy_install and pip not letting the install
-# step complete.
 set +ev
 brew install python
-brew link --overwrite python
 set -ev
 brew install cairo libspiro fontconfig
 
 #
 # this forces version 4.0.4 and 2.2.0 respectively.
 pushd .
-cd $( brew --prefix )
-git checkout ab7f37834a28b4d6f3c584f08e5b993d8c191653 Library/Formula/zeromq.rb
-git checkout 3ad14e1e3f7d0131b3eee7fb4ce38a65e22a5187 Library/Formula/czmq.rb
+cd $(brew --prefix)
+rm Library/Formula/zeromq.rb
+rm Library/Formula/czmq.rb
+wget https://raw.githubusercontent.com/Homebrew/homebrew/ab7f37834a28b4d6/Library/Formula/zeromq.rb -O Library/Formula/zeromq.rb
+wget https://raw.githubusercontent.com/Homebrew/homebrew/3ad14e1e3f7d0131b/Library/Formula/czmq.rb -O Library/Formula/czmq.rb
 brew install czmq zeromq
 popd
 

--- a/travis-scripts/script_osx.sh
+++ b/travis-scripts/script_osx.sh
@@ -9,7 +9,7 @@ rm -f /Users/travis/build/fontforge/fontforge/.git/shallow
 set +e
 mkdir -p /tmp/fontforge-source-tree
 echo "brew build starting..."
-brew install --verbose fontforge --HEAD --with-x 
+brew install --verbose fontforge --HEAD --with-x11 --with-libspiro
 echo "brew build complete..."
 PR=$TRAVIS_PULL_REQUEST
 chmod +x ./travis-scripts/create-osx-app-bundle-homebrew.sh


### PR DESCRIPTION
Resync with latest Homebrew/homebrew formulae. Changes:

* Spacing between the `defs` makes it easier to read. Not a big change though.
* Syncs the latest release, bottles, checksum, etc.
* Moves the `head` block into a simple `head` line - You don't need the whole block, if you declared the required dependencies in the normal formula, which is done for both `zeromq` and `czmq`, they'll apply to the whole formula and don't need redeclaring.
* Adds links tracking the Fontconfig issue.
* Fixes the Python issues where when a user has Homebrew's Python and system Python installed and it would hook into the Homebrew Python even though the dependency wasn't declared (`depends_on :python if MacOS.version <= :snow_leopard` = Unless you're using Snow Leopard or below, use system Python) and would cause silent linking problems that way. This was effectively breaking Python scripting a lot of the time. This shouldn't have impacted you guys as presumably you build with a relatively clean Travis system, but it's a useful fix.
* Removes the now redundant `post-install` part because you guys fixed the problem that required that workaround.
