### PR TITLE
File descriptor leak fixed + maps deference fixed

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3587,6 +3587,7 @@ static void dummyloca(struct alltabs *at) {
 }
 
 static void redohead(struct alltabs *at) {
+    if (at->headf) fclose(at->headf);
     at->headf = tmpfile();
 
     putlong(at->headf,at->head.version);

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -1847,11 +1847,16 @@ static void dumpGSUBmultiplesubs(FILE *gsub,SplineFont *sf,struct lookup_subtabl
 	putshort(gsub,offset);
 	if (maps[cnt] == NULL) {
 		fprintf( stderr, "maps[%d] is null; glyphs[%d] is \"%s\"; lookup name is \"%s\".\n" , cnt , cnt , (glyphs[cnt]->name ? glyphs[cnt]->name : ""), sub->subtable_name) ;
-	}
-	for ( gc=0; maps[cnt][gc]!=NULL; ++gc );
+            gc = 0;
+	} else {
+    	    for ( gc=0; maps[cnt][gc]!=NULL; ++gc );
+        }
 	offset += 2+2*gc;
     }
     for ( cnt = 0; glyphs[cnt]!=NULL; ++cnt ) {
+        if (maps[cnt] == NULL) {
+            break;
+        }
 	for ( gc=0; maps[cnt][gc]!=NULL; ++gc );
 	putshort(gsub,gc);
 	for ( gc=0; maps[cnt][gc]!=NULL; ++gc )


### PR DESCRIPTION
tottf.c:
If you redo the head, the previous file descriptor is not closed
`Closes #2903`

tottfgpos.c:
If maps[cnt] is NULL you print an error message but then immediately deference it = crash. I've seen this with Arial Unicode MS
