### PR TITLE
Rename Unicode Identifiers and fix Makefile.am

### DIFF
--- a/Unicode/Makefile.am
+++ b/Unicode/Makefile.am
@@ -65,10 +65,7 @@ libgunicode_la_SOURCES =	\
 	ustring.c		\
 	utype.c			\
 	gwwiconv.c		\
-	combiners.h		\
 	$(NULL)
-
-#	usprintf.c
 
 libgunicode_la_CFLAGS = $(WARN_CFLAGS)
 libgunicode_la_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"	\
@@ -84,12 +81,14 @@ libgunicode_la_LIBADD = $(MY_LIBS)
 
 #dump_SOURCES = dump.c
 #makebuildtables_SOURCES = makebuildtables.c utype.c
-#makeutype_SOURCES = makeutype.c
+#makeutype_SOURCES = makeutype.c combiners.h
 
-#noinst_PROGRAMS = dump makebuildtables makeutype
-
-EXTRA_DIST = README.TXT #dump.c makebuildtables.c makeutype.c
-
+EXTRA_DIST = README.TXT		\
+	combiners.h		\
+	dump.c			\
+	makebuildtables.c	\
+	makeutype.c		\
+	usprintf.c
 #--------------------------------------------------------------------------
 
 -include $(top_srcdir)/git.mk

