### PR TITLE
Streamline Makefile.am

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -38,29 +38,71 @@ noinst_HEADERS = \
 	autohint.h \
 	autosave.h \
 	autotrace.h \
-	autowidth.h \
 	autowidth2.h \
+	autowidth.h \
 	bitmapchar.h \
 	bitmapcontrol.h \
 	bvedit.h \
+	charview_private.h \
 	clipnoui.h \
+	configure-fontforge.h \
 	crctab.h \
 	cvexport.h \
 	cvimages.h \
+	cvundoes.h \
 	dumpbdf.h \
 	dumppfa.h \
-	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
-	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
+	flaglist.h \
+	fontforgeui.h \
+	sftextfieldP.h \
+	strlist.h \
+	tables.h \
+	views.h
 
-pkginclude_HEADERS = autowidth2.h configure-fontforge.h fontforge.h		\
-	libffstamp.h psfont.h stemdb.h autowidth.h delta.h fontforgevw.h	\
-	lookups.h savefont.h ttf.h baseviews.h fvmetrics.h mm.h			\
-	scriptfuncs.h ttfinstrs.h edgelist2.h namehash.h scripting.h		\
-	uiinterface.h bezctx_ff.h edgelist.h groups.h nonlineartrans.h		\
-	sd.h unicoderange.h bitmapcontrol.h encoding.h ofl.h search.h		\
-	usermenu.h fffreetype.h PfEd.h sfd1.h ffpython.h			\
-	plugins.h sflayoutP.h print.h splinefont.h cvruler.h ffglib.h           \
-	glif_name_hash.h
+pkginclude_HEADERS = \
+	autowidth2.h \
+	autowidth.h \
+	baseviews.h \
+	bezctx_ff.h \
+	bitmapcontrol.h \
+	configure-fontforge.h \
+	cvruler.h \
+	delta.h \
+	edgelist2.h \
+	edgelist.h \
+	encoding.h \
+	fffreetype.h \
+	ffglib.h \
+	ffpython.h \
+	fontforge.h \
+	fontforgevw.h \
+	fvmetrics.h \
+	glif_name_hash.h \
+	groups.h \
+	libffstamp.h \
+	lookups.h \
+	mm.h \
+	namehash.h \
+	nonlineartrans.h \
+	ofl.h \
+	PfEd.h \
+	plugins.h \
+	print.h \
+	psfont.h \
+	savefont.h \
+	scriptfuncs.h \
+	scripting.h \
+	sd.h \
+	search.h \
+	sfd1.h \
+	sflayoutP.h \
+	splinefont.h \
+	stemdb.h \
+	ttf.h \
+	ttfinstrs.h \
+	uiinterface.h \
+	unicoderange.h \
+	usermenu.h
 
 #--------------------------------------------------------------------------
 
@@ -79,27 +121,105 @@ AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 
 #--------------------------------------------------------------------------
 
