### PR TITLE
Make test926.py Python 3 compatible and add it to Makefile.am

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -155,7 +155,7 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
 	test1001.py test1001a.py test1001b.py test1001c.py	\
 	test1002.py test1003.py test1004.py test1005.py		\
-	test1006.py test1007.py test1008.py
+	test1006.py test1007.py test1008.py test926.py
 
 EXTRA_DIST += link_test.c randomtest.c build-aux/missing
 


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
This test was actually being skipped when it should not have. Furthermore, it needs to be Python 3 compatible as Travis compiles FF with Python 3 support.

I'm not entirely sure that I've covered all relevant changes for full Python 3 support of the validator, but it works enough in the context of this unit test. I've also confirmed it still works on Python 2, for what it's worth.

See #2524 

cc @JoesCat  - might need to do some rebasing depending on whether this or #2762 is merged first.