### PR TITLE
splinesave.c: Ensure that hintmask is properly set for referenced chars

### DIFF
--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -2908,6 +2908,10 @@ static void RSC2PS2(GrowBuf *gb, SplineChar *base,SplineChar *rsc,
 	rsc->hconflicts = false; rsc->vconflicts = false;
     } else {
 	for ( r=rsc->layers[layer].refs; r!=NULL; r=r->next ) {
+	    /* Ensure hintmask on refs are set correctly */
+	    if (SCNeedsSubsPts(r->sc, ff_otf, layer))
+	        SCFigureHintMasks(r->sc, layer);
+
 	    if ( !r->justtranslated )
 	continue;
 	    if ( r->sc->hconflicts || r->sc->vconflicts ) {


### PR DESCRIPTION
Note: No need to check for autohinting (i.e. running `SplineCharAutoHint`)
Because autohinting would have already been run on the base char if
needed (in `SplineChar2PS2`), which would have autohinted ref chars.

Related issue #1747 