### PR TITLE
Update combiners.h from 3.0.0 to 9.0

### DIFF
--- a/Unicode/combiners.h
+++ b/Unicode/combiners.h
@@ -72,13 +72,46 @@ static const int poses300[] = {
     FF_UNICODE_Above,
     FF_UNICODE_Above,
     FF_UNICODE_Below,
-    0
-};
-static const int poses360[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,		/* 0x348 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    0,				/* 0x034F, COMBINING GRAPHEME JOINER */
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above|FF_UNICODE_Right,	/* 0x358 */
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below|FF_UNICODE_Joins2,
     FF_UNICODE_Above|FF_UNICODE_Joins2,
     FF_UNICODE_Above|FF_UNICODE_Joins2,
     FF_UNICODE_Below|FF_UNICODE_Joins2,
-    0
+    FF_UNICODE_Above|FF_UNICODE_Joins2, /* 0x360 */
+    FF_UNICODE_Above|FF_UNICODE_Joins2,
+    FF_UNICODE_Below|FF_UNICODE_Joins2,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 static const int poses385[] = {
     FF_UNICODE_Above
@@ -88,10 +121,7 @@ static const int poses483[] = {
     FF_UNICODE_Above|FF_UNICODE_CenterLeft,
     FF_UNICODE_Above|FF_UNICODE_CenterLeft,
     FF_UNICODE_Above|FF_UNICODE_CenterLeft,
-    0
-};
-
-static const int poses488[] = {
+    FF_UNICODE_Above,
     FF_UNICODE_CenteredOutside,	/* 8 down half-circles distributed in a circle around the character */
     FF_UNICODE_CenteredOutside	/* 8 commas rotated as moved around circle, bottom is normal comma */
 };
@@ -113,10 +143,8 @@ static const int poses591[] = {
     FF_UNICODE_Above|FF_UNICODE_CenterRight,
     FF_UNICODE_Above,
     FF_UNICODE_Above|FF_UNICODE_RightEdge, /* 05a0 */
-    FF_UNICODE_Above|FF_UNICODE_LeftEdge
-};
-
-static const int poses5A3[] = {
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge,
+    FF_UNICODE_Below,
     FF_UNICODE_Below,
     FF_UNICODE_Below,
     FF_UNICODE_Below|FF_UNICODE_CenterLeft,
@@ -139,10 +167,8 @@ static const int poses5A3[] = {
     FF_UNICODE_Below,
     FF_UNICODE_Below,
     FF_UNICODE_Below,		/* 05b8 */
-    FF_UNICODE_Above|FF_UNICODE_LeftEdge
-};
-
-static const int poses5BB[] = {
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge,
+    FF_UNICODE_Above|FF_UNICODE_LeftEdge,
     FF_UNICODE_Below,
     FF_UNICODE_Overstrike,
     FF_UNICODE_Below
@@ -158,7 +184,12 @@ static const int poses5C1[] = {
 };
 
 static const int poses5C4[] = {
+    FF_UNICODE_Above,
     FF_UNICODE_Above
+};
+
+static const int poses5C7[] = {
+    FF_UNICODE_Below
 };
 
 static const int poses64b[] = {
@@ -253,6 +284,16 @@ static const int poses7A6[] = {
     FF_UNICODE_Above|FF_UNICODE_CenterLeft,
     FF_UNICODE_Above|FF_UNICODE_CenterLeft,
     FF_UNICODE_Above|FF_UNICODE_CenterLeft,
+};
+
+static const int poses7EB[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above
 };
 
 static const int poses901[] = {
@@ -466,7 +507,8 @@ static const int posesBD7[] = {
     FF_UNICODE_Right
 };
 
-static const int posesC01[] = {
+static const int posesC00[] = {
+    FF_UNICODE_Above,
     FF_UNICODE_Right,
     FF_UNICODE_Right,
     FF_UNICODE_Right
@@ -785,6 +827,11 @@ static const int poses1056[] = {
     FF_UNICODE_Below
 };
 
+static const int poses135E[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
+};
+
 static const int poses17B4[] = {
     FF_UNICODE_Overstrike,
     FF_UNICODE_Overstrike,
@@ -822,6 +869,102 @@ static const int poses17B4[] = {
 
 static const int poses18A9[] = {
     FF_UNICODE_Above|FF_UNICODE_Left
+};
+
+static const int poses1A7F[] = {
+    FF_UNICODE_Below
+};
+
+static const int poses1AB0[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Below|FF_UNICODE_CenterLeft,
+    FF_UNICODE_Above|FF_UNICODE_Left|FF_UNICODE_Right,
+    FF_UNICODE_Above|FF_UNICODE_Left|FF_UNICODE_Right,
+    FF_UNICODE_Below|FF_UNICODE_Left|FF_UNICODE_Right,
+    FF_UNICODE_Left|FF_UNICODE_Right
+};
+
+static const int poses1B6B[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
+};
+
+static const int poses1DC0[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,		/* 1DD0 */
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,		/* 1DDF */
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,		/* 1DF0 */
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below|FF_UNICODE_Right,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below
 };
 
 static const int poses1FBD[] = {	/* These aren't listed as combiners, but if we don't use them as such greek fonts don't work */
@@ -872,10 +1015,64 @@ static const int poses20D0[] = {
     FF_UNICODE_CenteredOutside,
     FF_UNICODE_CenteredOutside,
     FF_UNICODE_CenteredOutside,
-    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,	/* 20E0 */
     FF_UNICODE_Above,
     FF_UNICODE_CenteredOutside,
-    FF_UNICODE_CenteredOutside
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Overstrike,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above
+};
+
+static const int poses2CEF[] = {
+    FF_UNICODE_Above|FF_UNICODE_Right,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
+};
+
+static const int poses2DE0[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,		/* 2DF0 */
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
 };
 
 static const int poses302A[] = {
@@ -892,6 +1089,57 @@ static const int poses3099[] = {
     FF_UNICODE_Above|FF_UNICODE_Right,
 };
 
+static const int posesA66F[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside,
+    FF_UNICODE_CenteredOutside
+};
+
+static const int posesA674[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
+};
+
+static const int posesA69E[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
+};
+
+static const int posesA6F0[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
+};
+
+static const int posesA8E0[] = {
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above
+};
+
 static const int posesFB1E[] = {
     FF_UNICODE_Above
 };
@@ -900,24 +1148,33 @@ static const int posesFE20[] = {
     FF_UNICODE_Above,
     FF_UNICODE_Above,
     FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Above,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Below,
+    FF_UNICODE_Above,
     FF_UNICODE_Above
 };
 
 const static struct {
-    int low, high;
+    long low, high;
     const int *pos;
 } combiners[] = {
-    { 0x300, 0x345, poses300 },
-    { 0x360, 0x362, poses360 },
+    { 0x300, 0x36F, poses300 },
     { 0x385, 0x385, poses385 },
-    { 0x483, 0x486, poses483 },
-    { 0x488, 0x489, poses488 },
-    { 0x591, 0x5A1, poses591 },
-    { 0x5A3, 0x5B9, poses5A3 },
-    { 0x5BB, 0x5BD, poses5BB },
+    { 0x483, 0x489, poses483 },
+    { 0x591, 0x5BD, poses591 },
     { 0x5BF, 0x5BF, poses5BF },
     { 0x5C1, 0x5C2, poses5C1 },
-    { 0x5C4, 0x5C4, poses5C4 },
+    { 0x5C4, 0x5C5, poses5C4 },
+    { 0x5C7, 0x5C7, poses5C7 },
     { 0x64b, 0x655, poses64b },
     { 0x670, 0x670, poses670 },
     { 0x6D6, 0x6E4, poses6D6 },
@@ -926,6 +1183,7 @@ const static struct {
     { 0x711, 0x711, poses711 },
     { 0x730, 0x74A, poses730 },
     { 0x7A6, 0x7B0, poses7A6 },
+    { 0x7EB, 0x7FE, poses7EB },
     { 0x901, 0x903, poses901 },
     { 0x93C, 0x93C, poses93C },
     { 0x93E, 0x94D, poses93E },
@@ -960,7 +1218,7 @@ const static struct {
     { 0xBC6, 0xBC8, posesBC6 },
     { 0xBCA, 0xBCD, posesBCA },
     { 0xBD7, 0xBD7, posesBD7 },
-    { 0xC01, 0xC03, posesC01 },
+    { 0xC00, 0xC03, posesC00 },
     { 0xC3E, 0xC44, posesC3E },
     { 0xC46, 0xC48, posesC46 },
     { 0xC4A, 0xC4D, posesC4A },
@@ -1001,19 +1259,31 @@ const static struct {
     { 0x102c, 0x1032, poses102C },
     { 0x1036, 0x1039, poses1036 },
     { 0x1056, 0x1059, poses1056 },
+    { 0x135E, 0x135F, poses135E },
     { 0x17B4, 0x17D3, poses17B4 },
     { 0x18A9, 0x18A9, poses18A9 },
+    { 0x1A7F, 0x1A7F, poses1A7F },
+    { 0x1AB0, 0x1ABE, poses1AB0 },
+    { 0x1B6B, 0x1B73, poses1B6B },
+    { 0x1DC0, 0x1DFF, poses1DC0 },
     { 0x1FBD, 0x1FC2, poses1FBD },
     { 0x1FCD, 0x1FCF, poses1FCD },
     { 0x1FDD, 0x1FDF, poses1FDD },
     { 0x1FED, 0x1FEF, poses1FED },
     { 0x1FFD, 0x1FFE, poses1FFD },
-    { 0x20D0, 0x20E3, poses20D0 },
+    { 0x20D0, 0x20F0, poses20D0 },
+    { 0x2CEF, 0x2CF1, poses2CEF },
+    { 0x2DE0, 0x2DFF, poses2DE0 },
     { 0x302A, 0x302F, poses302A },
     { 0x3099, 0x309A, poses3099 },
+    { 0xA66F, 0xA672, posesA66F },
+    { 0xA674, 0xA67D, posesA674 },
+    { 0xA69E, 0xA69F, posesA69E },
+    { 0xA6F0, 0xA6F1, posesA6F0 },
+    { 0xA8E0, 0xA8F1, posesA8E0 },
     { 0xFB1E, 0xFB1E, posesFB1E },
-    { 0xFE20, 0xFB23, posesFE20 },
-    { 0 }
+    { 0xFE20, 0xFE2F, posesFE20 },
+    { -1 }
 };
 
 #endif /* FONTFORGE_UNICODE_COMBINERS_H */

--- a/Unicode/makeutype.c
+++ b/Unicode/makeutype.c
@@ -261,7 +261,7 @@ static void readin(void) {
     long index, lc, uc, tc, flg, val, indexend, wasfirst;
     int  cc;
     FILE *fp;
-    int i,j;
+    long i,j;
 
     buffer[512]='\0'; buf2[0] = buf2[300]='\0'; oldname[0]='\0';
     if ((fp = fopen("UnicodeData.txt","r"))==NULL ) {
@@ -550,7 +550,8 @@ static void readin(void) {
     }
     fclose(fp);
 
-    for ( i=0; combiners[i].low!=0; ++i ) {
+    /* TODO: 2016nov21 -> Get combiners directly from UnicodeData.txt */
+    for ( i=0; combiners[i].low>=0; ++i ) {
 	for ( j=combiners[i].low; j<=combiners[i].high; ++j )
 	    flags2[j] |= combiners[i].pos[j-combiners[i].low];
     }


### PR DESCRIPTION
Manual update, concentrated mostly on anything with "COMBIN" in the
range of {0...0xFFFF}. This is better done searching line-by-line
using a program as it is easy to miss codes without "COMBIN" in it.