### PR TITLE
Move to cvundoes.h all the prototypes of non-static cvundoes.c functions

### DIFF
--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "cvundoes.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforge/autotrace.c
+++ b/fontforge/autotrace.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth2.c
+++ b/fontforge/autowidth2.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -279,43 +279,13 @@ enum fvformats { fv_bdf, fv_ttf, fv_pk, fv_pcf, fv_mac, fv_win, fv_palm,
 	fv_fig,
 	fv_pythonbase = 0x100 };
 
-extern enum undotype CopyUndoType(void);
-extern int CopyContainsSomething(void);
-extern int CopyContainsBitmap(void);
-extern int CopyContainsVectors(void);
-extern const Undoes *CopyBufferGet(void);
 extern RefChar *CopyContainsRef(SplineFont *);
 extern char **CopyGetPosSubData(enum possub_type *type,SplineFont **copied_from,
 	int pst_depth);
 extern void CopyReference(SplineChar *sc);
-extern void SCCopyLookupData(SplineChar *sc);
 extern void PasteRemoveSFAnchors(SplineFont *);
-extern void PasteAnchorClassMerge(SplineFont *sf,AnchorClass *into,AnchorClass *from);
-extern void PasteRemoveAnchorClass(SplineFont *sf,AnchorClass *dying);
 
-/**
- * Serialize and undo into a string.
- * You must free() the returned string.
- */
-extern char* UndoToString( SplineChar* sc, Undoes *undo );
-
-/**
- * Dump a list of undos for a splinechar starting at the given 'undo'.
- * msg is used as a header message so that a dump at a particular time stands
- * out from one that occurs later in the code.
- */
-extern void dumpUndoChain( char* msg, SplineChar* sc, Undoes *undo );
-
-extern void ClipboardClear(void);
-extern SplineSet *ClipBoardToSplineSet(void);
-extern void BCCopySelected(BDFChar *bc,int pixelsize,int depth);
-extern void BCCopyReference(BDFChar *bc,int pixelsize,int depth);
-extern void PasteToBC(BDFChar *bc,int pixelsize,int depth);
-extern void FVCopyWidth(FontViewBase *fv,enum undotype ut);
-extern void FVCopyAnchors(FontViewBase *fv);
 enum fvcopy_type { ct_fullcopy, ct_reference, ct_lookups, ct_unlinkrefs };
-extern void FVCopy(FontViewBase *fv, enum fvcopy_type copytype);
-extern void PasteIntoFV(FontViewBase *fv, int pasteinto, real trans[6]);
 extern void FVCopyFgtoBg(FontViewBase *fv);
 extern void FVSameGlyphAs(FontViewBase *fv);
 extern void FVClearBackground(FontViewBase *fv);
@@ -489,21 +459,9 @@ extern void BCMergeReferences(BDFChar *base,BDFChar *cur,int8 xoff,int8 yoff);
 extern BDFChar *BDFGetMergedChar(BDFChar *bc) ;
 extern void BCUnlinkThisReference(struct fontviewbase *fv,BDFChar *bc);
 
-extern int CVLayer(CharViewBase *cv);
-extern Undoes *CVPreserveStateHints(CharViewBase *cv);
-extern Undoes *CVPreserveState(CharViewBase *cv);
 extern Undoes *_CVPreserveTState(CharViewBase *cv,PressedOn *);
-extern Undoes *CVPreserveWidth(CharViewBase *cv,int width);
-extern Undoes *CVPreserveVWidth(CharViewBase *cv,int vwidth);
-extern void CVDoRedo(CharViewBase *cv);
-extern void CVDoUndo(CharViewBase *cv);
-extern void _CVRestoreTOriginalState(CharViewBase *cv,PressedOn *p);
-extern void _CVUndoCleanup(CharViewBase *cv,PressedOn *p);
-extern void CVRemoveTopUndo(CharViewBase *cv);
 extern void CopySelected(CharViewBase *cv,int doanchors);
-extern void CVCopyGridFit(CharViewBase *cv);
 extern void CopyWidth(CharViewBase *cv,enum undotype);
-extern void PasteToCV(CharViewBase *cv);
 extern void CVYPerspective(CharViewBase *cv,bigreal x_vanish, bigreal y_vanish);
 extern void ScriptSCEmbolden(SplineChar *sc,int layer,enum embolden_type type,struct lcg_zones *zones);
 extern void CVEmbolden(CharViewBase *cv,enum embolden_type type,struct lcg_zones *zones);

