### PR TITLE
Items in File->Call Script work only first time.

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18158,7 +18158,8 @@ static PyObject* CreatePyModule( module_definition *mdef ) {
     PyObject *module;
 
     if ( mdef->runtime.module != NULL )
-	return mdef->runtime.module;
+	if ( mdef->runtime.module == PyImport_AddModule(mdef->module_name) )
+            return mdef->runtime.module;
 
     if ( mdef->types != NULL && FinalizePythonTypes( mdef->types ) < 0 )
 	return NULL;


### PR DESCRIPTION
My scripts from Call Script menu only work first time I use any. Subsequent attempts end up with message:
```
  File "script.py", line 2, in <module>
    import fontforge
SystemError: _PyImport_FixupExtension: module fontforge not loaded
```
I need to restart FontForge to avoid it.

Looks like it stores references from `Py_InitModule3()` for reuse. But they are "borrowed references", and in my setup (Ubuntu 14.04, Python 2.7.6) python forgets them after `Py_Finalize()`.