### PR TITLE
build dependencies for debian jessie

### DIFF
--- a/INSTALL-git.md
+++ b/INSTALL-git.md
@@ -14,6 +14,12 @@ Install all your typical build tools, build dependencies and runtime dependencie
 The exact method to do this depends on your OS distribution.
 You can see a list of the dependencies for Debian in the [debian/control](https://github.com/fontforge/fontforge/blob/master/debian/control) file, or to generate a list on Debian-like systems with `aptitude` installed, run `sudo ./debian/deb-build-dep`
 
+To download all dependencies on Debian Jessie, run:
+
+```sh
+sudo apt-get install autotools-dev libjpeg-dev libtiff5-dev libpng-dev libgif-dev libxt-dev libfreetype6-dev autoconf automake libtool libxml2-dev libuninameslist-dev libspiro-dev python-dev libpango1.0-dev libcairo2-dev chrpath
+```
+
 To download all dependencies on Ubuntu, run:
 
 ```sh


### PR DESCRIPTION
Hi.
With a fresh install of Debian Jessie i discovered missing dependencies to build FF by using latest Ubuntu PPA sources with https://wiki.debian.org/CreatePackageFromPPA as tutorial.

I just wonder why `build-essential` is missing in this list. Probably it depends on one of the other packages i listed.