### PR TITLE
Fix missing pointers for point info controls.

### DIFF
--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -3310,6 +3310,7 @@ static void PointGetInfo(CharView *cv, SplinePoint *sp, SplinePointList *spl) {
 
 	GGadgetsCreate(gi->gw,mb);
 	gi->group1ret = pb[4].ret; gi->group2ret = pb[5].ret;
+	memcpy( gi->gcd, gcd, gcdcount*sizeof(GGadgetCreateData) ); // This copies pointers, but only to static things.
 	GTextInfoListFree(hgcd[0].gd.u.list);
 	GTextInfoListFree(h2gcd[0].gd.u.list);
 


### PR DESCRIPTION
There were issues when dealing with interpolated points.

This is based on #2304 by @michal-n but copies the entire GGadgetCreateData structure.

Closes #2304.