### PR TITLE
cppcheck: fix "Suspicious condition and usage"

### DIFF
--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -2367,7 +2367,7 @@ static void dumptype0stuff(FILE *out,SplineFont *sf, EncMap *map) {
 
 static void dumpt1str(FILE *binary,uint8 *data, int len, int leniv) {
     if ( leniv==-1 )
-	fwrite(data,sizeof(1),len,binary);
+	fwrite(data,sizeof(uint8),len,binary);
     else
 	encodestrout((DumpChar) fputc,binary,data,len,leniv);
 }

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -4616,14 +4616,14 @@ static void MarkDStemCorner( struct glyphdata *gd,struct pointdata *pd ) {
     for ( i=0; i<pd->prevcnt && !has_stem; i++ ) {
 	stem = pd->prevstems[i];
 	if ( !stem->toobig && (
-	    ( x_dir && ( hv = IsUnitHV( &stem->unit,true ) == 1 )) ||
+	    ( x_dir && ( (hv = IsUnitHV( &stem->unit,true )) == 1 )) ||
 	    ( !x_dir && hv == 2 )))
 	    has_stem = true;
     }
     for ( i=0; i<pd->nextcnt && !has_stem; i++ ) {
 	stem = pd->nextstems[i];
 	if ( !stem->toobig && (
-	    ( x_dir && ( hv = IsUnitHV( &stem->unit,true ) == 1 )) ||
+	    ( x_dir && ( (hv = IsUnitHV( &stem->unit,true )) == 1 )) ||
 	    ( !x_dir && hv == 2 )))
 	    has_stem = true;
     }

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2043,7 +2043,7 @@ static void xmlParseColorSource(xmlNodePtr top,char *name,DBounds *bbox,
     *_grad = NULL; *_epat = NULL;
     if ( colour_source==NULL )
 	LogError(_("Could not find Color Source with id %s."), name );
-    else if ( ((islinear = xmlStrcmp(colour_source->name,(xmlChar *) "linearGradient"))==0) ||
+    else if ( (islinear = (xmlStrcmp(colour_source->name,(xmlChar *) "linearGradient")==0)) ||
 	    xmlStrcmp(colour_source->name,(xmlChar *) "radialGradient")==0 ) {
 	struct gradient *grad = chunkalloc(sizeof(struct gradient));
 	int bbox_units;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2043,7 +2043,7 @@ static void xmlParseColorSource(xmlNodePtr top,char *name,DBounds *bbox,
     *_grad = NULL; *_epat = NULL;
     if ( colour_source==NULL )
 	LogError(_("Could not find Color Source with id %s."), name );
-    else if ( (islinear = xmlStrcmp(colour_source->name,(xmlChar *) "linearGradient")==0) ||
+    else if ( ((islinear = xmlStrcmp(colour_source->name,(xmlChar *) "linearGradient"))==0) ||
 	    xmlStrcmp(colour_source->name,(xmlChar *) "radialGradient")==0 ) {
 	struct gradient *grad = chunkalloc(sizeof(struct gradient));
 	int bbox_units;

--- a/gdraw/gtabset.c
+++ b/gdraw/gtabset.c
@@ -405,7 +405,7 @@ static void GTabSet_Remetric(GTabSet *gts) {
 	/* Nothing much to do */
     } else if ( gts->scrolled ) {
 	free(gts->rowstarts);
-	gts->rowstarts = malloc(2*sizeof(16));
+	gts->rowstarts = malloc(2*sizeof(int16));
 	gts->rowstarts[0] = 0; gts->rowstarts[1] = gts->tabcnt;
 	gts->rcnt = 1;
     } else {


### PR DESCRIPTION
[fontforge/dumppfa.c:2370]: (warning) Suspicious usage of 'sizeof' with a numeric constant as parameter.
[gdraw/gtabset.c:408]: (warning) Suspicious usage of 'sizeof' with a numeric constant as parameter.
[fontforge/stemdb.c:4619]: (style) Suspicious condition (assignment + comparison); Clarify expression with parentheses.
[fontforge/stemdb.c:4626]: (style) Suspicious condition (assignment + comparison); Clarify expression with parentheses.
[fontforge/svg.c:2046]: (style) Suspicious condition (assignment + comparison); Clarify expression with parentheses.