### PR TITLE
Fix some memleaks as reported by Valgrind

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -777,7 +777,7 @@ return( copy( head->enc_name ) );
 }
 
 void LoadPfaEditEncodings(void) {
-    ParseEncodingFile(NULL, NULL);
+    free(ParseEncodingFile(NULL, NULL));
 }
 
 void DumpPfaEditEncodings(void) {

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -872,7 +872,7 @@ static void DrawPoint( CharView *cv, GWindow pixmap, SplinePoint *sp,
 {
     GRect r;
     int x, y, cx, cy;
-    Color col = sp==spl->first ? firstpointcol : pointcol, subcol;
+    Color col = sp==spl->first ? firstpointcol : pointcol;
     int pnum;
     char buf[16];
     int isfake;
@@ -12848,7 +12848,7 @@ CharView *CharViewCreateExtended(SplineChar *sc, FontView *fv,int enc, int show 
     wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_utf8_ititle;
     wattrs.event_masks = -1;
     wattrs.cursor = ct_mypointer;
-    wattrs.utf8_icon_title = CVMakeTitles(cv,buf,sizeof(buf));
+    wattrs.utf8_icon_title = (const char*)CVMakeTitles(cv,buf,sizeof(buf));
     wattrs.utf8_window_title = buf;
     wattrs.icon = CharIcon(cv, fv);
     if ( wattrs.icon )
@@ -12860,6 +12860,7 @@ CharView *CharViewCreateExtended(SplineChar *sc, FontView *fv,int enc, int show 
 
     cv->gw = gw = GDrawCreateTopWindow(NULL,&pos,cv_e_h,cv,&wattrs);
     free( (unichar_t *) wattrs.icon_title );
+    free((char*)wattrs.utf8_icon_title);
     GDrawSetWindowTypeName(cv->gw, "CharView");
 
     // FIXME: cant do this until gw is shown?

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1067,8 +1067,11 @@ static int HKActionMatchesFirstPartOf( char* action, char* prefix_const, int mun
     char prefix[PATH_MAX+1];
     char* pt = 0;
     strncpy( prefix, prefix_const, PATH_MAX );
-    if( munge )
-	strncpy( prefix, HKTextInfoToUntranslatedText( prefix_const ),PATH_MAX );
+    if( munge ) {
+	char *tofree = HKTextInfoToUntranslatedText(prefix_const);
+	strncpy( prefix, tofree,PATH_MAX );
+	free(tofree);
+    }
 //    TRACE("munge:%d prefix2:%s\n", munge, prefix );
 
     pt = strchr(action,'.');

--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -2030,6 +2030,8 @@ return;
     free(gt->lines);
     free(gt->oldtext);
     free(gt->text);
+    free(gt->utf8_text);
+    free(gt->lines8);
     _ggadget_destroy(g);
 }
 


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
These were found while I was running FF under Valgrind to see if there were any leaks in my GDK code.

Also: Remove one instance of a shadowed variable being
used in charview.