### PR TITLE
gxdraw.c: Use Xutf8SetWMProperties where available and remove mingw s…

### DIFF
--- a/gdraw/gxdraw.c
+++ b/gdraw/gxdraw.c
@@ -750,162 +750,6 @@ return( XCreateWindow(gdisp->display, gdisp->root,
 	    gdisp->depth, InputOutput, gdisp->visual, wmask, &attrs));
 }
 
-
-#if defined(__MINGW32__)
-/* FIXME: Xming+WindowsWM hack */
-
-/* unichar to ActiveCodePage, this is not limited to setlocale() */
-static char*  u2acp_copy(const unichar_t* ustr){
-    if(ustr){
-	int wlen = u_strlen(ustr);
-	if(wlen > 0){
-	    WCHAR* wcs = malloc(sizeof(WCHAR) * (wlen));
-	    char*  mbs = malloc(sizeof(char) * (wlen*3));
-	    if(wcs && mbs){
-		WCHAR* w = wcs;
-		const unichar_t* u = ustr;
-		for(; *u; *w++ = (WCHAR)*u++); /* unichar(4) to WCHAR(2) */
-
-		int alen = WideCharToMultiByte(CP_ACP,0, wcs,wlen, mbs,wlen*3, 0,0);
-		if(alen<0) alen=0;
-		mbs[alen]='\0';
-
-		free(wcs);
-		return mbs;
-	    }
-	    free(wcs);
-	    free(mbs);
-	}
-    }
-    return NULL;
-}
-
-/* SET WM Name unichar */
-static void  mingw_set_wm_name(Display* display, Window window, const unichar_t* name){
-    char* a_str = u2acp_copy(name);
-    if(a_str){
-	XTextProperty prop;
-	if( XStringListToTextProperty(&a_str, 1, &prop) >= Success ){
-	    XSetWMName(display, window, &prop);
-	    XFree(prop.value);
-	}
-    }
-}
-/* Set WM IconName unichar */
-static void  mingw_set_wm_icon_name(Display* display, Window window, const unichar_t* name){
-    char* a_str = u2acp_copy(name);
-    if(a_str){
-	XTextProperty prop;
-	if( XStringListToTextProperty(&a_str, 1, &prop) >= Success ){
-	    XSetWMIconName(display, window, &prop);
-	    XFree(prop.value);
-	}
-    }
-}
-/* SET WM Name utf8 */
-static void  mingw_set_wm_name_utf8(Display* display, Window window, const char* utf8){
-    if(utf8){
-	unichar_t* uni = utf82u_copy(utf8);
-	if(uni){
-	    mingw_set_wm_name(display, window, uni);
-	    free(uni);
-	}
-    }
-}
-/* SET WM IconName utf8 */
-static void  mingw_set_wm_icon_name_utf8(Display* display, Window window, const char* utf8){
-    if(utf8){
-	unichar_t* uni = utf82u_copy(utf8);
-	if(uni){
-	    mingw_set_wm_icon_name(display, window, uni);
-	    free(uni);
-	}
-    }
-}
-/* GET WM Name unichar */
-static unichar_t*  mingw_get_wm_name(Display* display, Window window){
-    unichar_t* result = NULL;
-    XTextProperty prop;
-    if( XGetWMName(display, window, &prop) >= Success ){
-	char** list;
-	int    count;
-	if( XTextPropertyToStringList(&prop, &list, &count) >= Success ){
-	    char      *m, *mbs;
-	    WCHAR     *w, *wcs;
-	    unichar_t *u, *ustr;
-
-	    int i, wlen, alen=0;
-	    for(i=0; i < count; i++){
-		alen += strlen(list[i]);
-	    }
-
-	    mbs  = malloc(sizeof(char)      * (alen+4));
-	    wcs  = malloc(sizeof(WCHAR)     * (alen+4));
-	    ustr = malloc(sizeof(unichar_t) * (alen+4));
-
-	    if(mbs && wcs && ustr){
-		m = mbs;
-		for(i=0; i < count; i++){
-		    strcpy(m, list[i]);
-		    m += strlen(list[i]);
-		}
-
-		wlen = MultiByteToWideChar(CP_ACP,0, mbs,alen, wcs,alen);
-		if(wlen < 0) wlen=0;
-
-		w = wcs;
-		u = ustr;
-		for(i=0; i < wlen; i++)
-		    *u++ = (unichar_t)*w++;
-		*u++ = '\0';
-
-		result = ustr;
-		ustr = 0;
-	    }
-	    free(ustr);
-	    free(wcs);
-	    free(mbs);
-	    XFreeStringList(list);
-	}
-	XFree(prop.value);
-    }
-    return result;
-}
-/* GET WM Name utf8 */
-static char*  mingw_get_wm_name_utf8(Display* display, Window window){
-    unichar_t* uni = mingw_get_wm_name(display, window);
-    if(uni){
-	char* utf8 = u2utf8_copy(uni);
-	free(uni);
-	return utf8;
-    }
-    return NULL;
-}
-
-/* translate GK_ keysyms to Virtual Keys */
-/* abort on unimplemented translations */
-int GDrawKeyToVK(int keysym) {
-    switch( keysym ) {
-      case ' ':
-return( VK_SPACE );
-      default:
-	if ( (keysym>='0' && keysym<='9') ||
-		(keysym>='A' && keysym<='Z') )
-return( keysym );
-    }
-    abort();
-return( 0 );
-}
-
-int GDrawKeyState(int keysym) {
-    if (GetAsyncKeyState(GDrawKeyToVK(keysym)) & 0x8000)
-return 1;
-    else
-return 0;
-}
-
-#endif
-
 #if 0
 static void _GXDraw_DestroyWindow(GXDisplay *gdisp, GWindow input) {
   // TODO: Reconcile differences between this function (written from _GXDraw_CreateWindow)
@@ -1061,38 +905,30 @@ return( NULL );
 	}
 	XSetWMHints(display,nw->w,&wm_hints);
 	if ( (wattrs->mask&wam_wtitle) && wattrs->window_title!=NULL ) {
-	    #if defined(__MINGW32__)
-	    mingw_set_wm_name(display, nw->w, wattrs->window_title);
-	    #else
 	    XmbSetWMProperties(display,nw->w,(pt = u2def_copy(wattrs->window_title)),NULL,NULL,0,NULL,NULL,NULL);
 	    free(pt);
-	    #endif
 	}
 	if ( (wattrs->mask&wam_ititle) && wattrs->icon_title!=NULL ) {
-	    #if defined(__MINGW32__)
-	    mingw_set_wm_icon_name(display, nw->w, wattrs->icon_title);
-	    #else
 	    XmbSetWMProperties(display,nw->w,NULL,(pt = u2def_copy(wattrs->icon_title)),NULL,0,NULL,NULL,NULL);
 	    free(pt);
-	    #endif
 	}
 	if ( (wattrs->mask&wam_utf8_wtitle) && wattrs->utf8_window_title!=NULL ) {
-	    #if defined(__MINGW32__)
-	    mingw_set_wm_name_utf8(display, nw->w, wattrs->utf8_window_title);
-	    #else
+#ifdef X_HAVE_UTF8_STRING
+        Xutf8SetWMProperties(display, nw->w, wattrs->utf8_window_title, NULL, NULL, 0, NULL, NULL, NULL);
+#else
 	    unichar_t *tit = utf82u_copy(wattrs->utf8_window_title);
 	    XmbSetWMProperties(display,nw->w,(pt = u2def_copy(tit)),NULL,NULL,0,NULL,NULL,NULL);
 	    free(pt); free(tit);
-	    #endif
+#endif
 	}
 	if ( (wattrs->mask&wam_utf8_ititle) && wattrs->utf8_icon_title!=NULL ) {
-	    #if defined(__MINGW32__)
-	    mingw_set_wm_icon_name_utf8(display, nw->w, wattrs->utf8_icon_title);
-	    #else
+#ifdef X_HAVE_UTF8_STRING
+        Xutf8SetWMProperties(display, nw->w, NULL, wattrs->utf8_icon_title, NULL, 0, NULL, NULL, NULL);
+#else
 	    unichar_t *tit = utf82u_copy(wattrs->utf8_icon_title);
 	    XmbSetWMProperties(display,nw->w,NULL,(pt = u2def_copy(tit)),NULL,0,NULL,NULL,NULL);
 	    free(pt); free(tit);
-	    #endif
+#endif
 	}
 	s_h.x = pos->x; s_h.y = pos->y;
 	s_h.base_width = s_h.width = pos->width; s_h.base_height = s_h.height = pos->height;
