### PR TITLE
cppcheck: fix some reports (part 4)

### DIFF
--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -2519,7 +2519,7 @@ static void DoRules(SplineFont *sf,SplineChar *sc,int layer,BDFFont *bdf,int dis
 static void BCDoRotation(BDFFont *bdf, int gid) {
     BDFChar *from, *to;
 
-    if ( gid>=bdf->glyphcnt || gid>=bdf->glyphcnt || bdf->glyphs[gid]==NULL )
+    if ( gid>=bdf->glyphcnt || bdf->glyphs[gid]==NULL )
 return;
     from = bdf->glyphs[gid];
     to = BDFMakeGID(bdf,gid);

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -1073,7 +1073,7 @@ static int RealCloser(extended ref0, extended ref1, extended queryval) {
 
 static void SplitMonotonicAtFlex(Monotonic *m,int which,bigreal coord,
 	struct inter_data *id, int doit) {
-    bigreal t;
+    bigreal t=0;
     int low=0, high=0;
     extended startx, starty, endx, endy;
     {

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -1039,7 +1039,7 @@ return( left_trace );
 static void SquareCap(StrokeContext *c,int isend) {
     int cnt, i, start, end, incr;
     int start_corner, end_corner, cc, nc;
-    BasePoint slope, slope1, slope2;
+    BasePoint slope1, slope2;
     StrokePoint done;
     StrokePoint *p;
     bigreal t;
@@ -1114,9 +1114,9 @@ static void SquareCap(StrokeContext *c,int isend) {
 	    p->line = true;
 	    p->needs_point_left = p->needs_point_right = i==cnt;
 	    p->left.x = done.left.x - t*slope1.x;
-	    p->left.y = done.left.y - t*slope2.y;
-	    p->right.x = done.right.x + t*slope.x;
-	    p->right.y = done.right.y + t*slope.y;
+	    p->left.y = done.left.y - t*slope1.y;
+	    p->right.x = done.right.x + t*slope1.x;
+	    p->right.y = done.right.y + t*slope1.y;
 	    if ( i==end )
 	break;
 	}

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -5663,7 +5663,7 @@ return( len );
 static int StemPairsSimilar( struct stemdata *s1, struct stemdata *s2,
     struct stemdata *ts1, struct stemdata *ts2 ) {
     
-    int normal, reversed, ret;
+    int normal, reversed, ret = 0;
     double olen1, olen2;
     
     /* Stem widths in the second pair should be nearly the same as */

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -1466,8 +1466,6 @@ static int UFOOutputGroups(const char *basedir, SplineFont *sf) {
                 xmlNodePtr grouparray = xmlNewChild(dictnode, NULL, BAD_CAST "array", NULL);
                 // We use the results of the preceding search in order to get the list.
                 char *rawglyphlist = (
-                  isv ?
-                  (isr ? kc->seconds[offset] : kc->firsts[offset]) :
                   (isr ? kc->seconds[offset] : kc->firsts[offset])
                 );
                 // We need to convert from the space-delimited string to something more easily accessed on a per-item basis.

--- a/fontforgeexe/basedlg.c
+++ b/fontforgeexe/basedlg.c
@@ -432,7 +432,7 @@ static void Base_FinishEdit(GGadget *g, int r, int c, int wasnew) {
 	struct matrix_data *md = GMatrixEditGet(g,&rows);
 	uint32 script = TagFromString(md[r*cols+0].u.md_str);
 	uint32 bsln;
-	int i,j,k;
+	int i=0,j,k;
 
 /* This if is duplicated (almost) in tottfaat.c: PerGlyphDefBaseline */
 	if ( script==CHR('k','a','n','a') || script==CHR('h','a','n','g') ||

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -750,7 +750,7 @@ static void BVExpose(BitmapView *bv, GWindow pixmap, GEvent *event ) {
     if ( bv->showoutline ) {
 	Color col = (view_bgcol<0x808080)
 		? (bv->bc->byte_data ? 0x008800 : 0x004400 )
-		: (bv->bc->byte_data ? 0x00ff00 : 0x00ff00 );
+		: 0x00ff00;
 	memset(&cvtemp,'\0',sizeof(cvtemp));
 	cvtemp.v = bv->v;
 	cvtemp.width = bv->width;

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -2385,7 +2385,7 @@ static void CVDrawGridRaster(CharView *cv, GWindow pixmap, DRect *clip ) {
 	real ygrid_spacing = (cv->b.sc->parent->ascent+cv->b.sc->parent->descent) / (real) cv->ft_ppemy;
 	real xgrid_spacing = (cv->b.sc->parent->ascent+cv->b.sc->parent->descent) / (real) cv->ft_ppemx;
 	int max,jmax,ii,i,jj,j;
-	int minx, maxx, miny, maxy, r,or;
+	int minx, maxx, miny, maxy, r,or=0;
 	Color clut[256];
 
 	pixel.width = xgrid_spacing*cv->scale+1;
@@ -8197,7 +8197,7 @@ static void CVNextPrevSpiroPt(CharView *cv, struct gmenuitem *mi) {
     SplineSet *spl, *ss;
     SplinePoint *junk;
     int x, y;
-    spiro_cp *selcp, *other;
+    spiro_cp *selcp = NULL, *other;
     int index;
 
     if ( mi->mid == MID_FirstPt ) {

--- a/fontforgeexe/cvexportdlg.c
+++ b/fontforgeexe/cvexportdlg.c
@@ -265,7 +265,7 @@ static int last_format = 0;
 
 static void DoExport(struct gfc_data *d,unichar_t *path) {
     char *temp;
-    int format, good;
+    int format, good = 0;
 
     temp = cu_copy(path);
     last_format = format = (intpt) (GGadgetGetListItemSelected(d->format)->userdata);

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -2784,8 +2784,8 @@ static void PrefsSubSetDlg(CharView *cv,char* windowTitle,struct prefs_list* pli
     GTabInfo aspects[TOPICS+5], subaspects[3];
     GGadgetCreateData **hvarray, boxes[2*TOPICS];
     struct pref_data p;
-    int line,line_max = 3;
-    int i = 0, gc = 0, ii, y, si=0, k=0;
+    int line = 0,line_max = 3;
+    int i = 0, gc = 0, ii, y=0, si=0, k=0;
     char buf[20];
     char *tempstr;
 

--- a/gdraw/growcol.c
+++ b/gdraw/growcol.c
@@ -397,7 +397,7 @@ return( false );
 	    GDrawFillRect(pixmap,&r,GRowColLabelBg);
 	    for ( i=0; i<grc->cols; ++i ) {
 		GTextInfoDraw(pixmap,g->inner.x+grc->colx[i]+grc->hpad-grc->xoff,y,grc->labels[i],
-			grc->font,grc->labels[l]->disabled?dfg:dfg,g->box->active_border
+			grc->font,dfg,g->box->active_border
 			g->inner.y+g->inner.height);
 	    }
 	}
@@ -411,7 +411,7 @@ return( false );
 		if ( l!=grc->tfr || i!=grc->tfc ) {
 		    GTextInfo *ti = grc->ti[l*grc->cols+i];
 		    GTextInfoDraw(pixmap,g->inner.x+grc->colx[i]-grc->xoff+grc->hpad,y,ti,
-			    grc->font,ti->disabled?dfg:dfg,g->box->active_border,
+			    grc->font,dfg,g->box->active_border,
 			    g->inner.y+g->inner.height);
 		} else {
 		    /* now we can draw the text field */

--- a/gdraw/gtextinfo.c
+++ b/gdraw/gtextinfo.c
@@ -731,7 +731,7 @@ return( NULL );
 	for ( i=0; i<len && array[i]!=NULL; ++i );
 	len = i;
     }
-    ti = malloc((i+1)*sizeof(GTextInfo *));
+    ti = malloc((len+1)*sizeof(GTextInfo *));
     for ( i=0; i<len; ++i ) {
 	ti[i] = calloc(1,sizeof(GTextInfo));
 	ti[i]->text = uc_copy(array[i]);

--- a/gdraw/hotkeys.c
+++ b/gdraw/hotkeys.c
@@ -386,7 +386,7 @@ Hotkey* isImmediateKey( GWindow w, char* path, GEvent *event )
     Hotkey* hk = hotkeyFindByAction( line );
     if( !hk )
 	return 0;
-    if( hk && !hk->action )
+    if( !hk->action )
 	return 0;
     
     if( event->u.chr.keysym == hk->keysym )


### PR DESCRIPTION
Provide a general summary of your changes in the **Title** above.

### Important
Mark with [x] to select. Leave as [ ] to unselect.

### Motivation and Context
- [ ] Why is this change required? What problem does it solve?
- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [ ] Describe your changes in detail.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [ ] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.

[fontforge/fvcomposite.c:2522] -> [fontforge/fvcomposite.c:2522]: (style) Same expression on both sides of '||'.
[fontforge/splineoverlap.c:1163]: (error) Uninitialized variable: t
[fontforge/splinestroke.c:1119]: (error) Uninitialized variable: slope
[fontforge/splinestroke.c:1117]: (error) Uninitialized variable: slope2
[fontforge/stemdb.c:5694]: (error) Uninitialized variable: ret
[fontforge/ufo.c:1470]: (style) Same expression in both branches of ternary operator.
[fontforgeexe/basedlg.c:459]: (error) Uninitialized variable: i
[fontforgeexe/bitmapview.c:753]: (style) Same expression in both branches of ternary operator.
[fontforgeexe/charview.c:2442]: (error) Uninitialized variable: or
[fontforgeexe/charview.c:8244]: (error) Uninitialized variable: selcp
[fontforgeexe/cvexportdlg.c:294]: (error) Uninitialized variable: good
[fontforgeexe/prefs.c:3001]: (error) Uninitialized variable: line
[gdraw/growcol.c:400]: (style) Same expression in both branches of ternary operator.
[gdraw/growcol.c:414]: (style) Same expression in both branches of ternary operator.
[gdraw/gtextinfo.c:734]: (error) Uninitialized variable: i
[gdraw/hotkeys.c:392] -> [gdraw/hotkeys.c:389]: (warning) Either the condition 'hk' is redundant or there is possible null pointer dereference: hk.