### PR TITLE
Call gl_EARLY before any other AC_PROG macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,8 @@ AM_INIT_AUTOMAKE([foreign -Wall subdir-objects tar-pax])
 AM_MAINTAINER_MODE([enable])
 AC_USE_SYSTEM_EXTENSIONS
 
+gl_EARLY
+
 #--------------------------------------------------------------------------
 # automake 1.12 requires AM_PROG_AR but automake < 1.11.2 doesn't recognize it.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
@@ -185,7 +187,6 @@ AC_PROG_AWK
 AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
-gl_EARLY
 AC_PROG_CPP
 AC_PROG_GREP
 AC_PROG_INSTALL


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

This change stops all the warnings about `AM_PROG_AR` being called too
early:

```
configure.ac:184: warning: AM_PROG_AR was called before gl_PROG_AR_RANLIB
m4/gnulib-common.m4:252: gl_PROG_AR_RANLIB is expanded from...
m4/gnulib-comp.m4:34: gl_EARLY is expanded from...
configure.ac:184: the top level
```

Fixes #2847.