### PR TITLE
Fix build out of source tree: uthash problem

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -74,7 +74,8 @@ AM_CFLAGS = $(WARN_CFLAGS)
 AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
 	"-DSHAREDIR=\"${MY_SHAREDIR}\"" "-DDOCDIR=\"${MY_DOCDIR}\""	\
-        "-I$(top_srcdir)/uthash/src" "-DFF_UTHASH_GLIF_NAMES=1"         \
+	"-I$(top_builddir)/uthash/src" "-I$(top_srcdir)/uthash/src"	\
+	"-DFF_UTHASH_GLIF_NAMES=1"					\
 	"-DPLUGINDIR=\"${MY_PLUGINDIR}\"" $(MY_CFLAGS)
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
Provide a general summary of your changes in the **Title** above.

### Important
Mark with [x] to select. Leave as [ ] to unselect.

### Motivation and Context
- [x] Why is this change required? What problem does it solve?
**It solves problem when compiling out of source tree:**
./bootstrap
cd ..;
mkdir build;
cd build;
../fontforge/configure --prefix=/usr;
make

I get error:
  CC       libfontforge_la-featurefile.lo
In file included from ../../t/fontforge/featurefile.c:2114:0:
../../t/fontforge/glif_name_hash.h:8:20: fatal error: uthash.h: No such file or directory
 #include "uthash.h"
                    ^
compilation terminated.
Makefile:1829: recipe for target 'libfontforge_la-featurefile.lo' failed

- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.
**Very simple change: top_srcdir -> top_builddir in Makefile.am for uthash. Because there is no uthash in src, it is cloned to build directory.**

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
**Changed Makefile.am only. So no problems with coding style :)**

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
**Well, I hope I've read enough for this small fix...**

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.