--- a/fontforge/bitmapchar.c
+++ b/fontforge/bitmapchar.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <string.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/bvedit.c
+++ b/fontforge/bvedit.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include "ustring.h"
 

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <sys/types.h>
 #include <dirent.h>

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "cvundoes.h"
+
 #include "config.h"
 #include "fontforgevw.h"
 #include "views.h"
@@ -52,9 +55,6 @@ int export_clipboard = 0;
 int export_clipboard = 1;
 #endif
 
-extern void *UHintCopy(SplineChar *sc,int docopy);
-extern void ExtractHints(SplineChar *sc,void *hints,int docopy);
-extern void UndoesFreeButRetainFirstN( Undoes** undopp, int retainAmount );
 
 /* ********************************* Undoes ********************************* */
 

--- a/fontforge/cvundoes.h
+++ b/fontforge/cvundoes.h
@@ -1,6 +1,84 @@
 #ifndef FONTFORGE_CVUNDOES_H
 #define FONTFORGE_CVUNDOES_H
 
+#include "splinefont.h"
+#include "baseviews.h"
+
 extern int no_windowing_ui, maxundoes;
+
+/**
+ * Serialize and undo into a string.
+ * You must free() the returned string.
+ */
+extern char* UndoToString(SplineChar* sc, Undoes *undo);
+
+extern const Undoes *CopyBufferGet(void);
+extern enum undotype CopyUndoType(void);
+extern int CopyContainsBitmap(void);
+extern int CopyContainsSomething(void);
+extern int CopyContainsVectors(void);
+extern int CVLayer(CharViewBase *cv);
+extern int getAdobeEnc(const char *name);
+extern int SCDependsOnSC(SplineChar *parent, SplineChar *child);
+extern int SCWasEmpty(SplineChar *sc, int skip_this_layer);
+extern RefChar *CopyContainsRef(SplineFont *sf);
+extern RefChar *RefCharsCopyState(SplineChar *sc, int layer);
+extern SplineSet *ClipBoardToSplineSet(void);
+extern Undoes *BCPreserveState(BDFChar *bc);
+extern Undoes *CVPreserveState(CharViewBase *cv);
+extern Undoes *CVPreserveStateHints(CharViewBase *cv);
+extern Undoes *_CVPreserveTState(CharViewBase *cv, PressedOn *p);
+extern Undoes *CVPreserveVWidth(CharViewBase *cv, int vwidth);
+extern Undoes *CVPreserveWidth(CharViewBase *cv, int width);
+extern Undoes *SCPreserveBackground(SplineChar *sc);
+extern Undoes *SCPreserveHints(SplineChar *sc, int layer);
+extern Undoes *_SCPreserveLayer(SplineChar *sc, int layer, int dohints);
+extern Undoes *SCPreserveLayer(SplineChar *sc, int layer, int dohints);
+extern Undoes *SCPreserveState(SplineChar *sc, int dohints);
+extern Undoes *SCPreserveVWidth(SplineChar *sc);
+extern Undoes *SCPreserveWidth(SplineChar *sc);
+extern Undoes *_SFPreserveGuide(SplineFont *sf);
+extern Undoes *SFPreserveGuide(SplineFont *sf);
+extern void BCCopyReference(BDFChar *bc, int pixelsize, int depth);
+extern void BCCopySelected(BDFChar *bc, int pixelsize, int depth);
+extern void BCDoRedo(BDFChar *bc);
+extern void BCDoUndo(BDFChar *bc);
+extern void ClipboardClear(void);
+extern void CopyBufferClearCopiedFrom(SplineFont *dying);
+extern void CopyBufferFree(void);
+extern void CopyWidth(CharViewBase *cv, enum undotype ut);
+extern void CVCopyGridFit(CharViewBase *cv);
+extern void CVDoRedo(CharViewBase *cv);
+extern void CVDoUndo(CharViewBase *cv);
+extern void CVRemoveTopUndo(CharViewBase *cv);
+extern void _CVRestoreTOriginalState(CharViewBase *cv, PressedOn *p);
+extern void _CVUndoCleanup(CharViewBase *cv, PressedOn *p);
+
+/**
+  * Dump a list of undos for a splinechar starting at the given 'undo'.
+  * msg is used as a header message so that a dump at a particular time stands
+  * out from one that occurs later in the code.
+  */
+extern void dumpUndoChain(char* msg, SplineChar* sc, Undoes *undo);
+
+extern void ExtractHints(SplineChar *sc, void *hints, int docopy);
+extern void FVCopyAnchors(FontViewBase *fv);
+extern void FVCopyWidth(FontViewBase *fv, enum undotype ut);
+extern void FVCopy(FontViewBase *fv, enum fvcopy_type copytype);
+extern void MVCopyChar(FontViewBase *fv, BDFFont *mvbdf, SplineChar *sc, enum fvcopy_type fullcopy);
+extern void PasteAnchorClassMerge(SplineFont *sf, AnchorClass *into, AnchorClass *from);
+extern void PasteIntoFV(FontViewBase *fv, int pasteinto, real trans[6]);
+extern void PasteIntoMV(FontViewBase *fv, BDFFont *mvbdf, SplineChar *sc, int doclear);
+extern void PasteRemoveAnchorClass(SplineFont *sf, AnchorClass *dying);
+extern void PasteRemoveSFAnchors(SplineFont *sf);
+extern void PasteToBC(BDFChar *bc, int pixelsize, int depth);
+extern void PasteToCV(CharViewBase *cv);
+extern void SCCopyLookupData(SplineChar *sc);
+extern void SCCopyWidth(SplineChar *sc, enum undotype ut);
+extern void SCDoRedo(SplineChar *sc, int layer);
+extern void SCDoUndo(SplineChar *sc, int layer);
+extern void SCUndoSetLBearingChange(SplineChar *sc, int lbc);
+extern void *UHintCopy(SplineChar *sc, int docopy);
+extern void UndoesFreeButRetainFirstN(Undoes** undopp, int retainAmount);
 
 #endif /* FONTFORGE_CVUNDOES_H */

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -27,6 +27,7 @@
  */
 #include "fontforge.h"
 #include "baseviews.h"
