### PR TITLE
Travis: Homebrew fixes

### DIFF
--- a/travis-scripts/script_osx.sh
+++ b/travis-scripts/script_osx.sh
@@ -9,7 +9,7 @@ rm -f /Users/travis/build/fontforge/fontforge/.git/shallow
 set +e
 mkdir -p /tmp/fontforge-source-tree
 echo "brew build starting..."
-brew install --verbose fontforge --HEAD --with-x11 --with-libspiro
+brew install --verbose fontforge --HEAD --with-libspiro
 echo "brew build complete..."
 PR=$TRAVIS_PULL_REQUEST
 chmod +x ./travis-scripts/create-osx-app-bundle-homebrew.sh


### PR DESCRIPTION
Re: https://github.com/fontforge/fontforge/pull/2371#issuecomment-113025801

The PR to remove X11 support from GTK+ in `Homebrew/homebrew` was merged yesterday afternoon, but because your build scripts do `--with-x11` and the local Fontforge formula here wasn't resynced essentially Fontforge was expecting to find `pangoxft` which no longer exists.

I'm not quite sure what the packaging intention is with [the Homebrew app build script](https://github.com/fontforge/fontforge/blob/master/travis-scripts/create-osx-app-bundle-homebrew.sh). It seems to lean on Homebrew but at the same time uses MacPorts paths. Homebrew hasn't been correctly producing working `FontForge.app` forever though, so that would imply you're packaging it up in a different way rather than using a Homebrew-generated `FontForge.app`?

If I can grab some clarity into the packaging process I'm happy to help rewrite it to use older versions of Homebrew formulae, or to switch it to another package manager, or even build the required elements from source directly, but I'm not quite sure step-by-step what `create-osx-app-bundle-homebrew.sh` is intended to do.

This PR at least will stop your Travis builds dying on you during `configure`.