### PR TITLE
uncommenting this line fixes #2506, #2481, #2479, & maybe #2470

### DIFF
--- a/osx/FontForge.app/Contents/MacOS/FontForge
+++ b/osx/FontForge.app/Contents/MacOS/FontForge
@@ -46,7 +46,7 @@ bundle_data="$bundle_res"/opt/local/share
 bundle_etc="$bundle_res"/opt/local/etc
 bundle_share="$bundle_res"/opt/local/share
 
-#export DYLD_LIBRARY_PATH="$bundle_lib"
+export DYLD_LIBRARY_PATH="$bundle_lib"
 export XDG_CONFIG_DIRS="$bundle_etc"/xdg
 export XDG_DATA_DIRS="$bundle_data"
 export GTK_DATA_PREFIX="$bundle_res"


### PR DESCRIPTION
I do not understand why this line was not needed prior to the August 2015 build. 

However, it is uncommented in the June 2015 build, but not in the May 2015 build.

See [this comment](https://github.com/fontforge/fontforge/issues/2506#issuecomment-144622453) for full details.

Should fix #2506, #2481, #2479 and maybe #2470 also.