### PR TITLE
Windows Mingw+CygWin patches

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -468,10 +468,13 @@ case $host in
       ;;
    *-apple-darwin*)
       ;;
-   *mingw* | *cygwin*)
+   *mingw*)
       dnl Explicitly export all symbols on Windows, since FontForge lacks an export table
 	  dnl See issue #1238 on GitHub for more information.
 	  my_lib_ldflags="${my_lib_ldflags} -no-undefined -Wl,--export-all-symbols"
+      ;;
+   *cygwin*)
+	  my_lib_ldflags="${my_lib_ldflags} -Wl,-no-undefined -Wl,--export-all-symbols"
       ;;
    *) saved_LDFLAGS=$LDFLAGS
       AC_MSG_CHECKING([whether the linker supports --no-undefined])

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -3548,7 +3548,7 @@ char * delimit_null(const char * input, char delimiter);
 
 #include "ustring.h"
 
-#ifdef __MINGW32__
+#ifdef _WIN32
 #define BAD_LOCALE_HACK
 typedef char* locale_t;
 #define LC_GLOBAL_LOCALE ((locale_t)-1)

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -272,7 +272,7 @@ static struct resed charview2_re[] = {
 };
 
 /* return 1 if anything changed */
-static int update_spacebar_hand_tool(CharView *cv) {
+static void update_spacebar_hand_tool(CharView *cv) {
     if ( GDrawKeyState(' ') ) {
 	if ( !cv->spacebar_hold  && !cv_auto_goto ) {
 	    cv->spacebar_hold = 1;
@@ -280,7 +280,6 @@ static int update_spacebar_hand_tool(CharView *cv) {
 	    cv->b1_tool = cvt_hand;
 	    cv->active_tool = cvt_hand;
 	    CVMouseDownHand(cv);
-return 1;
 	}
     } else {
 	if ( cv->spacebar_hold ) {
@@ -288,10 +287,8 @@ return 1;
 	    cv->b1_tool = cv->b1_tool_old;
 	    cv->active_tool = cvt_none;
 	    cv->b1_tool_old = cvt_none;
-return 1;
 	}
     }
-return 0;
 }
 
 /**
@@ -4758,7 +4755,7 @@ return;		/* I treat this more like a modifier key change than a button press */
     if( cv->charselector && cv->charselector == GWindowGetFocusGadgetOfWindow(cv->gw))
 	GWindowClearFocusGadgetOfWindow(cv->gw);
 
-    update_spacebar_hand_tool(cv); /* needed?  (left from MINGW) */
+    update_spacebar_hand_tool(cv);
 
     CVToolsSetCursor(cv,event->u.mouse.state|(1<<(7+event->u.mouse.button)), event->u.mouse.device );
     if( override_showing_tool != cvt_none )
@@ -5246,18 +5243,15 @@ static void CVMouseMove(CharView *cv, GEvent *event ) {
     GEvent fake;
     int stop_motion = false;
     int has_spiro = hasspiro();
-    int spacebar_changed;
 
 		/* Debug wacom !!!! */
  /* TRACE( "dev=%s (%d,%d) 0x%x\n", event->u.mouse.device!=NULL?event->u.mouse.device:"<None>", */
  /*     event->u.mouse.x, event->u.mouse.y, event->u.mouse.state); */
 
-    spacebar_changed = update_spacebar_hand_tool(cv);
-
-    if ( event->u.mouse.device!=NULL || spacebar_changed )
+    if ( event->u.mouse.device!=NULL )
 	CVToolsSetCursor(cv,event->u.mouse.state,event->u.mouse.device);
 
-    if ( !cv->p.pressed && !cv->spacebar_hold ) {
+    if ( !cv->p.pressed ) {
 	CVUpdateInfo(cv, event);
 	if ( cv->showing_tool==cvt_pointer ) {
 	    CVCheckResizeCursors(cv);
@@ -5506,7 +5500,7 @@ static void CVMouseUp(CharView *cv, GEvent *event ) {
     }
     cv->p.pressed = false;
     CVFreePreTransformSPL( cv );
-    update_spacebar_hand_tool(cv); /* needed? (left from MINGW) */
+    update_spacebar_hand_tool(cv);
 
     if ( cv->p.rubberbanding ) {
 	CVDrawRubberRect(cv->v,cv);

--- a/fontforgeexe/uiutil.c
+++ b/fontforgeexe/uiutil.c
@@ -42,125 +42,11 @@ extern void cygwin_conv_to_full_posix_path(const char *win,char *unx);
 extern void cygwin_conv_to_full_win32_path(const char *unx,char *win);
 #endif
 
-#if __CygWin
-/* Try to find the default browser by looking it up in the windows registry */
-/* The registry is organized as a tree. We are interested in the subtree */
-/*  starting at HKEY_CLASSES_ROOT. This contains two different kinds of things*/
-/*  Extensions and Programs. First we look up the extension and it refers us */
-/*  to a program. So we look up the program, and look up shell->open->command */
-/*  in it. The value of command is a path followed by potential arguments */
-/*  viz: c:\program files\foobar "%1" */
-
-/* Extensions seem to contain the ".", so ".html" not "html" */
-
-#include <w32api/wtypes.h>
-#include <w32api/winbase.h>
-#include <w32api/winreg.h>
-
-static char *win_program_from_extension(char *exten) {
-    DWORD type, dlen, err;
-    char programindicator[1000];
-    char programpath[1000];
-    HKEY hkey_prog, hkey_shell, hkey_open, hkey_exten, hkey_command;
-    char *pt;
-
-    if ( RegOpenKeyEx(HKEY_CLASSES_ROOT,exten,0,KEY_READ,&hkey_exten)!=ERROR_SUCCESS ) {
-	/*fprintf( stderr, "Failed to find extension \"%s\", did it have a period?\n", exten );*/
-return( NULL );
-    }
-    dlen = sizeof(programindicator);
-    if ( (err=RegQueryValueEx(hkey_exten,"",NULL,&type,(uint8 *)programindicator,&dlen))!=ERROR_SUCCESS ) {
-	LogError( _("Failed to default value of exten \"%s\".\n Error=%ld"), exten, err );
-	RegCloseKey(hkey_exten);
-return( NULL );
-    }
-    RegCloseKey(hkey_exten);
-
-    if ( RegOpenKeyEx(HKEY_CLASSES_ROOT,programindicator,0,KEY_READ,&hkey_prog)!=ERROR_SUCCESS ) {
-	LogError( _("Failed to find program \"%s\"\n"), programindicator );
-return( NULL );
-    }
-    if ( RegOpenKeyEx(hkey_prog,"shell",0,KEY_READ,&hkey_shell)!=ERROR_SUCCESS ) {
-	LogError( _("Failed to find \"%s->shell\"\n"), programindicator );
-	RegCloseKey(hkey_prog);
-return( NULL );
-    }
-    if ( RegOpenKeyEx(hkey_shell,"open",0,KEY_READ,&hkey_open)!=ERROR_SUCCESS ) {
-	LogError( _("Failed to find \"%s->shell->open\"\n"), programindicator );
-	RegCloseKey(hkey_prog); RegCloseKey(hkey_shell);
-return( NULL );
-    }
-    if ( RegOpenKeyEx(hkey_open,"command",0,KEY_READ,&hkey_command)!=ERROR_SUCCESS ) {
-	LogError( _("Failed to find \"%s->shell->open\"\n"), programindicator );
-	RegCloseKey(hkey_prog); RegCloseKey(hkey_shell); RegCloseKey(hkey_command);
-return( NULL );
-    }
-
-    dlen = sizeof(programpath);
-    if ( RegQueryValueEx(hkey_command,"",NULL,&type,(uint8 *)programpath,&dlen)!=ERROR_SUCCESS ) {
-	LogError( _("Failed to find default for \"%s->shell->open->command\"\n"), programindicator );
-	RegCloseKey(hkey_prog); RegCloseKey(hkey_shell); RegCloseKey(hkey_open); RegCloseKey(hkey_command);
-return( NULL );
-    }
-
-    RegCloseKey(hkey_prog); RegCloseKey(hkey_shell); RegCloseKey(hkey_open); RegCloseKey(hkey_command);
-
-    pt = strstr(programpath,"%1");
-    if ( pt!=NULL )
-	pt[1] = 's';
-return( copy(programpath));
-}
-
-static void do_windows_browser(char *fullspec) {
-    char *format, *start, *pt, ch, *temp, *cmd;
-
-    format = win_program_from_extension(".html");
-    if ( format==NULL )
-	format = win_program_from_extension(".htm");
-    if ( format==NULL ) {
-	gwwv_post_error(_("No Browser"),_("Could not find a browser. Set the BROWSER environment variable to point to one"));
-return;
-    }
-
-    if ( format[0]=='"' || format[0]=='\'' ) {
-	start = format+1;
-	pt = strchr(start,format[0]);
-    } else {
-	start = format;
-	pt = strchr(start,' ');
-    }
-    if ( pt==NULL ) pt = start+strlen(start);
-    ch = *pt; *pt='\0';
-
-    temp = malloc(strlen(start)+300+ (ch==0?0:strlen(pt+1)));
-    cygwin_conv_to_full_posix_path(start,temp+1);
-    temp[0]='"'; strcat(temp,"\" ");
-    if ( ch!='\0' )
-	strcat(temp,pt+1);
-    cmd = malloc(strlen(temp)+strlen(fullspec)+8);
-    if ( strstr("%s",temp)!=NULL )
-	sprintf( cmd, temp, fullspec );
-    else {
-	strcpy(cmd,temp);
-	strcat(cmd, " ");
-	strcat(cmd,fullspec);
-    }
-    strcat(cmd," &" );
-    system(cmd);
-    free( cmd ); free( temp ); free( format );
-}
-#endif
-
 static char browser[1025];
 
 static void findbrowser(void) {
 /* Find a browser to use so that help messages can be displayed */
-#if __CygWin
-    static char *stdbrowsers[] = { "netscape.exe", "opera.exe", "galeon.exe", "kfmclient.exe",
-	"firefox.exe", "chrome.exe", "seamonkey.exe", "mozilla.exe", "mosaic.exe", /*"grail",*/
-	"iexplore.exe",
-	/*"lynx.exe",*/
-#else
+
 /* Both xdg-open and htmlview are not browsers per se, but browser dispatchers*/
 /*  which try to figure out what browser the user intents. It seems no one */
 /*  uses (understands?) environment variables any more, so BROWSER is a bit */
@@ -171,7 +57,6 @@ static void findbrowser(void) {
 #endif
 	"firefox", "mozilla", "seamonkey", "iceweasel", "opera", "konqueror", "google-chrome",
 	"galeon", "kfmclient", "netscape", "mosaic", /*"grail",*/ "lynx",
-#endif
 	NULL };
     int i;
     char *path;
@@ -179,18 +64,6 @@ static void findbrowser(void) {
     if ( getenv("BROWSER")!=NULL ) {
 	strncpy(browser,getenv("BROWSER"),sizeof(browser));
     browser[sizeof(browser)-1] = '\0';
-#if __CygWin			/* Get rid of any dos style names */
-	if ( isalpha(browser[0]) && browser[1]==':' && browser[2]=='\\' )
-	    cygwin_conv_to_full_posix_path(getenv("BROWSER"),browser);
-	else if ( strchr(browser,'/')==NULL ) {
-	    if ( strstrmatch(browser,".exe")==NULL )
-		strcat(browser,".exe");
-	    if ( (path=_GFile_find_program_dir(browser))!=NULL ) {
-		snprintf(browser,sizeof(browser),"%s/%s", path, getenv("BROWSER"));
-		free(path);
-	    }
-	}
-#endif
 	if ( strcmp(browser,"kde")==0 || strcmp(browser,"kfm")==0 ||
 		strcmp(browser,"konqueror")==0 || strcmp(browser,"kfmclient")==0 )
 	    strcpy(browser,"kfmclient openURL");
@@ -201,11 +74,7 @@ return;
 	    if ( strcmp(stdbrowsers[i],"kfmclient")==0 )
 		strcpy(browser,"kfmclient openURL");
 	    else
-#if __CygWin
-		snprintf(browser,sizeof(browser),"%s/%s", path, stdbrowsers[i]);
-#else
 		strcpy(browser,stdbrowsers[i]);
-#endif
 	    free(path);
 return;
 	}
@@ -269,49 +138,85 @@ static void AppendSupportedLocale(char *fullspec) {
     }
 }
 
-#if defined(__MINGW32__)
+#ifdef _WIN32
 #include <gresource.h>
 #include <windows.h>
 void help(char *file) {
     if(file){
-	char*  p_file  = copy(file);
-	char*  p_uri   = p_file;
-	char*  p_param = strrchr(p_file,'#');
+	int   len     = strlen(file);
+	char* p_file  = (char*) malloc(len+1);
+	char* p_uri   = (char*) malloc(len+1024);
+	char* p_param = NULL;
 
-	if(p_param){
-	    *p_param = '\0';
+	strcpy(p_file,  file);
+
+	{
+	    char* delim = strrchr(p_file, '#');
+	    if(delim){
+		p_param = (char*) malloc(len+1);
+		strcpy(p_param, delim);
+		*delim = '\0';
+	    }
 	}
-	if(! GFileIsAbsolute(p_file)){
-	    p_uri = (char*) malloc( 256 + strlen(GResourceProgramDir) + strlen(p_file) );
 
-	    strcpy(p_uri, GResourceProgramDir); /*  doc/fontforge/ja/file  */
-	    strcat(p_uri, "/doc/fontforge/");
+	strcpy(p_uri, p_file);
+
+	if(! GFileIsAbsolute(p_uri)){
+	    char* p_helpdir = (char*) malloc(1024);
+
+	    #if __CygWin
+	    {   /* cygwin */
+		#if defined(DOCDIR)
+		strncpy( p_helpdir, DOCDIR "/", 1024 );
+		#elif defined(SHAREDIR)
+		strncpy( p_helpdir, SHAREDIR "/doc/fontforge/", 1024 );
+		#else
+		strncpy( p_helpdir, "/usr/local/share/doc/fontforge/", 1024 );
+		#endif
+	    }
+	    #else
+	    {   /* mingw */
+		strcpy( p_helpdir, GResourceProgramDir );
+		strcat( p_helpdir, "/doc/fontforge/");
+	    }
+	    #endif
+
+	    /* /usr/share/fontforge/doc/ja/file */
+	    strcpy(p_uri, p_helpdir);
 	    AppendSupportedLocale(p_uri);
 	    strcat(p_uri, p_file);
 
 	    if(!GFileReadable(p_uri)){
-		strcpy(p_uri, GResourceProgramDir);/*  doc/fontforge/file  */
-		strcat(p_uri, "/doc/fontforge/");
+		strcpy(p_uri, p_helpdir);
 		strcat(p_uri, p_file);
 
 		if(!GFileReadable(p_uri)){
-		    strcpy(p_uri, "http://fontforge.sourceforge.net/"); /*  http://host/ja/file  */
-		    AppendSupportedLocale(p_uri);
+		    strcpy(p_uri, "http://fontforge.org/");
+		    /* AppendSupportedLocale(p_uri); */
 		    strcat(p_uri, p_file);
 		}
 	    }
+	    free(p_helpdir);
 	}
+
+	#if __CygWin
+	if( strncmp(p_uri, "http:", 5) != 0 ){
+	    char*  temp = (char*) malloc(1024);
+	    cygwin_conv_to_full_win32_path(p_uri, temp);
+	    free(p_uri);
+	    p_uri = temp;
+	}
+	#endif
+
 	if(p_param){
-	    if(p_uri != p_file)
-		strcat(p_uri, p_param);
-	    else
-		*p_param = '#';
+	    strcat(p_uri, p_param);
+	    free(p_param);
 	}
 
 	/* using default browser */
 	ShellExecute(NULL, "open", p_uri, NULL, NULL, SW_SHOWDEFAULT);
 
-	if(p_uri!=p_file) free(p_uri);
+	free(p_uri);
 	free(p_file);
     }
 }
@@ -322,12 +227,10 @@ void help(char *file) {
 
     if ( browser[0]=='\0' )
 	findbrowser();
-#ifndef __CygWin
     if ( browser[0]=='\0' ) {
 	gwwv_post_error(_("No Browser"),_("Could not find a browser. Set the BROWSER environment variable to point to one"));
 return;
     }
-#endif
 
     if ( strstr(file,"http://")==NULL ) {
 	memset(fullspec,0,sizeof(fullspec));
@@ -350,22 +253,6 @@ return;
 	    *pt = '#';
     } else
 	strncpy(fullspec,file,sizeof(fullspec));
-#if __CygWin
-    if ( (browser[0]=='\0' || strstrmatch(browser,"/cygdrive")!=NULL ) && \
-		strstr(fullspec,":/")==NULL ) {
-	/* It looks as though the browser is a windows application, so we */
-	/*  should give it a windows file name */
-	char *pt, *tpt;
-	if ( (temp=malloc(1024))==NULL )
-	    return;
-	cygwin_conv_to_full_win32_path(fullspec,temp);
-	for ( pt = fullspec, tpt = temp; *tpt && pt<fullspec+sizeof(fullspec)-3; *pt++ = *tpt++ )
-	    if ( *tpt=='\\' )
-		*pt++ = '\\';
-	*pt = '\0';
-	free(temp);
-    }
-#endif
 #if __Mac
     if ( strcmp(browser,"open")==0 )
 	/* open doesn't want "file:" prepended */;
@@ -374,11 +261,7 @@ return;
     if ( strstr(fullspec,":/")==NULL ) {
 	if ( (temp=malloc(strlen(fullspec)+strlen("file:")+20))==NULL )
 	    return;
-#if __CygWin
-	sprintf(temp,"file:\\\\\\%s",fullspec);
-#else
 	sprintf(temp,"file:%s",fullspec);
-#endif
 	strncpy(fullspec,temp,sizeof(fullspec));
     fullspec[sizeof(fullspec)-1] = '\0';
 	free(temp);
@@ -392,10 +275,6 @@ return;
 	sprintf( temp, "%s \"%s\" &", str, fullspec );
 	system(temp);
 	free(temp);
-    } else {
-#elif __CygWin
-    if ( browser[0]=='\0' ) {
-	do_windows_browser(fullspec);
     } else {
 #else
     {

--- a/gdraw/hotkeys.c
+++ b/gdraw/hotkeys.c
@@ -329,6 +329,10 @@ void hotkeysSave() {
     // Atomic rename of new over the old.
     //
     char* newpath = getHotkeyFilename(0);
+#ifdef __MINGW32__
+    //Atomic rename doesn't exist on Windows.
+    unlink(newpath);
+#endif
     int rc = rename( fn, newpath );
     int e = errno;
     free(fn);

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -909,7 +909,7 @@ char *getFontForgeUserDir(int dir) {
 	fprintf(stderr, "%s\n", "cannot find home directory");
 return NULL;
 	}
-#if defined(__MINGW32__)
+#ifdef _WIN32
 	/* Allow for preferences to be saved locally in a 'portable' configuration. */ 
 	if (getenv("FF_PORTABLE") != NULL) {
 		buf = smprintf("%s/preferences/", getShareDir());

--- a/inc/dynamic.h
+++ b/inc/dynamic.h
@@ -39,10 +39,6 @@ extern const void *gwwv_NSAddImage(char *name,uint32_t options);
 #  elif defined(__MINGW32__)
 #  else
 #   include <dlfcn.h>
-#   ifdef __CygWin
-#    define dlopen(name,foo) libtool_laopen(name,foo)
-void *libtool_laopen(const char *filename, int flags);
-#   endif
 #define SO_EXT		".so"
 #define SO_0_EXT	".so.0"
 #define SO_1_EXT	".so.1"


### PR DESCRIPTION
This was split from #2299.

* Fix autorecover 'forget about it' and 'forget to all' bug on Windows (MinGW) @frank-trampe I added more comments and slightly reworked it to make it more obvious that the file pointer may be closed by `ask_about_file`.
* Fix hotkey saving on Windows (MinGW)
* Pull in most of the patches from the [CygWin build](http://www.geocities.jp/meir000/fontforge/fontforge-20150121-cygwin.patch.txt).

-----
On Windows, you can only unlink a file that has no open file handles.
So do `fclose` before `unlink`.