### PR TITLE
Fix crash when generating FON without 'X'.

### DIFF
--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -489,7 +489,7 @@ return( false );
     widbytes = avgwid+spacesize;
     if ( cnt!=0 ) avgwid = rint(avgwid/(bigreal) cnt);
     gid = map->map['X'];
-    if ( font->glyphs[gid]!=NULL && font->glyphs[gid]->sc!=NULL &&
+    if ( gid!=-1 && font->glyphs[gid]!=NULL && font->glyphs[gid]->sc!=NULL &&
 	    font->glyphs[gid]->sc->unicodeenc == 'X' )
 	avgwid = font->glyphs[gid]->width;
 


### PR DESCRIPTION
The conditional is fixed by doing the same thing currently done a few lines up with ' '. This allows generation of bitmap FON files without an 'X'. Currently generating a FON file without an 'X' glyph mysteriously crashes.