### PR TITLE
Build system: Cleanup a few options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -597,7 +597,6 @@ AC_SUBST([MY_CFLAGS],[${my_cflags}])
 #--------------------------------------------------------------------------
 # Create and Set FontForge Library Flags
 
-test x"${i_do_have_python_scripting}" = xyes && my_libs="${my_libs} ${PYTHON_LIBS}"
 test x"${i_do_have_giflib}" = xyes && my_libs="${my_libs} ${GIFLIB_LIBS}"
 test x"${i_do_have_libjpeg}" = xyes && my_libs="${my_libs} ${LIBJPEG_LIBS}"
 test x"${i_do_have_libpng}" = xyes && my_libs="${my_libs} ${LIBPNG_LIBS}"
@@ -609,7 +608,6 @@ test x"${i_do_have_cairo}" = xyes && my_libs="${my_libs} ${PANGOCAIRO_LIBS}"
 test x"${i_do_have_gui}" = xyes && my_libs="${my_libs} ${PANGO_LIBS}"
 test x"${i_do_have_x}" = xyes && my_libs="${my_libs} ${X_PRE_LIBS} ${X_LIBS} ${X_EXTRA_LIBS}"
 test x"${i_do_have_libreadline}" = xyes && my_libs="${my_libs} ${LIBREADLINE_LIBS}"
-my_libs="${my_libs} ${PYTHON_LIBS}"
 test x"${i_do_have_libspiro}" = xyes && my_libs="${my_libs} ${LIBSPIRO_LIBS}"
 my_libs="${my_libs} ${LIBSPIRO_LIBS}"
 my_libs="${my_libs} ${FREETYPE_LIBS}"

--- a/configure.ac
+++ b/configure.ac
@@ -215,20 +215,6 @@ AC_PATH_PROG([UPDATE_MIME_DATABASE],[update-mime-database],[:])
 AC_PATH_PROG([UPDATE_DESKTOP_DATABASE],[update-desktop-database],[:])
 AC_PATH_PROG([PLUTIL],[plutil],[:])
 
