### PR TITLE
libspiro version check in scripting and python

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -345,6 +345,18 @@
 	This can execute with no current font.</TD>
     </TR>
     <TR>
+      <TD><CODE>SpiroVersion</CODE></TD>
+      <TD><CODE>()</CODE></TD>
+      <TD>Returns the version of LibSpiro available to FontForge.<BR>
+	Versions 0.1 to 0.5 do not have a method to indicate version numbers,
+	but there is a limited method to estimate versions {'0.0'..'0.5'}.
+	<P>
+	'0.0' if FontForge has no LibSpiro available.<BR>
+	'0.1' if LibSpiro 20071029 is available.<BR>
+	'0.2' if LibSpiro 0.2 to 0.5 is available.<BR>
+	LibSpiro 0.6 and higher reports back it's version available.</TD>
+    </TR>
+    <TR>
       <TD><CODE>version</CODE></TD>
       <TD><CODE>()</CODE></TD>
       <TD>Returns fontforge's version number. This will be a large number like
@@ -1707,7 +1719,7 @@ pen = None;				# Finalize the pen. This tells FontForge
         if not used. The third is an empty field reserved for future use
         and currently must be set to zero.
         <P>
-        <CODE>glyph.altuni<?CODE> can be set to None to clear all alternates,
+        <CODE>glyph.altuni</CODE> can be set to None to clear all alternates,
         or to a tuple. The elements of the tuple may be either integers
     	(an alternate unicode value with no variation selector)
 	or a tuple with up to 3 values in it as explained above.</TD>

--- a/doc/html/scripting-alpha.html
+++ b/doc/html/scripting-alpha.html
@@ -1611,6 +1611,10 @@ SetLBearing(lbearing)
 	  <DD>
 	    Returns whether key exists in the private dictionary.
 	  <DT>
+	    <A NAME="HasSpiro">H</A>asSpiro()
+	  <DD>
+	    Returns true if Raph Levien's spiro package is available in FontForge.
+	  <DT>
 	    <A NAME="HFlip">H</A>Flip([about-x])
 	  <DD>
 	    All selected glyphs will be horizontally flipped about the vertical line
@@ -3086,6 +3090,18 @@ SetGasp([8,2,16,1,65535,3])
 		Horizontal stems will be scaled by this factor.
 		If unspecified or zero, defaults to the value of stemw-scale.
 	      </DD>
+	    </DL>
+	  <DT>
+	    <A NAME="SpiroVersion">S</A>piroVersion()
+	  <DD>
+	    Returns the version of LibSpiro available to FontForge.<BR>
+	    Versions 0.1 to 0.5 do not have a method to indicate version numbers,
+	    but there is a limited method to estimate versions {'0.0'..'0.5'}.
+	    <DL>
+	    <DD>'0.0' if FontForge has no LibSpiro available.</DD>
+	    <DD>'0.1' if LibSpiro 20071029 is available.</DD>
+	    <DD>'0.2' if LibSpiro 0.2 to 0.5 is available.</DD>
+	    <DD>LibSpiro 0.6 and higher reports back it's version available.</DD>
 	    </DL>
 	  <DT>
 	    <A NAME="Sqrt">S</A>qrt(val)

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1140,6 +1140,15 @@ static PyObject *PyFF_hasSpiro(PyObject *UNUSED(self), PyObject *UNUSED(args)) {
 return( ret );
 }
 
