### PR TITLE
Include scripting.h for DictionaryFree

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -33,6 +33,7 @@
 #include "fontforgeui.h"
 #include "groups.h"
 #include "psfont.h"
+#include "scripting.h"
 #include <gfile.h>
 #include <gio.h>
 #include <gresedit.h>


### PR DESCRIPTION
The function `DictionaryFree` has been moved to `scripting.h` in commit 1e61ac0e1cfe44913f9f4bd0f879deaaaf77f08b.

This commit fixes the following warning

```
fontview.c: In function 'FontView_Free':
fontview.c:7567:5: warning: implicit declaration of function 'DictionaryFree'
                   [-Wimplicit-function-declaration]
     DictionaryFree(fv->b.fontvars);
```