### PR TITLE
Redo ParseGlyphOrderAndAliasDB to work with arbitrarily long files

### DIFF
--- a/fontforgeexe/encodingui.c
+++ b/fontforgeexe/encodingui.c
@@ -222,7 +222,7 @@ return( item );
 }
 
 void LoadEncodingFile(void) {
-    static char filter[] = "*.{ps,PS,txt,TXT,enc,ENC}";
+    static char filter[] = "*{.ps,.PS,.txt,.TXT,.enc,.ENC,GlyphOrderAndAliasDB}";
     char *fn;
     char *filename;
 

--- a/gdraw/gfiledlg.c
+++ b/gdraw/gfiledlg.c
@@ -111,7 +111,7 @@ static unichar_t *GWidgetOpenFileWPath(const unichar_t *title, const unichar_t *
     memset(&gcd,0,sizeof(gcd));
     memset(&boxes,0,sizeof(boxes));
     gcd[0].gd.pos.x = 12; gcd[0].gd.pos.y = 6;
-    gcd[0].gd.pos.width = 223-24; gcd[0].gd.pos.height = 180;
+    gcd[0].gd.pos.width = 223; gcd[0].gd.pos.height = 180;
     gcd[0].gd.flags = gg_visible | gg_enabled;
     gcd[0].creator = GFileChooserCreate;
     varray[0] = &gcd[0]; varray[1] = NULL;


### PR DESCRIPTION
This supercedes #2785. cc @frank-trampe 

### Motivation and Context
- The current parser cannot handle more than 1024 entries in a GOADB file - after that it segfaults
- It does not adequately handle 3-column data or even 2-column data (newlines aren't stripped)

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Description
Compared to https://gist.github.com/jtanx/1d81deb5344e33c7e461594ad5b593b6 :
* I've removed the special case handling of '.notdef' - I don't see why it shouldn't be named '.notdef' in the encoding.
* Unparseable lines now cause a warning to be displayed. These lines are also now added to the encoding, with no name and a value of -1
* I've fixed the dialogue being clipped:

    Before:
    ![encoding-before](https://cloud.githubusercontent.com/assets/5137410/17955892/0232d6bc-6ab8-11e6-8c71-ca1a8b6497e0.png)
    After:
    ![encoding-after](https://cloud.githubusercontent.com/assets/5137410/17955894/02fb13a2-6ab8-11e6-820b-b08c8977cb8c.png)

#### Limitations
When the encoding is saved by FF and then reloaded, information is lost. For [example](https://github.com/i-tu/Hasklig/blob/master/GlyphOrderAndAliasDB), when loading the following line at slot 3:

    CR CR uni000D

This gets assigned a unicode value of U+000D. But when FF saves the encoding, it gets dumped simply as:

     /CR

And there's no way to know that it should be mapped to U+000D