### PR TITLE
fontview.c: Fix potential double-free

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -1085,7 +1085,9 @@ void _FVMenuOpen(FontView *fv) {
     
     free( NewDir );
     free( OpenDir );
-    free( DefaultDir );
+    if (OpenDir != DefaultDir) {
+        free( DefaultDir );
+    }
 }
 
 static void FVMenuOpen(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {


### PR DESCRIPTION
Preceding code may set `OpenDir = DefaultDir`. This was causing FontForge to crash on 64-bit Windows builds (I finally got these to work again after figuring out what was wrong with gnulib).

Surprisingly this never broke anything on 32-bit Windows builds.

