### PR TITLE
Fix read/write of bits USE_TYPO_METRICS and WWS for OS/2 version < 4

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -6272,7 +6272,8 @@ SplineFont *_SFReadTTF(FILE *ttf, int flags,enum openflags openflags, char *file
     memset(&info,'\0',sizeof(struct ttfinfo));
     info.onlystrikes = (flags&ttf_onlystrikes)?1:0;
     info.onlyonestrike = (flags&ttf_onlyonestrike)?1:0;
-    info.use_typo_metrics = true;
+    info.use_typo_metrics = false;
+    info.weight_width_slope_only = false;
     info.openflags = openflags;
     info.fd = fd;
     ret = readttf(ttf,&info,filename);

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3333,7 +3333,7 @@ static void setos2(struct os2 *os2,struct alltabs *at, SplineFont *sf,
 	os2->version = 3;
     if ( sf->use_typo_metrics || sf->weight_width_slope_only )
 	os2->version = 4;
-    if ( sf->os2_version!=0 )
+    if ( sf->os2_version > os2->version )
 	os2->version = sf->os2_version;
     if (( format>=ff_ttf && format<=ff_otfdfont) && (at->gi.flags&ttf_flag_symbol))
 	modformat = ff_ttfsym;


### PR DESCRIPTION
cc'ing @khaledhosny 

Download Asana Math and open it with fontforge:

http://www.ctan.org/tex-archive/fonts/Asana-Math/

ttx on Asana-Math.ttf generates fsSelection value="00000000 01000000" for the OS/2 table, USE_TYPO_METRICS is *not* set.

Open Asana-Math.ttf with fontforge. In the OS/2 menu, you should see that the option "use typo metrics" *is* checked. Generate a new ttf file (you can uncheck and check the box again if you want). A verification with ttx still indicates that USE_TYPO_METRICS is *not* set.

Analysis of the problem: parsettf.c sets use_typo_metrics to true by default but only overrides with the font value when OS/2 version >= 4. Also tottf.c set the bit USE_TYPO_METRICS in OS/2 table to true only if has version >= 4.

This patch makes use_typo_metrics default to false when loading a ttf file, so that it is not set by default when opening a font with OS/2 version < 4. It also tries to force upgrade to OS/2 when use_typo_metrics has been enabled by the user, so that this bit can be set during file generation. Similarly for info.weight_width_slope_only.