+#include "cvundoes.h"
 #include "groups.h"
 #include "psfont.h"
 #include "scripting.h"

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <chardata.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforge/fvmetrics.c
+++ b/fontforge/fvmetrics.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <ustring.h>
 #include "fvmetrics.h"

--- a/fontforge/glyphcomp.c
+++ b/fontforge/glyphcomp.c
@@ -27,6 +27,7 @@
  */
 
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include "scriptfuncs.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/nonlineartrans.c
+++ b/fontforge/nonlineartrans.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "cvundoes.h"
 #include "splinefont.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -47,6 +47,7 @@
 extern int old_sfnt_flags;
 
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -27,6 +27,7 @@
 /*			   Yet another interpreter			      */
 
 #include "fontforge.h"
+#include "cvundoes.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/search.c
+++ b/fontforge/search.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -27,6 +27,7 @@
 #include "fontforge.h"
 #include "splinefont.h"
 #include "baseviews.h"
+#include "cvundoes.h"
 #include "views.h"
 #include <gdraw.h>
 #include <ustring.h>
@@ -138,8 +139,6 @@ static void SFDDumpHintList(FILE *sfd,const char *key, StemInfo *h);
 static void SFDDumpDHintList( FILE *sfd,const char *key, DStemInfo *d );
 static StemInfo *SFDReadHints(FILE *sfd);
 static DStemInfo *SFDReadDHints( SplineFont *sf,FILE *sfd,int old );
