### PR TITLE
Mark three small functions static

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -403,7 +403,7 @@ return;
     putc('>',out);
 }
 
-int kernclass_for_feature_file(struct splinefont *sf, struct kernclass *kc, int flags) {
+static int kernclass_for_feature_file(struct splinefont *sf, struct kernclass *kc, int flags) {
   // Note that this is not a complete logical inverse of sister function kernclass_for_groups_plist.
   return ((flags & FF_KERNCLASS_FLAG_FEATURE) ||
   (!(flags & FF_KERNCLASS_FLAG_NATIVE) && (kc->feature || sf->preferred_kerning != 1)));
@@ -7289,7 +7289,7 @@ static void fea_NameLookups(struct parseState *tok) {
     FVRefreshAll(sf);
 }
 
-void CopySplineFontGroupsForFeatureFile(SplineFont *sf, struct parseState* tok) {
+static void CopySplineFontGroupsForFeatureFile(SplineFont *sf, struct parseState* tok) {
   struct ff_glyphclasses *ff_current = sf->groups;
   struct glyphclasses *feature_current = tok->classes;
   // It may be useful to run this multiple times, appending to an existing list, so we traverse to the end.

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -2716,7 +2716,7 @@ return( false );
 return( true );
 }
 
-int SCMakeDotless(SplineFont *sf, SplineChar *dotless, int layer, BDFFont *bdf, int disp_only, int doit) {
+static int SCMakeDotless(SplineFont *sf, SplineChar *dotless, int layer, BDFFont *bdf, int disp_only, int doit) {
     SplineChar *sc;
     BDFChar *bc;
     int ret = 0;


### PR DESCRIPTION
These two commits mark three small functions as static. They were never exported and are used only in the file where they are defined.

Found while working on part 2 of PR #2878.
