### PR TITLE
Python3 scripting: Don't call RegisterAllPyModules from imported modules

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18893,11 +18893,18 @@ return;
 ** function.
 */
 PyMODINIT_FUNC FFPY_PYTHON_ENTRY_FUNCTION(const char* modulename) {
-    doinitFontForgeMain();
-    no_windowing_ui = running_script = true;
+    static int initted = false;
 
-    RegisterAllPyModules();
-    CreateAllPyModules();
+    if (!initted) {
+        doinitFontForgeMain();
+        no_windowing_ui = running_script = true;
+
+#if PY_MAJOR_VERSION <= 2
+        RegisterAllPyModules();
+#endif
+        CreateAllPyModules();
+        initted = true;
+    }
 
 #if PY_MAJOR_VERSION >= 3
     /* Python 3 expects the module object to be returned */


### PR DESCRIPTION
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
RegisterAllPyModules calls PyImport_AppendInittab. The behaviour has changed between
Python 2 and 3. In 3, you cannot call this function anymore after
Py_Initialize has been called. Meaning since the module has already
been imported, Py_Initialize must have already been called before.

This change means that FFPY_PYTHON_ENTRY_FUNCTION will now be called
more than once (once for each module imported) on Python 3, so ensure
that the initialisation code only runs once.

Fixes #2886. See also #1731.