### PR TITLE
gmenu.c: Prevent unnecessary hotkey checking & move hotkey checking code to separate function

### DIFF
--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -495,7 +495,7 @@ static int _GWidget_TopLevel_Key(GWindow top, GWindow ew, GEvent *event) {
 	}
     }
     /* Check for mnemonics and shortcuts */
-    if ( event->type == et_char ) {
+    if ( event->type == et_char && !GKeysymIsModifier(event->u.chr.keysym) ) {
 	handled = GMenuPopupCheckKey(event);
 	if ( topd->ispalette ) {
 	    if ( !(handled = GMenuBarCheckKey(top,topd->owner->gmenubar,event)) )

--- a/gdraw/gkeysym.c
+++ b/gdraw/gkeysym.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <gdraw.h>
+#include <gkeysym.h>
 
 static unichar_t BackSpace[] = { 'B', 'a', 'c', 'k', 'S', 'p', 'a', 'c', 'e', '\0' };
 static unichar_t Tab[] = { 'T', 'a', 'b', '\0' };
@@ -338,3 +339,23 @@ unichar_t *GDrawKeysyms[] = {
 	Delete,
 	NULL
 };
+
+int GKeysymIsModifier(uint16 keysym) {
+    switch(keysym) {
+        case GK_Shift_L:
+        case GK_Shift_R:
+        case GK_Control_L:
+        case GK_Control_R:
+        case GK_Meta_L:
+        case GK_Meta_R:
+        case GK_Alt_L:
+        case GK_Alt_R:
+        case GK_Super_L:
+        case GK_Super_R:
+        case GK_Hyper_L:
+        case GK_Hyper_R:
+            return true;
+        default:
+            return false;
+    }
+}

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1853,64 +1853,16 @@ static int osx_handle_keysyms( int st, int k )
 int osx_fontview_copy_cut_counter = 0;
 
 
-
-
-int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
-    int i;
-    GMenuBar *mb = (GMenuBar *) g;
-    GMenuItem *mi;
-    unichar_t keysym = event->u.chr.keysym;
-
+static int GMenuBarCheckHotkey(GWindow top, GGadget *g, GEvent *event) {
 //    TRACE("GMenuBarCheckKey(top) keysym:%d upper:%d lower:%d\n",keysym,toupper(keysym),tolower(keysym));
-
-    int SkipUnQualifiedHotkeyProcessing = 0;
-    // see if we should skip processing
-    if( g )
-    {
+    // see if we should skip processing (e.g. no modifier key pressed)
+    GMenuBar *mb = (GMenuBar *) g;
 	GWindow w = GGadgetGetWindow(g);
 	GGadget* focus = GWindowGetFocusGadgetOfWindow(w);
-	if( GGadgetGetSkipHotkeyProcessing(focus))
+	if (GGadgetGetSkipHotkeyProcessing(focus) || event->u.chr.state == 0)
 	    return 0;
-	SkipUnQualifiedHotkeyProcessing = GGadgetGetSkipUnQualifiedHotkeyProcessing(focus);
-    }
 
-
-    if ( g==NULL || keysym==0 ) return( false ); /* exit if no gadget or key */
-
-    if ( (menumask&ksm_cmdmacosx) && keysym>0x7f &&
-	    (event->u.chr.state&ksm_meta) &&
-	    !(event->u.chr.state&menumask&(ksm_control|ksm_cmdmacosx)) )
-	keysym = GGadgetUndoMacEnglishOptionCombinations(event);
-
-    if ( keysym<GK_Special && islower(keysym))
-	keysym = toupper(keysym);
-    if ( event->u.chr.state&ksm_meta && !(event->u.chr.state&(menumask&~(ksm_meta|ksm_shift)))) {
-	/* Only look for mneumonics in the leaf of the displayed menu structure */
-	if ( mb->child!=NULL )
-	    return( gmenu_key(mb->child,event)); /* this routine will do shortcuts too */
-
-	for ( i=0; i<mb->mtot; ++i ) {
-	    if ( mb->mi[i].ti.mnemonic == keysym && !mb->mi[i].ti.disabled ) {
-		GMenuBarKeyInvoke(mb,i);
-		return( true );
-	    }
-	}
-    }
 //    TRACE("GMenuBarCheckKey(2) keysym:%d upper:%d lower:%d\n",keysym,toupper(keysym),tolower(keysym));
-
-    /* First check for an open menu underscore key being pressed */
-    mi = GMenuSearchShortcut(mb->g.base,mb->mi,event,mb->child==NULL);
-    if ( mi ) {
-//	TRACE("GMenuBarCheckKey(3) have mi... :%p\n", mi );
-//	TRACE("GMenuBarCheckKey(3) have mitext:%s\n", u_to_c(mi->ti.text) );
-	if ( mi->ti.checkable && !mi->ti.disabled )
-	    mi->ti.checked = !mi->ti.checked;
-	if ( mi->invoke!=NULL && !mi->ti.disabled )
-	    (mi->invoke)(mb->g.base,mi,NULL);
-	if ( mb->child != NULL )
-	    GMenuDestroy(mb->child);
-	return( true );
-    }
 
     /* then look for hotkeys everywhere */
 
@@ -1967,7 +1919,7 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 //    TRACE("     has ksm_meta:%d\n",    (event->u.chr.state & ksm_meta ));
 //    TRACE("     has ksm_shift:%d\n",   (event->u.chr.state & ksm_shift ));
 
-    if( SkipUnQualifiedHotkeyProcessing && !event->u.chr.state )
+    if( GGadgetGetSkipUnQualifiedHotkeyProcessing(focus) && !event->u.chr.state )
     {
 	TRACE("skipping unqualified hotkey for widget g:%p\n", g);
 	return 0;
@@ -1992,7 +1944,7 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
 
 	if( !skipkey )
 	{
-	    mi = GMenuSearchAction(mb->g.base,mb->mi,hk->action,event,mb->child==NULL);
+	    GMenuItem *mi = GMenuSearchAction(mb->g.base,mb->mi,hk->action,event,mb->child==NULL);
 	    if ( mi )
 	    {
 //		TRACE("GMenuBarCheckKey(x) have mi... :%p\n", mi );
@@ -2017,6 +1969,41 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
     dlist_free_external(&hklist);
 
 //    TRACE("menubarcheckkey(e1)\n");
+    return false;
+}
+
+
+int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
+    int i;
+    GMenuBar *mb = (GMenuBar *) g;
+    unichar_t keysym = event->u.chr.keysym;
+
+    if ( g==NULL || keysym==0 ) return( false ); /* exit if no gadget or key */
+
+    if ( (menumask&ksm_cmdmacosx) && keysym>0x7f &&
+	    (event->u.chr.state&ksm_meta) &&
+	    !(event->u.chr.state&menumask&(ksm_control|ksm_cmdmacosx)) )
+	keysym = GGadgetUndoMacEnglishOptionCombinations(event);
+
+    if ( keysym<GK_Special && islower(keysym))
+	keysym = toupper(keysym);
+    if ( event->u.chr.state&ksm_meta && !(event->u.chr.state&(menumask&~(ksm_meta|ksm_shift)))) {
+	/* Only look for mneumonics in the leaf of the displayed menu structure */
+	if ( mb->child!=NULL )
+	    return( gmenu_key(mb->child,event)); /* this routine will do shortcuts too */
+
+	for ( i=0; i<mb->mtot; ++i ) {
+	    if ( mb->mi[i].ti.mnemonic == keysym && !mb->mi[i].ti.disabled ) {
+		GMenuBarKeyInvoke(mb,i);
+		return( true );
+	    }
+	}
+    }
+
+    // See if it matches a hotkey
+    if (GMenuBarCheckHotkey(top, g, event)) {
+        return true;
+    }
 
     if ( mb->child )
     {

--- a/inc/gkeysym.h
+++ b/inc/gkeysym.h
@@ -296,3 +296,5 @@ SOFTWARE.
 #endif	/* No X */
 
 #endif
+
+int GKeysymIsModifier(uint16 keysym);


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
This PR prevents unnecessary checking of hotkeys - if we haven't pressed a modifier (e.g. Ctrl,Alt,Shift,Cmd) then there's no need to check if it's a hotkey. Secondly, there was a block that checked against all the mnemonics - this code was redundant (and part of the cause of the performance degradation found in #2843) as there was an equivalent check right above it.

I've moved the hotkey checking code into a separate function for clarity.

Fixes #2843

cc @frank-trampe 