### PR TITLE
Add boundary checks when allocating source/destination buffers when decompressing WOFF metadata

### DIFF
--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -1931,7 +1931,7 @@ typedef struct splinefont {
     int woffMajor;
 #define woffUnset		0x4455
     int woffMinor;
-    char *woffMetadata;
+    unsigned char *woffMetadata;
     real ufo_ascent, ufo_descent;	/* I don't know what these mean, they don't seem to correspond to any other ascent/descent pair, but retain them so round-trip ufo input/output leaves them unchanged */
 	    /* ufo_descent is negative */
     char *styleMapFamilyName;

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -1931,7 +1931,7 @@ typedef struct splinefont {
     int woffMajor;
 #define woffUnset		0x4455
     int woffMinor;
-    unsigned char *woffMetadata;
+    char *woffMetadata;
     real ufo_ascent, ufo_descent;	/* I don't know what these mean, they don't seem to correspond to any other ascent/descent pair, but retain them so round-trip ufo input/output leaves them unchanged */
 	    /* ufo_descent is negative */
     char *styleMapFamilyName;

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -359,12 +359,12 @@ return( NULL );
 	* it's never accessed anywhere else without a check for it being
 	* NULL first
 	*/
-	if(metaLenUncompressed == (uint32_t)0xffffffff) {
+	if(metaLenUncompressed == UINT32_MAX) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
 		return( sf );
 	}
-	if(metaLenCompressed == (uint32_t)0xffffffff) {
+	if(metaLenCompressed == UINT32_MAX) {
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		sf->woffMetadata = NULL;
 		return( sf );

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -366,7 +366,7 @@ return( NULL );
 	}
 	if(metaLenCompressed == 0xffffffff) {
 		LogError(_("WOFF compressed metadata section too large.\n"));
-		sf->woffMetaData = NULL;
+		sf->woffMetadata = NULL;
 		return( sf );
 	}
 	sf->woffMetadata = malloc(metaLenUncompressed+1);
@@ -377,8 +377,8 @@ return( NULL );
 	char *temp = malloc(metaLenCompressed+1);
 	if(temp == NULL) { 
 		LogError(_("WOFF compressed metadata section too large.\n"));
-		free(sf->woffMetaData);
-		sf->woffMetaData = NULL;
+		free(sf->woffMetadata); 
+		sf->woffMetadata = NULL;
 		free(temp);
 		return( sf );
 	}

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -359,12 +359,12 @@ return( NULL );
 	* it's never accessed anywhere else without a check for it being
 	* NULL first
 	*/
-	if(metaLenUncompressed == 0xffffffff) {
+	if(metaLenUncompressed == (unsigned int)0xffffffff) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
 		return( sf );
 	}
-	if(metaLenCompressed == 0xffffffff) {
+	if(metaLenCompressed == (unsigned int)0xffffffff) {
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		sf->woffMetadata = NULL;
 		return( sf );
@@ -374,7 +374,7 @@ return( NULL );
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		return( sf );
 	}
-	char *temp = malloc(metaLenCompressed+1);
+	unsigned char *temp = malloc(metaLenCompressed+1);
 	if(temp == NULL) { 
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		free(sf->woffMetadata); 
@@ -538,9 +538,9 @@ return( ret );
     fclose(sfnt);
 
     if ( sf->woffMetadata!= NULL ) {
-	int uncomplen = strlen(sf->woffMetadata);
+	int uncomplen = strlen((char*)sf->woffMetadata);
 	uLongf complen = 2*uncomplen;
-	char *temp=malloc(complen+1);
+	unsigned char *temp=malloc(complen+1);
 	newoffset = ftell(woff);
 	compress(temp,&complen,sf->woffMetadata,uncomplen);
 	fwrite(temp,1,complen,woff);

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -359,12 +359,12 @@ return( NULL );
 	* it's never accessed anywhere else without a check for it being
 	* NULL first
 	*/
-	if(metaLenUncompressed == (uint32_t)0xffffffff) {
+	if(metaLenUncompressed == (uint32_t)0xffffffffLU) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
 		return( sf );
 	}
-	if(metaLenCompressed == (uint32_t)0xffffffff) {
+	if(metaLenCompressed == (uint32_t)0xffffffffLU) {
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		sf->woffMetadata = NULL;
 		return( sf );

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -348,11 +348,45 @@ return( NULL );
     }
 
     if ( sf!=NULL && metaOffset!=0 ) {
+	/*
+1.	Check that the length of the compressed data is equal to or less than the length of the uncompressed data
+	Even though uncompress() is memory safe it's good practice to ensure that there's always enough room in our destination buffer
+
+2.	Allocate metadata destination buffer
+	Check if malloc returned a null pointer (requested too much memory) or if we overflowed and are pointing to a "0-size" buffer
+	If there's an overflow set it to null, if there's a null pointer, return
+
+3.	Allocate metadata source buffer
+	Same checks as #2
+	If either of these are true, then sf->woffMetadata = NULL, free(temp), and return sf
+	If neither of these things are true, then our call to fread() is safe.
+	*/
+	if(metaLenCompressed > metaLenUncompressed) {
+		LogError(_("WOFF compressed metadata should not be larger than uncompressed metadata.\n"));
+		sf->woffMetadata = NULL; 
+		return(sf);	
+	}
+	sf->woffMetadata = malloc(metaLenUncompressed+1); 
+	if(metaLenUncompressed == 0xffffffff) {
+		LogError(_("WOFF uncompressed metadata section too large.\n"));
+		sf->woffMetadata = NULL; 
+		return(sf);
+	}
+	if(sf->woffMetadata == NULL) {
+		LogError(_("WOFF uncompressed metadata section too large.\n"));
+		return(sf);
+	}
+
 	char *temp = malloc(metaLenCompressed+1);
+	if(metaLenCompressed == 0xffffffff || temp == NULL) { 
+		LogError(_("WOFF compressed metadata section too large.\n"));
+		sf->woffMetadata = NULL;
+		free(temp);
+		return(sf);
+	}
 	uLongf len = metaLenUncompressed;
 	fseek(woff,metaOffset,SEEK_SET);
 	fread(temp,1,metaLenCompressed,woff);
-	sf->woffMetadata = malloc(metaLenUncompressed+1);
 	sf->woffMetadata[metaLenUncompressed] ='\0';
 	uncompress(sf->woffMetadata,&len,temp,metaLenCompressed);
 	sf->woffMetadata[len] ='\0';

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -213,7 +213,7 @@ SplineFont *_SFReadWOFF(FILE *woff,int flags,enum openflags openflags, char *fil
     int len, len_stated;
     int num_tabs;
     int major, minor;
-    int metaOffset, metaLenCompressed, metaLenUncompressed;
+    uint32_t metaOffset, metaLenCompressed, metaLenUncompressed;
     int privOffset, privLength;
     int i,j,err;
     int tag, offset, compLen, uncompLen, checksum;
@@ -253,9 +253,9 @@ return( NULL );
     /* total_uncompressed_sfnt_size = */ getlong(woff);
     major = getushort(woff);
     minor = getushort(woff);
-    metaOffset = getlong(woff);
-    metaLenCompressed = getlong(woff);
-    metaLenUncompressed = getlong(woff);
+    metaOffset = (uint32_t)getlong(woff);
+    metaLenCompressed = (uint32_t)getlong(woff);
+    metaLenUncompressed = (uint32_t)getlong(woff);
     privOffset = getlong(woff);
     privLength = getlong(woff);
 
@@ -359,12 +359,12 @@ return( NULL );
 	* it's never accessed anywhere else without a check for it being
 	* NULL first
 	*/
-	if(metaLenUncompressed == (unsigned int)0xffffffff) {
+	if(metaLenUncompressed == (uint32_t)0xffffffff) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
 		return( sf );
 	}
-	if(metaLenCompressed == (unsigned int)0xffffffff) {
+	if(metaLenCompressed == (uint32_t)0xffffffff) {
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		sf->woffMetadata = NULL;
 		return( sf );

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -386,7 +386,7 @@ return( NULL );
 	fseek(woff,metaOffset,SEEK_SET);
 	fread(temp,1,metaLenCompressed,woff);
 	sf->woffMetadata[metaLenUncompressed] ='\0';
-	uncompress(sf->woffMetadata,&len,temp,metaLenCompressed);
+	uncompress((unsigned char *)sf->woffMetadata,&len,temp,metaLenCompressed);
 	sf->woffMetadata[len] ='\0';
 	free(temp);
     }
@@ -542,7 +542,7 @@ return( ret );
 	uLongf complen = 2*uncomplen;
 	unsigned char *temp=malloc(complen+1);
 	newoffset = ftell(woff);
-	compress(temp,&complen,sf->woffMetadata,uncomplen);
+	compress(temp,&complen,(unsigned char *)sf->woffMetadata,uncomplen);
 	fwrite(temp,1,complen,woff);
 	free(temp);
 	if ( (ftell(woff)&3)!=0 ) {

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -352,47 +352,42 @@ return( NULL );
 	* Boundary/integer overflow checks:
 	*
 	* We don't want to actually dereference a null pointer (returned
-	* by asking to allocate too much RAM) and we don't want to create
-	* a 0-sized chunk
+	* by asking to allocate too much RAM) and we don't want to allocate
+	* a 0-sized chunk (caused when one of the (metaLenxxx + 1) values overflows).
 	*
 	* uncompress() will always safely return an error if
-	* metaLenCompressed > metaLenUncompressed, might as well prevent
-	* this. Also prevents calling malloc(0) because 0xFFFFFFFF is the
-	* largest possible value for an unsigned 32bit int and the case
-	* where both values are 0xFFFFFFFF is prevented by check #2.
+	* metaLenCompressed > metaLenUncompressed, so check #1 prevents
+	* this. This check, in conjunction with #2, also prevents calling
+	* malloc(0) because 0xFFFFFFFF is the largest possible value for 
+	* an unsigned 32bit int and the case where both values are 0xFFFFFFFF 
+	* is prevented by check #2.
 	*
 	* We can safely pass sf->woffMetadata as a NULL pointer because
 	* it's never accessed anywhere else without a check for it being
 	* NULL first
 	*/
-	if(metaLenCompressed > metaLenUncompressed) {
+	if(metaLenCompressed > metaLenUncompressed) { // Check #1 to prevent uncompress from returning an error
 		LogError(_("WOFF compressed metadata should not be larger than uncompressed metadata.\n"));
 		sf->woffMetadata = NULL; 
-		return(sf);	
+		return( sf );	
 	}
-
-	if(metaLenUncompressed == 0xffffffff) {
+	if(metaLenUncompressed == 0xffffffff) { //check #2 to prevent sf->woffMetadata from pointing to 0-sized buffer
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
 		return( sf );
 	}
-
 	sf->woffMetadata = malloc(metaLenUncompressed+1);
-
-	if(sf->woffMetadata == NULL) {
+	if(sf->woffMetadata == NULL) { //check #3 to prevent dereferencing a null pointer later in this subroutine
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		return( sf );
 	}
-
 	char *temp = malloc(metaLenCompressed+1);
-
-	if(temp == NULL) { 
+	if(temp == NULL) { //check #4 to prevent dereferencing another null pointer later in this subroutine
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		sf->woffMetadata = NULL;
 		free(temp);
 		return( sf );
 	}
-
 	uLongf len = metaLenUncompressed;
 	fseek(woff,metaOffset,SEEK_SET);
 	fread(temp,1,metaLenCompressed,woff);

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -359,12 +359,12 @@ return( NULL );
 	* it's never accessed anywhere else without a check for it being
 	* NULL first
 	*/
-	if(metaLenUncompressed == (uint32_t)0xffffffffLU) {
+	if(metaLenUncompressed == (uint32_t)0xffffffff) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
 		return( sf );
 	}
-	if(metaLenCompressed == (uint32_t)0xffffffffLU) {
+	if(metaLenCompressed == (uint32_t)0xffffffff) {
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		sf->woffMetadata = NULL;
 		return( sf );

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -374,14 +374,14 @@ return( NULL );
 	if(metaLenUncompressed == 0xffffffff) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
-		return(sf);
+		return( sf );
 	}
 
 	sf->woffMetadata = malloc(metaLenUncompressed+1);
 
 	if(sf->woffMetadata == NULL) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
-		return(sf);
+		return( sf );
 	}
 
 	char *temp = malloc(metaLenCompressed+1);
@@ -390,7 +390,7 @@ return( NULL );
 		LogError(_("WOFF compressed metadata section too large.\n"));
 		sf->woffMetadata = NULL;
 		free(temp);
-		return(sf);
+		return( sf );
 	}
 
 	uLongf len = metaLenUncompressed;

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -355,36 +355,30 @@ return( NULL );
 	* by asking to allocate too much RAM) and we don't want to allocate
 	* a 0-sized chunk (caused when one of the (metaLenxxx + 1) values overflows).
 	*
-	* uncompress() will always safely return an error if
-	* metaLenCompressed > metaLenUncompressed, so check #1 prevents
-	* this. This check, in conjunction with #2, also prevents calling
-	* malloc(0) because 0xFFFFFFFF is the largest possible value for 
-	* an unsigned 32bit int and the case where both values are 0xFFFFFFFF 
-	* is prevented by check #2.
-	*
 	* We can safely pass sf->woffMetadata as a NULL pointer because
 	* it's never accessed anywhere else without a check for it being
 	* NULL first
 	*/
-	if(metaLenCompressed > metaLenUncompressed) { // Check #1 to prevent uncompress from returning an error
-		LogError(_("WOFF compressed metadata should not be larger than uncompressed metadata.\n"));
-		sf->woffMetadata = NULL; 
-		return( sf );	
-	}
-	if(metaLenUncompressed == 0xffffffff) { //check #2 to prevent sf->woffMetadata from pointing to 0-sized buffer
+	if(metaLenUncompressed == 0xffffffff) {
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		sf->woffMetadata = NULL; 
 		return( sf );
 	}
+	if(metaLenCompressed == 0xffffffff) {
+		LogError(_("WOFF compressed metadata section too large.\n"));
+		sf->woffMetaData = NULL;
+		return( sf );
+	}
 	sf->woffMetadata = malloc(metaLenUncompressed+1);
-	if(sf->woffMetadata == NULL) { //check #3 to prevent dereferencing a null pointer later in this subroutine
+	if(sf->woffMetadata == NULL) { 
 		LogError(_("WOFF uncompressed metadata section too large.\n"));
 		return( sf );
 	}
 	char *temp = malloc(metaLenCompressed+1);
-	if(temp == NULL) { //check #4 to prevent dereferencing another null pointer later in this subroutine
+	if(temp == NULL) { 
 		LogError(_("WOFF compressed metadata section too large.\n"));
-		sf->woffMetadata = NULL;
+		free(sf->woffMetaData);
+		sf->woffMetaData = NULL;
 		free(temp);
 		return( sf );
 	}

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -538,7 +538,7 @@ return( ret );
     fclose(sfnt);
 
     if ( sf->woffMetadata!= NULL ) {
-	int uncomplen = strlen((char*)sf->woffMetadata);
+	int uncomplen = strlen(sf->woffMetadata);
 	uLongf complen = 2*uncomplen;
 	unsigned char *temp=malloc(complen+1);
 	newoffset = ftell(woff);

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -349,13 +349,21 @@ return( NULL );
 
     if ( sf!=NULL && metaOffset!=0 ) {
 	/*
-	Boundary/integer overflow checks:
-
-	We don't want to actually dereference a null pointer (returned by asking to allocate too much RAM) and we don't want to create a 0-sized chunk
-
-	uncompress() will always safely return an error if metaLenCompressed > metaLenUncompressed, might as well prevent this. Also prevents calling malloc(0) because 0xFFFFFFFF is the largest possible value for an unsigned 32bit int and the case where they're both 0xFFFFFFFF is prevented by check #2.
-
-	We can safely pass sf->woffMetadata as a NULL pointer because it's never accessed anywhere else without a check for it being NULL first
+	* Boundary/integer overflow checks:
+	*
+	* We don't want to actually dereference a null pointer (returned
+	* by asking to allocate too much RAM) and we don't want to create
+	* a 0-sized chunk
+	*
+	* uncompress() will always safely return an error if
+	* metaLenCompressed > metaLenUncompressed, might as well prevent
+	* this. Also prevents calling malloc(0) because 0xFFFFFFFF is the
+	* largest possible value for an unsigned 32bit int and the case
+	* where both values are 0xFFFFFFFF is prevented by check #2.
+	*
+	* We can safely pass sf->woffMetadata as a NULL pointer because
+	* it's never accessed anywhere else without a check for it being
+	* NULL first
 	*/
 	if(metaLenCompressed > metaLenUncompressed) {
 		LogError(_("WOFF compressed metadata should not be larger than uncompressed metadata.\n"));


### PR DESCRIPTION
Provide a general summary of your changes in the **Title** above.

### Important
Mark with [x] to select. Leave as [ ] to unselect.

### Motivation and Context
- [x] Why is this change required? What problem does it solve?
Fixes memory safety issue when decompressing WOFF metadata and null pointer crashes caused by having metaLenCompressed or metaLenUncompressed values that are too large
- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.
In *_SFReadWOFF:
If either metaLenCompressed or metaLenUncompressed are 0xFFFFFFFF, set sf->woffMetadata as a null pointer and return. If malloc() fails when creating the destination buffer, return. If malloc() fails when creating the source buffer, call free(sf->woffMetadata) to avoid a memory leak, set sf->woffMetadata as a null pointer, and then return.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.
