### PR TITLE
cppcheck: fix some other reports

### DIFF
--- a/contrib/fonttools/showttf.c
+++ b/contrib/fonttools/showttf.c
@@ -2887,6 +2887,7 @@ static void gdefshowligcaretlist(FILE *ttf,int offset,struct ttfinfo *info) {
 		printf( "!!!! Unknown caret format %d !!!!\n", format );
 	    }
 	}
+	free(offsets);
     }
     free(lc_offsets);
     free(glyphs);

--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -3128,7 +3128,7 @@ static void FigureStems( SplineFont *sf, real snaps[12], real cnts[12],
 	}
 	/* Merge adjacent widths */
 	for ( i=smin; i<=smax; ++i ) {
-	    if ( stemwidths[i]!=0 && i<=smax-1 && stemwidths[i+1]!=0 ) {
+	    if ( i<=smax-1 && stemwidths[i]!=0 && stemwidths[i+1]!=0 ) {
 		if ( stemwidths[i]>stemwidths[i+1] ) {
 		    stemwidths[i] += stemwidths[i+1];
 		    stemwidths[i+1] = 0;

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -1490,7 +1490,10 @@ return( false );
 	SplineFontAutoHint(sf,layer);
     }
     if ( !ff_progress_next_stage())
-return( false );
+    {
+        PSCharsFree(subrs);
+        return( false );
+    }
 
     otherblues[0] = otherblues[1] = bluevalues[0] = bluevalues[1] = 0;
     if ( !hasblue ) {
@@ -1514,7 +1517,7 @@ return( false );
     if ( !hasv ) {
 	FindVStems(sf,stemsnapv,snapcnt);
 	mi = -1;
-	for ( i=0; stemsnapv[i]!=0 && i<12; ++i )
+	for ( i=0; i<12 && stemsnapv[i]!=0 ; ++i )
 	    if ( mi==-1 ) mi = i;
 	    else if ( snapcnt[i]>snapcnt[mi] ) mi = i;
 	if ( mi!=-1 ) stdvw[0] = stemsnapv[mi];
@@ -1524,7 +1527,10 @@ return( false );
 	ff_progress_next_stage();
 	ff_progress_change_line1(_("Converting PostScript"));
 	if ( (chars = SplineFont2ChrsSubrs(sf,iscjk,subrs,flags,format,layer))==NULL )
-return( false );
+        {
+            PSCharsFree(subrs);
+            return( false );
+        }
 	ff_progress_next_stage();
 	ff_progress_change_line1(_("Saving PostScript Font"));
     }

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -410,7 +410,7 @@ static bigreal IntersectLine(Spline *spline1,Spline *spline2) {
     if ( !SplinesIntersect(spline1,spline2,pts,t1s,t2s))
 return( -1 );
     for ( i=0; i<10 && t1s[i]!=-1; ++i ) {
-	if ( t1s[i]<.001 && t1s[i]>.999 )
+	if ( t1s[i]<.001 || t1s[i]>.999 )
 	    /* Too close to end point, ignore it */;
 	else if ( t1s[i]<mint )
 	    mint = t1s[i];

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3999,7 +3999,7 @@ return( 0 );
 	    SCConvertToOrder2(info->chars[i]);
     }
 
-    for ( i=0; fontnames[i]!=NULL && i<1; ++i ) {
+    for ( i=0; i<1 && fontnames[i]!=NULL ; ++i ) {
 	free(fontnames[i]);
 	TopDictFree(dicts[i]);
     }

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3999,10 +3999,11 @@ return( 0 );
 	    SCConvertToOrder2(info->chars[i]);
     }
 
-    for ( i=0; i<1 && fontnames[i]!=NULL ; ++i ) {
-	free(fontnames[i]);
-	TopDictFree(dicts[i]);
+    if (fontnames[0] != NULL) {
+	free(fontnames[0]);
+	TopDictFree(dicts[0]);
     }
+
     free(fontnames); free(dicts);
     if ( strings!=NULL ) {
 	for ( i=0; strings[i]!=NULL; ++i )

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -953,7 +953,7 @@ static void MVRemetric(MetricsView *mv) {
 
     anysc = goodsc = NULL; goodpos = -1;
     // We recurse through all of the characters in the metrics view.
-    for ( i=0; mv->chars[i] && i<mv->clen; ++i ) {
+    for ( i=0; i<mv->clen && mv->chars[i] ; ++i ) {
         // We assign the first splinechar to anysc.
 	if ( anysc==NULL ) anysc = mv->chars[i];
         // We assign the first splinechar of a non-default script to goodsc.


### PR DESCRIPTION
[contrib/fonttools/showttf.c:2867]: (error) Memory leak: offsets
[fontforge/autohint.c:3131]: (style) Array index 'i' is used before limits check
[fontforge/dumppfa.c:1493]: (error) Memory leak: subrs
[fontforge/dumppfa.c:1517]: (style) Array index 'i' is used before limits check
[fontforge/effects.c:413]: (warning) Logical conjunction always evaluates to false: EXPR < 0.001 && EXPR > 0.999
[fontforge/parsettf.c:4002]: (style) Array index 'i' is used before limits check
[fontforgeexe/metricsview.c:956]: (style) Array index 'i' is used before limits check