### PR TITLE
Allow the spacebar to enable preview mode.

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -79,6 +79,7 @@ int DrawOpenPathsWithHighlight = 1;
 #define default_cv_height 540
 int cv_width = default_cv_width;
 int cv_height = default_cv_height;
+int cv_show_fill_with_space = 1;
 
 #define prefs_cvEditHandleSize_default 5.0
 float prefs_cvEditHandleSize = prefs_cvEditHandleSize_default;
@@ -196,6 +197,16 @@ static void isAnyControlPointSelectedVisitor(SplinePoint* splfirst, Spline* s, S
 static int CV_OnCharSelectorTextChanged( GGadget *g, GEvent *e );
 static void CVHScrollSetPos( CharView *cv, int newpos );
 
+static void CVClear(GWindow,GMenuItem *mi, GEvent *);
+static void CVMouseMove(CharView *cv, GEvent *event );
+static void CVMouseUp(CharView *cv, GEvent *event );
+static void CVHScroll(CharView *cv,struct sbevent *sb);
+static void CVVScroll(CharView *cv,struct sbevent *sb);
+/*static void CVElide(GWindow gw,struct gmenuitem *mi,GEvent *e);*/
+static void CVMenuSimplify(GWindow gw,struct gmenuitem *mi,GEvent *e);
+static void CVMenuSimplifyMore(GWindow gw,struct gmenuitem *mi,GEvent *e);
+static void CVPreviewModeSet(GWindow gw, int checked);
+
 static int cvcolsinited = false;
 
 // Note that the GResource names for these preferences are defined separately in CVColInit.
@@ -280,6 +291,7 @@ static void update_spacebar_hand_tool(CharView *cv) {
 	    cv->b1_tool = cvt_hand;
 	    cv->active_tool = cvt_hand;
 	    CVMouseDownHand(cv);
+	    CVPreviewModeSet(cv->gw, cv_show_fill_with_space);
 	}
     } else {
 	if ( cv->spacebar_hold ) {
@@ -287,6 +299,7 @@ static void update_spacebar_hand_tool(CharView *cv) {
 	    cv->b1_tool = cv->b1_tool_old;
 	    cv->active_tool = cvt_none;
 	    cv->b1_tool_old = cvt_none;
+	    CVPreviewModeSet(cv->gw, false);
 	}
     }
 }
@@ -3816,17 +3829,6 @@ return( true );
 return( true );
 }
 
-static void CVClear(GWindow,GMenuItem *mi, GEvent *);
-static void CVMouseMove(CharView *cv, GEvent *event );
-static void CVMouseUp(CharView *cv, GEvent *event );
-static void CVHScroll(CharView *cv,struct sbevent *sb);
-static void CVVScroll(CharView *cv,struct sbevent *sb);
-/*static void CVElide(GWindow gw,struct gmenuitem *mi,GEvent *e);*/
-static void CVMenuSimplify(GWindow gw,struct gmenuitem *mi,GEvent *e);
-static void CVMenuSimplifyMore(GWindow gw,struct gmenuitem *mi,GEvent *e);
-static void CVPreviewModeSet(GWindow gw, int checked);
-
-
 static void CVFakeMove(CharView *cv, GEvent *event) {
     GEvent e;
 
@@ -7187,7 +7189,7 @@ static CharView* cvshowsCopyFrom( CharView* dst, struct cvshows* src )
 
 static void CVPreviewModeSet(GWindow gw, int checked ) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
-    if( checked && cv->inPreviewMode )
+    if( checked == cv->inPreviewMode )
         return;
 
     cv->inPreviewMode = checked;

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -158,6 +158,7 @@ extern int clear_tt_instructions_when_needed;	/* in cvundoes.c */
 extern int export_clipboard;			/* in cvundoes.c */
 extern int cv_width;			/* in charview.c */
 extern int cv_height;			/* in charview.c */
+extern int cv_show_fill_with_space; /* in charview.c */
 extern int interpCPsOnMotion;			/* in charview.c */
 extern int DrawOpenPathsWithHighlight;          /* in charview.c */
 extern float prefs_cvEditHandleSize;            /* in charview.c */
@@ -354,6 +355,7 @@ static struct prefs_list {
 	{ N_("EditHandleSize"), pr_real, &prefs_cvEditHandleSize, NULL, NULL, '\0', NULL, 0, N_("The size of the handles showing control points and other interesting points in the glyph editor (default is 5).") },
 	{ N_("InactiveHandleAlpha"), pr_int, &prefs_cvInactiveHandleAlpha, NULL, NULL, '\0', NULL, 0, N_("Inactive handles in the glyph editor will be drawn with this alpha value (range: 0-255 default is 255).") },
 	{ N_("ShowControlPointsAlways"), pr_bool, &prefs_cv_show_control_points_always_initially, NULL, NULL, '\0', NULL, 0, N_("Always show the control points when editing a glyph.\nThis can be turned off in the menu View/Show, this setting will effect if control points are shown initially.\nChange requires a restart of fontforge.") },
+	{ N_("ShowFillWithSpace"), pr_bool, &cv_show_fill_with_space, NULL, NULL, '\0', NULL, 0, N_("Also enable preview mode when the space bar is pressed.") },
 	{ N_("OutlineThickness"), pr_int, &prefs_cv_outline_thickness, NULL, NULL, '\0', NULL, 0, N_("Setting above 1 will cause a thick outline to be drawn for glyph paths\n which is only extended inwards from the edge of the glyph.\n See also the ForegroundThickOutlineColor Resource for the color of this outline.") },
 
     


### PR DESCRIPTION
Related issues: #2143.

A new preference, 'ShowFillWithSpace' allows this behaviour to be toggled by
the user. It is enabled by default.

I will need to update #2375 if this gets merged first or vice versa.