@@ -1594,11 +1430,6 @@ static void GXDrawLower(GWindow w) {
 }
 
 static void GXDrawSetWindowTitles(GWindow w, const unichar_t *title, const unichar_t *icontit) {
-#if defined(__MINGW32__)
-    GXWindow gw = (GXWindow) w;
-    mingw_set_wm_name      (gw->display->display, gw->w, title);
-    mingw_set_wm_icon_name (gw->display->display, gw->w, icontit);
-#else
     GXWindow gw = (GXWindow) w;
     Display *display = gw->display->display;
     char *ipt, *tpt;
@@ -1607,17 +1438,14 @@ static void GXDrawSetWindowTitles(GWindow w, const unichar_t *title, const unich
 			(ipt = u2def_copy(icontit)),
 			NULL,0,NULL,NULL,NULL);
     free(ipt); free(tpt);
-#endif
 }
 
 static void GXDrawSetWindowTitles8(GWindow w, const char *title, const char *icontit) {
-#if defined(__MINGW32__)
-    GXWindow gw = (GXWindow) w;
-    mingw_set_wm_name_utf8      (gw->display->display, gw->w, title);
-    mingw_set_wm_icon_name_utf8 (gw->display->display, gw->w, icontit);
-#else
     GXWindow gw = (GXWindow) w;
     Display *display = gw->display->display;
+#ifdef X_HAVE_UTF8_STRING
+    Xutf8SetWMProperties(display, gw->w, title, icontit, NULL, 0, NULL, NULL, NULL);
+#else
     unichar_t *tit = utf82u_copy(title), *itit = utf82u_copy(icontit);
     char *ipt, *tpt;
 
@@ -1720,10 +1548,6 @@ return( NULL );
 static char *GXDrawGetWindowTitle8(GWindow w);
 
 static unichar_t *GXDrawGetWindowTitle(GWindow w) {
-#if defined(__MINGW32__)
-    GXWindow gw = (GXWindow) w;
-    return mingw_get_wm_name(gw->display->display, gw->w);
-#else
 #if X_HAVE_UTF8_STRING
     char *ret1 = GXDrawGetWindowTitle8(w);
     unichar_t *ret = utf82u_copy(ret1);
@@ -1741,14 +1565,9 @@ return( ret );
     XFree(pt);
 return( ret );
 #endif
-#endif
 }
 
 static char *GXDrawGetWindowTitle8(GWindow w) {
-#if defined(__MINGW32__)
-    GXWindow gw = (GXWindow) w;
-    return mingw_get_wm_name_utf8(gw->display->display, gw->w);
-#else
 #if X_HAVE_UTF8_STRING
     GXWindow gw = (GXWindow) w;
     Display *display = gw->display->display;
@@ -1778,7 +1597,6 @@ return( ret );
 
     free(ret1);
 return( ret );
-#endif
 #endif
 }
 
@@ -4695,8 +4513,6 @@ void _XSyncScreen() {
     XSync(((GXDisplay *) screen_display)->display,false);
 }
 
-#if !defined(__MINGW32__)
-
 /* map GK_ keys to X keys */
 /* Assumes most are mapped 1-1, see gkeysym.h */
 /* abort on unimplemented translations */
@@ -4727,7 +4543,6 @@ return 0;
     }
 return ((key_map_stat[code >> 3] >> (code & 7)) & 1);
 }
-#endif
 
 #else	/* NO X */
 


### PR DESCRIPTION
…pecific window/icon setters/getters.

**Note**: The switch to Xutf8SetWMProperties where applicable is for **all platforms** - so much appreciated testing would be to check that all window titles still display fine.

Regarding the removal of the 'Mingw+WindowsWM hack':
Currently, window titles/icons work as expected without the MINGW specific code (or they will with the next release).

Looking at the original XMing `locale.alias`, it looks like this hack was used because it didn't define Windows specific locales (e.g `English_Australia.1252`) hence why it wasn't working. Using VcXsrv with a `locale.alias` from the standard libX11 distribution, everything works fine. (See also #1729).

So there's no reason to keep this MINGW specific code in place.

cc @frank-trampe 