### PR TITLE
gtextfield.c: Fix right click popup when text is selected

### DIFF
--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -1707,6 +1707,12 @@ return( true );
     }
 
     if ( event->type == et_mousedown ) {
+	if ( event->u.mouse.button==3 &&
+		GGadgetWithin(g,event->u.mouse.x,event->u.mouse.y)) {
+	    GTFPopupMenu(gt,event);
+return( true );
+	}
+
 	if ( i>=gt->lcnt )
 	    end1 = end2 = end;
 	else {
@@ -1743,12 +1749,6 @@ return( true );
 	} else {
 	    gt->sel_start = end-gt->text;
 	    gt->sel_end = gt->sel_base;
-	}
-
-	if ( event->u.mouse.button==3 &&
-		GGadgetWithin(g,event->u.mouse.x,event->u.mouse.y)) {
-	    GTFPopupMenu(gt,event);
-return( true );
 	}
 
 	if ( gt->pressed==NULL )


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
This moves the code that displays the context menu to run before
the text selection is changed - otherwise it's impossible to select
text then cut or copy it.

Before:
![tfbefore](https://cloud.githubusercontent.com/assets/5137410/18622569/b566f010-7e63-11e6-8463-8e7fd739e946.gif)
After:
![tfafter](https://cloud.githubusercontent.com/assets/5137410/18622570/b567d624-7e63-11e6-9124-5e9e2ecacf63.gif)
