### PR TITLE
Zero pfminfo structure to fix FNT file metrics, closes #2748

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -9346,6 +9346,7 @@ static void handlename(Context *c,Val *val) {
 		val->u.aval = malloc(sizeof(Array));
 		val->u.aval->argc = 10;
 		val->u.aval->vals = malloc((10+1)*sizeof(Val));
+		memset(&pfminfo,'\0',sizeof(pfminfo));
 		SFDefaultOS2Info(&pfminfo,sf,sf->fontname);
 		for ( cnt=0; cnt<10; ++cnt ) {
 		    val->u.aval->vals[cnt].type = v_int;

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -485,6 +485,7 @@ return( false );
     if ( badch!=-1 )
 	LogError( _("At pixelsize %d the character %s either starts before the origin or extends beyond the advance width.\n"),
 		font->pixelsize, font->glyphs[badch]->sc->name );
+    memset(&pfminfo,'\0',sizeof(pfminfo));
     SFDefaultOS2Info(&pfminfo,font->sf,font->sf->fontname);
     widbytes = avgwid+spacesize;
     if ( cnt!=0 ) avgwid = rint(avgwid/(bigreal) cnt);


### PR DESCRIPTION
### Motivation and Context

Closes #2748

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)

### Description

The _FntFontDump function uses the SFDefaultOS2Info function to populate a pfminfo structure with font metrics that are written to the FNT file.

The SFDefaultOS2Info function requires the pfminfo structure to be zeroed otherwise it can produce bogus values for a few metrics including linegap, which is used to calculate the external leading.

This fix zeroes the structure.  It also fixes the problem for FON files because they are made of FNT files.

With one exception, every other call to SFDefaultOS2Info either uses the pfminfo embedded in the SplineFont structure, or zeroes its local structure first.  The exception is in scripting.c, so I fixed that one too.  I don't know that this one was causing any observable problem.

### Final checklist

- [X] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
