### PR TITLE
fix StrSplit, and test for it

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -613,7 +613,7 @@ static void bStrSplit(Context *c) {
 	    c->return_val.u.aval->argc = cnt;
 	    c->return_val.u.aval->vals = malloc(cnt*sizeof(Val));
 	} else {
-	    if ( *pt!='\0' && cnt < max ) {
+	    if ((*pt!='\0') && ((max==-1) || (cnt<max))) {
 		c->return_val.u.aval->vals[cnt].type = v_str;
 		c->return_val.u.aval->vals[cnt].u.sval = copy(pt);
 	    }

--- a/tests/test128.pe
+++ b/tests/test128.pe
@@ -1,3 +1,16 @@
-#Tests buffer overflow condition in StrSplit
+#Tests buffer overflow condition and correct operation of StrSplit
 
 ToString(StrSplit("a;bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",";",1));
+
+x=StrSplit("aaa;bbb;ccc",";")
+if (x[0]!="aaa")
+  Quit(1)
+endif
+if (x[1]!="bbb")
+  Quit(1)
+endif
+if (x[2]!="ccc")
+  Quit(1)
+endif
+
+Quit(0)


### PR DESCRIPTION
A recent fix for a buffer overflow in StrSplit was an incomplete solution:  it fixed the case that was breaking (running past the optional element count limitation), but broke a case that was formerly working (unlimited element count).  This change should fix it in both cases, and updates the test to check them both.