### PR TITLE
Always normalise the file path out of GFileChooser

### DIFF
--- a/fontforgeexe/openfontdlg.c
+++ b/fontforgeexe/openfontdlg.c
@@ -457,7 +457,7 @@ static int GFD_Ok(GGadget *g, GEvent *e) {
 return(true);
 	    }
 	    d->done = true;
-	    d->ret = u_GFileNormalizePath(GGadgetGetTitle(d->gfc));
+	    d->ret = GGadgetGetTitle(d->gfc);
 
 	    // Trim trailing '/' if its there and put that string back as
 	    // the d->gfc string.
@@ -468,7 +468,7 @@ return(true);
 		    tmp[ tmplen-1 ] = '\0';
 		    GGadgetSetTitle(d->gfc, tmp);
 		    free(tmp);
-		    d->ret = u_GFileNormalizePath(GGadgetGetTitle(d->gfc));
+		    d->ret = GGadgetGetTitle(d->gfc);
 		}
 	    }
 	}

--- a/gdraw/gfilechooser.c
+++ b/gdraw/gfilechooser.c
@@ -1354,13 +1354,16 @@ static unichar_t *GFileChooserGetTitle(GGadget *g) {
     GFileChooser *gfc = (GFileChooser *) g;
     unichar_t *spt, *curdir, *file;
 
-    spt = (unichar_t *) _GGadgetGetTitle(&gfc->name->g);
+    spt = u_GFileNormalizePath(u_copy((unichar_t *)_GGadgetGetTitle(&gfc->name->g)));
     if ( u_GFileIsAbsolute(spt) )
-	file = u_copy(spt);
+	file = spt;
     else {
 	curdir = GFileChooserGetCurDir(gfc,-1);
 	file = u_GFileAppendFile(curdir,spt,gfc->lastname!=NULL);
 	free(curdir);
+    }
+    if (file != spt) {
+        free(spt);
     }
 return( file );
 }


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
This ensures that backslashes are always converted to slashes on
Windows, which is necessary as other code assumes slashes for the
path separator.

This also removes the burden of having to normalise the output by
the caller instead of doing it in the GFC.

Fixes #2834

cc @frank-trampe 