### PR TITLE
Avoid outputting trailing spaces in sfd files.

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -1758,8 +1758,12 @@ static int SFDDumpBitmapFont(FILE *sfd,BDFFont *bdf,EncMap *encm,int *newgids,
     BDFRefChar *ref;
 
     ff_progress_next_stage();
-    fprintf( sfd, "BitmapFont: %d %d %d %d %d %s\n", bdf->pixelsize, bdf->glyphcnt,
-	    bdf->ascent, bdf->descent, BDFDepth(bdf), bdf->foundry?bdf->foundry:"" );
+    if (bdf->foundry)
+        fprintf( sfd, "BitmapFont: %d %d %d %d %d %s\n", bdf->pixelsize, bdf->glyphcnt,
+                 bdf->ascent, bdf->descent, BDFDepth(bdf), bdf->foundry );
+    else
+        fprintf( sfd, "BitmapFont: %d %d %d %d %d\n", bdf->pixelsize, bdf->glyphcnt,
+                 bdf->ascent, bdf->descent, BDFDepth(bdf) );
     if ( bdf->prop_cnt>0 ) {
 	fprintf( sfd, "BDFStartProperties: %d\n", bdf->prop_cnt );
 	for ( i=0; i<bdf->prop_cnt; ++i ) {

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -2748,13 +2748,13 @@ static int SFD_Dump( FILE *sfd, SplineFont *sf, EncMap *map, EncMap *normal,
     }
     if ( sf->anchor!=NULL ) {
 	AnchorClass *an;
-	fprintf(sfd, "AnchorClass2: ");
+	fprintf(sfd, "AnchorClass2:");
 	for ( an=sf->anchor; an!=NULL; an=an->next ) {
-	    SFDDumpUTF7Str(sfd,an->name);
 	    putc(' ',sfd);
+	    SFDDumpUTF7Str(sfd,an->name);
             if ( an->subtable!=NULL ) {
-	        SFDDumpUTF7Str(sfd,an->subtable->subtable_name);
 	        putc(' ',sfd);
+	        SFDDumpUTF7Str(sfd,an->subtable->subtable_name);
             }
             else
                 fprintf(sfd, "\"\" ");


### PR DESCRIPTION
### Motivation and Context
- [x] Why is this change required? What problem does it solve?
- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.

This patch avoids outputting trailing spaces in sfd files.
E.g. Open a sfd file --> resize the window --> save --> without this patch I get lines like "BitmapFont: 10 987 8 2 1 " with a trailing space.
This PR prevents that space.

### Motivation and Context

The [Wine project] (https://www.winehq.org/) uses a [forked fontforge] (http://source.winehq.org/git/fontforge.git/) (this issue is about the 2nd of their 4 changes) to avoid spurious diffs when working with git. We discussed this [here] (https://www.winehq.org/pipermail/wine-devel/2016-April/112893.html).

The original Winehq patch by Alexandre Julliard (based on 20081224):
http://source.winehq.org/git/fontforge.git/commitdiff/37fa1cd216930f21081059b7e8b5bf9473711340

The currently used form (rebased on v20120731-b):
https://github.com/jre-wine/fontforge/commit/96d4f9d2aaf4708de56f0c5eeb1c1f7ec3e235d3

Most of this has already been fixed in b0132fe5b115bd589d511775a01af8236162c88e by @adrientetar

The remaining changes are in this pull request.

I successfully tested this locally (build fontforge, build Wine, test one application), and verified that the space isn't added in the sfd file.

Thanks and greets
jre

### Final checklist
- [?] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style). -- Not sure.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

I'm not the original author of this patch, do you need anything for the copyright written by Alexandre Julliard?