### PR TITLE
charview: Re-expose the whole wordlist area when charview is resized.

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -5969,6 +5969,8 @@ return;
 	  GGadgetResize(cv->charselector, new_charselector_width, charselector_size.height);
 	  GGadgetMove(cv->charselectorPrev, new_charselectorPrev_x, charselectorPrev_size.y);
 	  GGadgetMove(cv->charselectorNext, new_charselectorNext_x, charselectorNext_size.y);
+	  charselector_size.x = 0; charselector_size.y = cv->mbh; charselector_size.width = newwidth + sbsize; charselector_size.height = cv->charselectorh;
+	  GDrawRequestExpose(cv->gw, &charselector_size, false);
 	}
 
 	if ( cv->showrulers ) {


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
This fixes a bug that I noticed while working on the gdk branch. It prevents a display bug when resizing the window.

Before (nb: on X11/master branch):
![beforeexpose](https://cloud.githubusercontent.com/assets/5137410/18434479/f2e809c2-791f-11e6-9c36-78af5747a803.gif)

After (ignore the flicker/weird areas in resize - this is on the GDK branch (and the flicker is what I consider a GDK3 bug)):
![afterexpose](https://cloud.githubusercontent.com/assets/5137410/18434487/003e4604-7920-11e6-9cf1-fd0abab2d211.gif)
