### PR TITLE
Write device name as empty string in FON file header, issue #2741

### DIFF
--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -1035,11 +1035,17 @@ return( false );
     for(res = first_res, i = 0; i < num_files; i++, res++) {
         lputshort(fon,res);
 
+        /* The first 0x6D bytes of the FNT file and the FONTDIRENTRY match */
         rewind(fntarray[i]);
-        fread(buf, 0x72, 1, fntarray[i]);
+        fread(buf, 0x6D, 1, fntarray[i]);
         fnt_header = (struct _fnt_header *)buf;
         fnt_header->fi.dfBitsOffset = 0;	/* I can ignore endianness here. all is 0 */
-        fwrite(buf, 0x72, 1, fon);
+        fwrite(buf, 0x6D, 1, fon);
+
+        /* FONTDIRENTRY.dfReserved */
+        lputlong(fon,0);
+        /* FONTDIRENTRY.szDeviceName */
+        fputc(0x00, fon);
 
 	fseek(fntarray[i], 0x69, SEEK_SET);
 	off = lgetlong(fntarray[i]);

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -729,52 +729,6 @@ typedef struct
      */
 } NE_TYPEINFO;
 
-typedef struct
-{
-    INT16 dfType;
-    INT16 dfPoints;
-    INT16 dfVertRes;
-    INT16 dfHorizRes;
-    INT16 dfAscent;
-    INT16 dfInternalLeading;
-    INT16 dfExternalLeading;
-    CHAR  dfItalic;
-    CHAR  dfUnderline;
-    CHAR  dfStrikeOut;
-    INT16 dfWeight;
-    BYTE  dfCharSet;
-    INT16 dfPixWidth;
-    INT16 dfPixHeight;
-    CHAR  dfPitchAndFamily;
-    INT16 dfAvgWidth;
-    INT16 dfMaxWidth;
-    CHAR  dfFirstChar;
-    CHAR  dfLastChar;
-    CHAR  dfDefaultChar;
-    CHAR  dfBreakChar;
-    INT16 dfWidthBytes;
-    LONG  dfDevice;
-    LONG  dfFace;
-    LONG  dfBitsPointer;
-    LONG  dfBitsOffset;
-    CHAR  dfReserved;
-    /* Fields, introduced for Windows 3.x fonts */
-    LONG  dfFlags;
-    INT16 dfAspace;
-    INT16 dfBspace;
-    INT16 dfCspace;
-    LONG  dfColorPointer;
-    LONG  dfReserved1[4];
-} FONTINFO16, *LPFONTINFO16;
-
-struct _fnt_header
-{
-    short dfVersion;
-    long dfSize;
-    char dfCopyright[60];
-    FONTINFO16 fi;
-};
-
 static const BYTE MZ_hdr[] = {'M',  'Z',  0x0d, 0x01, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00,
                  0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -1038,8 +992,6 @@ return( false );
         /* The first 0x6D bytes of the FNT file and the FONTDIRENTRY match */
         rewind(fntarray[i]);
         fread(buf, 0x6D, 1, fntarray[i]);
-        fnt_header = (struct _fnt_header *)buf;
-        fnt_header->fi.dfBitsOffset = 0;	/* I can ignore endianness here. all is 0 */
         fwrite(buf, 0x6D, 1, fon);
 
         /* FONTDIRENTRY.dfReserved */


### PR DESCRIPTION
### Motivation and Context
Closes #2741

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
The FON file header is constructed by copying data from temporary FNT
files.  The code was previously copying five bytes too many which
left the device name non-empty.  The device name ran into the face
name, causing Windows to interpret whatever junk came next as the
face name.

### Final checklist
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
