### PR TITLE
Remove dead prototypes (A less controverse version of PR #2817)

### DIFF
--- a/fontforge/sftextfieldP.h
+++ b/fontforge/sftextfieldP.h
@@ -94,7 +94,6 @@ extern float SFTFGetDPI(GGadget *g);
 extern void SFTFInitLangSys(GGadget *g, int end, uint32 script, uint32 lang);
 extern GGadget *SFTextAreaCreate(struct gwindow *base, GGadgetData *gd,void *data);
 extern void SFTFPopupMenu(SFTextArea *st, GEvent *event);
-extern void SFTextAreaSetTitleNotFonts(GGadget *g,const unichar_t *tit);
 
 extern struct gfuncs sftextarea_funcs;
 #endif

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -3066,7 +3066,6 @@ extern void SFTemporaryRestoreGlyphNames(SplineFont *sf, char **former);
 extern void doversion(const char *);
 
 extern AnchorPos *AnchorPositioning(SplineChar *sc,unichar_t *ustr,SplineChar **sstr );
-extern void AnchorPosFree(AnchorPos *apos);
 
 extern int  SF_CloseAllInstrs(SplineFont *sf);
 extern int  SSTtfNumberPoints(SplineSet *ss);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2714,7 +2714,6 @@ extern real HIoverlap( HintInstance *mhi, HintInstance *thi);
 extern int StemInfoAnyOverlaps(StemInfo *stems);
 extern int StemListAnyConflicts(StemInfo *stems);
 extern HintInstance *HICopyTrans(HintInstance *hi, real mul, real offset);
-extern void MDAdd(SplineChar *sc, int x, SplinePoint *sp1, SplinePoint *sp2);
 extern int SFNeedsAutoHint( SplineFont *_sf);
 
 typedef struct bluezone {

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2612,7 +2612,6 @@ extern int Spline1DCantExtremeY(const Spline *s);
 extern Spline *SplineAddExtrema(Spline *s,int always,real lenbound,
 	real offsetbound,DBounds *b);
 extern void SplineSetAddExtrema(SplineChar *sc,SplineSet *ss,enum ae_type between_selected, int emsize);
-extern void SplineSetAddSpiroExtrema(SplineChar *sc,SplineSet *ss,enum ae_type between_selected, int emsize);
 extern void SplineCharAddExtrema(SplineChar *sc,SplineSet *head,enum ae_type between_selected,int emsize);
 extern SplineSet *SplineCharRemoveTiny(SplineChar *sc,SplineSet *head);
 extern SplineFont *SplineFontNew(void);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2164,7 +2164,6 @@ extern void OS2FigureUnicodeRanges(SplineFont *sf, uint32 Ranges[4]);
 extern void SFDefaultOS2Info(struct pfminfo *pfminfo,SplineFont *sf,char *fontname);
 extern void SFDefaultOS2Simple(struct pfminfo *pfminfo,SplineFont *sf);
 extern void SFDefaultOS2SubSuper(struct pfminfo *pfminfo,int emsize,double italicangle);
-extern void VerifyLanguages(SplineFont *sf);
 extern int ScriptIsRightToLeft(uint32 script);
 extern void ScriptMainRange(uint32 script, int *start, int *end);
 extern uint32 ScriptFromUnicode(uint32 u,SplineFont *sf);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -3303,7 +3303,6 @@ extern void SFRemoveGlyph(SplineFont *sf,SplineChar *sc);
 extern void SFAddEncodingSlot(SplineFont *sf,int gid);
 extern void SFAddGlyphAndEncode(SplineFont *sf,SplineChar *sc,EncMap *basemap, int baseenc);
 extern void SCCopyWidth(SplineChar *sc,enum undotype);
-extern void SCAppendPosSub(SplineChar *sc,enum possub_type type, char **d,SplineFont *copied_from);
 extern void SCClearBackground(SplineChar *sc);
 extern void BackgroundImageTransform(SplineChar *sc, ImageList *img,real transform[6]);
 extern int SFIsDuplicatable(SplineFont *sf, SplineChar *sc);

--- a/fontforge/ttf.h
+++ b/fontforge/ttf.h
@@ -835,7 +835,6 @@ extern int memushort(uint8 *data,int table_len, int offset);
 extern void memputshort(uint8 *data,int offset,uint16 val);
 extern int TTF__getcvtval(SplineFont *sf,int val);
 extern int TTF_getcvtval(SplineFont *sf,int val);
-extern void SCinitforinstrs(SplineChar *sc);
 extern int SSAddPoints(SplineSet *ss,int ptcnt,BasePoint *bp, char *flags);
 extern int Macable(SplineFont *sf, OTLookup *otl);
 

--- a/fontforge/ttf.h
+++ b/fontforge/ttf.h
@@ -845,7 +845,6 @@ extern uint16 *ClassesFromNames(SplineFont *sf,char **classnames,int class_cnt,
 extern SplineChar **SFGlyphsFromNames(SplineFont *sf,char *names);
 
 
-extern void AnchorClassOrder(SplineFont *sf);
 extern SplineChar **EntryExitDecompose(SplineFont *sf,AnchorClass *ac,
 	struct glyphinfo *gi);
 extern void AnchorClassDecompose(SplineFont *sf,AnchorClass *_ac, int classcnt, int *subcnts,

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -766,8 +766,6 @@ extern char *PST2Text(PST *pst,SplineFont *sf);
 
 void EmboldenDlg(FontView *fv, CharView *cv);
 void CondenseExtendDlg(FontView *fv, CharView *cv);
-void AddSmallCapsDlg(FontView *fv);
-void AddSubSupDlg(FontView *fv);
 void ObliqueDlg(FontView *fv, CharView *cv);
 void GlyphChangeDlg(FontView *fv, CharView *cv, enum glyphchange_type gc);
 void ItalicDlg(FontView *fv, CharView *cv);

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -1281,7 +1281,6 @@ static void FVMenuChangeGlyph(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *
 static void FVMenuSubSup(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
     GlyphChangeDlg(fv,NULL,gc_subsuper);
-    /*AddSubSupDlg(fv);*/
 }
 
 static void FVMenuOblique(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {

--- a/inc/gdraw.h
+++ b/inc/gdraw.h
@@ -457,9 +457,6 @@ extern void *GDrawRequestSelection(GWindow w,enum selnames sn, char *typename, i
 extern int GDrawSelectionHasType(GWindow w,enum selnames sn, char *typename);
 extern void GDrawBindSelection(GDisplay *disp,enum selnames sel, char *atomname);
 extern int GDrawSelectionOwned(GDisplay *disp,enum selnames sel);
-extern void GDrawPropertyToSelectionOwner(GDisplay *disp,enum selnames sel,
-	char *property, char *type, int format, int mode,
-	uint8 *data, int nelements);
 
 extern void GDrawPointerUngrab(GDisplay *disp);
 extern void GDrawPointerGrab(GWindow w);

--- a/inc/gdraw.h
+++ b/inc/gdraw.h
@@ -557,7 +557,6 @@ extern void GDrawSetBuildCharHooks(void (*hook)(GDisplay *), void (*inshook)(GDi
 extern int GDrawRequestDeviceEvents(GWindow w,int devcnt,struct gdeveventmask *de);
 
 extern enum gcairo_flags GDrawHasCairo(GWindow w);
-extern void GDrawQueueDrawing(GWindow w,void (*)(GWindow,void *),void *);
 extern void GDrawPathStartNew(GWindow w);
 extern void GDrawPathStartSubNew(GWindow w);
 extern int GDrawFillRuleSetWinding(GWindow w);

--- a/inc/gdraw.h
+++ b/inc/gdraw.h
@@ -589,11 +589,6 @@ extern int GDrawKeyState(int keysym);
 extern int GImageGetScaledWidth(GWindow gw, GImage *img);
 extern int GImageGetScaledHeight(GWindow gw, GImage *img);
 
-
-/* extern void setZeroMQReadFD( GDisplay *disp, */
-/* 			     int zeromq_fd, void* zeromq_datas, */
-/* 			     void (*zeromq_fd_callback)(int zeromq_fd, void* datas )); */
-
 extern void GDrawAddReadFD( GDisplay *disp,
 			    int fd, void* udata,
 			    void (*callback)(int fd, void* udata ));

--- a/inc/gio.h
+++ b/inc/gio.h
@@ -80,8 +80,6 @@ typedef struct gdirentry {
 extern void GIOdir(GIOControl *gc);
 extern void GIOstatFile(GIOControl *gc);
 extern void GIOfileExists(GIOControl *gc);
-extern void GIOgetFile(GIOControl *gc);
-extern void GIOputFile(GIOControl *gc);
 extern void GIOmkDir(GIOControl *gc);
 extern void GIOdelFile(GIOControl *gc);
 extern void GIOdelDir(GIOControl *gc);

--- a/inc/gwidget.h
+++ b/inc/gwidget.h
@@ -73,9 +73,6 @@ void GWidgetNextFocus(GWindow);
 void GWidgetPrevFocus(GWindow);
 void GWidgetRequestVisiblePalette(GWindow palette,int visible);
 void GWidgetHidePalettes(void);
-void GPaletteDock(GWindow palette,int x, int y);
-void GPaletteUndock(GWindow palette,int x, int y);
-int GPaletteIsDocked(GWindow palette);
 void GWidgetReparentWindow(GWindow child,GWindow newparent, int x,int y);
 
 struct ggadget *GWidgetGetControl(GWindow gw, int cid);


### PR DESCRIPTION
This PR is a reduced version of PR #2817 that only removes prototypes of functions that have been removed years ago or never implemented.