### PR TITLE
fix bluescale calculation to refer to integer point size

### DIFF
--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -1429,7 +1429,7 @@ return( -1 );
     if ( 1/max_diff > .039625 )
 return( -1 );
 
-return( .99/max_diff );
+    return rint(240.0*0.99/max_diff)/240.0;
 }
 
 double BlueScaleFigure(struct psdict *private_,real bluevalues[], real otherblues[]) {


### PR DESCRIPTION
The BlueScale value in the PS Private Dictionary has a poorly-explained definition, but one of the constraints on it boils down to that it must be smaller than the reciprocal of the size of the largest blue zone.  The code in dumppfa.c that sets this value does so by computing 0.99/LargestBlueZone, which usually will in fact be less than 1/LargestBlueZone.  However, the code in splinechar.c that tests this value when verifying a font actually does a more complicated calculation which includes a round-to-integer step, apparently a result of reading the wacky unclear text in the Adobe documentation as containing an assumption that point sizes must always be integers.  (That probably _is_ what Adobe intended.)  As a result, when the largest blue zone is sufficiently large, in some cases the BlueScale computed in dumppfa.c is a little too large and the resulting BlueScale _chosen by FontForge_ fails FontForge's own fontlint.

This change adds a rounding step to dumppfa.c which should match the criterion that is checked in splinechar.c more precisely.