### PR TITLE
scripting.c: Don't free format_spec; free tmp.

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -2358,6 +2358,7 @@ static void bExport(Context *c) {
 #endif
     if (( format>=4 && c->a.argc!=3 ) || (format<4 && c->a.argc==3 )) {
 	c->error = ce_wrongnumarg;
+	free(tmp);
 	return;
     }
     bdf=NULL;
@@ -2374,8 +2375,6 @@ static void bExport(Context *c) {
 	if ( c->curfv->selected[i] && (gid=c->curfv->map->map[i])!=-1 &&
 		SCWorthOutputting(c->curfv->sf->glyphs[gid]) )
 	    ScriptExport(c->curfv->sf,bdf,format,gid,format_spec,c->curfv->map);
-    if ( format_spec!=buffer )
-	free(format_spec);
     free(tmp);
 }
 


### PR DESCRIPTION
### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)


### Description
Just addressing some things that Coverity noticed.

CID1364088, CID1357888. It's no longer necessary to do so, because format_spec
will never point to a buffer that needs freeing - all the dynamically
allocated buffers are freed elsewhere.