### PR TITLE
remove build option FONTFORGE_CONFIG_USE_DOUBLE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,8 +231,6 @@ dnl###############################
 
 AM_CONDITIONAL([XDG_DESKTOP],[test x"$UPDATE_MIME_DATABASE" != "x:" -a x"$UPDATE_DESKTOP_DATABASE" != "x:"])
 
-FONTFORGE_ARG_ENABLE_REAL
-
 AC_ARG_ENABLE([programs],
         [AS_HELP_STRING([--disable-programs],[do not build "fontforge" and related programs
                                               (but do build libraries and possibly the Python extensions)])],

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -752,11 +752,7 @@ static SplineSet * slurpspline(FILE *fig,SplineChar *sc, SplineSet *sofar) {
     xs.s = malloc((cnt+1)*sizeof(real));
     xs.closed = (sub&1);
     for ( i=0; i<cnt; ++i )
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
 	fscanf(fig,"%lf",&xs.s[i]);
-#else
-	fscanf(fig,"%f",&xs.s[i]);
-#endif
     /* the spec says that the last point of a closed path will duplicate the */
     /* first, but it doesn't seem to */
     if ( xs.closed && ( !RealNear(xs.cp[cnt-1].x,xs.cp[0].x) ||

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -652,17 +652,6 @@ static void SFDDumpSplineSet(FILE *sfd,SplineSet *spl) {
     for ( ; spl!=NULL; spl=spl->next ) {
 	first = NULL;
 	for ( sp = spl->first; ; sp=sp->next->to ) {
-#ifndef FONTFORGE_CONFIG_USE_DOUBLE
-	    if ( first==NULL )
-		fprintf( sfd, "%g %g m ", (double) sp->me.x, (double) sp->me.y );
-	    else if ( sp->prev->islinear && sp->noprevcp )		/* Don't use known linear here. save control points if there are any */
-		fprintf( sfd, " %g %g l ", (double) sp->me.x, (double) sp->me.y );
-	    else
-		fprintf( sfd, " %g %g %g %g %g %g c ",
-			(double) sp->prev->from->nextcp.x, (double) sp->prev->from->nextcp.y,
-			(double) sp->prevcp.x, (double) sp->prevcp.y,
-			(double) sp->me.x, (double) sp->me.y );
-#else
 	    if ( first==NULL )
 		fprintf( sfd, "%.12g %.12g m ", (double) sp->me.x, (double) sp->me.y );
 	    else if ( sp->prev->islinear && sp->noprevcp )		/* Don't use known linear here. save control points if there are any */
@@ -672,7 +661,6 @@ static void SFDDumpSplineSet(FILE *sfd,SplineSet *spl) {
 			(double) sp->prev->from->nextcp.x, (double) sp->prev->from->nextcp.y,
 			(double) sp->prevcp.x, (double) sp->prevcp.y,
 			(double) sp->me.x, (double) sp->me.y );
-#endif
 	    int ptflags = 0;
 	    ptflags = sp->pointtype|(sp->selected<<2)|
 		(sp->nextcpdef<<3)|(sp->prevcpdef<<4)|

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -38,13 +38,8 @@
 #include "locale.h"
 #include <gnetwork.h>
 
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
 # define real		double
 # define bigreal	double
-#else
-# define real		float
-# define bigreal	double
-#endif
 
 #define extended	double
 	/* Solaris wants to define extended to be unsigned [3] unless we do this*/

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -57,12 +57,8 @@ typedef struct quartic {
 /*  into splinefont.h after (or instead of) the definition of chunkalloc()*/
 
 #define ALLOC_CHUNK	100		/* Number of small chunks to malloc at a time */
-#ifndef FONTFORGE_CONFIG_USE_DOUBLE
-# define CHUNK_MAX	100		/* Maximum size (in chunk units) that we are prepared to allocate */
+# define CHUNK_MAX	129		/* Maximum size (in chunk units) that we are prepared to allocate */
 					/* The size of our data structures */
-#else
-# define CHUNK_MAX	129
-#endif
 # define CHUNK_UNIT	sizeof(void *)	/*  will vary with the word size of */
 					/*  the machine. if pointers are 64 bits*/
 					/*  we may need twice as much space as for 32 bits */

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -47,13 +47,8 @@ int snaptoint=0;
 
 /*#define DEBUG	1*/
 
-#if defined( FONTFORGE_CONFIG_USE_DOUBLE )
 # define RE_NearZero	.00000001
 # define RE_Factor	(1024.0*1024.0*1024.0*1024.0*1024.0*2.0) /* 52 bits => divide by 2^51 */
-#else
-# define RE_NearZero	.00001
-# define RE_Factor	(1024.0*1024.0*4.0)	/* 23 bits => divide by 2^22 */
-#endif
 
 int Within4RoundingErrors(bigreal v1, bigreal v2) {
     bigreal temp=v1*v2;
@@ -148,21 +143,12 @@ return( v2-v1 > re );
 int RealNear(real a,real b) {
     real d;
 
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
     if ( a==0 )
 return( b>-1e-8 && b<1e-8 );
     if ( b==0 )
 return( a>-1e-8 && a<1e-8 );
 
     d = a/(1024*1024.);
-#else		/* For floats */
-    if ( a==0 )
-return( b>-1e-5 && b<1e-5 );
-    if ( b==0 )
-return( a>-1e-5 && a<1e-5 );
-
-    d = a/(1024*64.);
-#endif
     a-=b;
     if ( d<0 )
 return( a>d && a<-d );

--- a/fontforgeexe/startnoui.c
+++ b/fontforgeexe/startnoui.c
@@ -89,9 +89,7 @@ int fontforge_main( int argc, char **argv ) {
 #ifdef _NO_PYTHON
 	    "-NoPython"
 #endif
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
 	    "-D"
-#endif
 	    ".\n",
 	    FONTFORGE_MODTIME_STR );
     fprintf( stderr, " Based on source from git with hash: %s\n", FONTFORGE_GIT_VERSION );

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -275,9 +275,7 @@ static void SplashLayout() {
 #ifdef _NO_PYTHON
     uc_strcat(pt,"-NoPython");
 #endif
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
     uc_strcat(pt,"-D");
-#endif
     uc_strcat(pt,")");
     pt += u_strlen(pt);
     lines[linecnt++] = pt;
@@ -906,9 +904,7 @@ int fontforge_main( int argc, char **argv ) {
 #ifdef _NO_PYTHON
 	        "-NoPython"
 #endif
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
 	        "-D"
-#endif
 	        ".\n",
 	        FONTFORGE_MODTIME_STR );
         fprintf( stderr, " Based on source from git with hash: %s\n", FONTFORGE_GIT_VERSION );

--- a/gtkui/startgtk.c
+++ b/gtkui/startgtk.c
@@ -525,9 +525,7 @@ int main( int argc, char **argv ) {
 #ifdef _NO_PYTHON
 	    "-NoPython"
 #endif
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
 	    "-D"
-#endif
 	    ".\n",
 	    source_modtime_str );
     fprintf( stderr, " Library based on sources from %s.\n", library_version_configuration.library_source_modtime_string );

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -60,21 +60,3 @@ if test x"${force_off_python_extension}" = xyes; then
 fi
 AM_CONDITIONAL([PYTHON_EXTENSION],[test x"${i_do_have_python_extension}" = xyes])
 ])
-
-
-dnl FONTFORGE_ARG_ENABLE_REAL
-dnl -------------------------
-AC_DEFUN([FONTFORGE_ARG_ENABLE_REAL],
-[
-AC_ARG_ENABLE([real],
-        [AS_HELP_STRING([--enable-real=TYPE],
-                [TYPE is float or double;
-                 sets the floating point type used internally [default=double]])],
-        [my_real_type="${enableval}"],
-        [my_real_type=double])
-if test x"${my_real_type}" = x"double"; then
-   AC_DEFINE([FONTFORGE_CONFIG_USE_DOUBLE],1,[Define if using 'double' precision.])
-elif test x"${my_real_type}" != x"float"; then
-   AC_MSG_ERROR([Floating point type '${my_real_type}' not recognized.])
-fi   
-])


### PR DESCRIPTION
remove build option FONTFORGE_CONFIG_USE_DOUBLE (FONTFORGE_ARG_ENABLE_REAL).

Is there the person using & testing this?

todo : remove defined "real" and "bugreal" in fontforge/splinefont.h