### PR TITLE
Fix point info dialog for interpolated points

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18158,8 +18158,7 @@ static PyObject* CreatePyModule( module_definition *mdef ) {
     PyObject *module;
 
     if ( mdef->runtime.module != NULL )
-	if ( mdef->runtime.module == PyImport_AddModule(mdef->module_name) )
-            return mdef->runtime.module;
+	return mdef->runtime.module;
 
     if ( mdef->types != NULL && FinalizePythonTypes( mdef->types ) < 0 )
 	return NULL;

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18158,7 +18158,8 @@ static PyObject* CreatePyModule( module_definition *mdef ) {
     PyObject *module;
 
     if ( mdef->runtime.module != NULL )
-	return mdef->runtime.module;
+	if ( mdef->runtime.module == PyImport_AddModule(mdef->module_name) )
+            return mdef->runtime.module;
 
     if ( mdef->types != NULL && FinalizePythonTypes( mdef->types ) < 0 )
 	return NULL;

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -3309,7 +3309,12 @@ static void PointGetInfo(CharView *cv, SplinePoint *sp, SplinePointList *spl) {
 	mb[4].creator = GHBoxCreate;
 
 	GGadgetsCreate(gi->gw,mb);
-	gi->group1ret = pb[4].ret; gi->group2ret = pb[5].ret;
+
+	gi->group1ret = pb[4].ret;
+	gi->group2ret = pb[5].ret;
+	for ( j=0; j<gcdcount; ++j )
+	    gi->gcd[j].ret = gcd[j].ret;
+
 	GTextInfoListFree(hgcd[0].gd.u.list);
 	GTextInfoListFree(h2gcd[0].gd.u.list);
 


### PR DESCRIPTION
Point info dialog is unusable for interpolated points.

Looks like pointers to some gadgets are left uninitialized, and so the routine that shuffles them for various point types actually can't complete its work. This fixes it.
