### PR TITLE
Fix progress bar display on Windows.

### DIFF
--- a/gdraw/gprogress.c
+++ b/gdraw/gprogress.c
@@ -260,6 +260,8 @@ return;
 	rq.point_size = 12;
 	rq.weight = 400;
 	progress_font = GDrawAttachFont(root,&rq);
+    } else {
+        GDrawSetFont(root, progress_font);
     }
     GDrawWindowFontMetrics(root,new->font = progress_font,&as,&ds,&ld);
 


### PR DESCRIPTION
The font instance was not being set on the root window. This fixes a bug in how the progress window was being displayed since Cairo support was enabled.

Before:
![prog-old](https://cloud.githubusercontent.com/assets/5137410/8266714/18fd0d14-1770-11e5-8d43-184df7116cac.png)

After:
![prog-fix](https://cloud.githubusercontent.com/assets/5137410/8266715/1e16cdbc-1770-11e5-8c89-bd6d3ef0c4c6.png)