-libfontforge_la_SOURCES = activeinui.c asmfpst.c autohint.c autosave.c	\
-	autotrace.c autowidth.c autowidth2.c bezctx_ff.c bitmapchar.c	\
-	bitmapcontrol.c bvedit.c collabclient.c collabclient.h		\
-	collabclientpriv.h clipnoui.c crctab.c cvexport.c cvimages.c	\
-	cvundoes.c dumpbdf.c dumppfa.c effects.c encoding.c		\
-	featurefile.c flaglist.c fontviewbase.c freetype.c		\
-	fvcomposite.c fvfonts.c fvimportbdf.c fvmetrics.c ftdelta.c	\
-	glyphcomp.c groups.c http.c ikarus.c langfreq.c			\
-	lookups.c macbinary.c macenc.c mathconstants.c mm.c namelist.c	\
-	nonlineartrans.c noprefs.c nouiutil.c nowakowskittfinstr.c	\
-	ofl.c othersubrs.c palmfonts.c parsepdf.c parsepfa.c		\
-	parsettfatt.c parsettfbmf.c parsettf.c parsettfvar.c plugins.c	\
-	pluginloading.c print.c psread.c pua.c python.c savefont.c	\
-	scripting.c scstyles.c search.c sfd1.c sfd.c sflayout.c		\
-	sfundo.h spiro.c splinechar.c splinefill.c splinefont.c		\
-	splineorder2.c splineoverlap.c splinesaveafm.c splinesave.c	\
-	splinestroke.c splineutil2.c splineutil.c start.c		\
-	stemdb.c strlist.c svg.c tottfaat.c tottfgpos.c tottf.c		\
-	tottfvar.c ttfinstrs.c ttfspecial.c ufo.c unicoderange.c	\
-	utils.c winfonts.c woff.c zapfnomen.c \
-	glif_name_hash.c
+libfontforge_la_SOURCES = \
+	activeinui.c \
+	asmfpst.c \
+	autohint.c \
+	autosave.c \
+	autotrace.c \
+	autowidth2.c \
+	autowidth.c \
+	bezctx_ff.c \
+	bitmapchar.c \
+	bitmapcontrol.c \
+	bvedit.c \
+	clipnoui.c \
+	collabclient.c \
+	collabclient.h \
+	collabclientpriv.h \
+	crctab.c \
+	cvexport.c \
+	cvimages.c \
+	cvundoes.c \
+	dumpbdf.c \
+	dumppfa.c \
+	effects.c \
+	encoding.c \
+	featurefile.c \
+	flaglist.c \
+	fontviewbase.c \
+	freetype.c \
+	ftdelta.c \
+	fvcomposite.c \
+	fvfonts.c \
+	fvimportbdf.c \
+	fvmetrics.c \
+	glif_name_hash.c \
+	glyphcomp.c \
+	groups.c \
+	http.c \
+	ikarus.c \
+	langfreq.c \
+	lookups.c \
+	macbinary.c \
+	macenc.c \
+	mathconstants.c \
+	mm.c \
+	namelist.c \
+	nonlineartrans.c \
+	noprefs.c \
+	nouiutil.c \
+	nowakowskittfinstr.c \
+	ofl.c \
+	othersubrs.c \
+	palmfonts.c \
+	parsepdf.c \
+	parsepfa.c \
+	parsettfatt.c \
+	parsettfbmf.c \
+	parsettf.c \
+	parsettfvar.c \
+	pluginloading.c \
+	plugins.c \
+	print.c \
+	psread.c \
+	pua.c \
+	python.c \
+	savefont.c \
+	scripting.c \
+	scstyles.c \
+	search.c \
+	sfd1.c \
+	sfd.c \
+	sflayout.c \
+	sfundo.h \
+	spiro.c \
+	splinechar.c \
+	splinefill.c \
+	splinefont.c \
+	splineorder2.c \
+	splineoverlap.c \
+	splinesaveafm.c \
+	splinesave.c \
+	splinestroke.c \
+	splineutil2.c \
+	splineutil.c \
+	start.c \
+	stemdb.c \
+	strlist.c \
+	svg.c \
+	tottfaat.c \
+	tottf.c \
+	tottfgpos.c \
+	tottfvar.c \
+	ttfinstrs.c \
+	ttfspecial.c \
+	ufo.c \
+	unicoderange.c \
+	utils.c \
+	winfonts.c \
+	woff.c \
+	zapfnomen.c
 
 EXTRA_libfontforge_la_SOURCES = splinerefigure.c
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -45,7 +45,6 @@ noinst_HEADERS = \
 	bvedit.h \
 	charview_private.h \
 	clipnoui.h \
-	configure-fontforge.h \
 	crctab.h \
 	cvexport.h \
 	cvimages.h \

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -110,24 +110,86 @@ libfontforgeexe_la_CPPFLAGS = $(AM_CPPFLAGS)
 
 if GRAPHICAL_USER_INTERFACE
 
