### PR TITLE
cppcheck: fix some memleaks

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -8014,6 +8014,7 @@ return( NULL );
 	    ENDPYGETSTR();
 	    if ( sc==NULL ) {
 		PyErr_Format(PyExc_TypeError,"String, %s, is not the name of a glyph in the expected font.", str );
+                free(ret);
 return( NULL );
 	    }
 	    ret[i] = sc;

--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -1532,6 +1532,7 @@ return;
 		memset(sum,0,new.bytes_per_line*sizeof(uint32));
 	    }
 	}
+        free(sum);
     } else {
 	for ( i=0; i<=bc->ymax-bc->ymin; ++i ) {
 	    bpt = bc->bitmap + i*bc->bytes_per_line;

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -5785,7 +5785,7 @@ void SplineCharListsFree(struct splinecharlist *dlist) {
 }
 
 struct pattern *PatternCopy(struct pattern *old, real transform[6]) {
-    struct pattern *pat = chunkalloc(sizeof(struct pattern));
+    struct pattern *pat;
 
     if ( old==NULL )
 return( NULL );
@@ -5807,7 +5807,7 @@ return;
 }
 
 struct gradient *GradientCopy(struct gradient *old,real transform[6]) {
-    struct gradient *grad = chunkalloc(sizeof(struct gradient));
+    struct gradient *grad;
 
     if ( old==NULL )
 return( NULL );

--- a/fontforge/tottfvar.c
+++ b/fontforge/tottfvar.c
@@ -65,13 +65,7 @@ static int AssignPtNumbers(MMSet *mm,int gid) {
         free(ss);
         free(sp);
 	if ( stillmore )
-{
-free(ss);
-free(sp);
 return( false );
-}
-free(ss);
-free(sp);
 return( true );
     } else {
 	stillmore = true;

--- a/fontforge/tottfvar.c
+++ b/fontforge/tottfvar.c
@@ -63,14 +63,24 @@ static int AssignPtNumbers(MMSet *mm,int gid) {
 	for ( i=0; i<=mm->instance_count; ++i )
 	    if ( ss[i]!=NULL ) stillmore = true;
 	if ( stillmore )
+{
+free(ss);
+free(sp);
 return( false );
+}
+free(ss);
+free(sp);
 return( true );
     } else {
 	stillmore = true;
 	for ( i=0; i<=mm->instance_count; ++i )
 	    if ( ss[i]==NULL ) stillmore = false;
 	if ( !stillmore )
+{
+free(ss);
+free(sp);
 return( false );
+}
     }
 	    
     for (;;) {

--- a/fontforge/tottfvar.c
+++ b/fontforge/tottfvar.c
@@ -62,6 +62,8 @@ static int AssignPtNumbers(MMSet *mm,int gid) {
 	stillmore = false;
 	for ( i=0; i<=mm->instance_count; ++i )
 	    if ( ss[i]!=NULL ) stillmore = true;
+        free(ss);
+        free(sp);
 	if ( stillmore )
 {
 free(ss);

--- a/fontforge/ttfspecial.c
+++ b/fontforge/ttfspecial.c
@@ -2205,6 +2205,7 @@ return;
 	    }
 	}
     }
+    free(bdfinfo);
 }
 
 

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -914,6 +914,7 @@ return( false );
 	for ( j=0; j<num_files; ++j )
 	    fclose(fntarray[j]);
 	free(fntarray);
+        free(file_lens);
 return( false );
     }
 

--- a/fontforgeexe/acorn2sfd.c
+++ b/fontforgeexe/acorn2sfd.c
@@ -562,6 +562,8 @@ return;
 	    free(widths);
 	}
     }
+    if (m != 0)
+        free(mapping);
 
     outline->defxadvance = outline->defyadvance = 1000;
 

--- a/fontforgeexe/basedlg.c
+++ b/fontforgeexe/basedlg.c
@@ -467,7 +467,7 @@ static void Base_FinishEdit(GGadget *g, int r, int c, int wasnew) {
 	
 static void BaselineMatrixInit(struct matrixinit *mi,struct Base *old) {
     struct matrix_data *md;
-    int k, i, cnt;
+    int k, i, cnt, mustfreemem;
     int _maps[20], *mapping;
     char script[8];
     struct basescript *bs;
@@ -477,6 +477,7 @@ static void BaselineMatrixInit(struct matrixinit *mi,struct Base *old) {
     mi->col_init = baselinesci;
 
     cnt = 0;
+    mustfreemem = 0;
     if ( old!=NULL )
 	for ( cnt=0, bs=old->scripts; bs!=NULL; bs=bs->next, ++cnt );
     mi->initial_row_cnt = cnt;
@@ -485,8 +486,10 @@ static void BaselineMatrixInit(struct matrixinit *mi,struct Base *old) {
     if ( old!=NULL ) {
 	if ( old->baseline_cnt<sizeof(_maps)/sizeof(_maps[0]) )
 	    mapping = _maps;
-	else
+	else  {
+            mustfreemem = 1;
 	    mapping = malloc(old->baseline_cnt*sizeof(int));
+        }
 	for ( k=0; k<old->baseline_cnt; ++k ) {
 	    mapping[k] = -1;
 	    for ( i=0; stdtags[i]!=0; ++i )
@@ -506,6 +509,8 @@ static void BaselineMatrixInit(struct matrixinit *mi,struct Base *old) {
 	    }
 	    md[mi->col_cnt*cnt+mi->col_cnt-1].u.md_str = (char *) BaseLangCopy(bs->langs);
 	}
+        if (mustfreemem != 0) 
+            free(mapping);
     }
 
     mi->finishedit = Base_FinishEdit;

--- a/gdraw/gimageclut.c
+++ b/gdraw/gimageclut.c
@@ -504,8 +504,10 @@ return( PickGreyClut(clut,clutmax,grey_clut,cnt));
 	for ( i=0; i<cnt; ++i )
 	    clut->clut[i] = clutinf[i].col;
 	clut->clut[i] = transinf.col;
+        free(clutinf);
 return(clut);
     }
+    free(clutinf);
 	
 return( gimage_reduceclut(clut,clutmax,clutinf,cnt,&transinf));
 }


### PR DESCRIPTION
[fontforge/python.c:8017]: (error) Memory leak: ret
[fontforge/splinefill.c:1535]: (error) Memory leak: sum
[fontforge/splineutil.c:5791]: (error) Memory leak: pat
[fontforge/splineutil.c:5793]: (error) Memory leak: pat
[fontforge/splineutil.c:5813]: (error) Memory leak: grad
[fontforge/splineutil.c:5815]: (error) Memory leak: grad
[fontforge/tottfvar.c:67]: (error) Memory leak: ss
[fontforge/tottfvar.c:67]: (error) Memory leak: sp
[fontforge/ttfspecial.c:2208]: (error) Memory leak: bdfinfo
[fontforge/winfonts.c:917]: (error) Memory leak: file_lens
[fontforgeexe/acorn2sfd.c:616]: (error) Memory leak: mapping
[fontforgeexe/basedlg.c:516]: (error) Memory leak: mapping
[gdraw/gimageclut.c:507]: (error) Memory leak: clutinf