### PR TITLE
Fix configure.ac m4 syntax in homebrew PYTHON setup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,7 @@ if test "y$HOMEBREW_BREW_FILE" != "y"; then
    PYPKGCONFIG="$( cd "$PYLIBDIR/../../pkgconfig" && pwd )"
    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$PYPKGCONFIG"
    echo "found python pkg_config information: $PYPKGCONFIG"
-   if [ "y$PYTHON" = y ] ; then 
+   if test "y$PYTHON" = "y"; then 
      export PYTHON="${HOMEBREW_PREFIX}/bin/python"
    fi
 fi


### PR DESCRIPTION
Fixes #1836 

This fixes a problem with the m4 syntax in the homebrew-specific section of `configure.ac`. The impact of this error was that `PYTHON` was never getting set because the test was failing due to trying to run the bogus command `y` instead of doing a string comparison.

Here's the difference I see in my `./configure` output on OS X 10.9 under a Homebrew environment.

```
$ diff configure-old.out configure.out
158,164c158,162
< ./configure: line 18119: y: command not found
< checking for a Python interpreter with version >= 2.7... python
< checking for python... /usr/local/bin/python
< checking for python version... 2.7
< checking for python platform... darwin
< checking for python script directory... ${prefix}/lib/python2.7/site-packages
< checking for python extension module directory... ${exec_prefix}/lib/python2.7/site-packages
---
> checking whether /usr/local/bin/python version is >= 2.7... yes
> checking for /usr/local/bin/python version... 2.7
> checking for /usr/local/bin/python platform... darwin
> checking for /usr/local/bin/python script directory... ${prefix}/lib/python2.7/site-packages
> checking for /usr/local/bin/python extension module directory... ${exec_prefix}/lib/python2.7/site-packages
```

With this patch applied, FontForge builds and installs for me with `brew install fontforge`. (It did before too; just checking for regression.)