### PR TITLE
Some splinestroke fixes

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -864,7 +864,7 @@ static void HideStrokePointsCircle(StrokeContext *c) {
 		if ( dist1sq<400 )
 		    j -= (6-1);
 		else
-		    j -= .66667*sqrt(dist1sq)-1;
+		    j -= .5*sqrt(dist1sq)-1;
 		/* Minus 1 because we are going to add 1 anyway */
 	    }
 	}

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -3129,11 +3129,11 @@ return( NULL );
 		int isnext=sp->next->to==sp2, isprev=sp->prev->from==sp2;
 		BreakLine(sp->next,start,end,&first1,&second1);
 		BreakLine(sp2->next,end,start,&first2,&second2);
-		if ( first1->me.x!=second2->me.x || first1->me.y!=second2->me.y ) {
+		if ( first1->me.x!=second2->me.x || first1->me.y!=second2->me.y || first1==second2 ) {
 		    IError("Confusion reighns!");
 return( ss );
 		}
-		if ( second1->me.x!=first2->me.x || second1->me.y!=first2->me.y ) {
+		if ( second1->me.x!=first2->me.x || second1->me.y!=first2->me.y || first2==second1 ) {
 		    IError("Confusion regnas!");
 return( ss );
 		}


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
There's two commits here: One is to prevent a segfault/infinite loop experienced in #2832, and the second is to fix a bug I noticed while debugging that issue with regards to stroking paths of very small widths. 

As copied from the commit message:
* splinestroke.c: Prevent segfault/hang if BreakLine produces invalid results

    I'm unsure if there is a better fix to this situation, but if the added condition occurs, then the result will definitely be invalid, and if execution of the function is allowed to continue, either a segfault or infinite loop will result. This is because the following code will free first2 and second2, so if first2 *is* second1 or second2 *is* first1, then we're essentially use-after-freeing first1/second1.
*  splinestroke.c: Reduce skip distance in HideStrokePointsCircle.

    This helps to prevent anomalies in the output, especially in cases where the stroke width is very small. For an example, see fontforge/debugfonts@2f17183.

cc @frank-trampe 