### PR TITLE
Enable Travis-CI on all branches, not only master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ compiler: gcc
 sudo: required
 dist: trusty
 osx_image: xcode8
-branches:
-  only:
-    - master
 os:
   - linux
   - osx


### PR DESCRIPTION
This PR removes the Travis-CI setting that limits builds to the master branch. The rationale for this is:

1. Trying to build a pushed branch always provides useful information, even for WIP branches.
2. It is hard for contributors to test their own branches before submitting PRs, leading to brown-bag rebases like [this](https://github.com/fontforge/fontforge/pull/2878#issuecomment-250617450) ;).

One could remove that setting their own fork, but keeping diverging master branches is not fun.