### PR TITLE
Adjust the build in order to suit Xenial.

### DIFF
--- a/Packaging/debian/cp-src/control
+++ b/Packaging/debian/cp-src/control
@@ -11,7 +11,7 @@ Uploaders: Frank Trampe <frank.trampe@gmail.com>,
            Daniel Kahn Gillmor <dkg@fifthhorseman.net>
 XS-Python-Version: all
 Build-Depends: autoconf,
-               automake,
+               automake1.11,
                autotools-dev,
                bzip2,
                chrpath,

--- a/bootstrap
+++ b/bootstrap
@@ -4617,7 +4617,7 @@ bootstrap_options_prep ()
     # Option defaults:
     opt_copy=${copy-'false'}
     opt_dry_run=false
-    opt_force=false
+    opt_force=true
     opt_gnulib_srcdir=$GNULIB_SRCDIR
     opt_skip_git=false
     opt_skip_po=false


### PR DESCRIPTION
libtoolize now refuses to override files without the `--force` option, which is a problem for repeated builds and also for building from the Debian source packages, which are bootstrapped and configured as necessary to generate the Makefile that generates the source package.

The default version of automake is 1.15, but the build system is hardwired to use 1.11 and fails when it is missing. We now specify the version in the Debian control file.
