### PR TITLE
Fix a few expand stroke bugs

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -3682,6 +3682,10 @@ SplineSet *SplineSetStroke(SplineSet *ss,StrokeInfo *si, int order2) {
 	}
 	if ( si->resolution==0 && c.resolution>c.radius/3 )
 	    c.resolution = c.radius/3;
+    if (c.resolution == 0) {
+        ff_post_notice(_("Invalid stroke parameters"), _("Stroke resolution is zero"));
+        return SplinePointListCopy(ss);
+    }
 	ret = SplineSets_Stroke(ss,&c,order2);
     } else {
 	first = last = NULL;
@@ -3750,6 +3754,10 @@ return( NULL );				/* That's an error, must be closed */
 	    c.radius2 = maxd2;
 	    if ( si->resolution==0 && c.resolution>c.radius/3 )
 		c.resolution = c.radius/3;
+        if (c.resolution == 0) {
+            ff_post_notice(_("Invalid stroke parameters"), _("Stroke resolution is zero"));
+            return SplinePointListCopy(ss);
+        }
 	    cur = SplineSets_Stroke(ss,&c,order2);
 	    if ( !c.scaled_or_rotated ) {
 		trans[4] = -trans[4]; trans[5] = -trans[5];

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -3933,7 +3933,7 @@ static void CVCharUp(CharView *cv, GEvent *event ) {
 	    TRACE("was on charselector\n");
 	    GWidgetIndicateFocusGadget( cv->hsb );
 	}
-	else
+	else if ( cv->charselector != NULL )
 	{
 	    TRACE("was on NOT charselector\n");
 	    GWidgetIndicateFocusGadget( cv->charselector );

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -233,6 +233,10 @@ static int _Stroke_OK(StrokeDlg *sd,int isapply) {
 		GGadgetIsChecked( GWidgetGetControl(sw,CID_RoundJoin))?lj_round:
 		lj_miter;
 	si->radius = GetReal8(sw,CID_Width,_("Stroke _Width:"),&err)/2;
+    if (si->radius == 0) {
+        ff_post_error(_("Bad Value"), _("Stroke width cannot be zero"));
+        err = true;
+    }
 	if ( si->radius<0 ) si->radius = -si->radius;	/* Behavior is said to be very slow (but correct) for negative strokes */
 	si->penangle = GetReal8(sw,CID_PenAngle,_("Pen _Angle:"),&err);
 	if ( si->penangle>180 || si->penangle < -180 ) {


### PR DESCRIPTION
This addresses a couple of issues outlined in #2029 and #2384. 

* Fix crash when pressing 'esc' in the expand stroke dialogue
* Fix crash when trying to expand stroke with a stroke width of 0

@larsenwork I couldn't reproduce the crash that occurred sometimes when pressing the cancel button.

cc? @frank-trampe 