### PR TITLE
Include gstdio.h for g_unlink

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -44,6 +44,7 @@
 
 #define GTimer GTimer_GTK
 #include <glib.h>
+#include <glib/gstdio.h>
 #undef GTimer
 
 


### PR DESCRIPTION
This commit removes the following warning:

```
sfd.c: In function 'MakeTemporaryFile':
sfd.c:2077:9: warning: implicit declaration of function 'g_unlink' [-Wimplicit-function-declaration]
         g_unlink(loc);
         ^
```

