### PR TITLE
replace type boolean int to bool in fontforgeexe/startui.c and other.

### DIFF
--- a/fontforge/autosave.c
+++ b/fontforge/autosave.c
@@ -78,13 +78,13 @@ return;
 }
 
 
-int DoAutoRecoveryExtended(int inquire)
+bool DoAutoRecoveryExtended(int inquire)
 {
     char buffer[1025];
     char *recoverdir = getAutoDirName(buffer);
     DIR *dir;
     struct dirent *entry;
-    int any = false;
+    bool any = false;
     SplineFont *sf;
     int inquire_state=0;
 
@@ -98,7 +98,7 @@ return( false );
 	sprintf(buffer,"%s/%s",recoverdir,entry->d_name);
 	fprintf( stderr, "Recovering from %s... ", buffer);
 	if ( (sf = SFRecoverFile(buffer,inquire,&inquire_state)) ) {
-	    any=true;
+	    any = true;
 	    if ( sf->fv==NULL )		/* Doesn't work, cli arguments not parsed yet */
 		FontViewCreate(sf,false);
 	    fprintf( stderr, " Done\n" );

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2966,7 +2966,7 @@ extern void _DoAutoSaves(struct fontviewbase *);
 extern void CleanAutoRecovery(void);
 extern int DoAutoRecovery(int);
 typedef void (*DoAutoRecoveryPostRecoverFunc)(SplineFont *sf);
-extern int DoAutoRecoveryExtended(int inquire);
+extern bool DoAutoRecoveryExtended(int inquire);
 extern SplineFont *SFRecoverFile(char *autosavename,int inquire, int *state);
 extern void SFAutoSave(SplineFont *sf,EncMap *map);
 extern void SFClearAutoSave(SplineFont *sf);


### PR DESCRIPTION
replace int type of boolean like use.
change fontforgeexe/startui.c and relation files.

I don't touched "int splash".

concerned : 
The int splash variable is not changed.
Because extern in fontforgeexe/prefs.c and pointer convert to void * .

Todo : 
The int openflag variable is exist enum type.