### PR TITLE
parsettf.c: Add bounds checking for SJIS decoding

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -4227,6 +4227,11 @@ return( -1 );
 	} else if ( enc<255 ) {
 	    /* This is erroneous as I understand SJIS */
 	    enc = badencoding(info);
+	} else if (enc >= 0xeaa5) {
+        /* Encoded value is outside SJIS range */
+        /* If this happens, it's likely that it's actually CP932 encoded */
+        /* Todo: Detect CP932 encoding earlier and apply that instead of SJIS */
+        enc = badencoding(info);
 	} else {
 	    int ch1 = enc>>8, ch2 = enc&0xff;
 	    if ( ch1 >= 129 && ch1<= 159 )
@@ -4243,7 +4248,7 @@ return( -1 );
 		--ch1;
 		ch2 -= 31;
 	    }
-	    if ( ch1<0x21 || ch2<0x21 || ch1>0x7f || ch2>0x7f )
+	    if ( ch1<0x21 || ch2<0x21 || ch1>0x7e || ch2>0x7e )
 		enc = badencoding(info);
 	    else
 		enc = unicode_from_jis208[(ch1-0x21)*94+(ch2-0x21)];


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
Partial fix for #2820 (prevents segfault). Does not perform
CP932 detection, hence if font is actually encoded as such,
user must manually force re-encode to CP932.

Related Coverity ID: CID1083343