### PR TITLE
cvruler.c: Reenable the expose call for the ruler.

### DIFF
--- a/fontforgeexe/cvruler.c
+++ b/fontforgeexe/cvruler.c
@@ -651,13 +651,13 @@ return;
 // The following code may be unnecessary, and it can cause an infinite stack loop.
 // One would hope that the event queue can take care of these things when we return to it.
 // We'll find out.
-#if 0
-    GDrawProcessPendingEvents(NULL);		/* The resize needs to happen before the expose */
-    if ( !cv->p.pressed && (event->u.mouse.state&ksm_meta) ) /* but a mouse up might sneak in... */
-return;
+//#if 0
+//    GDrawProcessPendingEvents(NULL);		/* The resize needs to happen before the expose */
+//    if ( !cv->p.pressed && (event->u.mouse.state&ksm_meta) ) /* but a mouse up might sneak in... */
+//return;
     GDrawRequestExpose(cv->ruler_w,NULL,false);
-    GDrawRequestExpose(cv->v,NULL,false);
-#endif // 0
+//    GDrawRequestExpose(cv->v,NULL,false);
+//#endif // 0
 }
 
 void CVMouseUpRuler(CharView *cv, GEvent *event) {


### PR DESCRIPTION
Without this call, the ruler information won't be updated as the ruler
is used. I don't see the need to call GDrawProcessPendingEvents,
and indeed, it works without this call. Calling GDrawRequestExpose
will not cause an infinite stack recursion.

Similarly, it's not necessary to reexpose the whole CharView window,
just the ruler's window (`cv->ruler_w`)

Related to PR #1464 (Issues #1402 and #1458).

Before:
![input](https://cloud.githubusercontent.com/assets/5137410/17576768/1630ec7c-5fa9-11e6-92c8-1347ba6e35f8.gif)
After:
![after](https://cloud.githubusercontent.com/assets/5137410/17576771/1b9efa96-5fa9-11e6-9154-54043d81ae8a.gif)

cc @frank-trampe 