### PR TITLE
Do not accept libczmq version 4

### DIFF
--- a/m4/fontforge_arg_with.m4
+++ b/m4/fontforge_arg_with.m4
@@ -401,7 +401,7 @@ AC_DEFUN([FONTFORGE_ARG_WITH_ZEROMQ],
 [
 FONTFORGE_ARG_WITH([libzmq],
         [AS_HELP_STRING([--without-libzmq],[build without libzmq])],
-        [ libczmq >= 2.2.0 libzmq >= 4.0.4 ],
+        [ libczmq >= 2.2.0 libczmq < 4 libzmq >= 4.0.4 ],
         [FONTFORGE_WARN_PKG_NOT_FOUND([LIBZMQ])],
         [_NO_LIBZMQ], [NO_LIBZMQ=1])
 ])


### PR DESCRIPTION
The deprecated `zctx` API has been removed in version 4 of libczmq.

As reported in #2950, this causes compilation problems on recent versions of MacOS and homebrew.

Until the collabclient code is updated to the new `zsock` API, we cannot compile against libczmq version 4 and later, so let's limit ourselves to version 3.

This build will fail on Travis because of an unrelated MacOS issue: `The command "if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi" exited with 1.` @jtanx, @frank-trampe, could you have a look at it?