### PR TITLE
Fixup mkdir usage on Windows (Using Gnulib's mkdir now.)

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -793,11 +793,7 @@ static void ffensuredir( const char* basedir, const char* dirname, mode_t mode )
 
     snprintf(buffer,buffersz,"%s/%s", basedir, dirname );
     // ignore errors, this is just to help the user aftre all.
-#if !defined(__MINGW32__)
     mkdir( buffer, mode );
-#else
-    mkdir( buffer );
-#endif
 }
 
 static void ensureDotFontForgeIsSetup() {

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -38,12 +38,6 @@
 #include <glib/gstdio.h>
 #include <errno.h>			/* for mkdir_p */
 
-#ifdef _WIN32
-#define MKDIR(A,B) mkdir(A)
-#else
-#define MKDIR(A,B) mkdir(A,B)
-#endif
-
 static char dirname_[MAXPATHLEN+1];
 #if !defined(__MINGW32__)
  #include <pwd.h>
@@ -135,14 +129,14 @@ return -ENOTDIR;
 	for(p = tmp + 1; *p; p++)
 	if(*p == '/') {
 		*p = 0;
-		r = MKDIR(tmp, mode);
+		r = mkdir(tmp, mode);
 		if (r < 0 && errno != EEXIST)
 return -errno;
 		*p = '/';
 	}
 
 	/* try to make the whole path */
-	r = MKDIR(tmp, mode);
+	r = mkdir(tmp, mode);
 	if(r < 0 && errno != EEXIST)
 return -errno;
 	/* creation successful or the file already exists */
@@ -452,7 +446,7 @@ int GFileRemove(const char *path, int recursive) {
 }
 
 int GFileMkDir(const char *name) {
-return( MKDIR(name,0755));
+return( mkdir(name,0755));
 }
 
 int GFileRmDir(const char *name) {
@@ -746,7 +740,7 @@ return( access(buffer,04)==0 );
 int u_GFileMkDir(unichar_t *name) {
     char buffer[1024];
     u2def_strncpy(buffer,name,sizeof(buffer));
-return( MKDIR(buffer,0755));
+return( mkdir(buffer,0755));
 }
 
 int u_GFileRmDir(unichar_t *name) {

--- a/tests/randomtest.c
+++ b/tests/randomtest.c
@@ -480,11 +480,7 @@ exit(1);
     g_random_set_seed(now);
 
     FindFonts(dirs,exts);
-#if defined (__MINGW32__)
     mkdir(results_dir,0755);
-#else
-	mkdir(results_dir);
-#endif
     for (;;)
 	do_test();
 


### PR DESCRIPTION
Since Gnulib now handles the mkdir abstraction, the #ifdef'ed code is no longer necessary. cc @frank-trampe 
