### PR TITLE
fix tests/fetched-fonts/ on .gitignore

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -173,6 +173,7 @@ GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/merged.cff					\
 	fonts/MinionPro-Regular.otf				\
 	fonts/LucidaGrande.ttc					\
-	fonts/nuvo-medium-woff-demo.woff
+	fonts/nuvo-medium-woff-demo.woff			\
+	fetched-fonts/*
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
Fix a download font file is not included in .gitignore, from `$ make check`.

Description to tests/.gitignore add "/fetched-fonts/*" line.