### PR TITLE
Scrollbar: Allow horizontal scrolling with regular scroll wheel

### DIFF
--- a/gdraw/gscrollbar.c
+++ b/gdraw/gscrollbar.c
@@ -324,8 +324,8 @@ return( false );
 	    GDrawCancelTimer(gsb->pressed); gsb->pressed = NULL;
 	    int isv = event->u.mouse.button<=5;
 	    if ( event->u.mouse.state&ksm_shift ) isv = !isv;
-	    if ( isv != g->vert )
-return( false );	/* Only respond to scrolling events in our direction */
+	    if ( !isv && g->vert )
+return( false );	/* Allow horizontal scrolling with normal scroll but not vice versa */
 	    else if ( event->u.mouse.state&ksm_control )
 return( false );
 	    if ( event->u.mouse.button==5 || event->u.mouse.button==7 ) {


### PR DESCRIPTION
### Types of changes
Either a bug fix or a feature - depending on how you look at it.

### Description
Fixes #952.

This allows the normal scroll wheel to scroll a horizontal
scroll bar (but still prevents a horizontal scrolling action
from scrolling a vertical scroll bar).