### PR TITLE
Fix PyArg_ParseTupleAndKeywords calls.

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -4911,7 +4911,7 @@ pen = None;				# Finalize the pen. This tells FontForge
     </TR>
     <TR>
       <TD><CODE>autoWidth</CODE></TD>
-      <TD><CODE>(separation [,minBearing=,maxBearing=])</CODE></TD>
+      <TD><CODE>(separation [,minBearing=,maxBearing=,height=,loopCnt=])</CODE></TD>
       <TD>Guesses at reasonable horizontal advance widths for the selected glyphs</TD>
     </TR>
     <TR>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -14908,7 +14908,9 @@ return( NULL );
 Py_RETURN( self );
 }
 
-static const char *contextchain_keywords[] = { "afterSubtable",
+static const char *contextchain_keywords[] = {
+	"lookup", "subtable", "type", "rule",
+	"afterSubtable",
 	"bclasses", "mclasses", "fclasses",
 	"bclassnames", "mclassnames", "fclassnames", NULL };
 
@@ -14930,7 +14932,7 @@ static PyObject *PyFFFont_addContextualSubtable(PyFF_Font *self, PyObject *args,
     if ( CheckIfFontClosed(self) )
 return (NULL);
     sf = self->fv->sf;
-    if ( !PyArg_ParseTupleAndKeywords(args,keywds,"ssss|sOOO", (char **)contextchain_keywords,
+    if ( !PyArg_ParseTupleAndKeywords(args,keywds,"ssss|sOOOOOO", (char **)contextchain_keywords,
 	    &lookup, &subtable, &type, &rule,
 	    &after_str, &bclasses, &mclasses, &fclasses,
 	    &bclassnames, &mclassnames, &fclassnames))
@@ -15588,7 +15590,7 @@ return(NULL);
 	    "UTF-8",&filename, &others, &bitmaptype, &flags, &ttcflags,
 	    &namelist, &layer) ) {
 	PyErr_Clear();
-	if ( !PyArg_ParseTupleAndKeywords(args, keywds, "esO|sOOss", (char **)gen_keywords,
+	if ( !PyArg_ParseTupleAndKeywords(args, keywds, "esO|sOOss", (char **)genttc_keywords,
 		"UTF-8",&filename, &others, &bitmaptype, &flags, &ttcflags,
 		&namelist, &layer_str) )
 return( NULL );
@@ -16666,8 +16668,8 @@ return (NULL);
 Py_RETURN( self );
 }
 
-static const char *autowidth_keywords[] = { "minBearing", "maxBearing", "height",
-	"loopCnt", NULL };
+static const char *autowidth_keywords[] = { "separation", "minBearing", "maxBearing",
+	"height", "loopCnt", NULL };
 
 static PyObject *PyFFFont_autoWidth(PyFF_Font *self, PyObject *args, PyObject *keywds) {
     FontViewBase *fv;


### PR DESCRIPTION
### Motivation and Context
- [x] Why is this change required? What problem does it solve?

I was recently scripting fontforge with python and I discovered that calls to `addContextualSubtable` produced errors such as the following:

```
  File "/home/david/bodoni/convert_font.py", line 375, in merge_expert
    mclasses=(tuple(digits_num),), mclassnames=('num',))
TypeError: function takes at most 7 arguments (8 given)
```

- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.

When I looked at the code that implemented `addContextualSubtable`, I discovered a mistake in the [format argument](https://docs.python.org/2/c-api/arg.html#c.PyArg_ParseTupleAndKeywords) to the `PyArg_ParseTupleAndKeywords` call. When I looked at the other `PyArg_ParseTupleAndKeywords` calls I found errors there as well.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.

