### PR TITLE
cvruler.c: Fix placement of prev_rect. Fixes #2895.

### DIFF
--- a/fontforgeexe/cvruler.c
+++ b/fontforgeexe/cvruler.c
@@ -964,6 +964,7 @@ return;
 	int len;
 	int charwidth = 6; /* TBD */
 	Color textcolor = (cv->start_intersection_snapped && cv->end_intersection_snapped) ? measuretoolcanvasnumberssnappedcol : measuretoolcanvasnumberscol;
+	GRect prev_rect;
 
 	if ( measuretoolshowhorizontolvertical ) {
 	    char buf[40];
@@ -990,7 +991,7 @@ return;
 
 	GDrawSetFont(pixmap,cv->rfont);
 	for ( i=0 ; i<cv->num_ruler_intersections; ++i ) {
-	    GRect rect,prev_rect;
+	    GRect rect;
 
 	    rect.x = cv->xoff + rint(cv->ruler_intersections[i].x*cv->scale) - 1;
 	    rect.y = -cv->yoff + cv->height - rint(cv->ruler_intersections[i].y*cv->scale) - 1;


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

### Description
This is CID1082720. The prev_ruler variable was getting instatiated
on every run of the for loop, defeating the purpose of this variable.

This is a very long standing bug (present since at least 2013), that
seems to only show under higher optimisation levels (-O2? -O3?).

cc @frank-trampe 