-extern void ExtractHints(SplineChar *sc,void *hints,int docopy);
-extern void *UHintCopy(SplineChar *sc,int docopy);
 
 static int PeekMatch(FILE *stream, const char * target) {
   // This returns 1 if target matches the next characters in the stream.

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -27,6 +27,7 @@
  */
 
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <locale.h>
 # include <ustring.h>

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2215,8 +2215,6 @@ extern void SplineSetBeziersClear(SplineSet *spl);
 extern void RefCharFree(RefChar *ref);
 extern void RefCharsFree(RefChar *ref);
 extern void RefCharsFreeRef(RefChar *ref);
-extern void CopyBufferFree(void);
-extern void CopyBufferClearCopiedFrom(SplineFont *dying);
 extern void UndoesFree(Undoes *undo);
 extern void StemInfosFree(StemInfo *h);
 extern void StemInfoFree(StemInfo *h);
@@ -2445,7 +2443,6 @@ extern SplineChar *MakeDupRef(SplineChar *base, int local_enc, int uni_enc);
 extern void SCRemoveDependent(SplineChar *dependent,RefChar *rf,int layer);
 extern void SCRemoveLayerDependents(SplineChar *dependent,int layer);
 extern void SCRemoveDependents(SplineChar *dependent);
-extern int SCDependsOnSC(SplineChar *parent, SplineChar *child);
 extern void BCCompressBitmap(BDFChar *bdfc);
 extern void BCRegularizeBitmap(BDFChar *bdfc);
 extern void BCRegularizeGreymap(BDFChar *bdfc);
@@ -2919,21 +2916,7 @@ extern void SCLigCaretheck(SplineChar *sc,int clean);
 extern BDFChar *BDFMakeGID(BDFFont *bdf,int gid);
 extern BDFChar *BDFMakeChar(BDFFont *bdf,EncMap *map,int enc);
 
-extern RefChar *RefCharsCopyState(SplineChar *sc,int layer);
-extern int SCWasEmpty(SplineChar *sc, int skip_this_layer);
 extern void SCUndoSetLBearingChange(SplineChar *sc,int lb);
-extern Undoes *SCPreserveHints(SplineChar *sc,int layer);
-extern Undoes *SCPreserveLayer(SplineChar *sc,int layer,int dohints);
-extern Undoes *_SCPreserveLayer(SplineChar *sc,int layer,int dohints);
-extern Undoes *SCPreserveState(SplineChar *sc,int dohints);
-extern Undoes *SCPreserveBackground(SplineChar *sc);
-extern Undoes *SFPreserveGuide(SplineFont *sf);
-extern Undoes *_SFPreserveGuide(SplineFont *sf);
-extern Undoes *SCPreserveWidth(SplineChar *sc);
-extern Undoes *SCPreserveVWidth(SplineChar *sc);
-extern Undoes *BCPreserveState(BDFChar *bc);
-extern void BCDoRedo(BDFChar *bc);
-extern void BCDoUndo(BDFChar *bc);
 
 extern int isaccent(int uni);
 extern int SFIsCompositBuildable(SplineFont *sf,int unicodeenc,SplineChar *sc, int layer);
@@ -2943,7 +2926,6 @@ extern void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *
 extern int SCAppendAccent(SplineChar *sc,int layer, char *glyph_name,int uni,uint32 pos);
 extern const unichar_t *SFGetAlternate(SplineFont *sf, int base,SplineChar *sc,int nocheck);
 
-extern int getAdobeEnc(const char *name);
 
 extern void SFSplinesFromLayers(SplineFont *sf,int tostroke);
 extern void SFSetLayerWidthsStroked(SplineFont *sf, real strokewidth);
@@ -3323,8 +3305,6 @@ extern EncMap *EncMapFromEncoding(SplineFont *sf,Encoding *enc);
 extern void SFRemoveGlyph(SplineFont *sf,SplineChar *sc);
 extern void SFAddEncodingSlot(SplineFont *sf,int gid);
 extern void SFAddGlyphAndEncode(SplineFont *sf,SplineChar *sc,EncMap *basemap, int baseenc);
-extern void SCDoRedo(SplineChar *sc,int layer);
-extern void SCDoUndo(SplineChar *sc,int layer);
 extern void SCCopyWidth(SplineChar *sc,enum undotype);
 extern void SCAppendPosSub(SplineChar *sc,enum possub_type type, char **d,SplineFont *copied_from);
 extern void SCClearBackground(SplineChar *sc);

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "cvundoes.h"
 #include "splinefont.h"
 #include <math.h>
 #define PI      3.1415926535897932

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "cvundoes.h"
 #include "encoding.h"
 #include <math.h>
 #include "psfont.h"

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "cvundoes.h"
 #include <math.h>
 #include "ustring.h"
 #include "chardata.h"

--- a/fontforgeexe/alignment.c
+++ b/fontforgeexe/alignment.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 #include "splinefont.h"
 #include "ustring.h"

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <gkeysym.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -27,6 +27,7 @@
  */
 
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -28,6 +28,7 @@
 
 #include "fontforgeui.h"
 #include "cvruler.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/cvaddpoints.c
+++ b/fontforgeexe/cvaddpoints.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 #include "splinefont.h"
 #include "ustring.h"

--- a/fontforgeexe/cvdebug.c
+++ b/fontforgeexe/cvdebug.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <gkeysym.h>
 #include <ustring.h>

--- a/fontforgeexe/cvexportdlg.c
+++ b/fontforgeexe/cvexportdlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <locale.h>
 #include <string.h>

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 
 #undef DEBUG_FREEHAND

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/cvgridfit.c
+++ b/fontforgeexe/cvgridfit.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <math.h>

--- a/fontforgeexe/cvhints.c
+++ b/fontforgeexe/cvhints.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include "ustring.h"
 #include <math.h>
 

--- a/fontforgeexe/cvimportdlg.c
+++ b/fontforgeexe/cvimportdlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <sys/types.h>
 #include <dirent.h>

--- a/fontforgeexe/cvknife.c
+++ b/fontforgeexe/cvknife.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgeui.h"
 #include "collabclientui.h"
+#include "cvundoes.h"
 #include <math.h>
 
 #if defined(KNIFE_CONTINUOUS)	/* Use this code to do cuts as we move along. Probably a bad idea, let's wait till the end */

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgeui.h"
 #include "collabclientui.h"
+#include "cvundoes.h"
 
 int palettes_docked=1;
 int rectelipse=0, polystar=0, regular_star=1;

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -29,6 +29,7 @@
 #include <utype.h>
 #include <math.h>
 #include "collabclient.h"
+#include "cvundoes.h"
 extern void BackTrace( const char* msg );
 
 int stop_at_join = false;

--- a/fontforgeexe/cvshapes.c
+++ b/fontforgeexe/cvshapes.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 
 static struct shapedescrip {

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforgeexe/cvtranstools.c
+++ b/fontforgeexe/cvtranstools.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 
 void CVMouseDownTransform(CharView *cv) {

--- a/fontforgeexe/deltaui.c
+++ b/fontforgeexe/deltaui.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/displayfonts.c
+++ b/fontforgeexe/displayfonts.c
@@ -27,6 +27,7 @@
 #include "ffglib.h"
 
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include "sftextfieldP.h"
 #include <stdlib.h>
 #include <math.h>

--- a/fontforgeexe/effectsui.c
+++ b/fontforgeexe/effectsui.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -31,6 +31,7 @@
 #include "collabclientpriv.h"
 
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include "groups.h"
 #include "psfont.h"
 #include "scripting.h"

--- a/fontforgeexe/layer2layer.c
+++ b/fontforgeexe/layer2layer.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <gkeysym.h>
 

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include "lookups.h"
 #include <gkeysym.h>
 #include <gresource.h>

--- a/fontforgeexe/nonlineartransui.c
+++ b/fontforgeexe/nonlineartransui.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <utype.h>
 #include <ustring.h>
 #include "nonlineartrans.h"

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include "ttf.h"
 #include <gwidget.h>
 #include <ustring.h>

--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -38,6 +38,7 @@
 #include "structmember.h"
 
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "ustring.h"

--- a/fontforgeexe/scriptingdlg.c
+++ b/fontforgeexe/scriptingdlg.c
@@ -28,6 +28,7 @@
 #if !defined(_NO_FFSCRIPT) || !defined(_NO_PYTHON)
 
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <gresource.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/scstylesui.c
+++ b/fontforgeexe/scstylesui.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforgeexe/searchview.c
+++ b/fontforgeexe/searchview.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/ttfinstrsui.c
+++ b/fontforgeexe/ttfinstrsui.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include <gkeysym.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/usermenu.c
+++ b/fontforgeexe/usermenu.c
@@ -26,6 +26,7 @@
  */
 
 #include "fontforgeui.h"
+#include "cvundoes.h"
 #include "usermenu.h"
 #include "ustring.h"
 


### PR DESCRIPTION
This standalone commit has been extracted from the work being done for PR #2821.

The prototypes for the public functions implemented in `cvundoes.c` were peppered over many different header files. This commit moves them all to `cvundoes.h`. The few comments that were present have been preserved.

This commit also moves to `cvundoes.h` some `extern` prototypes weirdly contained in `.c` files. (I wonder if anybody ever successfully compiled an application against libfontforge.)

Thanks to this move, it is now possible to understand which parts of the library implementation depend on the undo logic implemented in `cvundoes.c`. (Unfortunately, too many. The undo logic belongs to the UI, not to the library.)

Please note that no code inside the `.c` files has been touched.