-if test "y$HOMEBREW_BREW_FILE" != "y"; then
-   echo "detected a homebrew build environment"
-   PYLIBDIR=$(${HOMEBREW_PREFIX}/bin/python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-   PYPKGCONFIG="$( cd "$PYLIBDIR/../../pkgconfig" && pwd )"
-   export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$PYPKGCONFIG"
-   echo "found python pkg_config information: $PYPKGCONFIG"
-   if test "y$PYTHON" = "y"; then
-     export PYTHON="${HOMEBREW_PREFIX}/bin/python"
-   fi
-fi
-
-AM_PATH_PYTHON([2.7])
-PKG_CHECK_MODULES([PYTHON],[python-"${PYTHON_VERSION}"])
-i_do_have_python_scripting=yes;
 
 dnl###############################
 dnl###############################
@@ -635,20 +621,15 @@ AC_SUBST([MY_LIBS],[${my_libs}])
 
 #--------------------------------------------------------------------------
 
-have_ipython=no
-
-if test x$use_python_cross_option = xyes ; then
-   echo "skipping ipython detection during a cross compile"
-else
-   pythonbinary=python
-   AC_ARG_WITH([pythonbinary],
-      [AS_HELP_STRING([--with-pythonbinary[[=/path/to/python2.7]]],[])],
-      [pythonbinary="${withval}"])
-
-   have_ipython=no
-   if $( $pythonbinary -c 'import IPython' 2> /dev/null ); then
-      have_ipython=yes;
-      AC_DEFINE([HAVE_IPYTHON],[1],[have ipython])
+if test x"${i_do_have_python_scripting}" = xyes; then
+   AC_MSG_CHECKING([for IPython])
+   if $( $PYTHON -c 'import IPython' 2>&5 ); then
+        have_ipython=yes;
+        AC_DEFINE([HAVE_IPYTHON],[1],[have ipython])
+        AC_MSG_RESULT([yes])
+   else
+        have_ipython=no
+        AC_MSG_RESULT([no])
    fi
 fi
 
@@ -662,7 +643,7 @@ AC_ARG_ENABLE([python-even],
         [AS_HELP_STRING([--enable-python-even],
                 [enable a menu entry for Even])],
         [have_python_even=yes])
-AM_CONDITIONAL([HAVE_PYTHON_EVEN],[test x"${have_python_even}" = xyes])
+AM_CONDITIONAL([HAVE_PYTHON_EVEN],[test x"${have_python_even}" = xyes && test x"${i_do_have_python_scripting}" = xyes])
 
 #--------------------------------------------------------------------------
 #--------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,32 @@ AM_MAINTAINER_MODE([enable])
 AC_USE_SYSTEM_EXTENSIONS
 
 #--------------------------------------------------------------------------
+#
+# Checks for programs.
+
+AC_PROG_AWK
+AC_PROG_CC
+AC_PROG_CC_C99
+AM_PROG_CC_C_O
+gl_EARLY
+AC_PROG_CPP
+AC_PROG_GREP
+AC_PROG_INSTALL
+AC_PROG_LN_S
+AC_PROG_MAKE_SET
+AC_PROG_MKDIR_P
+AC_PROG_SED
+
+# Check for Objective C compiler
+m4_ifdef([AC_PROG_OBJC], [
+    AC_PROG_OBJC
+], [
+    AM_CONDITIONAL([am__fastdepOBJC], false)
+    AC_SUBST([OBJC], [$CC])
+    AC_SUBST([OBJCFLAGS], [$CFLAGS])
+])
+
+#--------------------------------------------------------------------------
 # automake 1.12 requires AM_PROG_AR but automake < 1.11.2 doesn't recognize it.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
@@ -178,32 +204,7 @@ libjpeg_url="http://en.wikipedia.org/wiki/Libjpeg"
 libtiff_url="http://en.wikipedia.org/wiki/Libtiff"
 
 #--------------------------------------------------------------------------
-#
-# Checks for programs.
 
-AC_PROG_AWK
-AC_PROG_CC
-AC_PROG_CC_C99
-AM_PROG_CC_C_O
-gl_EARLY
-AC_PROG_CPP
-AC_PROG_GREP
-AC_PROG_INSTALL
-AC_PROG_LN_S
-AC_PROG_MAKE_SET
-AC_PROG_MKDIR_P
-AC_PROG_SED
-
-# Check for Objective C compiler
-m4_ifdef([AC_PROG_OBJC], [
-    AC_PROG_OBJC
-], [
-    AM_CONDITIONAL([am__fastdepOBJC], false)
-    AC_SUBST([OBJC], [$CC])
-    AC_SUBST([OBJCFLAGS], [$CFLAGS])
-])
-
-#--------------------------------------------------------------------------
 # Required for building FontForge package, plus we use PKG_CHECK_MODULES in
 # a few checks and searches for programs and libraries.
 # NOTE: Some distros don't have /usr/local included in the /etc/ld.so PATH,

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,15 @@ AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
 AC_PROG_SED
 
+# Check for Objective C compiler
+m4_ifdef([AC_PROG_OBJC], [
+    AC_PROG_OBJC
+], [
+    AM_CONDITIONAL([am__fastdepOBJC], false)
+    AC_SUBST([OBJC], [$CC])
+    AC_SUBST([OBJCFLAGS], [$CFLAGS])
+])
+
 #--------------------------------------------------------------------------
 # Required for building FontForge package, plus we use PKG_CHECK_MODULES in
 # a few checks and searches for programs and libraries.

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -101,7 +101,15 @@ endif LIBZMQ
 libfontforge_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGE_VERSION) \
 	${MY_LIB_LDFLAGS}
 
-libfontforge_la_LIBADD += $(MY_LIBS) $(LIBZMQ_LIBS)
+if PYTHON_SCRIPTING
+if !MACINTOSH
+libfontforge_la_LIBADD += $(PYTHON_LIBS)
+else
+libfontforge_la_LDFLAGS += -undefined dynamic_lookup
+endif MACINTOSH
+endif PYTHON_SCRIPTING
+
+libfontforge_la_LIBADD += $(MY_LIBS)
 
 #--------------------------------------------------------------------------
 

