### PR TITLE
Use git.mk for breakpad

### DIFF
--- a/breakpad/.gitignore
+++ b/breakpad/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/breakpad/server/.gitignore
+++ b/breakpad/server/.gitignore
@@ -1,5 +1,0 @@
-node_modules
-uploads
-Makefile
-Makefile.in
-

--- a/breakpad/server/Makefile.am
+++ b/breakpad/server/Makefile.am
@@ -27,4 +27,6 @@
 include $(top_srcdir)/mk/layout.am
 SUBDIRS = 
 EXTRA_DIST = package.json report-acceptor.js
+
+GITIGNOREFILES = node_modules uploads
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
This should prevent the `.gitignore` files in breakpad from showing as a modified item in git.

cc @monkeyiq @frank-trampe 