### PR TITLE
cppcheck: fix some reports (part 3)

### DIFF
--- a/Unicode/makeutype.c
+++ b/Unicode/makeutype.c
@@ -602,7 +602,7 @@ static void dumparabicdata(FILE *header) {
     fprintf(header,"} ArabicForms[256];\t/* for chars 0x600-0x6ff, subtract 0x600 to use array */\n" );
 
     data = fopen( "ArabicForms.c","w");
-    if ( data==NULL || data==NULL ) {
+    if (data==NULL) {
 	fprintf( stderr, CantSaveFile, "ArabicForms.c" );
 	FreeNamesMemorySpace();
 	exit(2);

--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -1787,7 +1787,7 @@ BDFFont *SplineFontPieceMeal(SplineFont *sf,int layer,int ptsize,int dpi,
 	bdf->recontext_freetype = bdf->unhinted_freetype = false;
     }
     
-    if ( (ftc || bdf->recontext_freetype || bdf->recontext_freetype) && (flags&pf_antialias) )
+    if ( (ftc || bdf->recontext_freetype || bdf->unhinted_freetype) && (flags&pf_antialias) )
 	BDFClut(bdf,16);
     else if ( flags&pf_antialias )
 	BDFClut(bdf,4);

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -2058,7 +2058,7 @@ return( false );	/* But otherwise, don't create a new tiny spline */
     /* Ok, if we've gotten this far we know that two of the end points are  */
     /*  on both splines.                                                    */
     t1s[2] = t2s[2] = -1;
-    if ( !m1->s->knownlinear || !m1->s->knownlinear ) {
+    if ( !m1->s->knownlinear || !m2->s->knownlinear ) {
 	if ( t1s[1]<t1s[0] ) {
 	    extended temp = t1s[1]; t1s[1] = t1s[0]; t1s[0] = temp;
 	    temp = t2s[1]; t2s[1] = t2s[0]; t2s[0] = temp;

--- a/fontforge/ttfspecial.c
+++ b/fontforge/ttfspecial.c
@@ -756,8 +756,10 @@ static void PfEd_Layers(SplineFont *sf, struct PfEd_subtabs *pfed,
 	if ( otherlayers[l] )
 	    ++cnt;
     cnt += has_spiro;
-    if ( cnt==0 )
+    if ( cnt==0 ) {
+    free(otherlayers);
 return;
+    }
 
     pfed->subtabs[pfed->next].tag = layr_TAG;
     pfed->subtabs[pfed->next++].data = layr = tmpfile();

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -774,7 +774,10 @@ xmlNodePtr _GlifToXML(const SplineChar *sc,int layer) {
 static int GlifDump(const char *glyphdir, const char *gfname, const SplineChar *sc, int layer) {
     char *gn = buildname(glyphdir,gfname);
     xmlDocPtr doc = xmlNewDoc(BAD_CAST "1.0");
-    if (doc == NULL) return 0;
+    if (doc == NULL) {
+        free(gn);
+        return 0;
+    }
     xmlNodePtr root_node = _GlifToXML(sc, layer);
     if (root_node == NULL) {xmlFreeDoc(doc); doc = NULL; return 0;}
     xmlDocSetRootElement(doc, root_node);
@@ -1319,7 +1322,6 @@ static int UFOOutputFontInfo(const char *basedir, SplineFont *sf, int layer) {
     xmlFreeDoc(plistdoc); // Free the memory.
     xmlCleanupParser();
     return true;
-return true;
 }
 
 int kernclass_for_groups_plist(struct splinefont *sf, struct kernclass *kc, int flags) {

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -831,6 +831,7 @@ int FONFontDump(char *filename,SplineFont *sf, int32 *sizes,int resol,
 		    sizes[i]&0xffff, sizes[i]>>16);
 	    for ( j=0; j<i; ++j )
 		fclose(fntarray[j]);
+            free(file_lens);
 	    free(fntarray);
 return( false );
 	}

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -635,7 +635,10 @@ static void BVDrawRefName(BitmapView *bv,GWindow pixmap,BDFRefChar *ref,int fg) 
     y = bv->height - bv->yoff - (bb.maxy + 1)*bv->scale;
     y -= 5;
     if ( x<-400 || y<-40 || x>bv->width+400 || y>bv->height )
+    {
+        free(refinfo);
 return;
+    }
 
     GDrawLayoutInit(pixmap,refinfo,-1,bv->small);
     GDrawLayoutExtents(pixmap,&size);

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -3252,8 +3252,10 @@ return( NULL );
     if ( ymax<=ICON_WIDTH ) ymax = ICON_WIDTH;
     if ( ymin>0 ) ymin = 0;
     if ( xmax<xmin ) {
+        for ( i=0; i<extracnt; ++i )
+            BDFCharFree(extras[i]);
         free(extras);
-return( NULL );
+        return( NULL );
     }
 
     if ( xmin>0 ) xmin = 0;

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -3251,8 +3251,11 @@ return( NULL );
 
     if ( ymax<=ICON_WIDTH ) ymax = ICON_WIDTH;
     if ( ymin>0 ) ymin = 0;
-    if ( xmax<xmin )
+    if ( xmax<xmin ) {
+        free(extras);
 return( NULL );
+    }
+
     if ( xmin>0 ) xmin = 0;
 
     img = GImageCreate(it_index,xmax - xmin + 2,ymax-ymin+2);

--- a/fontforgeexe/cvdgloss.c
+++ b/fontforgeexe/cvdgloss.c
@@ -88,6 +88,7 @@ static void scrprintf(struct scr *scr, char *format, ... ) {
     GDrawDrawText8(scr->pixmap,3,scr->y,buffer,-1,MAIN_FOREGROUND);
     scr->y += scr->fh;
     ++scr->lines;
+    va_end(ap);
 }
 
 static void scrrounding(struct scr *scr, TT_ExecContext exc ) {

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -3880,7 +3880,6 @@ return( true );
       case et_mousedown:
 	BVShadesMouse(bv,event);
       break;
-      break;
       case et_char: case et_charup:
 	PostCharToWindow(bv->gw,event);
       break;

--- a/fontforgeexe/histograms.c
+++ b/fontforgeexe/histograms.c
@@ -337,9 +337,12 @@ static char *ArrayOrder(char *old,int args,int val1,int val2) {
 	old = end;
 	while ( *old==' ' ) ++old;
     }
-    array[i++] = val1;
-    if ( args==2 )
-	array[i++] = val2;
+    if (i<40)
+        array[i++] = val1;
+    if (i<40) {
+        if ( args==2 )
+	    array[i++] = val2;
+    }
     for ( j=0; j<i; ++j ) for ( k=j+1; k<i; ++k ) if ( array[j]>array[k] ) {
 	double temp = array[j];
 	array[j] = array[k];

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -4898,8 +4898,10 @@ return;
     }
     cnt = i;
     free( cnames );
-    if ( cnt==0 )
+    if ( cnt==0 ) {
+        free(founds);
 return;
+    }
     if ( within<mv->glyphcnt )
 	within = mv->glyphs[within].orig_index;
     else


### PR DESCRIPTION
[Unicode/makeutype.c:605] -> [Unicode/makeutype.c:605]: (style) Same expression on both sides of '||'.
[fontforge/splinefill.c:1790] -> [fontforge/splinefill.c:1790]: (style) Same expression on both sides of '||'.
[fontforge/splineoverlap.c:2061] -> [fontforge/splineoverlap.c:2061]: (style) Same expression on both sides of '||'.
[fontforge/ttfspecial.c:760]: (error) Memory leak: otherlayers
[fontforge/ufo.c:777]: (error) Memory leak: gn
[fontforge/ufo.c:1322]: (style) Consecutive return, break, continue, goto or throw statements are unnecessary.
[fontforge/winfonts.c:835]: (error) Memory leak: file_lens
[fontforgeexe/bitmapview.c:638]: (error) Memory leak: refinfo
[fontforgeexe/charinfo.c:3255]: (error) Memory leak: extras
[fontforgeexe/cvdgloss.c:91]: (error) va_list 'ap' was opened but not closed by va_end().
[fontforgeexe/cvpalettes.c:3883]: (style) Consecutive return, break, continue, goto or throw statements are unnecessary.
[fontforgeexe/histograms.c:340]: (error) Array 'array[40]' accessed at index 40, which is out of bounds.
[fontforgeexe/metricsview.c:4902]: (error) Memory leak: founds