### PR TITLE
Fix building error with Python 3.5.

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18190,7 +18190,11 @@ static PyObject* CreatePyModule( module_definition *mdef ) {
     mdef->runtime.pymod_def.m_doc = mdef->docstring;
     mdef->runtime.pymod_def.m_methods = mdef->methods;
     mdef->runtime.pymod_def.m_size = -1;
+#if PY_MAJOR_VERSION > 3 || PY_MINOR_VERSION >= 5
+    mdef->runtime.pymod_def.m_slots = NULL;
+#else
     mdef->runtime.pymod_def.m_reload = NULL;
+#endif
     mdef->runtime.pymod_def.m_traverse = NULL;
     mdef->runtime.pymod_def.m_clear = NULL;
     mdef->runtime.pymod_def.m_free = NULL;


### PR DESCRIPTION
PyModuleDef has lost m_reload and gained m_slots in Python 3.5. Set the correct member to NULL according to the detected version. The Python changes are described in PEP489.