### PR TITLE
Refactoring conditional directives that break parts of statements.

### DIFF
--- a/gutils/gimagereadpng.c
+++ b/gutils/gimagereadpng.c
@@ -73,6 +73,7 @@ GImage *GImageRead_Png(FILE *fp) {
     int num_trans;
     png_color_16p trans_color;
     unsigned i;
+    int test;
 
     if ( libpng==NULL )
 	if ( !loadpng())
@@ -91,11 +92,12 @@ return( NULL );
     }
 
 #if (PNG_LIBPNG_VER < 10500)
-    if (setjmp(png_ptr->jmpbuf))
+    test = setjmp(png_ptr->jmpbuf);
 #else
-    if (setjmp(*png_set_longjmp_fn(png_ptr, longjmp, sizeof (jmp_buf))))
+    test = setjmp(*png_set_longjmp_fn(png_ptr, longjmp, sizeof (jmp_buf)));
 #endif
     {
+    if (test)
       /* Free all of the memory associated with the png_ptr and info_ptr */
       png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
       if ( ret!=NULL ) {

--- a/gutils/gimagereadpng.c
+++ b/gutils/gimagereadpng.c
@@ -96,8 +96,7 @@ return( NULL );
 #else
     test = setjmp(*png_set_longjmp_fn(png_ptr, longjmp, sizeof (jmp_buf)));
 #endif
-    {
-    if (test)
+    if (test) {
       /* Free all of the memory associated with the png_ptr and info_ptr */
       png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
       if ( ret!=NULL ) {


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.