-libfontforgeexe_la_SOURCES = alignment.c anchorsaway.c   \
-	autowidth2dlg.c basedlg.c bdfinfo.c bitmapdlg.c bitmapview.c	\
-	charinfo.c charview.c clipui.c combinations.c contextchain.c	\
-	cursors.c cvaddpoints.c cvdebug.c cvdgloss.c cvexportdlg.c		\
-	cvfreehand.c cvgetinfo.c cvgridfit.c cvhand.c cvhints.c			\
-	cvimportdlg.c cvknife.c cvpalettes.c cvpointer.c cvruler.c 		\
-	cvshapes.c cvstroke.c cvtranstools.c displayfonts.c effectsui.c	\
-	encodingui.c fontinfo.c fontview.c freetypeui.c fvfontsdlg.c	\
-	fvmetricsdlg.c gotodlg.c groupsdlg.c histograms.c images.c		\
-	kernclass.c layer2layer.c lookupui.c macencui.c math.c			\
-	metricsview.c mmdlg.c nonlineartransui.c openfontdlg.c	        \
-	prefs.c problems.c pythonui.c savefontdlg.c scriptingdlg.c		\
-	scstylesui.c searchview.c sftextfield.c showatt.c simplifydlg.c	        \
-	splashimage.c startui.c statemachine.c tilepath.c transform.c	        \
-	ttfinstrsui.c uiutil.c windowmenu.c justifydlg.c deltaui.c		\
-	usermenu.c macobjective.h                                               \
-	collabclientui.c collabclientui.h                                       \
-	sfundo.c wordlistparser.c wordlistparser.h fontforgeexe.h
+libfontforgeexe_la_SOURCES = \
+	alignment.c \
+	anchorsaway.c \
+	autowidth2dlg.c \
+	basedlg.c \
+	bdfinfo.c \
+	bitmapdlg.c \
+	bitmapview.c \
+	charinfo.c \
+	charview.c \
+	clipui.c \
+	collabclientui.c \
+	collabclientui.h \
+	combinations.c \
+	contextchain.c \
+	cursors.c \
+	cvaddpoints.c \
+	cvdebug.c \
+	cvdgloss.c \
+	cvexportdlg.c \
+	cvfreehand.c \
+	cvgetinfo.c \
+	cvgridfit.c \
+	cvhand.c \
+	cvhints.c \
+	cvimportdlg.c \
+	cvknife.c \
+	cvpalettes.c \
+	cvpointer.c \
+	cvruler.c \
+	cvshapes.c \
+	cvstroke.c \
+	cvtranstools.c \
+	deltaui.c \
+	displayfonts.c \
+	effectsui.c \
+	encodingui.c \
+	fontforgeexe.h \
+	fontinfo.c \
+	fontview.c \
+	freetypeui.c \
+	fvfontsdlg.c \
+	fvmetricsdlg.c \
+	gotodlg.c \
+	groupsdlg.c \
+	histograms.c \
+	images.c \
+	justifydlg.c \
+	kernclass.c \
+	layer2layer.c \
+	lookupui.c \
+	macencui.c \
+	macobjective.h \
+	math.c \
+	metricsview.c \
+	mmdlg.c \
+	nonlineartransui.c \
+	openfontdlg.c \
+	prefs.c \
+	problems.c \
+	pythonui.c \
+	savefontdlg.c \
+	scriptingdlg.c \
+	scstylesui.c \
+	searchview.c \
+	sftextfield.c \
+	sfundo.c \
+	showatt.c \
+	simplifydlg.c \
+	splashimage.c \
+	startui.c \
+	statemachine.c \
+	tilepath.c \
+	transform.c \
+	ttfinstrsui.c \
+	uiutil.c \
+	usermenu.c \
+	windowmenu.c \
+	wordlistparser.c \
+	wordlistparser.h
 
 EXTRA_libfontforgeexe_la_SOURCES = macobjective.m
 

--- a/gdraw/Makefile.am
+++ b/gdraw/Makefile.am
@@ -29,18 +29,65 @@ include $(top_srcdir)/mk/layout.am
 
 lib_LTLIBRARIES = libgdraw.la
 
-libgdraw_la_SOURCES = choosericons.c ctlvalues.c drawboxborder.c	\
-	gaskdlg.c gbuttons.c gcolor.c gchardlg.c gcontainer.c gdraw.c	\
-	gdrawbuildchars.c gdrawerror.c gdrawtxt.c gdrawtxtinit.c	\
-	gfilechooser.c gfiledlg.c ggadgets.c ggroupbox.c gimageclut.c	\
-	gimagecvt.c gimagepsdraw.c gimagewriteeps.c gdrawgimage.c	\
-	gimagexdraw.c gkeysym.c glist.c gmenu.c gprogress.c gpsdraw.c	\
-	gpstxtinit.c gradio.c gresource.c gresourceimage.c gresedit.c	\
-	gsavefiledlg.c gscrollbar.c gtabset.c gtextfield.c gtextinfo.c	\
-	gwidgets.c gxdraw.c gxcdraw.c ghvbox.c gmatrixedit.c		\
-	gdrawable.c gspacer.c xkeysyms_unicode.c colorP.h gdrawP.h	\
-	gimagebmpP.h gresourceP.h gxcdrawP.h fontP.h ggadgetP.h		\
-	gpsdrawP.h gwidgetP.h gxdrawP.h hotkeys.c hotkeys.h
+libgdraw_la_SOURCES = \
+	choosericons.c \
+	colorP.h \
+	ctlvalues.c \
+	drawboxborder.c \
+	fontP.h \
+	gaskdlg.c \
+	gbuttons.c \
+	gchardlg.c \
+	gcolor.c \
+	gcontainer.c \
+	gdrawable.c \
+	gdrawbuildchars.c \
+	gdraw.c \
+	gdrawerror.c \
+	gdrawgimage.c \
+	gdrawP.h \
+	gdrawtxt.c \
+	gdrawtxtinit.c \
+	gfilechooser.c \
+	gfiledlg.c \
+	ggadgetP.h \
+	ggadgets.c \
+	ggroupbox.c \
+	ghvbox.c \
+	gimagebmpP.h \
+	gimageclut.c \
+	gimagecvt.c \
+	gimagepsdraw.c \
+	gimagewriteeps.c \
+	gimagexdraw.c \
+	gkeysym.c \
+	glist.c \
+	gmatrixedit.c \
+	gmenu.c \
+	gprogress.c \
+	gpsdraw.c \
+	gpsdrawP.h \
+	gpstxtinit.c \
+	gradio.c \
+	gresedit.c \
+	gresource.c \
+	gresourceimage.c \
+	gresourceP.h \
+	gsavefiledlg.c \
+	gscrollbar.c \
+	gspacer.c \
+	gtabset.c \
+	gtextfield.c \
+	gtextinfo.c \
+	gwidgetP.h \
+	gwidgets.c \
+	gxcdraw.c \
+	gxcdrawP.h \
+	gxdraw.c \
+	gxdrawP.h \
+	hotkeys.c \
+	hotkeys.h \
+	xkeysyms_unicode.c
 
 libgdraw_la_CFLAGS = $(WARN_CFLAGS)
 