--- a/Unicode/combiners.h
+++ b/Unicode/combiners.h
@@ -2,905 +2,905 @@
 #define FONTFORGE_UNICODE_COMBINERS_H
 
 static const int poses300[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,		/* 0x310 */
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above|_CenterRight,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Above,
-    _Above|_Right|_Touching,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,		/* 0x320 */
-    _Below|_Touching,
-    _Below|_Touching,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below|_Touching,
-    _Below|_Touching,	/* 0x328 */
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,		/* 0x330 */
-    _Below,
-    _Below,
-    _Below,
-    _Overstrike,
-    _Overstrike,
-    _Overstrike,
-    _Overstrike,
-    _Overstrike,	/* 0x338 */
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Above,
-    _Above,
-    _Above,
-    _Above|_Left,	/* 0x340 */
-    _Above|_Right,
-    _Above,
-    _Above,
-    _Above,
-    _Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,		/* 0x310 */
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_CenterRight,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_Right|FF_UNICODE_Touching,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,		/* 0x320 */
+    FF_UNICODE_Below|FF_UNICODE_Touching,
+    FF_UNICODE_Below|FF_UNICODE_Touching,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below|FF_UNICODE_Touching,
+    FF_UNICODE_Below|FF_UNICODE_Touching, /* 0x328 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,		/* 0x330 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,	/* 0x338 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_Left, /* 0x340 */
+    FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
     0
 };
 static const int poses360[] = {
-    _Above|_Joins2,
-    _Above|_Joins2,
-    _Below|_Joins2,
+    FF_UNICODE_Above|FF_UNICODE_Joins2,
+    FF_UNICODE_Above|FF_UNICODE_Joins2,
+    FF_UNICODE_Below|FF_UNICODE_Joins2,
     0
 };
 static const int poses385[] = {
-    _Above
+    FF_UNICODE_Above
 };
 static const int poses483[] = {
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
     0
 };
 
 static const int poses488[] = {
-    _CenteredOutside,				/* 8 down half-circles distributed in a circle around the character */
-    _CenteredOutside				/* 8 commas rotated as moved around circle, bottom is normal comma */
+    FF_UNICODE_CenteredOutside,	/* 8 down half-circles distributed in a circle around the character */
+    FF_UNICODE_CenteredOutside	/* 8 commas rotated as moved around circle, bottom is normal comma */
 };
 
 static const int poses591[] = {
-    _Below,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Below|_CenterRight,
-    _Above,
-    _Above,
-    _Above|_LeftEdge,
-    _Below|_RightEdge,
-    _Below,
-    _Above|_CenterRight,
-    _Above|_RightEdge,
-    _Above|_CenterRight,
-    _Above,
-    _Above|_RightEdge,			/* 05a0 */
-    _Above|_LeftEdge
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below|FF_UNICODE_CenterRight,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge,
+    FF_UNICODE_Below|FF_UNICODE_RightEdge,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above|FF_UNICODE_CenterRight,
+    FF_UNICODE_Above|FF_UNICODE_RightEdge,
+    FF_UNICODE_Above|FF_UNICODE_CenterRight,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_RightEdge, /* 05a0 */
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge
 };
 
 static const int poses5A3[] = {
-    _Below,
-    _Below,
-    _Below|_CenterLeft,
-    _Below|_CenterLeft,
-    _Below,
-    _Above|_CenterLeft,
-    _Above|_LeftEdge,
-    _Below,
-    _Above,
-    _Above,
-    _Below|_RightEdge,
-    _Above|_LeftEdge,
-    _Above,
-    _Below,				/* 05b0 */
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Above|_LeftEdge
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Below|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below|FF_UNICODE_RightEdge,
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,		/* 05b0 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,		/* 05b8 */
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge
 };
 
 static const int poses5BB[] = {
-    _Below,
-    _Overstrike,
-    _Below
+    FF_UNICODE_Below,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Below
 };
 
 static const int poses5BF[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int poses5C1[] = {
-    _Above|_RightEdge,
-    _Above|_LeftEdge
+    FF_UNICODE_Above|FF_UNICODE_RightEdge,
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge
 };
 
 static const int poses5C4[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int poses64b[] = {
-    _Above,
-    _Above,
-    _Below,
-    _Above,
-    _Above,
-    _Below,
-    _Above,
-    _Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
     0
 };
 
 static const int poses670[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int poses6D6[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Overstrike,
-    _Overstrike,
-    _Above,
-    _Above,		/* 6e0 */
-    _Above,
-    _Above,
-    _Below,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,		/* 6e0 */
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above
 };
 
 static const int poses6E7[] = {
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses6EA[] = {
-    _Below,
-    _Above,
-    _Above,
-    _Below
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below
 };
 
 static const int poses711[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int poses730[] = {
-    _Above,
-    _Below,
-    _CenteredOutside,		/* Two dots, one above CenterRight, one below CenterLeft */
-    _Above,
-    _Below,
-    _Above,
-    _Above,
-    _Below,
-    _Below,
-    _Below,
-    _Above,
-    _Below,
-    _Below,
-    _Above,
-    _Below,
-    _Above,
-    _Above|_LeftEdge,	/* 0740 */
-    _Above,
-    _Below,
-    _Above,
-    _Below,
-    _Above,
-    _Below,
-    _Above,
-    _Below,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_CenteredOutside,	/* Two dots, one above CenterRight, one below CenterLeft */
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge, /* 0740 */
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses7A6[] = {
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Below|_CenterLeft,
-    _Below|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Below|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Below|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
 };
 
 static const int poses901[] = {
-    _Above,
-    _Above,
-    _Right
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right
 };
 
 static const int poses93C[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int poses93E[] = {
-    _Right,
-    _Left,
-    _Right,	/* 940 */
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Above,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Right,
-    _Right,
-    _Right,
-    _Right,
-    _Below|_CenterRight
+    FF_UNICODE_Right,
+    FF_UNICODE_Left,
+    FF_UNICODE_Right,		/* 940 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_CenterRight
 };
 
 static const int poses951[] = {
-    _Above,
-    _Below,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses962[] = {
-    _Below,
-    _Below
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int poses981[] = {
-    _Above,
-    _Right,
-    _Right
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int poses9BC[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int poses9BE[] = {
-    _Right,
-    _Left,
-    _Right,
-    _Below,
-    _Below,
-    _Below,
-    _Below|_CenterRight
+    FF_UNICODE_Right,
+    FF_UNICODE_Left,
+    FF_UNICODE_Right,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below|FF_UNICODE_CenterRight
 };
 
 static const int poses9C7[] = {
-    _Left,
-    _Left
+    FF_UNICODE_Left,
+    FF_UNICODE_Left
 };
 
 static const int poses9CB[] = {
-    _Overstrike,
-    _Overstrike,
-    _Below
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Below
 };
 
 static const int poses9D7[] = {
-    _Right
+    FF_UNICODE_Right
 };
 
 static const int poses9E2[] = {
-    _Below,
-    _Below
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int posesA02[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int posesA3C[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int posesA3E[] = {
-    _Right,
-    _Left,
-    _Right,		/* 0a40 */
-    _Below,
-    _Below
+    FF_UNICODE_Right,
+    FF_UNICODE_Left,
+    FF_UNICODE_Right,		/* 0a40 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int posesA47[] = {
-    _Above|_CenterLeft,
-    _Above|_CenterLeft
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft
 };
 
 static const int posesA4B[] = {
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Below
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Below
 };
 
 static const int posesA70[] = {
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int posesA81[] = {
-    _Above,
-    _Above,
-    _Right
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right
 };
 
 static const int posesABC[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int posesABE[] = {
-    _Right,
-    _Left,
-    _Right,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Above
+    FF_UNICODE_Right,
+    FF_UNICODE_Left,
+    FF_UNICODE_Right,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above
 };
 
 static const int posesAC7[] = {
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Right
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Right
 };
 
 static const int posesACB[] = {
-    _Right,
-    _Right,
-    _Below|_CenterRight
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_CenterRight
 };
 
 static const int posesB01[] = {
-    _Above,
-    _Above,
-    _Right
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right
 };
 
 static const int posesB3C[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int posesB3E[] = {
-    _Right,
-    _Above,
-    _Right,		/* 0b40 */
-    _Below,
-    _Below,
-    _Below
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,		/* 0b40 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int posesB47[] = {
-    _Left,
-    _Outside|_Left|_Above
+    FF_UNICODE_Left,
+    FF_UNICODE_Outside|FF_UNICODE_Left|FF_UNICODE_Above
 };
 
 static const int posesB4B[] = {
-    _CenteredOutside,
-    _CenteredOutside,
-    _Below
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_Below
 };
 
 static const int posesB56[] = {
-    _Above,
-    _Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,
 };
 
 static const int posesB82[] = {
-    _Above,
-    _Right
+    FF_UNICODE_Above,
+    FF_UNICODE_Right
 };
 
 static const int posesBBE[] = {
-    _Right,
-    _Right,
-    _Above,
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesBC6[] = {
-    _Left,
-    _Left,
-    _Left
+    FF_UNICODE_Left,
+    FF_UNICODE_Left,
+    FF_UNICODE_Left
 };
 
 static const int posesBCA[] = {
-    _CenteredOutside,
-    _CenteredOutside,
-    _CenteredOutside,
-    _Above
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_Above
 };
 
 static const int posesBD7[] = {
-    _Right
+    FF_UNICODE_Right
 };
 
 static const int posesC01[] = {
-    _Right,
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesC3E[] = {
-    _Above|_CenterRight,
-    _Above,
-    _Above,
-    _Right,
-    _Right,
-    _Right,
-    _Right
+    FF_UNICODE_Above|FF_UNICODE_CenterRight,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesC46[] = {
-    _Above,
-    _Above,
-    _CenteredOutside
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_CenteredOutside
 };
 
 static const int posesC4A[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int posesC55[] = {
-    _Above,
-    _Below
+    FF_UNICODE_Above,
+    FF_UNICODE_Below
 };
 
 static const int posesC82[] = {
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesCBE[] = {
-    _Right,
-    _Above,
-    _Outside|_Above|_Right,
-    _Right,
-    _Right,
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesCC6[] = {
-    _Above,
-    _Outside|_Above|_Right,
-    _Outside|_Above|_Right
+    FF_UNICODE_Above,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Right
 };
 
 static const int posesCCA[] = {
-    _Outside|_Above|_Right,
-    _Outside|_Above|_Right,
-    _Above,
-    _Above
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int posesCD5[] = {
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesD02[] = {
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesD3E[] = {
-    _Right,
-    _Right,
-    _Right,
-    _Below|_Right,
-    _Below|_Right,
-    _Below
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_Right,
+    FF_UNICODE_Below
 };
 
 static const int posesD46[] = {
-    _Left,
-    _Left,
-    _Left
+    FF_UNICODE_Left,
+    FF_UNICODE_Left,
+    FF_UNICODE_Left
 };
 
 static const int posesD4A[] = {
-    _Outside|_Left|_Right,
-    _Outside|_Left|_Right,
-    _Outside|_Left|_Right,
-    _Above|_Right
+    FF_UNICODE_Outside|FF_UNICODE_Left|FF_UNICODE_Right,
+    FF_UNICODE_Outside|FF_UNICODE_Left|FF_UNICODE_Right,
+    FF_UNICODE_Outside|FF_UNICODE_Left|FF_UNICODE_Right,
+    FF_UNICODE_Above|FF_UNICODE_Right
 };
 
 static const int posesD57[] = {
-    _Right
+    FF_UNICODE_Right
 };
 
 static const int posesD82[] = {
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesDCA[] = {
-    _Right
+    FF_UNICODE_Right
 };
 
 static const int posesDCF[] = {
-    _Right,
-    _Right,
-    _Right,
-    _Above,
-    _Above,
-    _Below
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below
 };
 
 static const int posesDD6[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int posesDD8[] = {
-    _Right,
-    _Left,
-    _CenteredOutside,
-    _Left,
-    _CenteredOutside,
-    _CenteredOutside,
-    _CenteredOutside,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Left,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_Left,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_Right
 };
 
 static const int posesDF2[] = {
-    _Right,
-    _Right
+    FF_UNICODE_Right,
+    FF_UNICODE_Right
 };
 
 static const int posesE31[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int posesE34[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Below|_Right,
-    _Below|_CenterRight,
-    _Below|_Right
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below|FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_CenterRight,
+    FF_UNICODE_Below|FF_UNICODE_Right
 };
 
 static const int posesE47[] = {
-    _Above,
-    _Above|_Right,
-    _Above,
-    _Above,
-    _Above|_CenterRight,
-    _Above,
-    _Above|_Right,
-    _Above|_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_CenterRight,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Above|FF_UNICODE_Right,
 };
 
 static const int posesEB1[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int posesEB4[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Below,
-    _Below
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int posesEBB[] = {
-    _Above,
-    _Below
+    FF_UNICODE_Above,
+    FF_UNICODE_Below
 };
 
 static const int posesEC8[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int posesF18[] = {
-    _Below|_Right
+    FF_UNICODE_Below|FF_UNICODE_Right
 };
 
 static const int posesF35[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int posesF37[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int posesF39[] = {
-    _Above|_Right|_Touching
+    FF_UNICODE_Above|FF_UNICODE_Right|FF_UNICODE_Touching
 };
 
 static const int posesF3E[] = {
-    _Below|_Right,
-    _Below|_Left
+    FF_UNICODE_Below|FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_Left
 };
 
 static const int posesF71[] = {
-    _Below,
-    _Above,
-    _Outside|_Above|_Below,
-    _Below,
-    _Below,
-    _Outside|_Above|_Below,
-    _Outside|_Above|_Below,
-    _Outside|_Above|_Below,
-    _Outside|_Above|_Below,
-    _Above|_CenterLeft,
-    _Above|_CenterLeft,
-    _Above,
-    _Above,
-    _Above,
-    _Right,
-    _Above,		/* 0f80 */
-    _Outside|_Above|_Below,
-    _Above,
-    _Above,
-    _Below|_Left
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Below,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Below,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Below,
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Below,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,		/* 0f80 */
+    FF_UNICODE_Outside|FF_UNICODE_Above|FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below|FF_UNICODE_Left
 };
 
 static const int posesF86[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int posesF90[] = {
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int posesF99[] = {
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below,
-    _Below
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int posesFC6[] = {
-    _Below
+    FF_UNICODE_Below
 };
 
 static const int poses102C[] = {
-    _Right,
-    _Above,
-    _Above,
-    _Below,
-    _Below,			/* 1030 */
-    _Left,
-    _Above
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,		/* 1030 */
+    FF_UNICODE_Left,
+    FF_UNICODE_Above
 };
 
 static const int poses1036[] = {
-    _Above,
-    _Below,
-    _Right,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Right,
+    FF_UNICODE_Above
 };
 
 static const int poses1056[] = {
-    _Right,
-    _Right,
-    _Below,
-    _Below
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below
 };
 
 static const int poses17B4[] = {
-    _Overstrike,
-    _Overstrike,
-    _Right,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Below,
-    _Below,
-    _Below,
-    _Outside|_Left|_Above,
-    _CenteredOutside,
-    _CenteredOutside,		/* 17c0 */
-    _Left,
-    _Left,
-    _Left,
-    _CenteredOutside,
-    _CenteredOutside,
-    _Above,
-    _Right,
-    _Right,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Above|_CenterRight,
-    _Above|_CenterRight,
-    _Above,
-    _Above|_CenterRight,	/* 17d0 */
-    _Above,
-    _Below,
-    _Above
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Outside|FF_UNICODE_Left|FF_UNICODE_Above,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,	/* 17c0 */
+    FF_UNICODE_Left,
+    FF_UNICODE_Left,
+    FF_UNICODE_Left,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_CenterRight,
+    FF_UNICODE_Above|FF_UNICODE_CenterRight,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_CenterRight, /* 17d0 */
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above
 };
 
 static const int poses18A9[] = {
-    _Above|_Left
+    FF_UNICODE_Above|FF_UNICODE_Left
 };
 
 static const int poses1FBD[] = {	/* These aren't listed as combiners, but if we don't use them as such greek fonts don't work */
-    _Above,
-    _Right,
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses1FCD[] = {	/* These aren't listed as combiners, but if we don't use them as such greek fonts don't work */
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses1FDD[] = {	/* These aren't listed as combiners, but if we don't use them as such greek fonts don't work */
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses1FED[] = {	/* These aren't listed as combiners, but if we don't use them as such greek fonts don't work */
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses1FFD[] = {	/* These aren't listed as combiners, but if we don't use them as such greek fonts don't work */
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses20D0[] = {
-    _Above,
-    _Above,
-    _Overstrike,
-    _Overstrike,
-    _Above,
-    _Above,
-    _Above,
-    _Above,
-    _Overstrike,
-    _Overstrike,
-    _Overstrike,
-    _Above,
-    _Above,
-    _CenteredOutside,
-    _CenteredOutside,
-    _CenteredOutside,
-    _Overstrike,
-    _Above,
-    _CenteredOutside,
-    _CenteredOutside
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Above,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside
 };
 
 static const int poses302A[] = {
-    _Below|_Left,
-    _Above|_Left,
-    _Above|_Right,
-    _Below|_Right,
-    _Left,
-    _Left
+    FF_UNICODE_Below|FF_UNICODE_Left,
+    FF_UNICODE_Above|FF_UNICODE_Left,
+    FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_Right,
+    FF_UNICODE_Left,
+    FF_UNICODE_Left
 };
 
 static const int poses3099[] = {
-    _Above|_Right,
-    _Above|_Right,
+    FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Above|FF_UNICODE_Right,
 };
 
 static const int posesFB1E[] = {
-    _Above
+    FF_UNICODE_Above
 };
 
 static const int posesFE20[] = {
-    _Above,
-    _Above,
-    _Above,
-    _Above
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 const static struct {

--- a/Unicode/is_Ligature.c
+++ b/Unicode/is_Ligature.c
@@ -12,7 +12,7 @@ Contributions:
 
 /* unicode.org codepoints for ligatures, vulgar fractions, other fractions */
 
-const uint16 ____ligature16[] = {
+const uint16 ligature16[] = {
   0x0132, 0x0133, 0x0152, 0x0153, 0x04a4, 0x04a5, 0x04b4, 0x04b5,
   0x04d4, 0x04d5, 0x0587, 0x05f0, 0x05f1, 0x05f2, 0x0616, 0x06d6,
   0x06d7, 0xa7f9, 0xfb00, 0xfb01, 0xfb02, 0xfb03, 0xfb04, 0xfb05,
@@ -78,22 +78,22 @@ const uint16 ____ligature16[] = {
   0xfdfa, 0xfdfb, 0xfdfd, 0xfe20, 0xfe21, 0xfe27, 0xfe28, 0xfef5,
   0xfef6, 0xfef7, 0xfef8, 0xfef9, 0xfefa, 0xfefb, 0xfefc};
 
-const uint32 ____ligature32[] = {
+const uint32 ligature32[] = {
   0x00011176};
 
-const uint16 ____vulgfrac16[] = {
+const uint16 vulgfrac16[] = {
   0x00bc, 0x00bd, 0x00be, 0x2150, 0x2151, 0x2152, 0x2153, 0x2154,
   0x2155, 0x2156, 0x2157, 0x2158, 0x2159, 0x215a, 0x215b, 0x215c,
   0x215d, 0x215e, 0x2189};
 
-const uint16 ____fraction16[] = {
+const uint16 fraction16[] = {
   0x0b72, 0x0b73, 0x0b74, 0x0b75, 0x0b76, 0x0b77, 0x0c78, 0x0c79,
   0x0c7a, 0x0c7b, 0x0c7c, 0x0c7d, 0x0c7e, 0x0d58, 0x0d59, 0x0d5a,
   0x0d5b, 0x0d5c, 0x0d5d, 0x0d5e, 0x0d73, 0x0d74, 0x0d75, 0x0d76,
   0x0d77, 0x0d78, 0x215f, 0x2cfd, 0xa830, 0xa831, 0xa832, 0xa833,
   0xa834, 0xa835};
 
-const uint32 ____fraction32[] = {
+const uint32 fraction32[] = {
   0x000109bc, 0x000109bd, 0x000109f6, 0x000109f7,
   0x000109f8, 0x000109f9, 0x000109fa, 0x000109fb,
   0x000109fc, 0x000109fd, 0x000109fe, 0x000109ff,
@@ -131,24 +131,24 @@ int32 Ligature_get_U(int n) {
     if ( n<0 || n>=512 )
 	return( -1 );
     if ( n<511 )
-	return( (int32)(____ligature16[n]) );
+	return( (int32)(ligature16[n]) );
     else
-	return( (int32)(____ligature32[n-511]) );
+	return( (int32)(ligature32[n-511]) );
 }
 
 int32 VulgFrac_get_U(int n) {
     if ( n<0 || n>=19 )
 	return( -1 );
-    return( (int32)(____vulgfrac16[n]) );
+    return( (int32)(vulgfrac16[n]) );
 }
 
 int32 Fraction_get_U(int n) {
     if ( n<0 || n>=50 )
 	return( -1 );
     if ( n<34 )
-	return( (int32)(____fraction16[n]) );
+	return( (int32)(fraction16[n]) );
     else
-	return( (int32)(____fraction32[n-34]) );
+	return( (int32)(fraction32[n-34]) );
 }
 
 int Ligature_find_N(uint32 uCode) {
@@ -160,13 +160,13 @@ int Ligature_find_N(uint32 uCode) {
 	return( -1 );
     if ( uCode<0xfefc ) {
 	uCode16 = uCode;
-	p16 = (uint16 *)(bsearch(&uCode16, ____ligature16, 511, \
+	p16 = (uint16 *)(bsearch(&uCode16, ligature16, 511, \
 				sizeof(uint16), compare_codepoints16));
-	if ( p16 ) n = p16 - ____ligature16;
+	if ( p16 ) n = p16 - ligature16;
     } else {
-	p32 = (uint32 *)(bsearch(&uCode, ____ligature32, 1, \
+	p32 = (uint32 *)(bsearch(&uCode, ligature32, 1, \
 				sizeof(uint32), compare_codepoints32));
-	if ( p32 ) n = p32 - ____ligature32 + 511;
+	if ( p32 ) n = p32 - ligature32 + 511;
     }
     return( n );
 }
@@ -178,9 +178,9 @@ int VulgFrac_find_N(uint32 uCode) {
     if ( uCode<0xbc || uCode>0x2189 || isligorfrac(uCode)==0 )
 	return( -1 );
     uCode16 = uCode;
-    p16 = (uint16 *)(bsearch(&uCode16, ____vulgfrac16, 19, \
+    p16 = (uint16 *)(bsearch(&uCode16, vulgfrac16, 19, \
 				sizeof(uint16), compare_codepoints16));
-    if ( p16 ) n = p16 - ____vulgfrac16;
+    if ( p16 ) n = p16 - vulgfrac16;
     return( n );
 }
 
@@ -193,13 +193,13 @@ int Fraction_find_N(uint32 uCode) {
 	return( -1 );
     if ( uCode<0xa835 ) {
 	uCode16 = uCode;
-	p16 = (uint16 *)(bsearch(&uCode16, ____fraction16, 34, \
+	p16 = (uint16 *)(bsearch(&uCode16, fraction16, 34, \
 				sizeof(uint16), compare_codepoints16));
-	if ( p16 ) n = p16 - ____fraction16;
+	if ( p16 ) n = p16 - fraction16;
     } else {
-	p32 = (uint32 *)(bsearch(&uCode, ____fraction32, 16, \
+	p32 = (uint32 *)(bsearch(&uCode, fraction32, 16, \
 				sizeof(uint32), compare_codepoints32));
-	if ( p32 ) n = p32 - ____fraction32 + 34;
+	if ( p32 ) n = p32 - fraction32 + 34;
     }
     return( n );
 }

--- a/Unicode/makeutype.c
+++ b/Unicode/makeutype.c
@@ -66,57 +66,57 @@
 #define MAXA	18
 
 /* These values get stored within flags[unicodechar={0..MAXC}] */
-#define _LOWER		1
-#define _UPPER		2
-#define _TITLE		4
-#define _DIGIT		8
-#define _SPACE		0x10
-#define _PUNCT		0x20
-#define _HEX		0x40
-#define _ZEROWIDTH	0x80
+#define FF_UNICODE_LOWER	1
+#define FF_UNICODE_UPPER	2
+#define FF_UNICODE_TITLE	4
+#define FF_UNICODE_DIGIT	8
+#define FF_UNICODE_SPACE	0x10
+#define FF_UNICODE_PUNCT	0x20
+#define FF_UNICODE_HEX		0x40
+#define FF_UNICODE_ZEROWIDTH	0x80
 
-#define _LEFT_2_RIGHT	0x100
-#define _RIGHT_2_LEFT	0x200
-#define _ENUMERIC	0x400
-#define _ANUMERIC	0x800
-#define _ENS		0x1000
-#define _CS		0x2000
-#define _ENT		0x4000
-#define _COMBINING	0x8000
+#define FF_UNICODE_LEFT_2_RIGHT	0x100
+#define FF_UNICODE_RIGHT_2_LEFT	0x200
+#define FF_UNICODE_ENUMERIC	0x400
+#define FF_UNICODE_ANUMERIC	0x800
+#define FF_UNICODE_ENS		0x1000
+#define FF_UNICODE_CS		0x2000
+#define FF_UNICODE_ENT		0x4000
+#define FF_UNICODE_COMBINING	0x8000
 
-#define _BREAKBEFOREOK	0x10000
-#define _BREAKAFTEROK	0x20000
-#define _NONSTART	0x40000		/* small kana, close punct, can't start a line */
-#define _NONEND		0x80000		/* open punct, can't end a line */
-/*#define _MUSTBREAK	0x100000	/* newlines, paragraphs, etc. */
-#define	_URLBREAKAFTER	0x100000	/* break after slash not followed by digits (ie. in URLs not fractions or dates) */
+#define FF_UNICODE_BREAKBEFOREOK 0x10000
+#define FF_UNICODE_BREAKAFTEROK	0x20000
+#define FF_UNICODE_NONSTART	0x40000		/* small kana, close punct, can't start a line */
+#define FF_UNICODE_NONEND	0x80000		/* open punct, can't end a line */
+//#define FF_UNICODE_MUSTBREAK	0x100000	/* newlines, paragraphs, etc. */
+#define FF_UNICODE_URLBREAKAFTER 0x100000	/* break after slash not followed by digits (ie. in URLs not fractions or dates) */
 
-#define _ALPHABETIC	0x200000
-#define _IDEOGRAPHIC	0x400000
+#define FF_UNICODE_ALPHABETIC	0x200000
+#define FF_UNICODE_IDEOGRAPHIC	0x400000
 
-#define _INITIAL	0x800000
-#define _MEDIAL		0x1000000
-#define _FINAL		0x2000000
-#define _ISOLATED	0x4000000
+#define FF_UNICODE_INITIAL	0x800000
+#define FF_UNICODE_MEDIAL	0x1000000
+#define FF_UNICODE_FINAL	0x2000000
+#define FF_UNICODE_ISOLATED	0x4000000
 
-#define _NOBREAK	0x8000000
-#define _DecompositionNormative	0x10000000
-#define _LIG_OR_FRAC	0x20000000
+#define FF_UNICODE_NOBREAK	0x8000000
+#define FF_UNICODE_DecompositionNormative 0x10000000
+#define FF_UNICODE_LIG_OR_FRAC	0x20000000
 
-#define _CombiningClass		0xff
-#define _Above			0x100
-#define _Below			0x200
-#define _Overstrike		0x400
-#define _Left			0x800
-#define _Right			0x1000
-#define _Joins2			0x2000
-#define _CenterLeft		0x4000
-#define _CenterRight		0x8000
-#define _CenteredOutside	0x10000
-#define _Outside		0x20000
-#define _RightEdge		0x40000
-#define _LeftEdge		0x80000
-#define _Touching		0x100000
+#define FF_UNICODE_CombiningClass	0xff
+#define FF_UNICODE_Above		0x100
+#define FF_UNICODE_Below		0x200
+#define FF_UNICODE_Overstrike		0x400
+#define FF_UNICODE_Left			0x800
+#define FF_UNICODE_Right		0x1000
+#define FF_UNICODE_Joins2		0x2000
+#define FF_UNICODE_CenterLeft		0x4000
+#define FF_UNICODE_CenterRight		0x8000
+#define FF_UNICODE_CenteredOutside	0x10000
+#define FF_UNICODE_Outside		0x20000
+#define FF_UNICODE_RightEdge		0x40000
+#define FF_UNICODE_LeftEdge		0x80000
+#define FF_UNICODE_Touching		0x100000
 
 #include "combiners.h"
 
@@ -181,7 +181,7 @@ static void FigureAlternates(long index, char *apt, int normative) {
     if ( i>MAXA )
 	fprintf( stderr, "%d is too many alternates for U+%04X\n", i, index );
     if ( i>0 && normative)
-	flags[index] |= _DecompositionNormative;
+	flags[index] |= FF_UNICODE_DecompositionNormative;
 
     /* arabic isolated forms are alternates for the standard forms */
     if ( isisolated && alts[index][0]>=0x600 && alts[index][0]<0x6ff && alts[index][1]==0 &&
@@ -210,7 +210,7 @@ static int processAssignment(long index,char *pt,long *flg) {
 	    }
 	    ligature[lgm] = index;
 	    if ( index < MAXC ) {
-		*flg |= _LIG_OR_FRAC;
+		*flg |= FF_UNICODE_LIG_OR_FRAC;
 	    }
 	    lgm++;
 	} else if ( strstr(pt,"VULGAR" /* FRACTION */) ) {
@@ -222,7 +222,7 @@ static int processAssignment(long index,char *pt,long *flg) {
 	    }
 	    vulgfrac[vfm] = index;
 	    if ( index < MAXC ) {
-		*flg |= _LIG_OR_FRAC;
+		*flg |= FF_UNICODE_LIG_OR_FRAC;
 	    }
 	    vfm++;
 	} else if ( strstr(pt,"FRACTION") ) {
@@ -235,7 +235,7 @@ static int processAssignment(long index,char *pt,long *flg) {
 	    }
 	    fraction[frm] = index;
 	    if ( index < MAXC ) {
-		*flg |= _LIG_OR_FRAC;
+		*flg |= FF_UNICODE_LIG_OR_FRAC;
 	    }
 	    frm++;
 	}
@@ -299,15 +299,15 @@ static void readin(void) {
 	    /* general category */
 	    for ( pt1=pt; *pt1!=';' && *pt1!='\0'; ++pt1 );
 	    if ( strncmp(pt,"Lu",pt1-pt)==0 )
-		flg |= _UPPER|_ALPHABETIC;
+		flg |= FF_UNICODE_UPPER|FF_UNICODE_ALPHABETIC;
 	    else if ( strncmp(pt,"Ll",pt1-pt)==0 )
-		flg |= _LOWER|_ALPHABETIC;
+		flg |= FF_UNICODE_LOWER|FF_UNICODE_ALPHABETIC;
 	    else if ( strncmp(pt,"Lt",pt1-pt)==0 )
-		flg |= _TITLE|_ALPHABETIC;
+		flg |= FF_UNICODE_TITLE|FF_UNICODE_ALPHABETIC;
 	    else if ( strncmp(pt,"Lo",pt1-pt)==0 )
-		flg |= _ALPHABETIC;
+		flg |= FF_UNICODE_ALPHABETIC;
 	    else if ( strncmp(pt,"Nd",pt1-pt)==0 )
-		flg |= _DIGIT;
+		flg |= FF_UNICODE_DIGIT;
 	    pt = pt1;
 	    if ( *pt==';' ) ++pt;
 	    /* Unicode combining classes, I do my own version later */
@@ -317,30 +317,30 @@ static void readin(void) {
 	    /* Bidirectional Category */
 	    for ( pt1=pt; *pt1!=';' && *pt1!='\0'; ++pt1 );
 	    if ( strncmp(pt,"L",pt1-pt)==0 || strncmp(pt,"LRE",pt1-pt)==0 || strncmp(pt,"LRO",pt1-pt)==0 )
-		flg |= _LEFT_2_RIGHT;
+		flg |= FF_UNICODE_LEFT_2_RIGHT;
 	    if ( strncmp(pt,"R",pt1-pt)==0 || strncmp(pt,"AL",pt1-pt)==0 || strncmp(pt,"RLE",pt1-pt)==0 || strncmp(pt,"RLO",pt1-pt)==0 )
-		flg |= _RIGHT_2_LEFT;
+		flg |= FF_UNICODE_RIGHT_2_LEFT;
 	    else if ( strncmp(pt,"EN",pt1-pt)==0 )
-		flg |= _ENUMERIC;
+		flg |= FF_UNICODE_ENUMERIC;
 	    else if ( strncmp(pt,"ES",pt1-pt)==0 )
-		flg |= _ENS;
+		flg |= FF_UNICODE_ENS;
 	    else if ( strncmp(pt,"ET",pt1-pt)==0 )
-		flg |= _ENT;
+		flg |= FF_UNICODE_ENT;
 	    else if ( strncmp(pt,"AN",pt1-pt)==0 )
-		flg |= _ANUMERIC;
+		flg |= FF_UNICODE_ANUMERIC;
 	    else if ( strncmp(pt,"CS",pt1-pt)==0 )
-		flg |= _CS;
+		flg |= FF_UNICODE_CS;
 	    pt = pt1;
 	    if ( *pt==';' ) ++pt;
 	    /* character decomposition */
 	    if ( strncmp(pt,"<initial>",strlen("<initial>"))==0 )
-		flg |= _INITIAL;
+		flg |= FF_UNICODE_INITIAL;
 	    else if ( strncmp(pt,"<final>",strlen("<final>"))==0 )
-		flg |= _FINAL;
+		flg |= FF_UNICODE_FINAL;
 	    else if ( strncmp(pt,"<medial>",strlen("<medial>"))==0 )
-		flg |= _MEDIAL;
+		flg |= FF_UNICODE_MEDIAL;
 	    else if ( strncmp(pt,"<isolated>",strlen("<isolated>"))==0 )
-		flg |= _ISOLATED;
+		flg |= FF_UNICODE_ISOLATED;
 	    FigureAlternates(index,pt, true);
 	    while ( *pt!=';' && *pt!='\0' ) ++pt;
 	    if ( *pt==';' ) ++pt;
@@ -443,25 +443,25 @@ static void readin(void) {
 	    ++pt;
 	    for ( pt1=pt; *pt1!=';' && *pt1!=' ' && *pt1!='\0'; ++pt1 );
 	    if ( strncmp(pt,"BK",pt1-pt)==0 || strncmp(pt,"CR",pt1-pt)==0 || strncmp(pt,"LF",pt1-pt)==0 )
-		/*flg |= _MUSTBREAK*/;
+		/*flg |= FF_UNICODE_MUSTBREAK*/;
 	    else if ( strncmp(pt,"NS",pt1-pt)==0 || strncmp(pt,"CL",pt1-pt)==0 )
-		flg |= _NONSTART;
+		flg |= FF_UNICODE_NONSTART;
 	    else if ( strncmp(pt,"OP",pt1-pt)==0 || strncmp(pt,"CM",pt1-pt)==0 )
-		flg |= _NONEND;
+		flg |= FF_UNICODE_NONEND;
 	    else if ( strncmp(pt,"GL",pt1-pt)==0 )
-		flg |= _NONEND|_NONSTART;
+		flg |= FF_UNICODE_NONEND|FF_UNICODE_NONSTART;
 	    else if ( strncmp(pt,"SP",pt1-pt)==0 || strncmp(pt,"HY",pt1-pt)==0 ||
 		    strncmp(pt,"BA",pt1-pt)==0 ||
 		    strncmp(pt,"ZW",pt1-pt)==0 )
-		flg |= _BREAKAFTEROK;
+		flg |= FF_UNICODE_BREAKAFTEROK;
 	    else if ( strncmp(pt,"BB",pt1-pt)==0 )
-		flg |= _BREAKBEFOREOK;
+		flg |= FF_UNICODE_BREAKBEFOREOK;
 	    else if ( strncmp(pt,"B2",pt1-pt)==0 )
-		flg |= _BREAKBEFOREOK|_BREAKAFTEROK;
+		flg |= FF_UNICODE_BREAKBEFOREOK|FF_UNICODE_BREAKAFTEROK;
 	    else if ( strncmp(pt,"ID",pt1-pt)==0 )
-		flg |= _BREAKBEFOREOK|_BREAKAFTEROK;
+		flg |= FF_UNICODE_BREAKBEFOREOK|FF_UNICODE_BREAKAFTEROK;
 	    else if ( strncmp(pt,"SY",pt1-pt)==0 )
-		flg |= _URLBREAKAFTER;
+		flg |= FF_UNICODE_URLBREAKAFTER;
 	    pt = pt1;
 	    for ( ; index<=indexend; ++index )
 		flags[index] |= flg;
@@ -484,21 +484,21 @@ static void readin(void) {
 	}
 	if ( true || strncmp(buffer,"Property dump for:", strlen("Property dump for:"))==0 ) {
 	    if ( strstr(buffer, "(Zero-width)")!=NULL || strstr(buffer, "ZERO WIDTH")!=NULL )
-		flg = _ZEROWIDTH;
+		flg = FF_UNICODE_ZEROWIDTH;
 	    else if ( strstr(buffer, "(White space)")!=NULL || strstr(buffer, "White_Space")!=NULL )
-		flg = _SPACE;
+		flg = FF_UNICODE_SPACE;
 	    else if ( strstr(buffer, "(Punctuation)")!=NULL || strstr(buffer, "Punctuation")!=NULL )
-		flg = _PUNCT;
+		flg = FF_UNICODE_PUNCT;
 	    else if ( strstr(buffer, "(Alphabetic)")!=NULL || strstr(buffer, "Alphabetic")!=NULL )
-		flg = _ALPHABETIC;
+		flg = FF_UNICODE_ALPHABETIC;
 	    else if ( strstr(buffer, "(Ideographic)")!=NULL || strstr(buffer, "Ideographic")!=NULL )
-		flg = _IDEOGRAPHIC;
+		flg = FF_UNICODE_IDEOGRAPHIC;
 	    else if ( strstr(buffer, "(Hex Digit)")!=NULL || strstr(buffer, "Hex_Digit")!=NULL )
-		flg = _HEX;
+		flg = FF_UNICODE_HEX;
 	    else if ( strstr(buffer, "(Combining)")!=NULL || strstr(buffer, "COMBINING")!=NULL )
-		flg = _COMBINING;
+		flg = FF_UNICODE_COMBINING;
 	    else if ( strstr(buffer, "(Non-break)")!=NULL )
-		flg = _NOBREAK;
+		flg = FF_UNICODE_NOBREAK;
 	    if ( flg!=0 ) {
 		if (( buffer[0]>='0' && buffer[0]<='9') || (buffer[0]>='A' && buffer[0]<='F')) {
 		    index = wasfirst = strtol(buffer,NULL,16);
@@ -512,16 +512,16 @@ static void readin(void) {
     }
     fclose(fp);
     /* There used to be a zero width property, but no longer */
-    flags[0x200B] |= _ZEROWIDTH;
-    flags[0x200C] |= _ZEROWIDTH;
-    flags[0x200D] |= _ZEROWIDTH;
-    flags[0x2060] |= _ZEROWIDTH;
-    flags[0xFEFF] |= _ZEROWIDTH;
+    flags[0x200B] |= FF_UNICODE_ZEROWIDTH;
+    flags[0x200C] |= FF_UNICODE_ZEROWIDTH;
+    flags[0x200D] |= FF_UNICODE_ZEROWIDTH;
+    flags[0x2060] |= FF_UNICODE_ZEROWIDTH;
+    flags[0xFEFF] |= FF_UNICODE_ZEROWIDTH;
     /* There used to be a No Break property, but no longer */
-    flags[0x00A0] |= _NOBREAK;
-    flags[0x2011] |= _NOBREAK;
-    flags[0x202F] |= _NOBREAK;
-    flags[0xFEFF] |= _NOBREAK;
+    flags[0x00A0] |= FF_UNICODE_NOBREAK;
+    flags[0x2011] |= FF_UNICODE_NOBREAK;
+    flags[0x202F] |= FF_UNICODE_NOBREAK;
+    flags[0xFEFF] |= FF_UNICODE_NOBREAK;
 
     if ((fp = fopen("NamesList.txt","r"))==NULL ) {
 	fprintf( stderr, CantReadFile, "NamesList.txt" );
@@ -538,11 +538,11 @@ static void readin(void) {
 	}
 	if ( (index = strtol(buffer,NULL,16))!=0 ) {
 	    if ( strstr(buffer, "COMBINING")!=NULL )
-		flg = _COMBINING;
+		flg = FF_UNICODE_COMBINING;
 	    else if ( strstr(buffer, "N0-BREAK")!=NULL )
-		flg = _NOBREAK;
+		flg = FF_UNICODE_NOBREAK;
 	    else if ( strstr(buffer, "ZERO WIDTH")!=NULL )
-		flg = _ZEROWIDTH;
+		flg = FF_UNICODE_ZEROWIDTH;
 
 	    if ( index<0xffff )		/* !!!!! BMP */
 		flags[wasfirst] |= flg;
@@ -839,9 +839,9 @@ static void dumpligaturesfractions(FILE *header) {
     for ( f16=0; f16<frm && fraction[f16]<=65535; ++f16 );
 
     fprintf( data, "/* unicode.org codepoints for ligatures, vulgar fractions, other fractions */\n\n" );
-    buildtables(data,ligature,l16,lgm,"____ligature");
-    buildtables(data,vulgfrac,v16,vfm,"____vulgfrac");
-    buildtables(data,fraction,f16,frm,"____fraction");
+    buildtables(data,ligature,l16,lgm,"ligature");
+    buildtables(data,vulgfrac,v16,vfm,"vulgfrac");
+    buildtables(data,fraction,f16,frm,"fraction");
 
     dumpbsearch(data,16); dumpbsearch(data,32);
 
@@ -854,16 +854,16 @@ static void dumpligaturesfractions(FILE *header) {
     fprintf( data, "int FractionCount(void) {\n" );
     fprintf( data, "    return( %d );\n}\n\n", vfm+frm );
 
-    dump_getU(data,ligature,l16,lgm,"____ligature","Ligature");
-    dump_getU(data,vulgfrac,v16,vfm,"____vulgfrac","VulgFrac");
-    dump_getU(data,fraction,f16,frm,"____fraction","Fraction");
+    dump_getU(data,ligature,l16,lgm,"ligature","Ligature");
+    dump_getU(data,vulgfrac,v16,vfm,"vulgfrac","VulgFrac");
+    dump_getU(data,fraction,f16,frm,"fraction","Fraction");
 
     fprintf( data, "int Ligature_find_N(uint32 uCode) {\n" );
-    dumpbsearchfindN(data,ligature,l16,lgm,"____ligature");
+    dumpbsearchfindN(data,ligature,l16,lgm,"ligature");
     fprintf( data, "int VulgFrac_find_N(uint32 uCode) {\n" );
-    dumpbsearchfindN(data,vulgfrac,v16,vfm,"____vulgfrac");
+    dumpbsearchfindN(data,vulgfrac,v16,vfm,"vulgfrac");
     fprintf( data, "int Fraction_find_N(uint32 uCode) {\n" );
-    dumpbsearchfindN(data,fraction,f16,frm,"____fraction");
+    dumpbsearchfindN(data,fraction,f16,frm,"fraction");
 
     fprintf( data, "/* Boolean-style tests (found==0) to see if your codepoint value is listed */\n" );
     fprintf( data, "/* unicode.org codepoints for ligatures, vulgar fractions, other fractions */\n\n" );
@@ -900,8 +900,8 @@ static void dump() {
 	exit(2);
     }
 
-    fprintf( header, "#ifndef _UTYPE_H\n" );
-    fprintf( header, "#define _UTYPE_H\n" );
+    fprintf( header, "#ifndef FONTFORGE_UNICODE_UTYPE_H\n" );
+    fprintf( header, "#define FONTFORGE_UNICODE_UTYPE_H\n" );
 
     fprintf( header, "/* Copyright: 2001 George Williams */\n" );
     fprintf( header, "/* License: BSD-3-clause */\n" );
@@ -941,113 +941,113 @@ static void dump() {
     fprintf( header, "# undef ishexdigit\n" );
     fprintf( header, "#endif\n\n" );
 
-    fprintf( header, "extern const unsigned short ____tolower[];\n" );
-    fprintf( header, "extern const unsigned short ____toupper[];\n" );
-    fprintf( header, "extern const unsigned short ____totitle[];\n" );
-    fprintf( header, "extern const unsigned short ____tomirror[];\n" );
-    fprintf( header, "extern const unsigned char  ____digitval[];\n" );
+    fprintf( header, "extern const unsigned short ff_unicode_tolower[];\n" );
+    fprintf( header, "extern const unsigned short ff_unicode_toupper[];\n" );
+    fprintf( header, "extern const unsigned short ff_unicode_totitle[];\n" );
+    fprintf( header, "extern const unsigned short ff_unicode_tomirror[];\n" );
+    fprintf( header, "extern const unsigned char  ff_unicode_digitval[];\n" );
     fprintf( header, "\n" );
 
     fprintf( header, "/* utype[] holds binary flags used for features of each unicode.org character */\n" );
-    fprintf( header, "#define ____L\t\t0x%0x\n", _LOWER );
-    fprintf( header, "#define ____U\t\t0x%0x\n", _UPPER );
-    fprintf( header, "#define ____TITLE\t0x%0x\n", _TITLE );
-    fprintf( header, "#define ____D\t\t0x%0x\n", _DIGIT );
-    fprintf( header, "#define ____S\t\t0x%0x\n", _SPACE );
-    fprintf( header, "#define ____P\t\t0x%0x\n", _PUNCT );
-    fprintf( header, "#define ____X\t\t0x%0x\n", _HEX );
-    fprintf( header, "#define ____ZW\t\t0x%0x\n", _ZEROWIDTH );
-    fprintf( header, "#define ____L2R\t\t0x%0x\n", _LEFT_2_RIGHT );
-    fprintf( header, "#define ____R2L\t\t0x%0x\n", _RIGHT_2_LEFT );
-    fprintf( header, "#define ____ENUM\t0x%0x\n", _ENUMERIC );
-    fprintf( header, "#define ____ANUM\t0x%0x\n", _ANUMERIC );
-    fprintf( header, "#define ____ENS\t\t0x%0x\n", _ENS );
-    fprintf( header, "#define ____CS\t\t0x%0x\n", _CS );
-    fprintf( header, "#define ____ENT\t\t0x%0x\n", _ENT );
-    fprintf( header, "#define ____COMBINE\t0x%0x\n", _COMBINING );
-    fprintf( header, "#define ____BB\t\t0x%0x\n", _BREAKBEFOREOK );
-    fprintf( header, "#define ____BA\t\t0x%0x\n", _BREAKAFTEROK );
-    fprintf( header, "#define ____NS\t\t0x%0x\n", _NONSTART );
-    fprintf( header, "#define ____NE\t\t0x%0x\n", _NONEND );
-    fprintf( header, "#define ____UB\t\t0x%0x\n", _URLBREAKAFTER );
-    fprintf( header, "#define ____NB\t\t0x%0x\n", _NOBREAK );
-    fprintf( header, "#define ____AL\t\t0x%0x\n", _ALPHABETIC );
-    fprintf( header, "#define ____ID\t\t0x%0x\n", _IDEOGRAPHIC );
-    fprintf( header, "#define ____INITIAL\t0x%0x\n", _INITIAL );
-    fprintf( header, "#define ____MEDIAL\t0x%0x\n", _MEDIAL );
-    fprintf( header, "#define ____FINAL\t0x%0x\n", _FINAL );
-    fprintf( header, "#define ____ISOLATED\t0x%0x\n", _ISOLATED );
-    fprintf( header, "#define ____DECOMPNORM\t0x%0x\n", _DecompositionNormative );
-    fprintf( header, "#define ____LIG_OR_FRAC\t0x%0x\n", _LIG_OR_FRAC );
+    fprintf( header, "#define FF_UNICODE_L\t\t0x%0x\n", FF_UNICODE_LOWER );
+    fprintf( header, "#define FF_UNICODE_U\t\t0x%0x\n", FF_UNICODE_UPPER );
+    fprintf( header, "#define FF_UNICODE_TITLE\t0x%0x\n", FF_UNICODE_TITLE );
+    fprintf( header, "#define FF_UNICODE_D\t\t0x%0x\n", FF_UNICODE_DIGIT );
+    fprintf( header, "#define FF_UNICODE_S\t\t0x%0x\n", FF_UNICODE_SPACE );
+    fprintf( header, "#define FF_UNICODE_P\t\t0x%0x\n", FF_UNICODE_PUNCT );
+    fprintf( header, "#define FF_UNICODE_X\t\t0x%0x\n", FF_UNICODE_HEX );
+    fprintf( header, "#define FF_UNICODE_ZW\t\t0x%0x\n", FF_UNICODE_ZEROWIDTH );
+    fprintf( header, "#define FF_UNICODE_L2R\t\t0x%0x\n", FF_UNICODE_LEFT_2_RIGHT );
+    fprintf( header, "#define FF_UNICODE_R2L\t\t0x%0x\n", FF_UNICODE_RIGHT_2_LEFT );
+    fprintf( header, "#define FF_UNICODE_ENUM\t\t0x%0x\n", FF_UNICODE_ENUMERIC );
+    fprintf( header, "#define FF_UNICODE_ANUM\t\t0x%0x\n", FF_UNICODE_ANUMERIC );
+    fprintf( header, "#define FF_UNICODE_ENS\t\t0x%0x\n", FF_UNICODE_ENS );
+    fprintf( header, "#define FF_UNICODE_CS\t\t0x%0x\n", FF_UNICODE_CS );
+    fprintf( header, "#define FF_UNICODE_ENT\t\t0x%0x\n", FF_UNICODE_ENT );
+    fprintf( header, "#define FF_UNICODE_COMBINE\t0x%0x\n", FF_UNICODE_COMBINING );
+    fprintf( header, "#define FF_UNICODE_BB\t\t0x%0x\n", FF_UNICODE_BREAKBEFOREOK );
+    fprintf( header, "#define FF_UNICODE_BA\t\t0x%0x\n", FF_UNICODE_BREAKAFTEROK );
+    fprintf( header, "#define FF_UNICODE_NS\t\t0x%0x\n", FF_UNICODE_NONSTART );
+    fprintf( header, "#define FF_UNICODE_NE\t\t0x%0x\n", FF_UNICODE_NONEND );
+    fprintf( header, "#define FF_UNICODE_UB\t\t0x%0x\n", FF_UNICODE_URLBREAKAFTER );
+    fprintf( header, "#define FF_UNICODE_NB\t\t0x%0x\n", FF_UNICODE_NOBREAK );
+    fprintf( header, "#define FF_UNICODE_AL\t\t0x%0x\n", FF_UNICODE_ALPHABETIC );
+    fprintf( header, "#define FF_UNICODE_ID\t\t0x%0x\n", FF_UNICODE_IDEOGRAPHIC );
+    fprintf( header, "#define FF_UNICODE_INITIAL\t0x%0x\n", FF_UNICODE_INITIAL );
+    fprintf( header, "#define FF_UNICODE_MEDIAL\t0x%0x\n", FF_UNICODE_MEDIAL );
+    fprintf( header, "#define FF_UNICODE_FINAL\t0x%0x\n", FF_UNICODE_FINAL );
+    fprintf( header, "#define FF_UNICODE_ISOLATED\t0x%0x\n", FF_UNICODE_ISOLATED );
+    fprintf( header, "#define FF_UNICODE_DECOMPNORM\t0x%0x\n", FF_UNICODE_DecompositionNormative );
+    fprintf( header, "#define FF_UNICODE_LIG_OR_FRAC\t0x%0x\n", FF_UNICODE_LIG_OR_FRAC );
     fprintf( header, "\n" );
 
-    fprintf( header, "#define islower(ch)\t\t(____utype[(ch)+1]&____L)\n" );
-    fprintf( header, "#define isupper(ch)\t\t(____utype[(ch)+1]&____U)\n" );
-    fprintf( header, "#define istitle(ch)\t\t(____utype[(ch)+1]&____TITLE)\n" );
-    fprintf( header, "#define isalpha(ch)\t\t(____utype[(ch)+1]&(____L|____U|____TITLE|____AL))\n" );
-    fprintf( header, "#define isdigit(ch)\t\t(____utype[(ch)+1]&____D)\n" );
-    fprintf( header, "#define isalnum(ch)\t\t(____utype[(ch)+1]&(____L|____U|____TITLE|____AL|____D))\n" );
-    fprintf( header, "#define isideographic(ch)\t(____utype[(ch)+1]&____ID)\n" );
-    fprintf( header, "#define isideoalpha(ch)\t\t(____utype[(ch)+1]&(____ID|____L|____U|____TITLE|____AL))\n" );
-    fprintf( header, "#define isspace(ch)\t\t(____utype[(ch)+1]&____S)\n" );
-    fprintf( header, "#define ispunct(ch)\t\t(____utype[(ch)+1]&_____P)\n" );
-    fprintf( header, "#define ishexdigit(ch)\t\t(____utype[(ch)+1]&____X)\n" );
-    fprintf( header, "#define iszerowidth(ch)\t\t(____utype[(ch)+1]&____ZW)\n" );
-    fprintf( header, "#define islefttoright(ch)\t(____utype[(ch)+1]&____L2R)\n" );
-    fprintf( header, "#define isrighttoleft(ch)\t(____utype[(ch)+1]&____R2L)\n" );
-    fprintf( header, "#define iseuronumeric(ch)\t(____utype[(ch)+1]&____ENUM)\n" );
-    fprintf( header, "#define isarabnumeric(ch)\t(____utype[(ch)+1]&____ANUM)\n" );
-    fprintf( header, "#define iseuronumsep(ch)\t(____utype[(ch)+1]&____ENS)\n" );
-    fprintf( header, "#define iscommonsep(ch)\t\t(____utype[(ch)+1]&____CS)\n" );
-    fprintf( header, "#define iseuronumterm(ch)\t(____utype[(ch)+1]&____ENT)\n" );
-    fprintf( header, "#define iscombining(ch)\t\t(____utype[(ch)+1]&____COMBINE)\n" );
-    fprintf( header, "#define isbreakbetweenok(ch1,ch2) (((____utype[(ch1)+1]&____BA) && !(____utype[(ch2)+1]&____NS)) || ((____utype[(ch2)+1]&____BB) && !(____utype[(ch1)+1]&____NE)) || (!(____utype[(ch2)+1]&____D) && ch1=='/'))\n" );
-    fprintf( header, "#define isnobreak(ch)\t\t(____utype[(ch)+1]&____NB)\n" );
-    fprintf( header, "#define isarabinitial(ch)\t(____utype[(ch)+1]&____INITIAL)\n" );
-    fprintf( header, "#define isarabmedial(ch)\t(____utype[(ch)+1]&____MEDIAL)\n" );
-    fprintf( header, "#define isarabfinal(ch)\t\t(____utype[(ch)+1]&____FINAL)\n" );
-    fprintf( header, "#define isarabisolated(ch)\t(____utype[(ch)+1]&____ISOLATED)\n" );
-    fprintf( header, "#define isdecompositionnormative(ch) (____utype[(ch)+1]&____DECOMPNORM)\n" );
-    fprintf( header, "#define isligorfrac(ch)\t\t(____utype[(ch)+1]&____LIG_OR_FRAC)\n" );
+    fprintf( header, "#define islower(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_L)\n" );
+    fprintf( header, "#define isupper(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_U)\n" );
+    fprintf( header, "#define istitle(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_TITLE)\n" );
+    fprintf( header, "#define isalpha(ch)\t\t(ff_unicode_utype[(ch)+1]&(FF_UNICODE_L|FF_UNICODE_U|FF_UNICODE_TITLE|FF_UNICODE_AL))\n" );
+    fprintf( header, "#define isdigit(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_D)\n" );
+    fprintf( header, "#define isalnum(ch)\t\t(ff_unicode_utype[(ch)+1]&(FF_UNICODE_L|FF_UNICODE_U|FF_UNICODE_TITLE|FF_UNICODE_AL|FF_UNICODE_D))\n" );
+    fprintf( header, "#define isideographic(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_ID)\n" );
+    fprintf( header, "#define isideoalpha(ch)\t\t(ff_unicode_utype[(ch)+1]&(FF_UNICODE_ID|FF_UNICODE_L|FF_UNICODE_U|FF_UNICODE_TITLE|FF_UNICODE_AL))\n" );
+    fprintf( header, "#define isspace(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_S)\n" );
+    fprintf( header, "#define ispunct(ch)\t\t(ff_unicode_utype[(ch)+1]&_FF_UNICODE_P)\n" );
+    fprintf( header, "#define ishexdigit(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_X)\n" );
+    fprintf( header, "#define iszerowidth(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_ZW)\n" );
+    fprintf( header, "#define islefttoright(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_L2R)\n" );
+    fprintf( header, "#define isrighttoleft(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_R2L)\n" );
+    fprintf( header, "#define iseuronumeric(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_ENUM)\n" );
+    fprintf( header, "#define isarabnumeric(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_ANUM)\n" );
+    fprintf( header, "#define iseuronumsep(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_ENS)\n" );
+    fprintf( header, "#define iscommonsep(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_CS)\n" );
+    fprintf( header, "#define iseuronumterm(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_ENT)\n" );
+    fprintf( header, "#define iscombining(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_COMBINE)\n" );
+    fprintf( header, "#define isbreakbetweenok(ch1,ch2) (((ff_unicode_utype[(ch1)+1]&FF_UNICODE_BA) && !(ff_unicode_utype[(ch2)+1]&FF_UNICODE_NS)) || ((ff_unicode_utype[(ch2)+1]&FF_UNICODE_BB) && !(ff_unicode_utype[(ch1)+1]&FF_UNICODE_NE)) || (!(ff_unicode_utype[(ch2)+1]&FF_UNICODE_D) && ch1=='/'))\n" );
+    fprintf( header, "#define isnobreak(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_NB)\n" );
+    fprintf( header, "#define isarabinitial(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_INITIAL)\n" );
+    fprintf( header, "#define isarabmedial(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_MEDIAL)\n" );
+    fprintf( header, "#define isarabfinal(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_FINAL)\n" );
+    fprintf( header, "#define isarabisolated(ch)\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_ISOLATED)\n" );
+    fprintf( header, "#define isdecompositionnormative(ch) (ff_unicode_utype[(ch)+1]&FF_UNICODE_DECOMPNORM)\n" );
+    fprintf( header, "#define isligorfrac(ch)\t\t(ff_unicode_utype[(ch)+1]&FF_UNICODE_LIG_OR_FRAC)\n" );
     fprintf( header, "\n" );
 
-    fprintf( header, "extern const uint32\t____utype[];\t\t/* hold character type features for each Unicode.org defined character */\n\n" );
+    fprintf( header, "extern const uint32 ff_unicode_utype[];\t/* hold character type features for each Unicode.org defined character */\n\n" );
 
     fprintf( header, "/* utype2[] binary flags used for position/layout of each unicode.org character */\n" );
-    fprintf( header, "#define ____COMBININGCLASS\t0x%0x\n", _CombiningClass );
-    fprintf( header, "#define ____ABOVE\t\t0x%0x\n", _Above );
-    fprintf( header, "#define ____BELOW\t\t0x%0x\n", _Below );
-    fprintf( header, "#define ____OVERSTRIKE\t\t0x%0x\n", _Overstrike );
-    fprintf( header, "#define ____LEFT\t\t0x%0x\n", _Left );
-    fprintf( header, "#define ____RIGHT\t\t0x%0x\n", _Right );
-    fprintf( header, "#define ____JOINS2\t\t0x%0x\n", _Joins2 );
-    fprintf( header, "#define ____CENTERLEFT\t\t0x%0x\n", _CenterLeft );
-    fprintf( header, "#define ____CENTERRIGHT\t\t0x%0x\n", _CenterRight );
-    fprintf( header, "#define ____CENTEREDOUTSIDE\t0x%0x\n", _CenteredOutside );
-    fprintf( header, "#define ____OUTSIDE\t\t0x%0x\n", _Outside );
-    fprintf( header, "#define ____LEFTEDGE\t\t0x%0x\n", _LeftEdge );
-    fprintf( header, "#define ____RIGHTEDGE\t\t0x%0x\n", _RightEdge );
-    fprintf( header, "#define ____TOUCHING\t\t0x%0x\n", _Touching );
-    fprintf( header, "#define ____COMBININGPOSMASK\t0x%0x\n",
-	    _Outside|_CenteredOutside|_CenterRight|_CenterLeft|_Joins2|
-	    _Right|_Left|_Overstrike|_Below|_Above|_RightEdge|_LeftEdge|
-	    _Touching );
-    fprintf( header, "#define ____NOPOSDATAGIVEN\t(uint32)(-1)\t/* -1 == no position data given */\n\n" );
+    fprintf( header, "#define FF_UNICODE_COMBININGCLASS\t0x%0x\n", FF_UNICODE_CombiningClass );
+    fprintf( header, "#define FF_UNICODE_ABOVE\t\t0x%0x\n", FF_UNICODE_Above );
+    fprintf( header, "#define FF_UNICODE_BELOW\t\t0x%0x\n", FF_UNICODE_Below );
+    fprintf( header, "#define FF_UNICODE_OVERSTRIKE\t\t0x%0x\n", FF_UNICODE_Overstrike );
+    fprintf( header, "#define FF_UNICODE_LEFT\t\t\t0x%0x\n", FF_UNICODE_Left );
+    fprintf( header, "#define FF_UNICODE_RIGHT\t\t0x%0x\n", FF_UNICODE_Right );
+    fprintf( header, "#define FF_UNICODE_JOINS2\t\t0x%0x\n", FF_UNICODE_Joins2 );
+    fprintf( header, "#define FF_UNICODE_CENTERLEFT\t\t0x%0x\n", FF_UNICODE_CenterLeft );
+    fprintf( header, "#define FF_UNICODE_CENTERRIGHT\t\t0x%0x\n", FF_UNICODE_CenterRight );
+    fprintf( header, "#define FF_UNICODE_CENTEREDOUTSIDE\t0x%0x\n", FF_UNICODE_CenteredOutside );
+    fprintf( header, "#define FF_UNICODE_OUTSIDE\t\t0x%0x\n", FF_UNICODE_Outside );
+    fprintf( header, "#define FF_UNICODE_LEFTEDGE\t\t0x%0x\n", FF_UNICODE_LeftEdge );
+    fprintf( header, "#define FF_UNICODE_RIGHTEDGE\t\t0x%0x\n", FF_UNICODE_RightEdge );
+    fprintf( header, "#define FF_UNICODE_TOUCHING\t\t0x%0x\n", FF_UNICODE_Touching );
+    fprintf( header, "#define FF_UNICODE_COMBININGPOSMASK\t0x%0x\n",
+	    FF_UNICODE_Outside|FF_UNICODE_CenteredOutside|FF_UNICODE_CenterRight|FF_UNICODE_CenterLeft|FF_UNICODE_Joins2|
+	    FF_UNICODE_Right|FF_UNICODE_Left|FF_UNICODE_Overstrike|FF_UNICODE_Below|FF_UNICODE_Above|FF_UNICODE_RightEdge|FF_UNICODE_LeftEdge|
+	    FF_UNICODE_Touching);
+    fprintf( header, "#define FF_UNICODE_NOPOSDATAGIVEN\t(uint32)(-1)\t/* -1 == no position data given */\n\n" );
 
-    fprintf( header, "#define combiningclass(ch)\t(____utype2[(ch)+1]&____COMBININGCLASS)\n" );
-    fprintf( header, "#define combiningposmask(ch)\t(____utype2[(ch)+1]&____COMBININGPOSMASK)\n\n" );
+    fprintf( header, "#define combiningclass(ch)\t(ff_unicode_utype2[(ch)+1]&FF_UNICODE_COMBININGCLASS)\n" );
+    fprintf( header, "#define combiningposmask(ch)\t(ff_unicode_utype2[(ch)+1]&FF_UNICODE_COMBININGPOSMASK)\n\n" );
 
-    fprintf( header, "extern const uint32\t____utype2[];\t\t/* hold position boolean flags for each Unicode.org defined character */\n\n" );
+    fprintf( header, "extern const uint32 ff_unicode_utype2[];\t/* hold position boolean flags for each Unicode.org defined character */\n\n" );
 
-    fprintf( header, "#define isunicodepointassigned(ch) (____codepointassigned[(ch)/32]&(1<<((ch)%%32)))\n\n" );
+    fprintf( header, "#define isunicodepointassigned(ch) (ff_unicode_codepointassigned[(ch)/32]&(1<<((ch)%%32)))\n\n" );
 
-    fprintf( header, "extern const uint32\t____codepointassigned[]; /* 1bit_boolean_flag x 32 = exists in Unicode.org character chart list. */\n\n" );
+    fprintf( header, "extern const uint32 ff_unicode_codepointassigned[]; /* 1bit_boolean_flag x 32 = exists in Unicode.org character chart list. */\n\n" );
 
-    fprintf( header, "#define tolower(ch) (____tolower[(ch)+1])\n" );
-    fprintf( header, "#define toupper(ch) (____toupper[(ch)+1])\n" );
-    fprintf( header, "#define totitle(ch) (____totitle[(ch)+1])\n" );
-    fprintf( header, "#define tomirror(ch) (____tomirror[(ch)+1])\n" );
-    fprintf( header, "#define tovalue(ch) (____digitval[(ch)+1])\n" );
+    fprintf( header, "#define tolower(ch) (ff_unicode_tolower[(ch)+1])\n" );
+    fprintf( header, "#define toupper(ch) (ff_unicode_toupper[(ch)+1])\n" );
+    fprintf( header, "#define totitle(ch) (ff_unicode_totitle[(ch)+1])\n" );
+    fprintf( header, "#define tomirror(ch) (ff_unicode_tomirror[(ch)+1])\n" );
+    fprintf( header, "#define tovalue(ch) (ff_unicode_digitval[(ch)+1])\n" );
     fprintf( header, "\n" );
 
     fprintf( data, "/* Copyright: 2001 George Williams */\n" );
@@ -1055,7 +1055,7 @@ static void dump() {
     fprintf( data, "/* Contributions: Werner Lemberg, Khaled Hosny, Joe Da Silva */\n\n" );
     fprintf( data, "#include \"utype.h\"\n" );
     fprintf( data, GeneratedFileMessage, UnicodeMajor, UnicodeMinor );
-    fprintf( data, "const unsigned short ____tolower[]= { 0,\n" );
+    fprintf( data, "const unsigned short ff_unicode_tolower[]= { 0,\n" );
     for ( i=0; i<MAXC; i+=j ) {
 	fprintf( data, " " );
 	for ( j=0; j<8 && i+j<MAXC-1; ++j )
@@ -1069,7 +1069,7 @@ static void dump() {
 	    else
 		fprintf( data, "\n");
     }
-    fprintf( data, "const unsigned short ____toupper[] = { 0,\n" );
+    fprintf( data, "const unsigned short ff_unicode_toupper[] = { 0,\n" );
     for ( i=0; i<MAXC; i+=j ) {
 	fprintf( data, " " );
 	for ( j=0; j<8 && i+j<MAXC-1; ++j )
@@ -1083,7 +1083,7 @@ static void dump() {
 	    else
 		fprintf( data, "\n");
     }
-    fprintf( data, "const unsigned short ____totitle[] = { 0,\n" );
+    fprintf( data, "const unsigned short ff_unicode_totitle[] = { 0,\n" );
     for ( i=0; i<MAXC; i+=j ) {
 	fprintf( data, " " );
 	for ( j=0; j<8 && i+j<MAXC-1; ++j )
@@ -1097,7 +1097,7 @@ static void dump() {
 	    else
 		fprintf( data, "\n");
     }
-    fprintf( data, "const unsigned short ____tomirror[] = { 0,\n" );
+    fprintf( data, "const unsigned short ff_unicode_tomirror[] = { 0,\n" );
     for ( i=0; i<MAXC; i+=j ) {
 	fprintf( data, " " );
 	for ( j=0; j<8 && i+j<MAXC-1; ++j )
@@ -1111,7 +1111,7 @@ static void dump() {
 	    else
 		fprintf( data, "\n");
     }
-    fprintf( data, "const unsigned char ____digitval[] = { 0,\n" );
+    fprintf( data, "const unsigned char ff_unicode_digitval[] = { 0,\n" );
     for ( i=0; i<MAXC; i+=j ) {
 	fprintf( data, " " );
 	for ( j=0; j<8 && i+j<MAXC-1; ++j )
@@ -1125,7 +1125,7 @@ static void dump() {
 	    else
 		fprintf( data, "\n");
     }
-    fprintf( data, "const uint32 ____utype[] = { 0,\n" );
+    fprintf( data, "const uint32 ff_unicode_utype[] = { 0,\n" );
     for ( i=0; i<MAXC; i+=j ) {
 	fprintf( data, " " );
 	for ( j=0; j<8 && i+j<MAXC-1; ++j )
@@ -1139,7 +1139,7 @@ static void dump() {
 	    else
 		fprintf( data, "\n");
     }
-    fprintf( data, "const uint32 ____utype2[] = { 0,\n" );
+    fprintf( data, "const uint32 ff_unicode_utype2[] = { 0,\n" );
     fprintf( data, "  /* binary flags used for physical layout of each unicode.org character */\n" );
     for ( i=0; i<MAXC; i+=j ) {
 	fprintf( data, " " );
@@ -1155,7 +1155,7 @@ static void dump() {
 		fprintf( data, "\n");
     }
 
-    fprintf( data, "const uint32 ____codepointassigned[] = {\n" );
+    fprintf( data, "const uint32 ff_unicode_codepointassigned[] = {\n" );
     fprintf( data, "  /* 32 unicode.org characters represented for each data value in array */\n" );
     for ( i=0; i<0x120000/32; i+=j ) {
 	fprintf( data, " " );
@@ -1175,9 +1175,9 @@ static void dump() {
 
     dumparabicdata(header);
     dumpligaturesfractions(header);
-    fprintf( header, "\n#define _SOFT_HYPHEN\t0xad\n" );
-    fprintf( header, "\n#define _DOUBLE_S\t0xdf\n" );
-    fprintf( header, "\n#endif\n" );
+    fprintf( header, "\n#define FF_UNICODE_SOFT_HYPHEN\t0xad\n" );
+    fprintf( header, "\n#define FF_UNICODE_DOUBLE_S\t0xdf\n" );
+    fprintf( header, "\n#endif /* FONTFORGE_UNICODE_UTYPE_H */\n" );
     fclose( header );
 }
 

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -1541,13 +1541,13 @@ return( 0x70000000 );
     if ( autohint_before_generate && sc->changedsincelasthinted && !sc->manualhints )
 	SplineCharAutoHint(sc,layer,NULL);
     if ( (best=sc->vstem)!=NULL ) {
-	if ( pos&____CENTERLEFT ) {
+	if ( pos & FF_UNICODE_CENTERLEFT ) {
 	    for ( h=best->next; h!=NULL && h->start<best->start+best->width; h=h->next )
 		if ( h->start+h->width<best->start+best->width )
 		    best = h;
 	    if ( best->start+best->width/2>(bb->maxx+bb->minx)/2 )
 		best = NULL;
-	} else if ( pos&____CENTERRIGHT ) {
+	} else if ( pos & FF_UNICODE_CENTERRIGHT ) {
 	    while ( best->next!=NULL )
 		best = best->next;
 	    if ( best->start+best->width/2<(bb->maxx+bb->minx)/2 )
@@ -1589,15 +1589,15 @@ return( best->start + best->width/2 - (rbb->maxx-rbb->minx)/2 - rbb->minx );
                 temp = rbxtest; rbxtest = lbxtest; lbxtest = temp;
             }
             if ( d == sc->dstem ||
-                ( pos&____CENTERLEFT && rbxtest < rbx ) ||
-                ( pos&____CENTERRIGHT && lbxtest > lbx )) {
+                ( ( pos & FF_UNICODE_CENTERLEFT ) && rbxtest < rbx ) ||
+                ( ( pos & FF_UNICODE_CENTERRIGHT ) && lbxtest > lbx ) ) {
                 lbx = lbxtest; rbx = rbxtest;
             }
         }
         if ( lbx < rbx && (
-            ( pos&____CENTERLEFT &&
+            ( ( pos & FF_UNICODE_CENTERLEFT ) &&
             ( lbx + rbx )/2 <= ( bb->maxx + bb->minx )/2 ) ||
-            ( pos&____CENTERRIGHT &&
+            ( ( pos & FF_UNICODE_CENTERRIGHT ) &&
             ( lbx + rbx )/2 >= ( bb->maxx + bb->minx )/2 )))
 return(( lbx + rbx )/2 - ( rbb->maxx - rbb->minx )/2 - rbb->minx );
     }
@@ -1949,34 +1949,34 @@ static void _BCCenterAccent( BDFFont *bdf, int gid, int rgid, int ch, int basech
 	BDFCharQuickBounds( bc,&ibb,0,0,false,true );
 	BDFCharQuickBounds( rbc,&irb,0,0,false,true );
 
-	if ( (pos&____ABOVE) && (pos&(____LEFT|____RIGHT)) )
+	if ( (pos & FF_UNICODE_ABOVE) && (pos & (FF_UNICODE_LEFT|FF_UNICODE_RIGHT)) )
 	    iyoff = ibb.maxy - irb.maxy;
-	else if ( pos&____ABOVE )
+	else if ( pos & FF_UNICODE_ABOVE )
 	    iyoff = ibb.maxy + ispacing - irb.miny;
-	else if ( pos&____BELOW ) {
+	else if ( pos & FF_UNICODE_BELOW ) {
 	    iyoff = ibb.miny - irb.maxy;
-	    if ( !( pos&____TOUCHING) )
+	    if ( !( pos & FF_UNICODE_TOUCHING) )
 		iyoff -= ispacing;
-	} else if ( pos&____OVERSTRIKE )
+	} else if ( pos & FF_UNICODE_OVERSTRIKE )
 	    iyoff = ibb.miny - irb.miny + ((ibb.maxy-ibb.miny)-(irb.maxy-irb.miny))/2;
 	else
 	    iyoff = ibb.miny - irb.miny;
 	if ( isupper(basech) && ch==0x342)
 	    ixoff = ibb.minx - irb.minx;
-	else if ( pos&____LEFT )
+	else if ( pos & FF_UNICODE_LEFT )
 	    ixoff = ibb.minx - ispacing - irb.maxx;
-	else if ( pos&____RIGHT ) {
+	else if ( pos & FF_UNICODE_RIGHT ) {
 	    ixoff = ibb.maxx - irb.minx + ispacing/2;
-	    if ( !( pos&____TOUCHING) )
+	    if ( !( pos & FF_UNICODE_TOUCHING) )
 		ixoff += ispacing;
 	} else {
-	    if ( pos&____CENTERLEFT )
+	    if ( pos & FF_UNICODE_CENTERLEFT )
 		ixoff = ibb.minx + (ibb.maxx-ibb.minx)/2 - irb.maxx;
-	    else if ( pos&____LEFTEDGE )
+	    else if ( pos & FF_UNICODE_LEFTEDGE )
 		ixoff = ibb.minx - irb.minx;
-	    else if ( pos&____CENTERRIGHT )
+	    else if ( pos & FF_UNICODE_CENTERRIGHT )
 		ixoff = ibb.minx + (ibb.maxx-ibb.minx)/2 - irb.minx;
-	    else if ( pos&____RIGHTEDGE )
+	    else if ( pos & FF_UNICODE_RIGHTEDGE )
 		ixoff = ibb.maxx - irb.maxx;
 	    else
 		ixoff = ibb.minx - irb.minx + ((ibb.maxx-ibb.minx)-(irb.maxx-irb.minx))/2;
@@ -2034,12 +2034,12 @@ return;
     }
     if ( ia==0 && baserch!=basech && basersc!=NULL ) {
 	ybase = SplineCharFindSlantedBounds(basersc,layer,&bbb,ia);
-	if ( ____utype2[1+ch]&(____ABOVE|____BELOW) ) {
+	if ( ff_unicode_utype2[1+ch] & (FF_UNICODE_ABOVE|FF_UNICODE_BELOW) ) {
 	    /* if unicode.org character definition matches ABOVE or BELOW, then... */
 	    bbb.maxy = bb.maxy;
 	    bbb.miny = bb.miny;
 	}
-	if ( ____utype2[1+ch]&(____RIGHT|____LEFT) ) {
+	if ( ff_unicode_utype2[1+ch] & (FF_UNICODE_RIGHT|FF_UNICODE_LEFT) ) {
 	    /* if unicode.org character definition matches RIGHT or LEFT, then... */
 	    bbb.maxx = bb.maxx;
 	    bbb.minx = bb.minx;
@@ -2059,11 +2059,11 @@ return;
 	/*  If so then figure offsets relative to it. */
 	xoff = ap1->me.x-ap2->me.x + sc->layers[layer].refs->transform[4];
 	yoff = ap1->me.y-ap2->me.y + sc->layers[layer].refs->transform[5];
-	pos = ____utype2[1+ch];	/* init with unicode.org position information */
+	pos = ff_unicode_utype2[1+ch];	/* init with unicode.org position information */
     } else if ( AnchorClassMatch(basersc,rsc,(AnchorClass *) -1,&ap1,&ap2)!=NULL && ap2->type==at_mark ) {
 	xoff = ap1->me.x-ap2->me.x;
 	yoff = ap1->me.y-ap2->me.y;
-	pos = ____utype2[1+ch];	/* init with unicode.org position information */
+	pos = ff_unicode_utype2[1+ch];	/* init with unicode.org position information */
     } else {
  /* try to establish a common line on which all accents lie. The problem being*/
  /*  that an accent above a,e,o will usually be slightly higher than an accent */
@@ -2099,59 +2099,59 @@ return;
 	    transform[3] = -1;
 	    transform[5] = rbb.maxy+rbb.miny;
 	}
-	if ( pos==____NOPOSDATAGIVEN ) {
+	if ( pos==FF_UNICODE_NOPOSDATAGIVEN ) {
 	    /* if here, then we need to initialize some type of position info for the accent */
 	    if ( ch<0 || ch>=0x10000 )	/* makeutype.c only built data in utype.c for {0...MAXC} */
-		pos = ____ABOVE;
+		pos = FF_UNICODE_ABOVE;
 	    else
-		pos = ____utype2[1+ch];	/* init with unicode.org position information */
+		pos = ff_unicode_utype2[1+ch];	/* init with unicode.org position information */
 	    /* In greek, PSILI and friends are centered above lower case, and kern left*/
 	    /*  for upper case */
 	    if (( basech>=0x390 && basech<=0x3ff) || (basech>=0x1f00 && basech<=0x1fff)) {
 		if ( ( basech==0x1fbf || basech==0x1fef || basech==0x1ffe ) &&
 			(ch==0x1fbf || ch==0x1fef || ch==0x1ffe || ch==0x1fbd || ch==0x1ffd )) {
-		    pos = ____ABOVE|____RIGHT;
+		    pos = FF_UNICODE_ABOVE|FF_UNICODE_RIGHT;
 		} else if ( isupper(basech) &&
 			(ch==0x313 || ch==0x314 || ch==0x301 || ch==0x300 || ch==0x30d ||
 			 ch==0x1ffe || ch==0x1fbf || ch==0x1fcf || ch==0x1fdf ||
 			 ch==0x1fbd || ch==0x1fef || ch==0x1ffd ||
 			 ch==0x1fcd || ch==0x1fdd || ch==0x1fce || ch==0x1fde ) )
-		    pos = ____ABOVE|____LEFT;
+		    pos = FF_UNICODE_ABOVE|FF_UNICODE_LEFT;
 		else if ( isupper(basech) && ch==0x1fbe )
-		    pos = ____RIGHT;
+		    pos = FF_UNICODE_RIGHT;
 		else if ( ch==0x1fcd || ch==0x1fdd || ch==0x1fce || ch==0x1fde ||
 			 ch==0x1ffe || ch==0x1fbf || ch==0x1fcf || ch==0x1fdf ||
 			 ch==0x384 )
-		    pos = ____ABOVE;
+		    pos = FF_UNICODE_ABOVE;
 	    } else if ( (basech==0x1ffe || basech==0x1fbf) && (ch==0x301 || ch==0x300))
-		pos = ____RIGHT;
+		pos = FF_UNICODE_RIGHT;
 	    else if ( sc->unicodeenc==0x1fbe && ch==0x345 )
-		pos = ____RIGHT;
+		pos = FF_UNICODE_RIGHT;
 	    else if ( basech=='l' && ch==0xb7 )
-		pos = ____RIGHT|____OVERSTRIKE;
+		pos = FF_UNICODE_RIGHT|FF_UNICODE_OVERSTRIKE;
 	    else if ( basech=='L' && ch==0xb7 )
-		pos = ____OVERSTRIKE;
+		pos = FF_UNICODE_OVERSTRIKE;
 	    else if ( ch==0xb7 )
-		pos = ____RIGHT;
+		pos = FF_UNICODE_RIGHT;
 	    else if ( basech=='A' && ch==0x30a )	/* Aring usually touches */
-		pos = ____ABOVE|____TOUCHING;
+		pos = FF_UNICODE_ABOVE|FF_UNICODE_TOUCHING;
 	    else if (( basech=='A' || basech=='a' || basech=='E' || basech=='u' ) &&
 		    ch == 0x328 )
-		pos = ____BELOW|____CENTERRIGHT|____TOUCHING;	/* ogonek off to the right for these in polish (but not lc e) */
+		pos = FF_UNICODE_BELOW|FF_UNICODE_CENTERRIGHT|FF_UNICODE_TOUCHING;	/* ogonek off to the right for these in polish (but not lc e) */
 	    else if (( basech=='N' || basech=='n' || basech=='K' || basech=='k' || basech=='R' || basech=='r' || basech=='H' || basech=='h' ) &&
 		    ch == 0x327 )
-		pos = ____BELOW|____CENTERLEFT|____TOUCHING;	/* cedilla off under left stem for these guys */
-	    if ( basech==0x391 && pos==(____ABOVE|____LEFT) ) {
+		pos = FF_UNICODE_BELOW|FF_UNICODE_CENTERLEFT|FF_UNICODE_TOUCHING;	/* cedilla off under left stem for these guys */
+	    if ( basech==0x391 && pos==(FF_UNICODE_ABOVE|FF_UNICODE_LEFT) ) {
 		bb.minx += (bb.maxx-bb.minx)/4;
 	    }
 	}
 	if ( sc->unicodeenc==0x0149 )
-	    pos = ____ABOVE|____LEFT;
+	    pos = FF_UNICODE_ABOVE|FF_UNICODE_LEFT;
 	else if ( sc->unicodeenc==0x013d || sc->unicodeenc==0x013e )
-	    pos = ____ABOVE|____RIGHT;
+	    pos = FF_UNICODE_ABOVE|FF_UNICODE_RIGHT;
 	else if ( sc->unicodeenc==0x010f || sc->unicodeenc==0x013d ||
 		  sc->unicodeenc==0x013e || sc->unicodeenc==0x0165 )
-	    pos = ____ABOVE|____RIGHT;
+	    pos = FF_UNICODE_ABOVE|FF_UNICODE_RIGHT;
 	else if ( (sc->unicodeenc==0x1fbd || sc->unicodeenc==0x1fbf ||
 		sc->unicodeenc==0x1ffe || sc->unicodeenc==0x1fc0 ) &&
 		bb.maxy==0 && bb.miny==0 ) {
@@ -2159,26 +2159,26 @@ return;
 	    bb.maxy = 7*sf->ascent/10;
 	}
 
-	if ( (pos&____ABOVE) && (pos&(____LEFT|____RIGHT)) )
+	if ( (pos & FF_UNICODE_ABOVE) && (pos & (FF_UNICODE_LEFT|FF_UNICODE_RIGHT)) )
 	    yoff = bb.maxy - rbb.maxy;
-	else if ( pos&____ABOVE ) {
+	else if ( pos & FF_UNICODE_ABOVE ) {
 	    yoff = bb.maxy - rbb.miny;
-	    if ( !( pos&____TOUCHING) )
+	    if ( !( pos & FF_UNICODE_TOUCHING) )
 		yoff += spacing;
-	} else if ( pos&____BELOW ) {
+	} else if ( pos & FF_UNICODE_BELOW ) {
 	    yoff = bb.miny - rbb.maxy;
-	    if ( !( pos&____TOUCHING) )
+	    if ( !( pos & FF_UNICODE_TOUCHING) )
 		yoff -= spacing;
-	} else if ( pos&____OVERSTRIKE )
+	} else if ( pos & FF_UNICODE_OVERSTRIKE )
 	    yoff = bb.miny - rbb.miny + ((bb.maxy-bb.miny)-(rbb.maxy-rbb.miny))/2;
 	else /* If neither Above, Below, nor overstrike then should use the same baseline */
 	    yoff = bb.miny - rbb.miny;
 
-	if ( pos&(____ABOVE|____BELOW) ) {
+	if ( pos & (FF_UNICODE_ABOVE|FF_UNICODE_BELOW) ) {
 	    /* When we center an accent above an asymetric character like "C" we */
 	    /*  should not pick the mid point of the char. Rather we should pick */
 	    /*  the highest point (mostly anyway, there are exceptions) */
-	    if ( pos&____ABOVE ) {
+	    if ( pos & FF_UNICODE_ABOVE ) {
 		static DBounds pointless;
 		if ( CharCenterHighest ) {
 		    if ( basech!='b' && basech!='d' && basech!='h' && basech!='n' && basech!='r' && basech!=0xf8 &&
@@ -2192,30 +2192,30 @@ return;
 			    (xoff=SCStemCheck(sf,layer,basech,&bb,&pointless,pos))!=0x70000000 )
 			bb.minx = bb.maxx = xoff;		/* While on "t" we should center over the stem */
 		}
-	    } else if ( ( pos&____BELOW ) && !eta )
+	    } else if ( ( pos & FF_UNICODE_BELOW ) && !eta )
 		if ( CharCenterHighest )
 		    ybase = SCFindBottomXRange(sc,layer,&bb,ia);
 	}
 
 	if ( isupper(basech) && ch==0x342)	/* While this guy rides above PSILI on left */
 	    xoff = bb.minx - rbb.minx;
-	else if ( pos&____LEFT )
+	else if ( pos & FF_UNICODE_LEFT )
 	    xoff = bb.minx - spacing - rbb.maxx;
-	else if ( pos&____RIGHT ) {
+	else if ( pos & FF_UNICODE_RIGHT ) {
 	    xoff = bb.maxx - rbb.minx+spacing/2;
-	    if ( !( pos&____TOUCHING) )
+	    if ( !( pos & FF_UNICODE_TOUCHING) )
 		xoff += spacing;
 	} else {
-	    if ( (pos&(____CENTERLEFT|____CENTERRIGHT)) &&
+	    if ( (pos & (FF_UNICODE_CENTERLEFT|FF_UNICODE_CENTERRIGHT)) &&
 		    (xoff=SCStemCheck(sf,layer,basech,&bb,&rbb,pos))!=0x70000000 )
 		/* Done */;
-	    else if ( pos&____CENTERLEFT )
+	    else if ( pos & FF_UNICODE_CENTERLEFT )
 		xoff = bb.minx + (bb.maxx-bb.minx)/2 - rbb.maxx;
-	    else if ( pos&____LEFTEDGE )
+	    else if ( pos & FF_UNICODE_LEFTEDGE )
 		xoff = bb.minx - rbb.minx;
-	    else if ( pos&____CENTERRIGHT )
+	    else if ( pos & FF_UNICODE_CENTERRIGHT )
 		xoff = bb.minx + (bb.maxx-bb.minx)/2 - rbb.minx;
-	    else if ( pos&____RIGHTEDGE )
+	    else if ( pos & FF_UNICODE_RIGHTEDGE )
 		xoff = bb.maxx - rbb.maxx;
 	    else
 		xoff = bb.minx - rbb.minx + ((bb.maxx-bb.minx)-(rbb.maxx-rbb.minx))/2;
@@ -2228,9 +2228,9 @@ return;
 
     if ( bdf == NULL || !disp_only ) {
 	_SCAddRef(sc,rsc,layer,transform);
-	if ( pos!=____NOPOSDATAGIVEN && (pos&____RIGHT) )
+	if ( pos != FF_UNICODE_NOPOSDATAGIVEN && (pos & FF_UNICODE_RIGHT) )
 	    SCSynchronizeWidth(sc,sc->width + rbb.maxx-rbb.minx+spacing,sc->width,NULL);
-	if ( pos!=____NOPOSDATAGIVEN && (pos&(____LEFT|____RIGHT|____CENTERLEFT|____LEFTEDGE|____CENTERRIGHT|____RIGHTEDGE)) )
+	if ( pos != FF_UNICODE_NOPOSDATAGIVEN && (pos & (FF_UNICODE_LEFT|FF_UNICODE_RIGHT|FF_UNICODE_CENTERLEFT|FF_UNICODE_LEFTEDGE|FF_UNICODE_CENTERRIGHT|FF_UNICODE_RIGHTEDGE)) )
 	    TurnOffUseMyMetrics(sc);
     }
     if ( !disp_only ) {
@@ -2249,7 +2249,7 @@ static void SCCenterAccent(SplineChar *sc,SplineChar *basersc, SplineFont *sf,
     SplineChar *rsc = GetGoodAccentGlyph(sf,ch,basech,&invert,ia,dot,sc);
 
     /* find a location to put an accent on this character */
-    _SCCenterAccent(sc,basersc,sf,layer,ch,bdf,disp_only,rsc,ia,basech,invert,____NOPOSDATAGIVEN);
+    _SCCenterAccent(sc,basersc,sf,layer,ch,bdf,disp_only,rsc,ia,basech,invert,FF_UNICODE_NOPOSDATAGIVEN);
 }
 
 static void _BCPutRefAfter( BDFFont *bdf,int gid,int rgid,int normal,int under ) {
@@ -2835,7 +2835,7 @@ return;
     if ( dot==NULL && ( ch=='i' || ch=='j' || ch==0x456 )) {
 	/* if we're combining i (or j) with an accent that would interfere */
 	/*  with the dot, then get rid of the dot. (use dotlessi) */
-	for ( apt = pt; *apt && combiningposmask(*apt)!=____ABOVE; ++apt);
+	for ( apt = pt; *apt && combiningposmask(*apt) != FF_UNICODE_ABOVE; ++apt);
 	if ( *apt!='\0' ) {
 	    if ( ch=='i' || ch==0x456 ) ch = 0x0131;
 	    else if ( ch=='j' ) {

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -7389,7 +7389,7 @@ static const char *appendaccent_keywords[] = { "name", "unicode", "pos", NULL };
 static PyObject *PyFFGlyph_appendAccent(PyObject *self, PyObject *args, PyObject *keywds) {
     SplineChar *sc = ((PyFF_Glyph *) self)->sc;
     int layer = ((PyFF_Glyph *) self)->layer;
-    int pos = ____NOPOSDATAGIVEN;	/* unicode char pos info, see #define for (uint32)(utype2[]) */
+    int pos = FF_UNICODE_NOPOSDATAGIVEN; /* unicode char pos info, see #define for (uint32)(utype2[]) */
     int uni=-1;				/* unicode char value */
     char *name = NULL;			/* unicode char name */
     int ret;

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -5453,7 +5453,7 @@ static void bBuildAccented(Context *c) {
 }
 
 static void bAppendAccent(Context *c) {
-    int pos = ____NOPOSDATAGIVEN;	/* unicode char pos info, see #define for (uint32)(utype2[]) */
+    int pos = FF_UNICODE_NOPOSDATAGIVEN; /* unicode char pos info, see #define for (uint32)(utype2[]) */
     char *glyph_name = NULL;		/* unicode char name */
     int uni = -1;			/* unicode char value */
 

--- a/inc/utype.h
+++ b/inc/utype.h
@@ -1,5 +1,5 @@
-#ifndef _UTYPE_H
-#define _UTYPE_H
+#ifndef FONTFORGE_UNICODE_UTYPE_H
+#define FONTFORGE_UNICODE_UTYPE_H
 /* Copyright: 2001 George Williams */
 /* License: BSD-3-clause */
 /* Contributions: Joe Da Silva */
@@ -39,107 +39,107 @@
 # undef ishexdigit
 #endif
 
-extern const unsigned short ____tolower[];
-extern const unsigned short ____toupper[];
-extern const unsigned short ____totitle[];
-extern const unsigned short ____tomirror[];
-extern const unsigned char  ____digitval[];
+extern const unsigned short ff_unicode_tolower[];
+extern const unsigned short ff_unicode_toupper[];
+extern const unsigned short ff_unicode_totitle[];
+extern const unsigned short ff_unicode_tomirror[];
+extern const unsigned char  ff_unicode_digitval[];
 
 /* utype[] holds binary flags used for features of each unicode.org character */
-#define ____L		0x1
-#define ____U		0x2
-#define ____TITLE	0x4
-#define ____D		0x8
-#define ____S		0x10
-#define ____P		0x20
-#define ____X		0x40
-#define ____ZW		0x80
-#define ____L2R		0x100
-#define ____R2L		0x200
-#define ____ENUM	0x400
-#define ____ANUM	0x800
-#define ____ENS		0x1000
-#define ____CS		0x2000
-#define ____ENT		0x4000
-#define ____COMBINE	0x8000
-#define ____BB		0x10000
-#define ____BA		0x20000
-#define ____NS		0x40000
-#define ____NE		0x80000
-#define ____UB		0x100000
-#define ____NB		0x8000000
-#define ____AL		0x200000
-#define ____ID		0x400000
-#define ____INITIAL	0x800000
-#define ____MEDIAL	0x1000000
-#define ____FINAL	0x2000000
-#define ____ISOLATED	0x4000000
-#define ____DECOMPNORM	0x10000000
-#define ____LIG_OR_FRAC	0x20000000
+#define FF_UNICODE_L		0x1
+#define FF_UNICODE_U		0x2
+#define FF_UNICODE_TITLE	0x4
+#define FF_UNICODE_D		0x8
+#define FF_UNICODE_S		0x10
+#define FF_UNICODE_P		0x20
+#define FF_UNICODE_X		0x40
+#define FF_UNICODE_ZW		0x80
+#define FF_UNICODE_L2R		0x100
+#define FF_UNICODE_R2L		0x200
+#define FF_UNICODE_ENUM		0x400
+#define FF_UNICODE_ANUM		0x800
+#define FF_UNICODE_ENS		0x1000
+#define FF_UNICODE_CS		0x2000
+#define FF_UNICODE_ENT		0x4000
+#define FF_UNICODE_COMBINE	0x8000
+#define FF_UNICODE_BB		0x10000
+#define FF_UNICODE_BA		0x20000
+#define FF_UNICODE_NS		0x40000
+#define FF_UNICODE_NE		0x80000
+#define FF_UNICODE_UB		0x100000
+#define FF_UNICODE_NB		0x8000000
+#define FF_UNICODE_AL		0x200000
+#define FF_UNICODE_ID		0x400000
+#define FF_UNICODE_INITIAL	0x800000
+#define FF_UNICODE_MEDIAL	0x1000000
+#define FF_UNICODE_FINAL	0x2000000
+#define FF_UNICODE_ISOLATED	0x4000000
+#define FF_UNICODE_DECOMPNORM	0x10000000
+#define FF_UNICODE_LIG_OR_FRAC	0x20000000
 
-#define islower(ch)		(____utype[(ch)+1]&____L)
-#define isupper(ch)		(____utype[(ch)+1]&____U)
-#define istitle(ch)		(____utype[(ch)+1]&____TITLE)
-#define isalpha(ch)		(____utype[(ch)+1]&(____L|____U|____TITLE|____AL))
-#define isdigit(ch)		(____utype[(ch)+1]&____D)
-#define isalnum(ch)		(____utype[(ch)+1]&(____L|____U|____TITLE|____AL|____D))
-#define isideographic(ch)	(____utype[(ch)+1]&____ID)
-#define isideoalpha(ch)		(____utype[(ch)+1]&(____ID|____L|____U|____TITLE|____AL))
-#define isspace(ch)		(____utype[(ch)+1]&____S)
-#define ispunct(ch)		(____utype[(ch)+1]&_____P)
-#define ishexdigit(ch)		(____utype[(ch)+1]&____X)
-#define iszerowidth(ch)		(____utype[(ch)+1]&____ZW)
-#define islefttoright(ch)	(____utype[(ch)+1]&____L2R)
-#define isrighttoleft(ch)	(____utype[(ch)+1]&____R2L)
-#define iseuronumeric(ch)	(____utype[(ch)+1]&____ENUM)
-#define isarabnumeric(ch)	(____utype[(ch)+1]&____ANUM)
-#define iseuronumsep(ch)	(____utype[(ch)+1]&____ENS)
-#define iscommonsep(ch)		(____utype[(ch)+1]&____CS)
-#define iseuronumterm(ch)	(____utype[(ch)+1]&____ENT)
-#define iscombining(ch)		(____utype[(ch)+1]&____COMBINE)
-#define isbreakbetweenok(ch1,ch2) (((____utype[(ch1)+1]&____BA) && !(____utype[(ch2)+1]&____NS)) || ((____utype[(ch2)+1]&____BB) && !(____utype[(ch1)+1]&____NE)) || (!(____utype[(ch2)+1]&____D) && ch1=='/'))
-#define isnobreak(ch)		(____utype[(ch)+1]&____NB)
-#define isarabinitial(ch)	(____utype[(ch)+1]&____INITIAL)
-#define isarabmedial(ch)	(____utype[(ch)+1]&____MEDIAL)
-#define isarabfinal(ch)		(____utype[(ch)+1]&____FINAL)
-#define isarabisolated(ch)	(____utype[(ch)+1]&____ISOLATED)
-#define isdecompositionnormative(ch) (____utype[(ch)+1]&____DECOMPNORM)
-#define isligorfrac(ch)		(____utype[(ch)+1]&____LIG_OR_FRAC)
+#define islower(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_L)
+#define isupper(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_U)
+#define istitle(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_TITLE)
+#define isalpha(ch)		(ff_unicode_utype[(ch)+1]&(FF_UNICODE_L|FF_UNICODE_U|FF_UNICODE_TITLE|FF_UNICODE_AL))
+#define isdigit(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_D)
+#define isalnum(ch)		(ff_unicode_utype[(ch)+1]&(FF_UNICODE_L|FF_UNICODE_U|FF_UNICODE_TITLE|FF_UNICODE_AL|FF_UNICODE_D))
+#define isideographic(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_ID)
+#define isideoalpha(ch)		(ff_unicode_utype[(ch)+1]&(FF_UNICODE_ID|FF_UNICODE_L|FF_UNICODE_U|FF_UNICODE_TITLE|FF_UNICODE_AL))
+#define isspace(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_S)
+#define ispunct(ch)		(ff_unicode_utype[(ch)+1]&_FF_UNICODE_P)
+#define ishexdigit(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_X)
+#define iszerowidth(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_ZW)
+#define islefttoright(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_L2R)
+#define isrighttoleft(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_R2L)
+#define iseuronumeric(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_ENUM)
+#define isarabnumeric(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_ANUM)
+#define iseuronumsep(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_ENS)
+#define iscommonsep(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_CS)
+#define iseuronumterm(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_ENT)
+#define iscombining(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_COMBINE)
+#define isbreakbetweenok(ch1,ch2) (((ff_unicode_utype[(ch1)+1]&FF_UNICODE_BA) && !(ff_unicode_utype[(ch2)+1]&FF_UNICODE_NS)) || ((ff_unicode_utype[(ch2)+1]&FF_UNICODE_BB) && !(ff_unicode_utype[(ch1)+1]&FF_UNICODE_NE)) || (!(ff_unicode_utype[(ch2)+1]&FF_UNICODE_D) && ch1=='/'))
+#define isnobreak(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_NB)
+#define isarabinitial(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_INITIAL)
+#define isarabmedial(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_MEDIAL)
+#define isarabfinal(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_FINAL)
+#define isarabisolated(ch)	(ff_unicode_utype[(ch)+1]&FF_UNICODE_ISOLATED)
+#define isdecompositionnormative(ch) (ff_unicode_utype[(ch)+1]&FF_UNICODE_DECOMPNORM)
+#define isligorfrac(ch)		(ff_unicode_utype[(ch)+1]&FF_UNICODE_LIG_OR_FRAC)
 
-extern const uint32	____utype[];		/* hold character type features for each Unicode.org defined character */
+extern const uint32 ff_unicode_utype[];	/* hold character type features for each Unicode.org defined character */
 
 /* utype2[] binary flags used for position/layout of each unicode.org character */
-#define ____COMBININGCLASS	0xff
-#define ____ABOVE		0x100
-#define ____BELOW		0x200
-#define ____OVERSTRIKE		0x400
-#define ____LEFT		0x800
-#define ____RIGHT		0x1000
-#define ____JOINS2		0x2000
-#define ____CENTERLEFT		0x4000
-#define ____CENTERRIGHT		0x8000
-#define ____CENTEREDOUTSIDE	0x10000
-#define ____OUTSIDE		0x20000
-#define ____LEFTEDGE		0x80000
-#define ____RIGHTEDGE		0x40000
-#define ____TOUCHING		0x100000
-#define ____COMBININGPOSMASK	0x1fff00
-#define ____NOPOSDATAGIVEN	(uint32)(-1)	/* -1 == no position data given */
+#define FF_UNICODE_COMBININGCLASS	0xff
+#define FF_UNICODE_ABOVE		0x100
+#define FF_UNICODE_BELOW		0x200
+#define FF_UNICODE_OVERSTRIKE		0x400
+#define FF_UNICODE_LEFT			0x800
+#define FF_UNICODE_RIGHT		0x1000
+#define FF_UNICODE_JOINS2		0x2000
+#define FF_UNICODE_CENTERLEFT		0x4000
+#define FF_UNICODE_CENTERRIGHT		0x8000
+#define FF_UNICODE_CENTEREDOUTSIDE	0x10000
+#define FF_UNICODE_OUTSIDE		0x20000
+#define FF_UNICODE_LEFTEDGE		0x80000
+#define FF_UNICODE_RIGHTEDGE		0x40000
+#define FF_UNICODE_TOUCHING		0x100000
+#define FF_UNICODE_COMBININGPOSMASK	0x1fff00
+#define FF_UNICODE_NOPOSDATAGIVEN	(uint32)(-1)	/* -1 == no position data given */
 
-#define combiningclass(ch)	(____utype2[(ch)+1]&____COMBININGCLASS)
-#define combiningposmask(ch)	(____utype2[(ch)+1]&____COMBININGPOSMASK)
+#define combiningclass(ch)	(ff_unicode_utype2[(ch)+1]&FF_UNICODE_COMBININGCLASS)
+#define combiningposmask(ch)	(ff_unicode_utype2[(ch)+1]&FF_UNICODE_COMBININGPOSMASK)
 
-extern const uint32	____utype2[];		/* hold position boolean flags for each Unicode.org defined character */
+extern const uint32 ff_unicode_utype2[];	/* hold position boolean flags for each Unicode.org defined character */
 
-#define isunicodepointassigned(ch) (____codepointassigned[(ch)/32]&(1<<((ch)%32)))
+#define isunicodepointassigned(ch) (ff_unicode_codepointassigned[(ch)/32]&(1<<((ch)%32)))
 
-extern const uint32	____codepointassigned[]; /* 1bit_boolean_flag x 32 = exists in Unicode.org character chart list. */
+extern const uint32 ff_unicode_codepointassigned[]; /* 1bit_boolean_flag x 32 = exists in Unicode.org character chart list. */
 
-#define tolower(ch) (____tolower[(ch)+1])
-#define toupper(ch) (____toupper[(ch)+1])
-#define totitle(ch) (____totitle[(ch)+1])
-#define tomirror(ch) (____tomirror[(ch)+1])
-#define tovalue(ch) (____digitval[(ch)+1])
+#define tolower(ch) (ff_unicode_tolower[(ch)+1])
+#define toupper(ch) (ff_unicode_toupper[(ch)+1])
+#define totitle(ch) (ff_unicode_totitle[(ch)+1])
+#define tomirror(ch) (ff_unicode_tomirror[(ch)+1])
+#define tovalue(ch) (ff_unicode_digitval[(ch)+1])
 
 
 extern struct arabicforms {
@@ -187,8 +187,8 @@ extern int is_LIGATURE_or_OTHER_FRACTION(uint32 codepoint);
 extern int is_LIGATURE_or_FRACTION(uint32 codepoint);
 
 
-#define _SOFT_HYPHEN	0xad
+#define FF_UNICODE_SOFT_HYPHEN	0xad
 
-#define _DOUBLE_S	0xdf
+#define FF_UNICODE_DOUBLE_S	0xdf
 
-#endif
+#endif /* FONTFORGE_UNICODE_UTYPE_H */


### PR DESCRIPTION
Re-edit Issue #2940 "Unicode: Do not start identifiers with underscores" to maintain more consistent alignment after name changes. Add brackets around several conditions as that has been a problem with some older compilers throwing warnings about & and &&. Credit to Giole for this large patch (originally as #2940).

Noted combiners.h is only used by makeutype.c, therefore corrected Makefile.am accordingly.