### PR TITLE
OSX shell fixes

### DIFF
--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -124,4 +124,9 @@ cd ~/ || true
 
 export PATH="$PATH:$bundle_bin"
 echo $WRAPPER $bundle_bin/fontforge > /tmp/oo
-$WRAPPER $bundle_bin/fontforge -new "$@" &
+
+if [ $# -eq 0 ] ; then
+    ( exec $WRAPPER $bundle_bin/fontforge -new )
+else
+    ( exec $WRAPPER $bundle_bin/fontforge "$@" )
+fi

--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -117,7 +117,13 @@ export LD_LIBRARY_PATH="$bundle_lib"
 $scriptdir/fcprogress.pl >|/tmp/zz 2>&1
 
 # This ensures that File Open and File Save (etc) dialogs open in Home
-cd ~/ || true
+# when FontForge is launched via normal OS X methods (double-clicking
+# on the application or a SFD file, spotlight, etc.). If this script is
+# invoked via command line, assume the user knows what they are doing,
+# and don't change the current directory.
+if [ "$( ps -o comm= $PPID)" = "/sbin/launchd" ] ; then
+    cd ~/ || true
+fi
 
 # starting more than one does nothing, and it will close itself.
 /Applications/FontForge.app/Contents/MacOS/fontforge-crash-reporter.py &

--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -123,5 +123,5 @@ cd ~/ || true
 /Applications/FontForge.app/Contents/MacOS/fontforge-crash-reporter.py &
 
 export PATH="$PATH:$bundle_bin"
-echo $WRAPPER $bundle_bin/fontforge -new "$@" > /tmp/oo
+echo $WRAPPER $bundle_bin/fontforge > /tmp/oo
 $WRAPPER $bundle_bin/fontforge -new "$@" &

--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -132,7 +132,7 @@ export PATH="$PATH:$bundle_bin"
 echo $WRAPPER $bundle_bin/fontforge > /tmp/oo
 
 if [ $# -eq 0 ] ; then
-    ( exec $WRAPPER $bundle_bin/fontforge -new )
+    ( exec $WRAPPER $bundle_bin/fontforge -new & )
 else
-    ( exec $WRAPPER $bundle_bin/fontforge "$@" )
+    ( exec $WRAPPER $bundle_bin/fontforge "$@" & )
 fi


### PR DESCRIPTION
This fixes a few annoying problems when trying to launch FontForge on Mac OS X from the command line a la:

     $ /Applications/FontForge.app/Contents/MacOS/FontForge ~/path/to/Font.sfd

Previously, this would open the font *and* a new, "Untitled" font window. This changes the behavior so that FontForge only creates a new font when no font to open was specified.

Previously, this also only worked if the path to the file to open was an absolute path. If you passed a relative path, FontForge would pop up a dialog saying "The requested file, Font.sfd, does not exist" and would not open the font. That was because of the `cd ~` in this script. Now the script only changes to the `~` directory if it's invoked via normal Mac OS X methods (double clicking on the application, an SFD file, or launching via Spotlight, for example). If the application is invoked via the command line, it assumes the user knows what they are doing and won't change the working directory, which also means you can pass relative paths on the command line and FontForge will open them no problem. So the following now works:

    $ cd ~/path/to/
    $ /Applications/FontForge.app/Contents/MacOS/FontForge Font.sfd

Tested on Mac OS X 10.9 Mavericks.

These changes mean that you can now put an alias in your `.bashrc` to invoke FontForge from the command line:

    alias FontForge='/Applications/FontForge.app/Contents/MacOS/FontForge'