### PR TITLE
Fix the loading of EBDT format 1 bitmaps with type 2 index subtables

### DIFF
--- a/fontforge/parsettfbmf.c
+++ b/fontforge/parsettfbmf.c
@@ -78,6 +78,9 @@ return;
 	big.vbearingX = 0;
 	big.vbearingY = 0;
 	big.vadvance = bdf->pixelsize;
+    /* Sometimes the index format (e.g. 2) already specifies the metrics */
+    /* Only use the provided metrics if it hasn't already been set */
+    if (metrics == NULL)
 	metrics = &big;
 	if ( imageformat==8 )
 	    /* pad = */ getc(ttf);


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
If the EBLC header specifies fonts using the type 2 index (indexSubTable2),
then all the bitmaps will have the same metrics as specified by that
subtable.

Therefore, when loading format 1 data from the EBDT table,
ignore the smallGlyphMetrics data that accompanies each entry.

Fixes #2543.

https://www.microsoft.com/typography/otspec/eblc.htm
https://www.microsoft.com/typography/otspec140/ebdt.htm