### PR TITLE
Mac OS X build fixes

### DIFF
--- a/osx/Portfile
+++ b/osx/Portfile
@@ -121,7 +121,7 @@ post-extract {
     foreach file [ exec grep -R --include "*.c" "Python\.h" ${worksrcpath} | cut -d: -f1 | sort | uniq ] {
         system "sed -i -e 's|Python\.h|python2.7/Python\.h|g' ${file}"
     }
-    set xcodebase    [ exec xcode-select -print-path . ]
+    set xcodebase    [ exec xcode-select -print-path ]
     set xcodesdkpath [ exec ls -rv1 "${xcodebase}/Platforms/MacOSX.platform/Developer/SDKs/" | head -1 ]
     system "ln -s ${xcodesdkpath}/Developer ${worksrcpath}/. "
 }

--- a/osx/README
+++ b/osx/README
@@ -22,7 +22,7 @@ cd /usr/local/src/github-fontforge
 sudo portindex
 cd fontforge/osx
 ./force-rebuild.sh
-cd /opt/local/var/macports/build/_usr_local_src_github-fontforge_fontforge_osx/
+cd /opt/local/var/macports/build/_usr_local_src_github-fontforge_fontforge_osx/fontforge/work/fontforge-2.0.0_beta1
 bash ./osx/create-osx-app-bundle.sh
 
 As you can see in the post-extract of the Portfile a copy of gnulib is

--- a/osx/README
+++ b/osx/README
@@ -12,12 +12,14 @@ specific to the current distribution site.
 
 Before this starts, change to the directory
 /usr/local/src/github-fontforge
-and clone the fontforge sources into there.
+and clone the fontforge sources into there:
+git clone git@github.com:fontforge/fontforge.git fontforge
 Add the aforementioned path to /opt/local/etc/macports/sources.conf as
 file:///usr/local/src/github-fontforge
 above the default MacPorts sources.
 
-portindex
+cd /usr/local/src/github-fontforge
+sudo portindex
 cd fontforge/osx
 ./force-rebuild.sh
 cd /opt/local/var/macports/build/_usr_local_src_github-fontforge_fontforge_osx/


### PR DESCRIPTION
This fixes some issues with the Mac OS X build process and documentation, some which are mentioned in #2356. 

After these changes, I was able to get a built `.dmg` with a working `.app`.