### PR TITLE
Do not add libzmq twice

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -101,7 +101,7 @@ endif LIBZMQ
 libfontforge_la_LDFLAGS = $(MY_CFLAGS) -version-info $(LIBFONTFORGE_VERSION) \
 	${MY_LIB_LDFLAGS}
 
-libfontforge_la_LIBADD += $(MY_LIBS) $(LIBZMQ_LIBS)
+libfontforge_la_LIBADD += $(MY_LIBS)
 
 #--------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

There is no need to add `$(LIBZMQ_LIBS)`: it is already added in the previous lines, if available:

```make
if LIBZMQ
libfontforge_la_LIBADD += $(top_builddir)/collab/libzmqcollab.la $(LIBZMQ_LIBS)
endif LIBZMQ
```

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)