### PR TITLE
charview: Don't generate rasterised glyph when using Cairo

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -3174,7 +3174,7 @@ static void SC_OutOfDateBackground(SplineChar *sc) {
 void CVRegenFill(CharView *cv) {
     BDFCharFree(cv->filled);
     cv->filled = NULL;
-    if ( cv->showfilled ) {
+    if ( cv->showfilled && !shouldShowFilledUsingCairo(cv) ) {
 	extern int use_freetype_to_rasterize_fv;
 	int layer = CVLayer((CharViewBase *) cv);
 	int size = cv->scale*(cv->b.fv->sf->ascent+cv->b.fv->sf->descent);


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
It's not needed - it's done in Cairo instead. This prevents a segfault
if you zoom in too far with fill turned on. It should also help speed
up zooming.

Should fix #1391. That was surprisingly easy to fix.

Note: If you run with Cairo disabled, it will still be slow/crash if you zoom in too far. Oh well.