### PR TITLE
Attempted fix of #2025 (bug in expand stroke)

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -708,7 +708,7 @@ return;		/* Essentially colinear */ /* Won't be perfect because control points l
 	    p->needs_point_left = p->needs_point_right = false;
 	    p->left_hidden = bends_left;
 	    p->right_hidden = !bends_left;
-	    if ( rot.x<=fabs(diff_angle.x) ) {
+	    if ( rot.x<=diff_angle.x || (diff_angle.x <= -1 && rot.x <= -0.999999) ) { /* close enough */
 		p->right = done.right;
 		p->left = done.left;
 		p->needs_point_left = p->needs_point_right = true;


### PR DESCRIPTION
4f883fd broke expand stroke (see #2025) while attempting to fix an infinite loop found in regression testing (test1003.py, circular stroke as applied to backslash character in StrokeTests.sfd).

This attempts to provide a better fix for the infinite loop condition while not causing the effects of #2025.