### PR TITLE
Spiros: Add dummy _SpiroCP2SplineSet when compiling without Spiros.

### DIFF
--- a/fontforge/spiro.c
+++ b/fontforge/spiro.c
@@ -35,6 +35,10 @@
 
 static int has_spiro = false;
 
+static SplineSet *_SpiroCP2SplineSet(spiro_cp *spiros) {
+	return NULL;
+}
+
 SplineSet *SpiroCP2SplineSet(spiro_cp *spiros) {
     return( NULL );
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -111,7 +111,7 @@ fonts/Ambrosia.pt3: fonts/Ambrosia.sfd
 # Inputs we can download
 $(srcdir)/fetched-fonts/MunhwaGothic-Bold:
 	$(MKDIR_P) $(srcdir)/fetched-fonts
-	if [ ! -e $@ ] ; then $(WGET) http://ftp.netbsd.org/pub/pkgsrc/distfiles/adobe-cidfonts/MunhwaGothic-Bold -O $@ ; fi ;
+	if [ ! -e $@ ] ; then $(WGET) https://github.com/fontforge/debugfonts/raw/master/MunhwaGothic-Bold -O $@ ; fi ;
 
 fonts/MunhwaGothic-Bold:
 	$(MKDIR_P) $(builddir)/fonts
@@ -119,7 +119,7 @@ fonts/MunhwaGothic-Bold:
 	if [ -e $(srcdir)/fetched-fonts/MunhwaGothic-Bold ]; then \
 	cp -pRP $(srcdir)/fetched-fonts/MunhwaGothic-Bold $@ ; \
 	else \
-	$(WGET) http://ftp.netbsd.org/pub/pkgsrc/distfiles/adobe-cidfonts/MunhwaGothic-Bold -O $@ ; \
+	$(WGET) https://github.com/fontforge/debugfonts/raw/master/MunhwaGothic-Bold -O $@ ; \
 	fi ; \
 	fi ;
 


### PR DESCRIPTION
Fixes #2617