### PR TITLE
gmenu.c Don't skip hotkey checking even if no modifiers are pressed

### DIFF
--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1859,7 +1859,7 @@ static int GMenuBarCheckHotkey(GWindow top, GGadget *g, GEvent *event) {
     GMenuBar *mb = (GMenuBar *) g;
 	GWindow w = GGadgetGetWindow(g);
 	GGadget* focus = GWindowGetFocusGadgetOfWindow(w);
-	if (GGadgetGetSkipHotkeyProcessing(focus) || event->u.chr.state == 0)
+	if (GGadgetGetSkipHotkeyProcessing(focus))
 	    return 0;
 
 //    TRACE("GMenuBarCheckKey(2) keysym:%d upper:%d lower:%d\n",keysym,toupper(keysym),tolower(keysym));


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
This backs out one of the changes from #2844. One of my assumptions was wrong: It turns out hotkeys can be specified without a modifier, e.g. the 'Delete' key to delete CPs in the charview.

 cc @frank-trampe 