### PR TITLE
cppcheck: fix some reports (part 5)

### DIFF
--- a/contrib/cidmap/src/mapcns1.c
+++ b/contrib/cidmap/src/mapcns1.c
@@ -37,7 +37,7 @@ return( *buffer=='\0' );
 }
 
 static int getnth(char *buffer, int col, int *mults) {
-    int i,j, val=0, best;
+    int i,j=0, val=0, best;
     char *end;
     int vals[10];
     int pua, nonbmp;

--- a/contrib/cidmap/src/mapgb1.c
+++ b/contrib/cidmap/src/mapgb1.c
@@ -36,7 +36,7 @@ return( *buffer=='\0' );
 }
 
 static int getnth(char *buffer, int col,int *mults) {
-    int i,j, val=0, best;
+    int i,j=0, val=0, best;
     char *end;
     int vals[10];
 

--- a/contrib/cidmap/src/mapjapan1.c
+++ b/contrib/cidmap/src/mapjapan1.c
@@ -39,7 +39,7 @@ return( 5 );
 }
 
 static int getnth(char *buffer, int col, int *mults) {
-    int i,j, val=0, best;
+    int i,j=0, val=0, best;
     char *end;
     int vals[10];
 

--- a/contrib/cidmap/src/mapjapan2.c
+++ b/contrib/cidmap/src/mapjapan2.c
@@ -35,7 +35,7 @@ return( *buffer=='\0' );
 }
 
 static int getnth(char *buffer, int col, int *mults) {
-    int i,j, val=0, best;
+    int i,j=0, val=0, best;
     char *end;
     int vals[10];
 

--- a/contrib/cidmap/src/mapkorean.c
+++ b/contrib/cidmap/src/mapkorean.c
@@ -36,7 +36,7 @@ return( *buffer=='\0' );
 }
 
 static int getnth(char *buffer, int col, int *mults) {
-    int i,j, val=0, best;
+    int i,j=0, val=0, best;
     char *end;
     int vals[10];
 

--- a/contrib/fonttools/showttf.c
+++ b/contrib/fonttools/showttf.c
@@ -5637,7 +5637,7 @@ return;
 static void readcffset(FILE *ttf,struct topdicts *dict,char **strings,int smax,
 	struct ttfinfo *info) {
     int len = dict->glyphs.cnt;
-    int i;
+    int i=0;
     int format, cnt, j, first;
 
     if ( dict->charsetoff==0 ) {

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -1207,7 +1207,7 @@ return( NULL );
 		    cmap->registry = readpsstr(pt+strlen(reg));
 		else if ( strncmp(pt,ord,strlen(ord))==0 )
 		    cmap->ordering = readpsstr(pt+strlen(ord));
-		else if ( strncmp(pt,ord,strlen(ord))==0 ) {
+		else if ( strncmp(pt,sup,strlen(sup))==0 ) {
 		    for ( pt += strlen(sup); isspace(*pt); ++pt );
 		    cmap->supplement = strtol(pt,NULL,10);
 		}

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -2615,7 +2615,7 @@ return;
 static int SCMakeRightToLeftLig(SplineChar *sc,SplineFont *sf,
 	int layer, const unichar_t *start,BDFFont *bdf,int disp_only) {
     int cnt = u_strlen(start);
-    int ret, ch, alt_ch;
+    int ret=false, ch, alt_ch;
     const unichar_t *pt;
 
     pt = start+cnt-1;

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -2632,9 +2632,9 @@ return;
 	simple_pos = 8;
     else if ( strcmp(langbuf,"pl")==0 )
 	simple_pos = 9;
-    else if ( strcmp(langbuf,"pl")==0 )
+    else if ( strcmp(langbuf,"sl")==0 )
 	simple_pos = 10;
-    else if ( strcmp(langbuf,"cz")==0 )
+    else if ( strcmp(langbuf,"cs")==0 )
 	simple_pos = 11;
     else
 	simple_pos = rand()&3;

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -1475,14 +1475,14 @@ StemInfo *SCHintOverlapInMask(SplineChar *sc,HintMask *hm) {
 			    end1 = start1+h1->width;
 			} else {
 			    end1 = h1->start;
-			    start1 = start1+h1->width;
+			    start1 = end1+h1->width;
 			}
 			if ( h2->width>0 ) {
 			    start2 = h2->start;
 			    end2 = start2+h2->width;
 			} else {
 			    end2 = h2->start;
-			    start2 = start2+h2->width;
+			    start2 = end2+h2->width;
 			}
 			if ( end1<start2 || start1>end2 )
 			    /* No overlap */;

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -5831,7 +5831,7 @@ static void CVExposeRulers(CharView *cv, GWindow pixmap ) {
 	units = 1000; littleunits=200;
     } else if ( onehundred<10000/2 ) {
 	units = 2500; littleunits=500;
-    } else if ( onehundred<10000/2 ) {
+    } else if ( onehundred<50000/2 ) {
 	units = 10000; littleunits=2000;
     } else {
 	for ( units=1 ; units<onehundred*2; units *= 10 );

--- a/fontforgeexe/cvimportdlg.c
+++ b/fontforgeexe/cvimportdlg.c
@@ -467,8 +467,6 @@ return( true );
 		d->done = FVImportImages((FontViewBase *) d->fv,temp,format,toback,-1);
 	    else if ( format==fv_gliftemplate )
 		d->done = FVImportImageTemplate((FontViewBase *) d->fv,temp,format,toback,-1);
-	    else if ( format==fv_glif )
-		d->done = FVImportImages((FontViewBase *) d->fv,temp,format,toback,-1);
 	    else if ( format>=fv_pythonbase )
 		d->done = FVImportImages((FontViewBase *) d->fv,temp,format,toback,-1);
 	} else if ( d->bv!=NULL )

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -582,7 +582,6 @@ return( true );
 	}
 return( false );
     } else if ( event->type == et_mousemove ) {
-    } else if ( event->type == et_expose ) {
     } else if ( event->type == et_map ) {
 	/* Above palettes */
 	GDrawRaise(gw);

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -4141,7 +4141,7 @@ return( true );
 	} else if ( styleid!=0 && fontstyle_name==NULL ) {
 	    ff_post_error(_("Bad Design Size Info"),_("If you specify a style id for the design size, then you must specify a style name"));
 return( true );
-	} else if ( fontstyle_name==NULL && styleid!=0 ) {
+	} else if ( fontstyle_name!=NULL && styleid==0 ) {
 	    ff_post_error(_("Bad Design Size Info"),_("If you specify a style name for the design size, then you must specify a style id"));
 return( true );
 	} else if ( design_size<0 ) {

--- a/gtkui/gwwvask.c
+++ b/gtkui/gwwvask.c
@@ -316,7 +316,7 @@ static int _gwwv_choose_with_buttons(const char *title,
 	ret = -1;
     else {
 	GList *endsel = gtk_tree_selection_get_selected_rows(select,NULL);
-	if ( sel==NULL )
+	if ( endsel==NULL )
 	    ret = -1;
 	else {
 	    if ( sel==NULL ) {


### PR DESCRIPTION
[contrib/cidmap/src/mapcns1.c:98]: (error) Uninitialized variable: j
[contrib/cidmap/src/mapgb1.c:89]: (error) Uninitialized variable: j
[contrib/cidmap/src/mapjapan1.c:93]: (error) Uninitialized variable: j
[contrib/cidmap/src/mapjapan2.c:88]: (error) Uninitialized variable: j
[contrib/cidmap/src/mapkorean.c:89]: (error) Uninitialized variable: j
[contrib/fonttools/showttf.c:5744]: (error) Uninitialized variable: i
fontforge/fvcomposite.c:2643]: (error) Uninitialized variable: ret
[fontforge/splinechar.c:1478]: (error) Uninitialized variable: start1
[fontforge/splinechar.c:1485]: (error) Uninitialized variable: start2

[fontforge/encoding.c:1205]: (style) Expression is always false because 'else if' condition matches previous condition at line 1203.
[fontforge/print.c:2635]: (style) Expression is always false because 'else if' condition matches previous condition at line 2633.
(+ Czech language is "cs", Czech Republic is "cz", see https://en.wikipedia.org/wiki/Locale, POSIX example)
[fontforgeexe/charview.c:5834]: (style) Expression is always false because 'else if' condition matches previous condition at line 5832.
[fontforgeexe/cvimportdlg.c:470]: (style) Expression is always false because 'else if' condition matches previous condition at line 466.
[fontforgeexe/cvstroke.c:585]: (style) Expression is always false because 'else if' condition matches previous condition at line 572.
[fontforgeexe/fontinfo.c:4144]: (style) Expression is always false because 'else if' condition matches previous condition at line 4141.
[gtkui/gwwvask.c:322]: (style) Expression is always false because 'else if' condition matches previous condition at line 319.