### PR TITLE
Windows: Add `tmpfile` to bootstrap.conf.

### DIFF
--- a/bootstrap.conf
+++ b/bootstrap.conf
@@ -51,6 +51,7 @@ gnulib_modules='
 	strcase
 	strtok_r
 	strndup
+	tmpfile
 	xalloc
 	xvasprintf
 '


### PR DESCRIPTION
`tmpfile` generates temporary files in the root (e.g. C:\) directory, which
normally will fail for non-administrators. The gnulib implementation fixes
this by not trying to generate temporary files in the root directory but
it a more sensible location.

I'm still unclear as to how this managed to work in the past.

Fixes #2465.  cc @frank-trampe 