--- a/fontforge/bezctx_ff.c
+++ b/fontforge/bezctx_ff.c
@@ -57,7 +57,7 @@ nancheck(bezctx_ff *bc) {
 static void bezctx_ff_moveto(bezctx *z, double x, double y, int is_open) {
     bezctx_ff *bc = (bezctx_ff *)z;
 
-    if ( !finite(x) || !finite(y)) {	/* Protection against NaNs */
+    if ( !isfinite(x) || !isfinite(y)) {	/* Protection against NaNs */
 	nancheck(bc);
 	x = y = 0;
     }
@@ -78,7 +78,7 @@ static void bezctx_ff_lineto(bezctx *z, double x, double y) {
     bezctx_ff *bc = (bezctx_ff *)z;
     SplinePoint *sp;
 
-    if ( !finite(x) || !finite(y)) {
+    if ( !isfinite(x) || !isfinite(y)) {
 	nancheck(bc);
 	x = y = 0;
     }
@@ -97,7 +97,7 @@ bezctx_ff_quadto(bezctx *z, double xm, double ym, double x3, double y3) {
     double x2, y2;
     SplinePoint *sp;
 
-    if ( !finite(xm) || !finite(ym) || !finite(x3) || !finite(y3)) {
+    if ( !isfinite(xm) || !isfinite(ym) || !isfinite(x3) || !isfinite(y3)) {
 	nancheck(bc);
 	xm = ym = x3 = y3 = 0;
     }
@@ -126,7 +126,7 @@ bezctx_ff_curveto(bezctx *z, double x1, double y1, double x2, double y2,
     bezctx_ff *bc = (bezctx_ff *)z;
     SplinePoint *sp;
 
-    if ( !finite(x1) || !finite(y1) || !finite(x2) || !finite(y2) || !finite(x3) || !finite(y3)) {
+    if ( !isfinite(x1) || !isfinite(y1) || !isfinite(x2) || !isfinite(y2) || !isfinite(x3) || !isfinite(y3)) {
 	nancheck(bc);
 	x1 = y1 = x2 = y2 = x3 = y3 = 0;
     }

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -533,7 +533,7 @@ static void GICImportBlues(GlobalInstrCt *gic) {
 	    if (values != NULL) {
 	        /* First pair is a bottom zone (see Type1 specification). */
 	        for (j=0; j<bluecnt; j++)
-		    if (finite(gic->blues[j].family_base))
+		    if (isfinite(gic->blues[j].family_base))
 		        continue;
 		    else if (values[1] != gic->blues[j].base &&
 		             SegmentsOverlap(gic->blues[j].base,
@@ -544,7 +544,7 @@ static void GICImportBlues(GlobalInstrCt *gic) {
 		/* Next pairs are top zones (see Type1 specification). */
 		for (i=1; i<cnt; i++) {
 		    for (j=0; j<bluecnt; j++)
-		        if (finite(gic->blues[j].family_base))
+		        if (isfinite(gic->blues[j].family_base))
 			    continue;
 			else if (values[2*i] != gic->blues[j].base &&
 			         SegmentsOverlap(gic->blues[j].base,
@@ -564,7 +564,7 @@ static void GICImportBlues(GlobalInstrCt *gic) {
 		/* All pairs are bottom zones (see Type1 specification). */
 		for (i=0; i<cnt; i++) {
 		    for (j=0; j<bluecnt; j++)
-		        if (finite(gic->blues[j].family_base))
+		        if (isfinite(gic->blues[j].family_base))
 			    continue;
 			else if (values[2*i+1] != gic->blues[j].base &&
 			         SegmentsOverlap(gic->blues[j].base,
@@ -691,7 +691,7 @@ static void init_cvt(GlobalInstrCt *gic) {
         gic->blues[i].cvtindex = cvtindex;
         memputshort(cvt, 2*cvtindex++, rint(gic->blues[i].base));
 
-	if (finite(gic->blues[i].family_base)) {
+	if (isfinite(gic->blues[i].family_base)) {
 	    gic->blues[i].family_cvtindex = cvtindex;
             memputshort(cvt, 2*cvtindex++, rint(gic->blues[i].family_base));
 	}
@@ -1677,7 +1677,7 @@ static uint8 *use_family_blues(uint8 *prep_head, GlobalInstrCt *gic) {
     int callargs[3];
 
     for (i=0; i<gic->bluecnt; i++) {
-        if (finite(gic->blues[i].family_base))
+        if (isfinite(gic->blues[i].family_base))
         {
             for (stopat=0; stopat<32768; stopat++) {
                 h1 = compute_blue_height(gic->blues[i].base, EM, bs, stopat);

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1198,7 +1198,7 @@ return( pt_number );
 	    }
 	} else {
 	    *val = strtod(tokbuf,&end);
-	    if ( !finite(*val) ) {
+	    if ( !isfinite(*val) ) {
 /* GT: NaN is a concept in IEEE floating point which means "Not a Number" */
 /* GT: it is used to represent errors like 0/0 or sqrt(-1). */
 		LogError( _("Bad number, infinity or nan: %s\n"), tokbuf );

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -534,7 +534,7 @@ return( pt_number );
 	    }
 	} else {
 	    *val = strtod(tokbuf,&end);
-	    if ( !finite(*val) ) {
+	    if ( !isfinite(*val) ) {
 /* GT: NaN is a concept in IEEE floating point which means "Not a Number" */
 /* GT: it is used to represent errors like 0/0 or sqrt(-1). */
 		LogError( _("Bad number, infinity or nan: %s\n"), tokbuf );
@@ -685,14 +685,14 @@ return( sp );
 }
 
 static void CheckMakeB(BasePoint *test, BasePoint *good) {
-    if ( !finite(test->x) || test->x>100000 || test->x<-100000 ) {
+    if ( !isfinite(test->x) || test->x>100000 || test->x<-100000 ) {
 	LogError( _("Value out of bounds in spline.\n") );
 	if ( good!=NULL )
 	    test->x = good->x;
 	else
 	    test->x = 0;
     }
-    if ( !finite(test->y) || test->y>100000 || test->y<-100000 ) {
+    if ( !isfinite(test->y) || test->y>100000 || test->y<-100000 ) {
 	LogError( _("Value out of bounds in spline.\n") );
 	if ( good!=NULL )
 	    test->y = good->y;

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -1374,7 +1374,7 @@ static void bIsNan(Context *c) {
 
 static void bIsFinite(Context *c) {
     c->return_val.type = v_int;
-    c->return_val.u.ival = finite( c->a.vals[1].u.fval );
+    c->return_val.u.ival = isfinite( c->a.vals[1].u.fval );
 }
 
 

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -2126,7 +2126,7 @@ static int MakeEllipseWithAxis(CharViewBase *cv,SplinePoint *sp1,SplinePoint *sp
     clockwise = EllipseClockwise(sp1,sp2,&slope1,&slope2);
     dot = slope1.y*slope2.x - slope1.x*slope2.y;
     theta = atan2(-slope1.x,slope1.y);
-    if ( !finite(theta))
+    if ( !isfinite(theta))
 return( false );
     c = cos(theta); s = sin(theta);
     if ( RealNear(dot,0) ) {

--- a/fontforge/splinerefigure.c
+++ b/fontforge/splinerefigure.c
@@ -85,7 +85,7 @@ void SplineRefigure3(Spline *spline) {
 		spline->isquadratic = true;	/* Only likely if we read in a TTF */
 	}
     }
-    if ( !finite(ysp->a) || !finite(xsp->a) || !finite(ysp->c) || !finite(xsp->c) || !finite(ysp->d) || !finite(xsp->d))
+    if ( !isfinite(ysp->a) || !isfinite(xsp->a) || !isfinite(ysp->c) || !isfinite(xsp->c) || !isfinite(ysp->d) || !isfinite(xsp->d))
 	IError("NaN value in spline creation");
     LinearApproxFree(spline->approx);
     spline->approx = NULL;

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -4645,7 +4645,7 @@ int LineTangentToSplineThroughPt(Spline *s, BasePoint *pt, extended ts[4],
     Quartic quad;
     int i,j,k;
 
-    if ( !finite(pt->x) || !finite(pt->y) ) {
+    if ( !isfinite(pt->x) || !isfinite(pt->y) ) {
 	IError( "Non-finite arguments passed to LineTangentToSplineThroughPt");
 return( -1 );
     }

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -43,16 +43,6 @@ endif THE_PROGRAMS
 
 lib_LTLIBRARIES = libfontforgeexe.la
 
-#--------------------------------------------------------------------------
-
-macobjective.o: macobjective.m
-	clang -I../inc -I../osx/FontForge.app/Contents/Frameworks/Breakpad.framework/Headers \
-            -g -arch x86_64 -arch i386 \
-            -c "${srcdir}/macobjective.m" -o macobjective.o
-
-
-#--------------------------------------------------------------------------
-
 SUBDIRS = pixmaps
 if LIBZMQ
 SUBDIRS += collab
@@ -116,6 +106,8 @@ endif THE_PROGRAMS
 
 #--------------------------------------------------------------------------
 
+libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS)
+
 if GRAPHICAL_USER_INTERFACE
 
 libfontforgeexe_la_SOURCES = alignment.c anchorsaway.c   \
@@ -137,18 +129,23 @@ libfontforgeexe_la_SOURCES = alignment.c anchorsaway.c   \
 	collabclientui.c collabclientui.h                                       \
 	sfundo.c wordlistparser.c wordlistparser.h fontforgeexe.h
 
+EXTRA_libfontforgeexe_la_SOURCES = macobjective.m
+
+libfontforgeexe_la_CPPFLAGS +=  $(LIBZMQ_CFLAGS) $(GTK2_CFLAGS)
+
+if MACINTOSH
+libfontforgeexe_la_OBJCFLAGS = -I../osx/FontForge.app/Contents/Frameworks/Breakpad.framework/Headers
+libfontforgeexe_la_SOURCES += macobjective.m
+endif
+
 else !GRAPHICAL_USER_INTERFACE
 
 libfontforgeexe_la_SOURCES = startnoui.c
 
 endif !GRAPHICAL_USER_INTERFACE
 
-if MACINTOSH
-MACFFEXE_LIBADD=macobjective.o
-endif MACINTOSH
 
-libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBZMQ_CFLAGS) $(GTK2_CFLAGS)
-libfontforgeexe_la_LIBADD = $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MACFFEXE_LIBADD) $(MY_LIBS) $(GTK2_LIBS) $(top_builddir)/fontforge/libfontforge.la $(BREAKPAD_LIBADD)
+libfontforgeexe_la_LIBADD = $(LTDLDEPS) $(LIBADD) $(GUILIBADD) $(MY_LIBS) $(GTK2_LIBS) $(top_builddir)/fontforge/libfontforge.la $(BREAKPAD_LIBADD)
 
 libfontforgeexe_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGEEXE_VERSION) \
 	${MY_LIB_LDFLAGS}
@@ -165,7 +162,7 @@ endif PYTHON_SCRIPTING
 
 EXTRA_DIST = fontimage.pe fontlint.pe sfddiff.pe	\
 	fontimage.1 fontlint.1 sfddiff.1		\
-	acorn2sfd.c darwinsetup.in macobjective.m
+	acorn2sfd.c darwinsetup.in
 # MacFontForgeApp.zip
 MOSTLYCLEANFILES = fontimage fontlint sfddiff
 DISTCLEANFILES = $(MOSTLYCLEANFILES)

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -157,6 +157,10 @@ if LIBZMQ
 libfontforgeexe_la_LIBADD += $(top_builddir)/collab/libzmqcollab.la $(LIBZMQ_LIBS)
 endif
 
+if PYTHON_SCRIPTING
+libfontforgeexe_la_LIBADD += $(PYTHON_LIBS)
+endif PYTHON_SCRIPTING
+
 #--------------------------------------------------------------------------
 
 EXTRA_DIST = fontimage.pe fontlint.pe sfddiff.pe	\

--- a/fontforgeexe/macobjective.m
+++ b/fontforgeexe/macobjective.m
@@ -25,8 +25,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "macobjective.h"
 #include "fontforge-config.h"
+#include "macobjective.h"
 
 #ifdef USE_BREAKPAD
 

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -34,7 +34,7 @@ AC_ARG_ENABLE([python-scripting],
         [i_do_have_python_scripting="${enableval}"],
         [i_do_have_python_scripting=yes])
 if test x"${i_do_have_python_scripting}" = xyes; then
-   AM_PATH_PYTHON([2.3])
+   AM_PATH_PYTHON([2.7])
    PKG_CHECK_MODULES([PYTHON],[python-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=no; force_off_python_extension=yes])
 fi
 if test x"${i_do_have_python_scripting}" != xyes; then

--- a/osx/FontForge.app/Contents/Frameworks/Breakpad.framework/Makefile.am
+++ b/osx/FontForge.app/Contents/Frameworks/Breakpad.framework/Makefile.am
@@ -40,10 +40,10 @@ if PLATFORM_OSX
 
 install-exec-hook:
 	cd $(DESTDIR)/$(pkgdatadir)/osx/FontForge.app/Contents/Frameworks/Breakpad.framework && \
-	$(LN_S) Versions/Current/Resources Resources && \
-	$(LN_S) Versions/Current/Headers   Headers   && \
-	$(LN_S) Versions/Current/Breakpad  Breakpad  && \
-	$(LN_S) Versions/Current/Breakpad  libBreakpad.dylib
+	$(LN_S) -f Versions/Current/Resources Resources && \
+	$(LN_S) -f Versions/Current/Headers   Headers   && \
+	$(LN_S) -f Versions/Current/Breakpad  Breakpad  && \
+	$(LN_S) -f Versions/Current/Breakpad  libBreakpad.dylib
 
 endif
 

--- a/osx/FontForge.app/Contents/Frameworks/Breakpad.framework/Versions/Makefile.am
+++ b/osx/FontForge.app/Contents/Frameworks/Breakpad.framework/Versions/Makefile.am
@@ -32,7 +32,7 @@ if PLATFORM_OSX
 
 install-exec-hook:
 	cd $(DESTDIR)/$(pkgdatadir)/osx/FontForge.app/Contents/Frameworks/Breakpad.framework/Versions && \
-	$(LN_S) A Current
+	$(LN_S) -f A Current
 endif
 
 

--- a/travis-scripts/fontforge.rb
+++ b/travis-scripts/fontforge.rb
@@ -87,7 +87,6 @@ class Fontforge < Formula
       --prefix=#{prefix}
       --enable-silent-rules
       --disable-dependency-tracking
-      --with-pythonbinary=#{which "python2.7"}
       --without-x
     ]
 


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
    - Removal of `--with-pythonbinary` option that was misleading (see description below). Whoever manages the Homebrew formula will want to remove this option if/when this is merged.

### Description
* Remove homebrew check. Fixes #2425.
* Remove bogus option `--with-pythonbinary`. This was only used for checking
  IPython - it's nonsensical to have this option given that Python has
  already been checked for by AM_PATH_PYTHON. If you want to override which
  Python to use, export the PYTHON variable before running the configure script.
* Cleanup the IPython detection code. the `use_python_cross_option` variable no
  longer exists. Also only check for IPython only if we're building with Python
  support.
* Remove the Python check in configure.ac - this is already handled by
  FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING. This allows FontForge to build without
  having Python installed and `--disable-python-scripting` is passed. Previously,
  even if --disable-python-scripting was specified, configure would fall over
  because of the unconditional AM_PATH_PYTHON check.
* Don't link libfontforge to Python on OS X - fixes #2553.
* Remove the non-standard way of compiling `macobjective.m`. Instead use a method more canonical with autotools. This method of compiling objective C files was stolen from my GDK PR.
* Force symlink creation (again, stolen from my GDK PR) so that repeated `make install`s on OS X work.
* Move program detection and `gl_EARLY` to run before `AM_PROG_AR`.