### PR TITLE
configure.ac: intelligently check for <execinfo.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -377,6 +377,7 @@ AC_CHECK_HEADERS([strings.h sys/ioctl.h sys/socket.h sys/time.h unistd.h])
 if test x"${i_do_want_iconv}" = xyes; then
    AC_CHECK_HEADERS([iconv.h])
 fi
+AC_CHECK_HEADERS([execinfo.h])
 gl_INIT
 
 #--------------------------------------------------------------------------

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -24,6 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 #include "fontforgevw.h"
 #include "views.h"
 #include <math.h>
@@ -33,8 +34,8 @@
 #include "inc/gfile.h"
 #include "psfont.h"
 
-#if defined(__MINGW32__)||defined(__CYGWIN__)
-// no backtrace on windows yet
+#ifndef HAVE_EXECINFO_H
+// no backtrace available
 #else
     #include <execinfo.h>
 #endif


### PR DESCRIPTION
Currently, it is assume that only MINGW32 and CYGWIN on windows do
not provide backtrace.  However, other libc's in the Linux world
do not provide it either.  uClibc only provides it if configured
to do so, and musl doesn't provide it at all.  As a result, the
build fails on those systems.

This patch checks for <execinfo.h> in configure.ac and skip its
inclusion in fontforge/cvundoes.c if it is not available.

Signed-off-by: Anthony G. Basile <blueness@gentoo.org>