### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -4251,7 +4251,7 @@ return( 0 );
     t1min = ISolveWithin(s1,major,(&min.x)[major],lowt1,hight1);
     t2max = ISolveWithin(s2,major,(&max.x)[major],lowt2,hight2);
     t2min = ISolveWithin(s2,major,(&min.x)[major],lowt2,hight2);
-    if ( t1max==-1 || t1min==-1 || t2max==-1 || t1min==-1 )
+    if ( t1max==-1 || t1min==-1 || t2max==-1 || t2min==-1 )
 return( 0 );
     t1diff = (t1max-t1min)/64.0;
     if (RealNear(t1diff,0))

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -947,9 +947,9 @@ return( event->u.chr.state & ~ksm_capslock );
 	bit = ksm_shift;
     else if ( keysym == GK_Control_L || keysym == GK_Control_R )
 	bit = ksm_control;
-    else if ( keysym == GK_Super_L || keysym == GK_Super_L )
+    else if ( keysym == GK_Super_L || keysym == GK_Super_R )
 	bit = ksm_super;
-    else if ( keysym == GK_Hyper_L || keysym == GK_Hyper_L )
+    else if ( keysym == GK_Hyper_L || keysym == GK_Hyper_R )
 	bit = ksm_hyper;
     else
 return( event->u.chr.state );

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -1876,7 +1876,7 @@ static void FVSelectByScript(FontView *fv,int merge) {
     memset(&label,0,sizeof(label));
     memset(&boxes,0,sizeof(boxes));
 
-    wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_undercursor|wam_isdlg|wam_restrict|wam_isdlg;
+    wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_undercursor|wam_isdlg|wam_restrict;
     wattrs.event_masks = ~(1<<et_charup);
     wattrs.restrict_input_to_me = false;
     wattrs.is_dlg = 1;


### PR DESCRIPTION
[fontforge/splineutil.c:4254] -> [fontforge/splineutil.c:4254]: (style) Same expression on both sides of '||'
[fontforgeexe/cvpalettes.c:950] -> [fontforgeexe/cvpalettes.c:950]: (style) Same expression on both sides of '||'.
[fontforgeexe/cvpalettes.c:952] -> [fontforgeexe/cvpalettes.c:952]: (style) Same expression on both sides of '||'.
[fontforgeexe/fontview.c:1879] -> [fontforgeexe/fontview.c:1879]: (style) Same expression on both sides of '|'