### PR TITLE
Use include guards

### DIFF
--- a/fontforge/autowidth.h
+++ b/fontforge/autowidth.h
@@ -1,3 +1,5 @@
+#ifndef FONTFORGE_AUTOWIDTH_H
+#define FONTFORGE_AUTOWIDTH_H
 
 struct charone {
     real lbearing, rmax;
@@ -64,3 +66,5 @@ extern void AW_KernRemoveBelowThreshold(SplineFont *sf,int threshold);
 
 extern SplineFont *aw_old_sf;
 extern int aw_old_spaceguess;
+
+#endif /* FONTFORGE_AUTOWIDTH_H */

--- a/fontforge/bezctx_ff.h
+++ b/fontforge/bezctx_ff.h
@@ -4,6 +4,9 @@ License: GPL-2+
 Modified bezctx_ps.h for FontForge by George Williams - 2007
 */
 
+#ifndef FONTFORGE_BEZCTX_FF_H
+#define FONTFORGE_BEZCTX_FF_H
+
 #include <spiroentrypoints.h>
 #include <bezctx.h>
 
@@ -13,3 +16,5 @@ struct splinepointlist;
 
 struct splinepointlist *
 bezctx_ff_close(bezctx *bc);
+
+#endif /* FONTFORGE_BEZCTX_FF_H */

--- a/fontforge/bitmapcontrol.h
+++ b/fontforge/bitmapcontrol.h
@@ -25,6 +25,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_BITMAPCONTROL_H
+#define FONTFORGE_BITMAPCONTROL_H
+
 typedef struct createbitmapdata {
     FontViewBase *fv;
     SplineFont *sf;
@@ -41,3 +44,5 @@ enum { bd_all, bd_selected, bd_current };
 extern int bdfcontrol_lastwhich;
 
 void BitmapsDoIt(CreateBitmapData *bd,int32 *sizes,int usefreetype);
+
+#endif /* FONTFORGE_BITMAPCONTROL_H */

--- a/fontforge/cvundoes.h
+++ b/fontforge/cvundoes.h
@@ -1,2 +1,6 @@
+#ifndef FONTFORGE_CVUNDOES_H
+#define FONTFORGE_CVUNDOES_H
+
 extern int no_windowing_ui, maxundoes;
 
+#endif /* FONTFORGE_CVUNDOES_H */

--- a/fontforge/ffpython.h
+++ b/fontforge/ffpython.h
@@ -25,6 +25,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_FFPYTHON_H
+#define FONTFORGE_FFPYTHON_H
+
 #include "flaglist.h"
 
 /*********** PYTHON 3 **********/
@@ -247,3 +250,4 @@ typedef void (*pyFF_sendRedoIfInSession_Func_t)( void* cv );
 pyFF_sendRedoIfInSession_Func_t get_pyFF_sendRedoIfInSession_Func( void );
 void set_pyFF_sendRedoIfInSession_Func( pyFF_sendRedoIfInSession_Func_t f );
 
+#endif /* FONTFORGE_FFPYTHON_H */

--- a/fontforge/fvmetrics.h
+++ b/fontforge/fvmetrics.h
@@ -24,6 +24,10 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#ifndef FONTFORGE_FVMETRICS_H
+#define FONTFORGE_FVMETRICS_H
+
 #include "fontforgeui.h"
 #include <math.h>
 #include <ustring.h>
@@ -45,3 +49,5 @@ typedef struct createwidthdata {
 extern void CVDoit(CreateWidthData *wd);
 extern void FVDoit(CreateWidthData *wd);
 extern void GenericVDoit(CreateWidthData *wd);
+
+#endif /* FONTFORGE_FVMETRICS_H */

--- a/fontforge/lookups.h
+++ b/fontforge/lookups.h
@@ -1,3 +1,6 @@
+#ifndef FONTFORGE_LOOKUPS_H
+#define FONTFORGE_LOOKUPS_H
+
 extern const char *lookup_type_names[2][10];
 extern void SortInsertLookup(SplineFont *sf, OTLookup *newotl);
 extern char *SuffixFromTags(FeatureScriptLangList *fl);
@@ -27,3 +30,5 @@ extern char *SuffixFromTags(FeatureScriptLangList *fl);
 extern int KernClassFindIndexContaining( char **firsts_or_seconds,
 					 int firsts_or_seconds_size,
 					 const char *name );
+
+#endif /* FONTFORGE_LOOKUPS_H */

--- a/fontforge/mm.h
+++ b/fontforge/mm.h
@@ -25,8 +25,13 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_MM_H
+#define FONTFORGE_MM_H
+
 extern void MMWeightsUnMap(real weights[MmMax], real axiscoords[4],
 	int axis_count);
 extern bigreal MMAxisUnmap(MMSet *mm,int axis,bigreal ncv);
 extern SplineFont *_MMNewFont(MMSet *mm,int index,char *familyname,real *normalized);
 extern SplineFont *MMNewFont(MMSet *mm,int index,char *familyname);
+
+#endif /* FONTFORGE_MM_H */

--- a/fontforge/nonlineartrans.h
+++ b/fontforge/nonlineartrans.h
@@ -24,6 +24,10 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#ifndef _NONLINEARTRANS_H
+#define _NONLINEARTRANS_H
+
 #include "fontforgeui.h"
 #include <utype.h>
 #include <ustring.h>
@@ -31,9 +35,6 @@
 #ifdef HAVE_IEEEFP_H
 # include <ieeefp.h>		/* Solaris defines isnan in ieeefp rather than math.h */
 #endif
-
-#ifndef _NONLINEARTRANS_H
-#define _NONLINEARTRANS_H
 
 enum operator {
     op_base = 0x100,			/* Bigger than any character */

--- a/fontforge/ofl.h
+++ b/fontforge/ofl.h
@@ -3,6 +3,9 @@ Copyright: 2007 George Williams
 License: BSD-3-clause
 */
 
+#ifndef FONTFORGE_OFL_H
+#define FONTFORGE_OFL_H
+
 #include "splinefont.h"
 
 extern struct str_lang_data {
@@ -10,3 +13,5 @@ extern struct str_lang_data {
     int lang;
     char **data;
 } ofl_str_lang_data[];
+
+#endif /* FONTFORGE_OFL_H */

--- a/fontforge/plugins.h
+++ b/fontforge/plugins.h
@@ -25,6 +25,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_PLUGINS_H
+#define FONTFORGE_PLUGINS_H
+
 /* If a user wants to write a fontforge plugin s/he should include this file */
 
 /*
@@ -96,3 +99,5 @@ extern int LoadPlugin(const char *dynamic_lib_name);
 extern void LoadPluginDir(const char *search_path);
     /* Loads any dynamic libs from this search path. if search_path is
      * NULL loads from the path returned by lt_dlgetsearchpath() */
+
+#endif /* FONTFORGE_PLUGINS_H */

--- a/fontforge/print.h
+++ b/fontforge/print.h
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#ifndef FONTFORGE_PRINT_H
+#define FONTFORGE_PRINT_H
+
 enum { pt_lp, pt_lpr, pt_ghostview, pt_file, pt_other, pt_pdf, pt_unknown=-1 };
 extern int pagewidth, pageheight;
 extern char *printlazyprinter;
@@ -114,3 +117,5 @@ extern void DoPrinting(PI *pi,char *filename);
 extern int PdfDumpGlyphResources(PI *pi,SplineChar *sc);
 extern void makePatName(char *buffer,
 	RefChar *ref,SplineChar *sc,int layer,int isstroke,int isgrad);
+
+#endif /* FONTFORGE_PRINT_H */

--- a/fontforge/savefont.h
+++ b/fontforge/savefont.h
@@ -25,6 +25,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_SAVEFONT_H
+#define FONTFORGE_SAVEFONT_H
+
 extern const char (*savefont_extensions[]), (*bitmapextensions[]);
 extern int old_sfnt_flags;
 
@@ -33,3 +36,5 @@ void RestoreUnlinkRmOvrlp(SplineFont *sf,const char *filename,int layer);
 int _DoSave(SplineFont *sf,char *newname,int32 *sizes,int res,
 	EncMap *map, char *subfontdefinition,int layer);
 int CheckIfTransparent(SplineFont *sf);
+
+#endif /* FONTFORGE_SAVEFONT_H */

--- a/fontforge/search.h
+++ b/fontforge/search.h
@@ -25,9 +25,14 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_SEARCH_H
+#define FONTFORGE_SEARCH_H
+
 extern void SDDestroy(SearchData *sd);
 extern SearchData *SDFillup(SearchData *sd, FontViewBase *fv);
 extern int SearchChar(SearchData *sv, int gid,int startafter);
 extern int _DoFindAll(SearchData *sv);
 extern int DoRpl(SearchData *sv);
 extern void SVResetPaths(SearchData *sv);
+
+#endif /* FONTFORGE_SEARCH_H */

--- a/fontforge/tables.h
+++ b/fontforge/tables.h
@@ -1,4 +1,9 @@
+#ifndef FONTFORGE_TABLES_H
+#define FONTFORGE_TABLES_H
+
 /* Declarations for data tables */
 
 extern const int amspua[], cns14pua[];
 extern const char (*SaveTablesPref[]);
+
+#endif /* FONTFORGE_TABLES_H */

--- a/fontforge/ttf.h
+++ b/fontforge/ttf.h
@@ -24,7 +24,10 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
+#ifndef FONTFORGE_TTF_H
+#define FONTFORGE_TTF_H
+
 #include "psfont.h"		/* for struct fddata */
 
 #define MAC_DELETED_GLYPH_NAME	"<Delete>"
@@ -931,3 +934,5 @@ extern struct otfname *FindAllLangEntries(FILE *ttf, struct ttfinfo *info, int i
 #define TeX_BigOpSpace5		CHR('B','O','S','5')
 
 extern void SFDummyUpCIDs(struct glyphinfo *gi,SplineFont *sf);
+
+#endif /* FONTFORGE_TTF_H */

--- a/fontforge/ttfinstrs.h
+++ b/fontforge/ttfinstrs.h
@@ -25,6 +25,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_TTFINSTRS_H
+#define FONTFORGE_TTFINSTRS_H
+
 enum ttf_instructions {
  ttf_npushb=0x40, ttf_npushw=0x41, ttf_pushb=0xb0, ttf_pushw=0xb8,
  ttf_aa=0x7f, ttf_abs=0x64, ttf_add=0x60, ttf_alignpts=0x27, ttf_alignrp=0x3c,
@@ -66,3 +69,5 @@ typedef struct instrbase {
 
 extern char *__IVUnParseInstrs(InstrBase *iv);
 extern int instr_typify(struct instrdata *);
+
+#endif /* FONTFORGE_TTFINSTRS_H */

--- a/fontforge/unicoderange.h
+++ b/fontforge/unicoderange.h
@@ -25,6 +25,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FONTFORGE_UNICODERANGE_H
+#define FONTFORGE_UNICODERANGE_H
+
 extern struct unicoderange {
     char *name;		/* The range's name */
     int32 first, last, defined;
@@ -51,3 +54,5 @@ struct rangeinfo {
 enum ur_flags { ur_includeempty = 1, ur_sortbyname = 2, ur_sortbyunicode = 4 };
 extern struct rangeinfo *SFUnicodeRanges(SplineFont *sf, enum ur_flags flags);
 extern int unicoderange_cnt;
+
+#endif /* FONTFORGE_UNICODERANGE_H */

--- a/fontforge/usermenu.h
+++ b/fontforge/usermenu.h
@@ -1,3 +1,6 @@
+#ifndef FONTFORGE_USERMENU_H
+#define FONTFORGE_USERMENU_H
+
 #include <ggadget.h>
 
 extern SplineChar *sc_active_in_ui;
@@ -22,3 +25,5 @@ void fv_tl2listcheck(GWindow gw, struct gmenuitem *mi, GEvent *e);
 void RegisterMenuItem(menu_info_func func, menu_info_check check,
                       menu_info_data data, int flags,
                       char *shortcut_str, char **submenu_names);
+
+#endif /* FONTFORGE_USERMENU_H */


### PR DESCRIPTION
This PR adds include guards to all the headers in `fontforge/`.

There is a commit for each modified file. This helps minimizing the "conflict surface" for long-living branches like PR #2821.