### PR TITLE
File chooser: Make the right click context menu work

### DIFF
--- a/gdraw/gfilechooser.c
+++ b/gdraw/gfilechooser.c
@@ -891,7 +891,14 @@ static int gotten=false;
 
 static void GFCPopupMenu(GGadget *g, GEvent *e) {
     int i;
-    GFileChooser *gfc = (GFileChooser *) GGadgetGetUserData(g);
+    // The reason this casting works is a bit of a hack.
+    // If this was initiated from a right click, `g` will be the GFC GGadget.
+    // Then its userdata would be the initiator's, and NOT the GFC struct.
+    // Thus we cannot call GGadgetGetUserData.
+    // However, since in the GFC struct, its GGadget comes first, effectively
+    // the pointer to its GGadget will equal the pointer to its GFC struct.
+    // I have ensured that all calls to this function pass the GFC GGadget.
+    GFileChooser *gfc = (GFileChooser *) g;
 
     for ( i=0; gfcpopupmenu[i].ti.text!=NULL || gfcpopupmenu[i].ti.line; ++i )
 	gfcpopupmenu[i].ti.userdata = gfc;
@@ -917,7 +924,7 @@ static int GFileChooserConfigure(GGadget *g, GEvent *e) {
 	fake.w = g->base;
 	fake.u.mouse.x = pos.x;
 	fake.u.mouse.y = pos.y+pos.height;
-	GFCPopupMenu(g,&fake);
+	GFCPopupMenu((GGadget*)GGadgetGetUserData(g),&fake);
     }
 return( true );
 }


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Fixes #2691 (this bug has been present since forever, or at least since the 2012 release).

If initiated from a right click, the GGadget passed to the popup menu
handler will be the GFC GGadget itself. As so, its userdata would be the
initiator's user data, and NOT the GFC struct, as is normally expected.

Thus, we cannot call GGadgetGetUserData. However, since in the GFC struct,
its GGadget comes first, effectively the pointer to its GGadget will equal
the pointer to its GFC struct.

Therefore, ensure to always pass the GFC GGadget to the popup handler and
simply cast from this to the GFC struct.