### PR TITLE
cppcheck: fix some reports (part2)

### DIFF
--- a/contrib/fonttools/portablecompositor.cpp
+++ b/contrib/fonttools/portablecompositor.cpp
@@ -98,7 +98,7 @@ fontfile.open (FileName);
     while ( getline (fontfile,line) )
     {
 
-	if (line.substr(0,10) == "Encoding: " && ( line.substr(0,20) != "Encoding: Custom")) {
+	if (line.substr(0,10) == "Encoding: " && ( line.substr(0,16) != "Encoding: Custom")) {
 		encoding = line;
 		&split(encoding, ' ', encodings);
 

--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -171,8 +171,7 @@ void FindBlues( SplineFont *sf, int layer, real blues[14], real otherblues[10]) 
 		    ascenth[1] += b.maxy*b.maxy;
 		    ++ascenth[2];
 		} else if ( enc=='c' || enc=='e' || enc=='o' || enc=='s' || enc=='u' || 
-		            enc=='u' || enc=='v' || enc=='w' || enc=='x' || enc=='y' || 
-			    enc=='z' || 
+		            enc=='v' || enc=='w' || enc=='x' || enc=='y' || enc=='z' || 
 			    enc==0x3b5 /* epsilon */ ||
 			    enc==0x3b9 /* iota */ ||
 			    enc==0x3ba /* kappa */ ||
@@ -291,8 +290,7 @@ void FindBlues( SplineFont *sf, int layer, real blues[14], real otherblues[10]) 
 		    enc == 0x431 ) {
 		AddBlue(b.maxy,ascenth,false);
 	    } else if ( enc=='c' || enc=='e' || enc=='o' || enc=='s' || enc=='u' || 
-			enc=='u' || enc=='v' || enc=='w' || enc=='x' || enc=='y' || 
-			enc=='z' || 
+			enc=='v' || enc=='w' || enc=='x' || enc=='y' || enc=='z' || 
 			enc==0x3b5 /* epsilon */ ||
 			enc==0x3b9 /* iota */ ||
 			enc==0x3ba /* kappa */ ||
@@ -1755,7 +1753,7 @@ return( false );
         roff =  ( test->right.x - dn->right.x ) * dn->unit.y - 
                 ( test->right.y - dn->right.y ) * dn->unit.x;
         if (loff <= -dist_error_diag || loff >= dist_error_diag ||
-            roff <= -dist_error_diag || loff >= dist_error_diag )
+            roff <= -dist_error_diag || roff >= dist_error_diag )
     continue;
         soff =  ( test->left.x - dn->left.x ) * dn->unit.x + 
                 ( test->left.y - dn->left.y ) * dn->unit.y;

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -1683,7 +1683,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 	  case pt_and:
 	    if ( sp>=2 ) {
 		if ( stack[sp-2].type == ps_num )
-		    stack[sp-2].u.val = ((int) stack[sp-1].u.val) & (int) stack[sp-1].u.val;
+		    stack[sp-2].u.val = ((int) stack[sp-2].u.val) & (int) stack[sp-1].u.val;
 		else if ( stack[sp-2].type == ps_bool )
 		    stack[sp-2].u.tf &= stack[sp-1].u.tf;
 		--sp;
@@ -1692,7 +1692,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 	  case pt_or:
 	    if ( sp>=2 ) {
 		if ( stack[sp-2].type == ps_num )
-		    stack[sp-2].u.val = ((int) stack[sp-1].u.val) | (int) stack[sp-1].u.val;
+		    stack[sp-2].u.val = ((int) stack[sp-2].u.val) | (int) stack[sp-1].u.val;
 		else if ( stack[sp-2].type == ps_bool )
 		    stack[sp-2].u.tf |= stack[sp-1].u.tf;
 		--sp;
@@ -1701,7 +1701,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 	  case pt_xor:
 	    if ( sp>=2 ) {
 		if ( stack[sp-2].type == ps_num )
-		    stack[sp-2].u.val = ((int) stack[sp-1].u.val) ^ (int) stack[sp-1].u.val;
+		    stack[sp-2].u.val = ((int) stack[sp-2].u.val) ^ (int) stack[sp-1].u.val;
 		else if ( stack[sp-2].type == ps_bool )
 		    stack[sp-2].u.tf ^= stack[sp-1].u.tf;
 		--sp;

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -4971,7 +4971,7 @@ static void bShadow(Context *c) {
     double a;
 
     if ( (c->a.vals[1].type!=v_int && c->a.vals[1].type!=v_real ) || c->a.vals[2].type!=v_int ||
-	    c->a.vals[2].type!=v_int )
+	    c->a.vals[3].type!=v_int )
 	ScriptError(c,"Bad argument type");
     if ( c->a.vals[1].type == v_int ) a = c->a.vals[1].u.ival;
     else a = c->a.vals[1].u.fval;
@@ -4984,7 +4984,7 @@ static void bWireframe(Context *c) {
     double a;
 
     if ( (c->a.vals[1].type!=v_int && c->a.vals[1].type!=v_real ) || c->a.vals[2].type!=v_int ||
-	    c->a.vals[2].type!=v_int )
+	    c->a.vals[3].type!=v_int )
 	ScriptError(c,"Bad argument type");
     if ( c->a.vals[1].type == v_int ) a = c->a.vals[1].u.ival;
     else a = c->a.vals[1].u.fval;

--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -2096,7 +2096,7 @@ uint16 *props_array(SplineFont *sf,struct glyphinfo *gi) {
 	    dir = 0;
 	    if ( sc->unicodeenc>=0x10300 && sc->unicodeenc<=0x103ff )
 		dir = 0;
-	    else if ( sc->unicodeenc>=0x10800 && sc->unicodeenc<=0x103ff )
+	    else if ( sc->unicodeenc>=0x10800 && sc->unicodeenc<=0x10fff )
 		dir = 1;
 	    else if ( sc->unicodeenc!=-1 && sc->unicodeenc<0x10fff ) {
 		if ( iseuronumeric(sc->unicodeenc) )

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -269,7 +269,7 @@ return( false );
     sf->familyname[i] = '\0';
     temp = malloc(i+50);
     strcpy(temp,sf->familyname);
-    if ( fntheader.weight<=300 && fntheader.weight>500 ) {
+    if ( fntheader.weight<=300 || fntheader.weight>500 ) {
 	strcat(temp," ");
 	strcat(temp,sf->weight);
     }

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -666,7 +666,7 @@ return;
 	trace->first->prevcp.y = trace->first->me.y -
 		sin(hangle)*llen;
 	trace->first->nextcp = oldn;
-    } else if ( trace->first->nonextcp ) {
+    } else if ( trace->first->noprevcp ) {
 	SplineCharDefaultPrevCP(trace->first);
 	dx = trace->first->me.x-trace->first->nextcp.x;
 	dy = trace->first->me.y-trace->first->nextcp.y;

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -1960,7 +1960,7 @@ static void BuildTop(struct att_dlg *att) {
     do {
 	sf = _sf->subfonts==NULL ? _sf : _sf->subfonts[k];
 	for ( i=0; i<sf->glyphcnt; ++i ) if ( (sc=sf->glyphs[i])!=NULL ) {
-	    if (( sc->unicodeenc>=0x10800 && sc->unicodeenc<=0x103ff ) ||
+	    if (( sc->unicodeenc>=0x10800 && sc->unicodeenc<=0x10fff ) ||
 		    ( sc->unicodeenc!=-1 && sc->unicodeenc<0x10fff &&
 			isrighttoleft(sc->unicodeenc)) ||
 			ScriptIsRightToLeft(SCScriptFromUnicode(sc)) ) {


### PR DESCRIPTION
[contrib/fonttools/portablecompositor.cpp:101]: (warning) String literal "Encoding: Custom" doesn't match length argument for substr()
[fontforge/autohint.c:174] -> [fontforge/autohint.c:174]: (style) Same expression on both sides of '||'.
[fontforge/autohint.c:294] -> [fontforge/autohint.c:294]: (style) Same expression on both sides of '||'.
[fontforge/autohint.c:1758] -> [fontforge/autohint.c:1757]: (style) Same expression on both sides of '||'.
[fontforge/psread.c:1686] -> [fontforge/psread.c:1686]: (style) Same expression on both sides of '&'.
[fontforge/psread.c:1695] -> [fontforge/psread.c:1695]: (style) Same expression on both sides of '|'.
[fontforge/psread.c:1704] -> [fontforge/psread.c:1704]: (style) Same expression on both sides of '^'.
[fontforge/scripting.c:4974] -> [fontforge/scripting.c:4974]: (style) Same expression on both sides of '||'.
[fontforge/scripting.c:4987] -> [fontforge/scripting.c:4987]: (style) Same expression on both sides of '||'.
[fontforge/winfonts.c:272]: (warning) Logical conjunction always evaluates to false: EXPR <= 300 && EXPR > 500.
[fontforgeexe/cvfreehand.c:669]: (style) Expression is always false because 'else if' condition matches previous condition at line 659.
[fontforge/tottfaat.c:2099]: (warning) Logical conjunction always evaluates to false: EXPR >= 67584 && EXPR <= 66559.
[fontforgeexe/showatt.c:1963]: (warning) Logical conjunction always evaluates to false: EXPR >= 67584 && EXPR <= 66559.