### PR TITLE
Fix improper use of cu_copy on GMenuItem's. Fixes #1927.

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -13056,7 +13056,7 @@ return;
  	if( mblist_nomm[i].shortcut )
 	    mblist_nomm[i].ti.text_untranslated = copy(mblist_nomm[i].shortcut);
 	else
-	    mblist_nomm[i].ti.text_untranslated = cu_copy(mblist_nomm[i].ti.text);
+	    mblist_nomm[i].ti.text_untranslated = copy((char*)mblist_nomm[i].ti.text);
 
 	mblist_nomm[i].ti.text = (unichar_t *) _((char *) mblist_nomm[i].ti.text);
     }

--- a/fontforgeexe/windowmenu.c
+++ b/fontforgeexe/windowmenu.c
@@ -292,7 +292,7 @@ return;
 	    tmp[1] = (unichar_t)(0);
 	    mb[i].ti.text_untranslated = cu_copy(tmp);
 	} else
-	    mb[i].ti.text_untranslated = cu_copy(mb[i].ti.text);
+	    mb[i].ti.text_untranslated = copy((char*)mb[i].ti.text);
 	if ( mb[i].ti.text!=NULL ) {
 	    mb[i].ti.text = (unichar_t *) S_((char *) mb[i].ti.text);
 	    if ( mb[i].sub!=NULL )
@@ -326,7 +326,7 @@ return;
 	if( mb[i].shortcut )
 	    mb[i].ti.text_untranslated = copy(mb[i].shortcut);
 	else
-	    mb[i].ti.text_untranslated = cu_copy(mb[i].ti.text);
+	    mb[i].ti.text_untranslated = copy((char*)mb[i].ti.text);
 	if ( mb[i].ti.text!=NULL ) {
 	    mb[i].ti.text = (unichar_t *) S_((char *) mb[i].ti.text);
 	    if ( mb[i].sub!=NULL )

--- a/inc/intl.h
+++ b/inc/intl.h
@@ -28,6 +28,8 @@
 #ifndef _INTL_H
 #define _INTL_H
 
+#include "fontforge-config.h"
+
 #if !defined( HAVE_LIBINTL_H )
 
 # define _(str)			(str)


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
In all the changed cases, the fields are actually just normal
strings and not the unichar variant. This stems from:
82322a4a4898aeb099b2a1f834bd111bf434ea3e

This bug was discovered after compiling at -O3 optimisation level.