### PR TITLE
Fix and better document the native scripting Chr() function.

### DIFF
--- a/doc/html/scripting-alpha.html
+++ b/doc/html/scripting-alpha.html
@@ -494,11 +494,14 @@ a[4][0] = "Nested array";
 	    <A NAME="Chr">C</A>hr(int)<BR>
 	    Chr(array)
 	  <DD>
-	    Takes an integer [0,255] and returns a single character string containing
-	    that code point. Internally FontForge interprets strings as if they were
-	    in utf8 (well really, FontForge almost always just uses ASCII-US internally).
-	    If passed an array, it should be an array of integers and the result is the
-	    string. It can execute with no current font.
+	    Takes an integer [-128,255] and returns a single character
+	    string containing that byte.  Negative numbers are treated as
+	    signed bytes in two's complement.  Internally FontForge interprets
+	    strings as if they were in UTF-8, so it is possible to construct
+	    higher code points and strings that are not valid UTF-8 by
+	    passing in appropriate values.  If passed an array, it
+	    should be an array of integers and the result is the string.  It
+	    can execute with no current font.
 	  <DT>
 	    <A NAME="CIDChangeSubFont">C</A>IDChangeSubFont(new-sub-font-name)
 	  <DD>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -1220,7 +1220,7 @@ static void bChr(Context *c) {
 	for ( i=0; i<arr->argc; ++i ) {
 	    if ( arr->vals[i].type!=v_int )
 		ScriptError( c, "Bad type for argument" );
-	    else if ( c->a.vals[1].u.ival<-128 || c->a.vals[1].u.ival>255 )
+	    else if ( arr->vals[i].u.ival<-128 || arr->vals[i].u.ival>255 )
 		ScriptError( c, "Bad value for argument" );
 	    temp[i] = arr->vals[i].u.ival;
 	}


### PR DESCRIPTION
It looks like this function never actually worked as documented.  Change backported from FontAnvil.