### PR TITLE
make bearing- and width-copying script functions actually work

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -2547,21 +2547,21 @@ static void bCopyUnlinked(Context *c) {
 }
 
 static void bCopyWidth(Context *c) {
-    FVCopy(c->curfv,ut_width);
+    FVCopyWidth(c->curfv,ut_width);
 }
 
 static void bCopyVWidth(Context *c) {
     if ( c->curfv!=NULL && !c->curfv->sf->hasvmetrics )
 	ScriptError(c,"Vertical metrics not enabled in this font");
-    FVCopy(c->curfv,ut_vwidth);
+    FVCopyWidth(c->curfv,ut_vwidth);
 }
 
 static void bCopyLBearing(Context *c) {
-    FVCopy(c->curfv,ut_lbearing);
+    FVCopyWidth(c->curfv,ut_lbearing);
 }
 
 static void bCopyRBearing(Context *c) {
-    FVCopy(c->curfv,ut_rbearing);
+    FVCopyWidth(c->curfv,ut_rbearing);
 }
 
 static void bCopyAnchors(Context *c) {


### PR DESCRIPTION
- [X] Why is this change required? What problem does it solve?

The CopyLBearing() scripting function, and a few other similar ones, did not work; they had basically no effect.  This change makes them work.

- [X] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

Closes #2850

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [X] Describe your changes in detail.

As described in #2850, there were four places in scripting.c where the function FVCopy() was called with an enum value of type undotype, even though that function requires an enum value of type fvcopy_type.  On further analysis it appears the reason is because those calls actually should have been made to the FVCopyWidth() function instead.  The two functions have similar enough argument lists and behaviour that this caused no visible error or compiler warning.  As far as I can tell, these scripting functions *never* worked, or at least, have not worked since 2007, when the incorrect calls were put into the code.

Note that if you select a glyph and do "Copy L Bearing" in the GUI, and then select another glyph and do "Paste", it works, copying the left bearing from one glyph to the other.  The GUI is calling FVCopyWidth().  Doing the same operations in native scripting, prior to this change, would have no apparent effect.  With this change, the commands work the same way in native scripting and the GUI.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [X] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.