### PR TITLE
Move declaration of DictionaryFree to scripting.h near similar functions

### DIFF
--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -475,10 +475,6 @@ extern int AutoWidthScript(FontViewBase *fv,int spacing);
 extern int AutoKernScript(FontViewBase *fv,int spacing, int threshold,
 	struct lookup_subtable *sub, char *kernfile);
 
-#ifndef _NO_FFSCRIPT
-extern void DictionaryFree(struct dictionary *dica);
-#endif
-
 extern void BCTrans(BDFFont *bdf,BDFChar *bc,BVTFunc *bvts,FontViewBase *fv );
 extern void BCSetPoint(BDFChar *bc, int x, int y, int color);
 extern void BCTransFunc(BDFChar *bc,enum bvtools type,int xoff,int yoff);

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -29,6 +29,7 @@
 #include "baseviews.h"
 #include "groups.h"
 #include "psfont.h"
+#include "scripting.h"
 #include <gfile.h>
 #include <gio.h>
 #include <ustring.h>

--- a/fontforge/scripting.h
+++ b/fontforge/scripting.h
@@ -28,6 +28,8 @@
 #ifndef _SCRIPTING_H
 #define _SCRIPTING_H
 
+#include "fontforge-config.h"
+
 #include "fontforgevw.h"
 #include <setjmp.h>
 #include <stdarg.h>
@@ -150,5 +152,9 @@ extern void ff_VerboseCheck(void);
 extern enum token_type ff_NextToken(Context *c);
 extern void ff_backuptok(Context *c);
 extern void ff_statement(Context*);
+
+#ifndef _NO_FFSCRIPT
+extern void DictionaryFree(struct dictionary *dica);
+#endif
 
 #endif	/* _SCRIPTING_H */


### PR DESCRIPTION
The declaration of `DictionaryFree` does not belong to `baseview.h`; `scripting.h` is where the `dictionary` struct is defined.

This is a self-contained commit extracted from the ongoing work for PR #2821.