### PR TITLE
Replace `rm -rf` with more portable code. Fixes #2424.

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -3043,8 +3043,7 @@ return;
 	    else
 		sprintf( markerfile,"%s/" FONT_PROPS, buffer );
 	    if ( !GFileExists(markerfile)) {
-		sprintf( markerfile, "rm -rf %s", buffer );
-		system( buffer );
+		GFileRemove(buffer, false);
 	    }
 	}
     }

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -635,12 +635,8 @@ struct archivers archivers[] = {
 
 void ArchiveCleanup(char *archivedir) {
     /* Free this directory and all files within it */
-    char *cmd;
-
-    cmd = malloc(strlen(archivedir) + 20);
-    sprintf( cmd, "rm -rf %s", archivedir );
-    system( cmd );
-    free( cmd ); free(archivedir);
+    GFileRemove(archivedir, true);
+    free(archivedir);
 }
 
 static char *ArchiveParseTOC(char *listfile, enum archive_list_style ars, int *doall) {

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -1935,16 +1935,15 @@ int WriteUFOLayer(const char * glyphdir, SplineFont * sf, int layer) {
 
 int WriteUFOFontFlex(const char *basedir, SplineFont *sf, enum fontformat ff,int flags,
 	const EncMap *map,int layer, int all_layers) {
-    char *foo = NULL, *glyphdir, *gfname;
+    char *glyphdir, *gfname;
     int err;
     FILE *plist;
     int i;
     SplineChar *sc;
 
     /* Clean it out, if it exists */
-    if (asprintf(&foo, "rm -rf %s", basedir) >= 0) {
-      if (system( foo ) == -1) fprintf(stderr, "Error clearing %s.\n", basedir);
-      free( foo ); foo = NULL;
+    if (!GFileRemove(basedir, true)) {
+        LogError(_("Error clearing %s."), basedir);
     }
 
     /* Create it */

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>		/* for mkdir */
 #include <unistd.h>
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <errno.h>			/* for mkdir_p */
 
 #ifdef _WIN32
@@ -417,6 +418,37 @@ int GFileModifyableDir(const char *file) {
 
 int GFileReadable(const char *file) {
 return( access(file,04)==0 );
+}
+
+/**
+ * Removes a file or folder.
+ *
+ * @param [in] path The path to be removed.
+ * @param [in] recursive Specify true to remove a folder and all of its
+ *                       sub-contents.
+ * @return true if the deletion was successful or the path does not exist. It
+ *         will fail if trying to remove a directory that is not empty and
+ *         where `recursive` is false.
+ */
+int GFileRemove(const char *path, int recursive) {
+    GDir *dir;
+    const gchar *entry;
+
+    if (g_remove(path) != 0) {
+        if (recursive && (dir = g_dir_open(path, 0, NULL))) {
+            while ((entry = g_dir_read_name(dir))) {
+                gchar *fpath = g_build_filename(path, entry, NULL);
+                if (g_remove(fpath) != 0 && GFileIsDir(fpath)) {
+                    GFileRemove(fpath, recursive);
+                }
+                g_free(fpath);
+            }
+            g_dir_close(dir);
+        }
+        return (g_remove(path) == 0 || !GFileExists(path));
+    }
+
+    return true;
 }
 
 int GFileMkDir(const char *name) {

--- a/inc/gfile.h
+++ b/inc/gfile.h
@@ -70,6 +70,7 @@ extern int GFileExists(const char *file);
 extern int GFileModifyable(const char *file);
 extern int GFileModifyableDir(const char *file);
 extern int GFileReadable(const char *file);
+extern int GFileRemove(const char *path, int recursive);
 extern int GFileMkDir(const char *name);
 extern int GFileRmDir(const char *name);
 extern int GFileUnlink(const char *name);


### PR DESCRIPTION
Using `rm -rf` is not portable, especially given that it doesn't exist on Windows, unless you are running through CygWin.