### PR TITLE
Using e.g. "Fontname" instead of the generic "Postscript name"

### DIFF
--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -2657,7 +2657,7 @@ static int CheckNames(struct gfi_data *d) {
     buts[0] = _("_OK"); buts[1] = _("_Cancel"); buts[2]=NULL;
 
     if ( u_strlen(ufont)>63 ) {
-	ff_post_error(_("Bad Font Name"),_("A PostScript name should be ASCII\nand must not contain (){}[]<>%%/ or space\nand must be shorter than 63 characters"));
+	ff_post_error(_("Bad Font Name"),_("A Fontname should be ASCII\nand must not contain (){}[]<>%%/ or space\nand must be shorter than 63 characters"));
 return( false );
     }
 
@@ -2688,7 +2688,7 @@ return( false );
     }
     while ( *ufamily ) {
 	if ( *ufamily<' ' || *ufamily>=0x7f ) {
-	    ff_post_error(_("Bad Font Family Name"),_("A PostScript name should be ASCII\nand must not contain (){}[]<>%%/ or space"));
+	    ff_post_error(_("Bad Font Family Name"),_("A Family Name should be ASCII\nand must not contain (){}[]<>%%/ or space"));
 return( false );
 	}
 	++ufamily;
@@ -2705,7 +2705,7 @@ return( false );
 		*pt=='(' || *pt=='[' || *pt=='{' || *pt=='<' ||
 		*pt==')' || *pt==']' || *pt=='}' || *pt=='>' ||
 		*pt=='%' || *pt=='/' ) {
-	    ff_post_error(_("Bad Font Name"),_("A PostScript name should be ASCII\nand must not contain (){}[]<>%%/ or space"));
+	    ff_post_error(_("Bad Font Name"),_("A Fontname should be ASCII\nand must not contain (){}[]<>%%/ or space"));
 return( false );
 	}
     }
@@ -3316,8 +3316,8 @@ static int GFI_AddOFL(GGadget *g, GEvent *e) {
 	ff_post_notice(_("Using the OFL for your open fonts"),_(
 	    "The OFL is a community-approved software license designed for libre/open font projects. \n"
 	    "Fonts under the OFL can be used, studied, copied, modified, embedded, merged and redistributed while giving authors enough control and artistic integrity. For more details including an FAQ see http://scripts.sil.org/OFL. \n\n"
-	    "This font metadata will help users, designers and distribution channels to know who you are, how to contact you and what rights you are granting. \n" 
-        "When releasing modified versions, remember to add your additional notice, including any extra Reserved Font Name(s). \n\n" 
+	    "This font metadata will help users, designers and distribution channels to know who you are, how to contact you and what rights you are granting. \n"
+        "When releasing modified versions, remember to add your additional notice, including any extra Reserved Font Name(s). \n\n"
 	    "Have fun designing open fonts!" ));
     }
 return( true );