--- a/gutils/Makefile.am
+++ b/gutils/Makefile.am
@@ -29,15 +29,44 @@ lib_LTLIBRARIES = libgutils.la libgioftp.la
 
 #--------------------------------------------------------------------------
 
-libgutils_la_SOURCES = divisors.c dlist.c fsys.c g_giomime.c gcol.c	\
-	gimage.c gimagebmpP.h gimageread.c gimagereadbmp.c		\
-	gimagereadgif.c gimagereadjpeg.c gimagereadpng.c		\
-	gimagereadras.c gimagereadrgb.c gimagereadtiff.c		\
-	gimagereadxbm.c gimagereadxpm.c gimagewritebmp.c		\
-	gimagewritegimage.c gimagewritejpeg.c gimagewritepng.c		\
-	gimagewritexbm.c gimagewritexpm.c gio.c giofile.c giohosts.c	\
-	giothread.c giotrans.c giofuncP.h gioP.h gnetwork.c gutils.c	\
-	gwwintl.c prefs.c prefs.h unicodelibinfo.c unicodelibinfo.h
+libgutils_la_SOURCES = \
+	divisors.c \
+	dlist.c \
+	fsys.c \
+	gcol.c \
+	g_giomime.c \
+	gimagebmpP.h \
+	gimage.c \
+	gimagereadbmp.c \
+	gimageread.c \
+	gimagereadgif.c \
+	gimagereadjpeg.c \
+	gimagereadpng.c \
+	gimagereadras.c \
+	gimagereadrgb.c \
+	gimagereadtiff.c \
+	gimagereadxbm.c \
+	gimagereadxpm.c \
+	gimagewritebmp.c\
+	gimagewritegimage.c \
+	gimagewritejpeg.c \
+	gimagewritepng.c \
+	gimagewritexbm.c \
+	gimagewritexpm.c \
+	gio.c \
+	giofile.c \
+	giofuncP.h \
+	giohosts.c \
+	gioP.h \
+	giothread.c \
+	giotrans.c \
+	gnetwork.c \
+	gutils.c\
+	gwwintl.c \
+	prefs.c \
+	prefs.h \
+	unicodelibinfo.c \
+	unicodelibinfo.h
 
 libgutils_la_CFLAGS = $(WARN_CFLAGS)
 

--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -33,10 +33,32 @@ DISTCLEANFILES=fontforge-config.h stamp-h1 stamp-h2
 # installation. In particular, they ought to have <> instead of "" and
 # they should require a "fontforge/" prefix.
 
-pkginclude_HEADERS = basics.h chardata.h charset.h dynamic.h	\
-	fileutil.h fontforge-config.h gdraw.h gfile.h ggadget.h gicons.h gimage.h gio.h		\
-	gkeysym.h gprogress.h gresedit.h gresource.h gwidget.h gwwiconv.h	\
-	intl.h ustring.h utype.h dlist.h carbon.h gnetwork.h gutils.h
+pkginclude_HEADERS = \
+	basics.h \
+	carbon.h \
+	chardata.h \
+	charset.h \
+	dlist.h \
+	dynamic.h \
+	fileutil.h \
+	fontforge-config.h \
+	gdraw.h \
+	gfile.h \
+	ggadget.h \
+	gicons.h \
+	gimage.h \
+	gio.h \
+	gkeysym.h \
+	gnetwork.h \
+	gprogress.h \
+	gresedit.h \
+	gresource.h \
+	gutils.h \
+	gwidget.h \
+	gwwiconv.h \
+	intl.h \
+	ustring.h \
+	utype.h
 
 noinst_HEADERS = pluginloading.h
 


### PR DESCRIPTION
(Simple PR extracted from the always ongoing work on fixing the mess that is the current header situation and the library/application separation border, see PR #2878.)

The commits in this PR put some order in the various `*_HEADERS` and `*_SOURCES` automake variables. This cleanup will make the next commits much more concise and understandable.