### PR TITLE
ufo: Avoid empty format strings

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -101,7 +101,7 @@ static void extractNumericVersion(const char * textVersion, int * versionMajor, 
 
 static void injectNumericVersion(char ** textVersion, int versionMajor, int versionMinor) {
   // We generate a version string from numeric values if available.
-  if (versionMajor == -1) asprintf(textVersion, "");
+  if (versionMajor == -1) asprintf(textVersion, "%s", "");
   else if (versionMinor == -1) asprintf(textVersion, "%d", versionMajor);
   else asprintf(textVersion, "%d.%d", versionMajor, versionMinor);
   return;


### PR DESCRIPTION
This change fixes the warning

```
ufo.c: In function 'injectNumericVersion':
ufo.c:109:3: warning: zero-length gnu_printf format string
[-Wformat-zero-length]
   if (versionMajor == -1) asprintf(textVersion, "");
      ^
```