@@ -4060,7 +4060,7 @@ return( true );
 		char *tit, *msg;
 	    } msgs[] = {
 		{ CID_Notice, N_("Bad Copyright"), NU_("Copyright text (in the Names pane) must be entirely ASCII. So, use (c) instead of ©.")},
-		{ CID_Human, N_("Bad Human Fontname"), N_("The human-readable fontname text (in the Names pane) must be entirely ASCII.")},
+		{ CID_Human, N_("Bad Human Fontname"), N_("The Name For Humans (in the Names pane) must be entirely ASCII.")},
 		{ CID_Weight, N_("Bad Weight"), N_("The weight text (in the Names pane) must be entirely ASCII.")},
 		{ CID_Version, N_("Bad Version"), N_("The version text (in the Names pane) must be entirely ASCII.")},
 		{ 0, NULL, NULL }
@@ -8462,7 +8462,7 @@ return;
     vgcd[16].gd.cid = CID_OS2Version;
     vgcd[16].gd.u.list = os2versions;
     vgcd[16].creator = GListFieldCreate;
-    
+
     vgcd[17].gd.pos.x = 10; vgcd[17].gd.pos.y = vgcd[13].gd.pos.y+26+6;
     vlabel[17].text = (unichar_t *) _("Style Map:");
     vlabel[17].text_is_1byte = true;

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -2657,12 +2657,12 @@ static int CheckNames(struct gfi_data *d) {
     buts[0] = _("_OK"); buts[1] = _("_Cancel"); buts[2]=NULL;
 
     if ( u_strlen(ufont)>63 ) {
-	ff_post_error(_("Bad Font Name"),_("A Fontname should be ASCII\nand must not contain (){}[]<>%%/ or space\nand must be shorter than 63 characters"));
+	ff_post_error(_("Bad Font Name"),_("PostScript name should be ASCII\nand must not contain (){}[]<>%%/ or space\nand must be shorter than 63 characters"));
 return( false );
     }
 
     if ( *ufamily=='\0' ) {
-	ff_post_error(_("A Font Family name is required"),_("A Font Family name is required"));
+	ff_post_error(_("A Font Family name is required"),_("Font Family name is required"));
 return( false );
     }
     /* A postscript name cannot be a number. There are two ways it can be a */
@@ -2671,24 +2671,24 @@ return( false );
     /*  do a cursory test for that */
     u_strtod(ufamily,&end);
     if ( *end=='\0' || (isdigit(ufamily[0]) && u_strchr(ufamily,'#')!=NULL) ) {
-	ff_post_error(_("Bad Font Family Name"),_("A PostScript name may not be a number"));
+	ff_post_error(_("Bad Font Family Name"),_("Family name may not be a number"));
 return( false );
     }
     if ( u_strlen(ufamily)>31 ) {
-	if ( gwwv_ask(_("Bad Font Family Name"),(const char **) buts,0,1,_("Some versions of Windows will refuse to install postscript fonts if the familyname is longer than 31 characters. Do you want to continue anyway?"))==1 )
+	if ( gwwv_ask(_("Bad Font Family Name"),(const char **) buts,0,1,_("Some versions of Windows will refuse to install postscript fonts if the Family name is longer than 31 characters. Do you want to continue anyway?"))==1 )
 return( false );
     } else {
 	if ( u_strlen(ufont)>31 ) {
-	    if ( gwwv_ask(_("Bad Font Name"),(const char **) buts,0,1,_("Some versions of Windows will refuse to install postscript fonts if the fontname is longer than 31 characters. Do you want to continue anyway?"))==1 )
+	    if ( gwwv_ask(_("Bad Font Name"),(const char **) buts,0,1,_("Some versions of Windows will refuse to install postscript fonts if the PostScript name is longer than 31 characters. Do you want to continue anyway?"))==1 )
 return( false );
 	} else if ( u_strlen(ufont)>29 ) {
-	    if ( gwwv_ask(_("Bad Font Name"),(const char **) buts,0,1,_("Adobe's fontname spec (5088.FontNames.pdf) says that fontnames should not be longer than 29 characters. Do you want to continue anyway?"))==1 )
+	    if ( gwwv_ask(_("Bad Font Name"),(const char **) buts,0,1,_("Adobe's fontname spec (5088.FontNames.pdf) says that PostScript names should not be longer than 29 characters. Do you want to continue anyway?"))==1 )
 return( false );
 	}
     }
     while ( *ufamily ) {
 	if ( *ufamily<' ' || *ufamily>=0x7f ) {
-	    ff_post_error(_("Bad Font Family Name"),_("A Family Name should be ASCII\nand must not contain (){}[]<>%%/ or space"));
+	    ff_post_error(_("Bad Font Family Name"),_("Family Name should be ASCII\nand must not contain (){}[]<>%%/ or space"));
 return( false );
 	}
 	++ufamily;
@@ -2697,7 +2697,7 @@ return( false );
     u_strtod(ufont,&end);
     if ( (*end=='\0' || (isdigit(ufont[0]) && u_strchr(ufont,'#')!=NULL)) &&
 	    *ufont!='\0' ) {
-	ff_post_error(_("Bad Font Name"),_("A PostScript name may not be a number"));
+	ff_post_error(_("Bad Font Name"),_("PostScript name may not be a number"));
 return( false );
     }
     for ( pt=ufont; *pt; ++pt ) {
@@ -2705,7 +2705,7 @@ return( false );
 		*pt=='(' || *pt=='[' || *pt=='{' || *pt=='<' ||
 		*pt==')' || *pt==']' || *pt=='}' || *pt=='>' ||
 		*pt=='%' || *pt=='/' ) {
-	    ff_post_error(_("Bad Font Name"),_("A Fontname should be ASCII\nand must not contain (){}[]<>%%/ or space"));
+	    ff_post_error(_("Bad Font Name"),_("PostScript name should be ASCII\nand must not contain (){}[]<>%%/ or space"));
 return( false );
 	}
     }


### PR DESCRIPTION
Bumped into this alert today and figured it wasn't precise enough (especially for a beginner who are the ones most likely to make the mistake.)

I've changed it to Fontname, Family Name and Name For Humans as that's what the labels are called.

![screen shot 2015-06-03 at 18 52 58](https://cloud.githubusercontent.com/assets/3859425/7967536/e8170f9e-0a2a-11e5-9f61-b3e5bb784262.png)
