### PR TITLE
Fix a crash loading Skia.

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -5820,7 +5820,7 @@ static SplineFont *SFFromTuple(SplineFont *basesf,struct variations *v,int tuple
     sf->glyphmax = sf->glyphcnt = basesf->glyphcnt;
     sf->glyphs = v->tuples[tuple].chars;
     sf->layers[ly_fore].order2 = sf->layers[ly_back].order2 = true;
-    for ( i=0; i<sf->glyphcnt; ++i ) if ( basesf->glyphs[i]!=NULL ) {
+    for ( i=0; i<sf->glyphcnt; ++i ) if ( basesf->glyphs[i]!=NULL && sf->glyphs[i]!=NULL ) {
 	SplineChar *sc = sf->glyphs[i];
 	sc->orig_pos = i;
 	sc->parent = sf;

--- a/fontforge/parsettfatt.c
+++ b/fontforge/parsettfatt.c
@@ -4758,6 +4758,7 @@ return;
     /*  removes the flag */
     if ( info->badgid_cnt!=0 ) {
 	/* Merge the fake glyphs in with the real ones */
+	int oldgc = info->glyph_cnt;
 	info->chars = realloc(info->chars,(info->glyph_cnt+info->badgid_cnt)*sizeof(SplineChar *));
 	for ( i=0; i<info->badgid_cnt; ++i ) {
 	    info->chars[info->glyph_cnt+i] = info->badgids[i];
@@ -4765,6 +4766,17 @@ return;
 	}
 	info->glyph_cnt += info->badgid_cnt;
 	free(info->badgids);
+	/* We also need to adjust the variations. */
+	if (info->variations) {
+	    int ctup;
+	    for (ctup = 0; ctup < info->variations->tuple_count; ctup++) {
+		SplineChar ** tscs = info->variations->tuples[ctup].chars;
+		info->variations->tuples[ctup].chars = calloc(info->glyph_cnt, sizeof(SplineChar *));
+		memcpy(info->variations->tuples[ctup].chars, tscs, oldgc * sizeof(SplineChar *));
+		free(tscs);
+		tscs = NULL;
+	    }
+	}
     }
 }
 

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -7319,7 +7319,7 @@ static FontView *__FontViewCreate(SplineFont *sf) {
 	    if ( fv->b.nextsame==NULL ) { sf->map = fv->b.map; }
 	}
     }
-    fv->b.selected = calloc(fv->b.map->enccount,sizeof(char));
+    fv->b.selected = calloc((fv->b.map ? fv->b.map->enccount : 0), sizeof(char));
     fv->user_requested_magnify = -1;
     fv->magnify = (ps<=9)? 3 : (ps<20) ? 2 : 1;
     fv->cbw = (ps*fv->magnify)+1;


### PR DESCRIPTION
Fix a crash that occurs when a file contains TrueType variations and fake glyphs from Apple. This closes #2959.