+static PyObject *PyFF_SpiroVersion(PyObject *UNUSED(self), PyObject *UNUSED(args)) {
+    char *temp;
+
+    temp=libspiro_version();	/* Return libspiro Version number */
+
+    PyObject *ret=Py_BuildValue("s",temp); free(temp);
+    return( ret );
+}
+
 GList_Glib* closingFunctionList = 0;
 
 static PyObject *PyFF_onAppClosing(PyObject *self, PyObject *args) {
@@ -1158,7 +1167,7 @@ static PyObject *PyFF_onAppClosing(PyObject *self, PyObject *args) {
     PyObject *func = PyTuple_GetItem(args,0);
     Py_INCREF(func);
     closingFunctionList = g_list_prepend( closingFunctionList, func );
-    
+
     PyObject *ret = Py_True;
     Py_INCREF(ret);
     return( ret );
@@ -1174,7 +1183,7 @@ static void python_call_onClosingFunctions_fe( gpointer data, gpointer udata )
 	arglist = PyTuple_New(0);
 	result = PyEval_CallObject( func, arglist);
 	if ( !result )
-	{ // error 
+	{ // error
 	}
     }
 }
@@ -2863,8 +2872,8 @@ return( NULL );
 		pnum = 0;
 	    if ( self->points[pnum]->on_curve ) {
 		end.x = self->points[pnum]->x; end.y = self->points[pnum]->y;
-                return( Py_BuildValue("((dddd)(dddd))", 
-                                        0.0, 0.0,end.x-start.x,start.x, 
+                return( Py_BuildValue("((dddd)(dddd))",
+                                        0.0, 0.0,end.x-start.x,start.x,
                                         0.0, 0.0,end.y-start.y,start.y ));
 	    } else {
 		ncp.x = self->points[pnum]->x; ncp.y = self->points[pnum]->y;
@@ -4559,7 +4568,7 @@ static PyFF_Contour *ContourFromSS(SplineSet *ss,PyFF_Contour *ret) {
 		if ( !sp->nonextcp && sp!=skip ) {
 		    if ( k )
 			ret->points[cnt] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,
-							  sp->selected && SPInterpolate(sp), 
+							  sp->selected && SPInterpolate(sp),
 							  sp->name);
 		    ++cnt;
 		}
@@ -10179,12 +10188,12 @@ static int PyFF_PrivateIndexAssign( PyObject *self, PyObject *index, PyObject *v
 	PSDictChangeEntry(private,name,string);
 	ENDPYGETSTR();
     } else {
-        if ( freeme!=NULL) 
+        if ( freeme!=NULL)
             free(freeme);
 	PyErr_Format(PyExc_TypeError, "Private dictionary index must be a string" );
         return( -1 );
     }
-    if ( freeme!=NULL) 
+    if ( freeme!=NULL)
         free(freeme);
     return( 0 );
 }
@@ -12283,7 +12292,7 @@ return( -1 );
 	int lang;
 
         if ( (!PyTuple_Check(subtuple) && !PyList_Check(subtuple)) ||
-	         (PySequence_Size(subtuple) != 2) ) { 
+	         (PySequence_Size(subtuple) != 2) ) {
 	    PyErr_Format(PyExc_TypeError, "Value must be a tuple of a language name and string" );
 	    OtfNameListFree(head);
 return( -1 );
@@ -15975,7 +15984,7 @@ static PyObject *PyFFFont_printSample(PyFF_Font *self, PyObject *args) {
         if ( PySequence_Size(pointsizeTuple) < 1 ) {
             PyErr_Format(PyExc_TypeError, "Second arg must be an integer, or a tuple or list of integers" );
             return( NULL );
-        } 
+        }
     }
 
     type = FlagsFromString(typeArg,printflags,"print sample type");
@@ -17631,7 +17640,8 @@ PyMethodDef module_fontforge_methods[] = {
     { "savePrefs", PyFF_SavePrefs, METH_NOARGS, "Save FontForge preference items" },
     { "loadPrefs", PyFF_LoadPrefs, METH_NOARGS, "Load FontForge preference items" },
     { "hasSpiro", PyFF_hasSpiro, METH_NOARGS, "Returns whether this fontforge has access to Raph Levien's spiro package"},
-    { "onAppClosing", PyFF_onAppClosing, METH_VARARGS, "add a python function which is called when fontforge is closing down"},    
+    { "SpiroVersion", PyFF_SpiroVersion, METH_NOARGS, "Return Spiro Library Version" },
+    { "onAppClosing", PyFF_onAppClosing, METH_VARARGS, "add a python function which is called when fontforge is closing down"},
     { "defaultOtherSubrs", PyFF_DefaultOtherSubrs, METH_NOARGS, "Use FontForge's default \"othersubrs\" functions for Type1 fonts" },
     { "readOtherSubrsFile", PyFF_ReadOtherSubrsFile, METH_VARARGS, "Read from a file, \"othersubrs\" functions for Type1 fonts" },
     { "loadEncodingFile", PyFF_LoadEncodingFile, METH_VARARGS, "Load an encoding file into the list of encodings" },

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -212,9 +212,9 @@ static void DicaNewEntry(struct dictionary *dica,char *name,Val *val) {
 static void calldatafree(Context *c) {
     int i;
 
-    /* child may have freed some args itself by shifting, 
+    /* child may have freed some args itself by shifting,
        but argc will reflect the proper values none the less */
-    for ( i=1; i<c->a.argc; ++i ) {     
+    for ( i=1; i<c->a.argc; ++i ) {
         if ( c->a.vals[i].type == v_str ) {
             free( c->a.vals[i].u.sval );
             c->a.vals[i].u.sval = NULL;
@@ -1072,6 +1072,27 @@ static void bGetEnv(Context *c) {
 	ScriptErrorString( c, "Unknown Preference variable", c->a.vals[1].u.sval );
     c->return_val.type = v_str;
     c->return_val.u.sval = strdup(env);
+}
+
+static void bHasSpiro(Context *c) {
+    if ( c->a.argc!=1 )
+	ScriptError( c, "Wrong number of arguments" );
+
+    c->return_val.type=v_int;
+    c->return_val.u.ival=hasspiro();
+}
+
+static void bSpiroVersion(Context *c) {
+/* Return libspiro Version number */
+    char *temp;
+
+    if ( c->a.argc!=1 )
+	ScriptError( c, "Wrong number of arguments" );
+
+    temp=libspiro_version();	/* Return libspiro Version number */
+
+    c->return_val.type = v_str;
+    c->return_val.u.sval = temp;
 }
 
 static void bUnicodeFromName(Context *c) {
@@ -8437,6 +8458,8 @@ static struct builtins { const char *name; void (*func)(Context *); int nofontok
     { "DefaultOtherSubrs", bDefaultOtherSubrs, 1 },
     { "ReadOtherSubrsFile", bReadOtherSubrsFile, 1 },
     { "GetEnv", bGetEnv, 1 },
+    { "HasSpiro", bHasSpiro, 1 },
+    { "SpiroVersion", bSpiroVersion, 1 },
     { "UnicodeFromName", bUnicodeFromName, 1 },
     { "NameFromUnicode", bNameFromUnicode, 1 },
     { "UnicodeBlockCountFromLib", bUnicodeBlockCountFromLib, 1 },

--- a/fontforge/spiro.c
+++ b/fontforge/spiro.c
@@ -228,6 +228,29 @@ int hasspiro(void) {
     return has_spiro;
 }
 
+char *libspiro_version(void){
+/* Return Spiro library version. If there is no library, return "0.0" for */
+/* the internal built-in spiro generator, "0.1" for library ver 20071029, */
+/* "0.2" for libspiro {0.2...0.5} which did not have LibSpiroGetVersion() */
+/* and "0.6" or higher for Libspiro 0.6.2015xxxx or more recent versions. */
+    char *version_str;
+
+#if defined(_NO_LIBSPIRO)
+    version_str=copy("0.0");
+#else
+#ifndef _LIBSPIRO_FUN
+    version_str=copy("0.1");
+#else
+#if (_LIBSPIRO_FUN < 2)
+    version_str=copy("0.2");
+#else
+    version_str=copy(LibSpiroVersion());
+#endif
+#endif
+#endif
+    return( version_str ); /* free this string when you are done. */
+}
+
 spiro_cp *SpiroCPCopy(spiro_cp *spiros,uint16 *_cnt) {
 /* Make a copy of a (closed='z' or open='{}') spiro */
     int ch, n = 0;

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -3392,6 +3392,7 @@ extern int SFValidate(SplineFont *sf, int layer, int force);
 extern int VSMaskFromFormat(SplineFont *sf, int layer, enum fontformat format);
 
 extern int hasspiro(void);
+extern char *libspiro_version(void);
 extern SplineSet *SpiroCP2SplineSet(spiro_cp *spiros);
 extern spiro_cp *SplineSet2SpiroCP(SplineSet *ss,uint16 *_cnt);
 extern spiro_cp *SpiroCPCopy(spiro_cp *spiros,uint16 *_cnt);

--- a/m4/fontforge_arg_with.m4
+++ b/m4/fontforge_arg_with.m4
@@ -55,7 +55,7 @@ dnl that call ./bootstrap or ./autogen.sh enable a quiet mode where users
 dnl won't see why ./configure fails. This forced-halt also aids users by
 dnl giving an immediate answer as to why ./configure fails (see lots of
 dnl issues before this where users run into problems, but reason for fail
-dnl isn't immediately clear) - anser is usually in adding a developer pkg
+dnl isn't immediately clear) - answer is usually in adding a developer pkg
 dnl since some distros normally distribute compiled binaries to save space.
 dnl This also avoids using pkg-config since some versions don't check the
 dnl additional directories such as /usr/local by default without users
@@ -299,7 +299,8 @@ dnl ---------------------------
 dnl Add with libspiro support by default (only if libspiro library exists AND
 dnl spiroentrypoints.h header file exist). If both found, then check further
 dnl to see if this version of libspiro also has TaggedSpiroCPsToBezier0().
-dnl If TaggedSpiroCPsToBezier0() also exists, then also set _LIBSPIRO_FUN=1
+dnl If LibSpiroGetVersion() also exists, then also set _LIBSPIRO_FUN=2, else
+dnl if TaggedSpiroCPsToBezier0() also exists, then also set _LIBSPIRO_FUN=1
 dnl If user defines --without-libspiro, then do not include libspiro.
 dnl If user defines --with-libspiro, then fail with error if there is no
 dnl libspiro library OR no spiroentrypoints.h header file.
@@ -312,9 +313,11 @@ fi
 if test x"${i_do_have_libspiro}" = xyes -a x"${LIBSPIRO_LIBS}" = x; then
    FONTFORGE_SEARCH_LIBS([TaggedSpiroCPsToBezier],[spiro],
          [LIBSPIRO_LIBS="${LIBSPIRO_LIBS} ${found_lib}"
+          AC_CHECK_FUNC([LibSpiroVersion],
+                [AC_DEFINE([_LIBSPIRO_FUN],[2],[LibSpiro >= 0.6, includes LibSpiroVersion()])],
           AC_CHECK_FUNC([TaggedSpiroCPsToBezier0],
-                [AC_DEFINE([_LIBSPIRO_FUN],[1],[LibSpiro >= 0.2, includes TaggedSpiroCPsToBezier0()])])],
-         [i_do_have_libspiro=no])
+                [AC_DEFINE([_LIBSPIRO_FUN],[1],[LibSpiro >= 0.2, includes TaggedSpiroCPsToBezier0()])]))
+         ],[i_do_have_libspiro=no])
 fi
 
 FONTFORGE_BUILD_YES_NO_HALT([libspiro],[LIBSPIRO],[Build with LibSpiro Curve Contour support?])


### PR DESCRIPTION
Allow native scripts and python to query which version of libspiro is available.
Various distros, BSDs, Windows, MAC are at different stages ranging from none, to 20071029 to current version, as well as HEAD.

This feature is mainly useful for font developers that share scripts with other font developers.
This will allow user created scripts to continue, or stop based on if libspiro has the features needed or not for the script running.

Here is a sample native script:
#!/usr/local/bin/fontforge
temp = SpiroVersion()
Print( "SpiroVersion" )
Print( temp )
Print( "done" )

Developer note (before libspiro 0.6):
Developers experimenting with the latest HEAD may likely see 0.5 (when libspiro is further upgraded to include the LibSpiroVersion function AND before TAG version 0.6 is announced) because this feature looks for the function and doesn't rely on package numbers (for compatibility with older distros).