### PR TITLE
Consolidate fontforge/ headers, part2

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -60,6 +60,7 @@ noinst_HEADERS = \
 	ikarus.h\
 	langfreq.h\
 	libstamp.h\
+	macbinary.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -54,6 +54,7 @@ noinst_HEADERS = \
 	featurefile.h \
 	fvcomposite.h \
 	fvfonts.h \
+	fvimportbdf.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -53,6 +53,7 @@ noinst_HEADERS = \
 	encoding.h \
 	featurefile.h \
 	fvcomposite.h \
+	fvfonts.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -59,6 +59,7 @@ noinst_HEADERS = \
 	http.h\
 	ikarus.h\
 	langfreq.h\
+	libstamp.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -55,6 +55,7 @@ noinst_HEADERS = \
 	fvcomposite.h \
 	fvfonts.h \
 	fvimportbdf.h \
+	glyphcomp.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -61,6 +61,7 @@ noinst_HEADERS = \
 	langfreq.h\
 	libstamp.h\
 	macbinary.h\
+	macenc.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -62,6 +62,7 @@ noinst_HEADERS = \
 	libstamp.h\
 	macbinary.h\
 	macenc.h\
+	mathconstants.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -50,6 +50,7 @@ noinst_HEADERS = \
 	dumpbdf.h \
 	dumppfa.h \
 	effects.h \
+	encoding.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -51,6 +51,7 @@ noinst_HEADERS = \
 	dumppfa.h \
 	effects.h \
 	encoding.h \
+	featurefile.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -56,6 +56,7 @@ noinst_HEADERS = \
 	fvfonts.h \
 	fvimportbdf.h \
 	glyphcomp.h\
+	http.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -52,6 +52,7 @@ noinst_HEADERS = \
 	effects.h \
 	encoding.h \
 	featurefile.h \
+	fvcomposite.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -58,6 +58,7 @@ noinst_HEADERS = \
 	glyphcomp.h\
 	http.h\
 	ikarus.h\
+	langfreq.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -49,6 +49,7 @@ noinst_HEADERS = \
 	cvimages.h \
 	dumpbdf.h \
 	dumppfa.h \
+	effects.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -63,6 +63,7 @@ noinst_HEADERS = \
 	macbinary.h\
 	macenc.h\
 	mathconstants.h\
+	namelist.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -57,6 +57,7 @@ noinst_HEADERS = \
 	fvimportbdf.h \
 	glyphcomp.h\
 	http.h\
+	ikarus.h\
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/asmfpst.c
+++ b/fontforge/asmfpst.c
@@ -28,6 +28,7 @@
 #include "asmfpst.h"
 
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "ttf.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforge/autotrace.c
+++ b/fontforge/autotrace.c
@@ -29,6 +29,7 @@
 
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "fvimportbdf.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -31,6 +31,7 @@
 #include "autohint.h"
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -32,6 +32,7 @@
 #include "cvundoes.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth2.c
+++ b/fontforge/autowidth2.c
@@ -28,6 +28,7 @@
 
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -318,7 +318,6 @@ extern void FVAutoInstr(FontViewBase *fv);
 extern void FVClearInstrs(FontViewBase *fv);
 extern void FVClearHints(FontViewBase *fv);
 extern void SCAutoTrace(SplineChar *sc,int layer, int ask);
-extern void FVAddEncodingSlot(FontViewBase *fv,int gid);
 extern int FVImportMult(FontViewBase *fv, char *filename,int toback,int bf);
 extern int FVImportBDF(FontViewBase *fv, char *filename,int ispk, int toback);
 extern void MergeFont(FontViewBase *fv,SplineFont *other,int preserveCrossFontKerning);

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -526,7 +526,6 @@ extern uint8 *_IVParse(SplineFont *sf, char *text, int *len,
 	void (*IVError)(void *,char *, int), void *iv);
 extern char *_IVUnParseInstrs(uint8 *instrs,int instr_cnt);
 
-extern void FVSetWidthScript(FontViewBase *fv,enum widthtype wtype,int val,int incr);
 extern void FVMetricsCenter(FontViewBase *fv,int docenter);
 extern void FVRevert(FontViewBase *fv);
 extern void FVRevertBackup(FontViewBase *fv);

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -529,8 +529,6 @@ extern void FVRevert(FontViewBase *fv);
 extern void FVRevertBackup(FontViewBase *fv);
 extern void FVRevertGlyph(FontViewBase *fv);
 extern void FVClearSpecialData(FontViewBase *fv);
-extern int   MMReblend(FontViewBase *fv, MMSet *mm);
-extern FontViewBase *MMCreateBlendedFont(MMSet *mm,FontViewBase *fv,real blends[MmMax],int tonew );
 extern void FVB_MakeNamelist(FontViewBase *fv, FILE *file);
 
 /**

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -335,10 +335,6 @@ extern int SSNLTrans(SplineSet *ss,char *x_expr,char *y_expr);
 extern int SCNLTrans(SplineChar *sc, int layer,char *x_expr,char *y_expr);
 extern void FVPointOfView(FontViewBase *fv,struct pov_data *);
 extern void FVStrokeItScript(void *fv, StrokeInfo *si,int pointless);
-extern void FVOutline(struct fontviewbase *fv, real width);
-extern void FVInline(struct fontviewbase *fv, real width, real inset);
-extern void FVShadow(struct fontviewbase *fv,real angle, real outline_width,
-	real shadow_length,int wireframe);
 extern void CI_Init(struct counterinfo *ci,SplineFont *sf);
 extern void FVEmbolden(struct fontviewbase *fv,enum embolden_type type,struct lcg_zones *zones);
 extern void FVCondenseExtend(struct fontviewbase *fv,struct counterinfo *ci);

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -504,7 +504,6 @@ extern void PyFF_SCImport(SplineChar *sc,int ie_index,char *filename,
 	int layer, int clear);
 extern void PyFF_InitFontHook(FontViewBase *fv);
 
-extern int UserFeaturesDiffer(void);
 extern uint32 *StdFeaturesOfScript(uint32 script);
 
 enum byte_types { bt_instr, bt_cnt, bt_byte, bt_wordhi, bt_wordlo, bt_impliedreturn };

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -318,8 +318,6 @@ extern void FVAutoInstr(FontViewBase *fv);
 extern void FVClearInstrs(FontViewBase *fv);
 extern void FVClearHints(FontViewBase *fv);
 extern void SCAutoTrace(SplineChar *sc,int layer, int ask);
-extern int FVImportMult(FontViewBase *fv, char *filename,int toback,int bf);
-extern int FVImportBDF(FontViewBase *fv, char *filename,int ispk, int toback);
 extern void ScriptPrint(FontViewBase *fv,int type,int32 *pointsizes,char *samplefile,
 	unichar_t *sample, char *outputfile);
 extern int FVBParseSelectByPST(FontViewBase *fv,struct lookup_subtable *sub,

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -320,7 +320,6 @@ extern void FVClearHints(FontViewBase *fv);
 extern void SCAutoTrace(SplineChar *sc,int layer, int ask);
 extern int FVImportMult(FontViewBase *fv, char *filename,int toback,int bf);
 extern int FVImportBDF(FontViewBase *fv, char *filename,int ispk, int toback);
-extern void MergeFont(FontViewBase *fv,SplineFont *other,int preserveCrossFontKerning);
 extern void ScriptPrint(FontViewBase *fv,int type,int32 *pointsizes,char *samplefile,
 	unichar_t *sample, char *outputfile);
 extern int FVBParseSelectByPST(FontViewBase *fv,struct lookup_subtable *sub,

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -504,7 +504,6 @@ extern void PyFF_SCImport(SplineChar *sc,int ie_index,char *filename,
 	int layer, int clear);
 extern void PyFF_InitFontHook(FontViewBase *fv);
 
-extern void LookupInit(void);
 extern int UserFeaturesDiffer(void);
 extern uint32 *StdFeaturesOfScript(uint32 script);
 

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -327,9 +327,6 @@ extern void TransHints(StemInfo *stem,real mul1, real off1, real mul2, real off2
 extern void TransDStemHints(DStemInfo *ds,real xmul, real xoff, real ymul, real yoff, int round_to_int );
 extern void VrTrans(struct vr *vr,real transform[6]);
 extern int SFNLTrans(FontViewBase *fv,char *x_expr,char *y_expr);
-extern int SSNLTrans(SplineSet *ss,char *x_expr,char *y_expr);
-extern int SCNLTrans(SplineChar *sc, int layer,char *x_expr,char *y_expr);
-extern void FVPointOfView(FontViewBase *fv,struct pov_data *);
 extern void FVStrokeItScript(void *fv, StrokeInfo *si,int pointless);
 extern void CI_Init(struct counterinfo *ci,SplineFont *sf);
 extern void FVEmbolden(struct fontviewbase *fv,enum embolden_type type,struct lcg_zones *zones);
@@ -426,7 +423,6 @@ extern void FVDetachAndRemoveGlyphs(FontViewBase *fv);
 extern Undoes *_CVPreserveTState(CharViewBase *cv,PressedOn *);
 extern void CopySelected(CharViewBase *cv,int doanchors);
 extern void CopyWidth(CharViewBase *cv,enum undotype);
-extern void CVYPerspective(CharViewBase *cv,bigreal x_vanish, bigreal y_vanish);
 extern void ScriptSCEmbolden(SplineChar *sc,int layer,enum embolden_type type,struct lcg_zones *zones);
 extern void CVEmbolden(CharViewBase *cv,enum embolden_type type,struct lcg_zones *zones);
 extern void SCCondenseExtend(struct counterinfo *ci,SplineChar *sc, int layer,

--- a/fontforge/bitmapchar.c
+++ b/fontforge/bitmapchar.c
@@ -31,6 +31,7 @@
 #include "cvundoes.h"
 #include "dumpbdf.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <string.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -29,6 +29,7 @@
 
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <sys/types.h>
 #include <dirent.h>

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -34,6 +34,7 @@
 #include "cvexport.h"
 #include "cvimages.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "views.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -35,6 +35,7 @@
 #include "cvimages.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "namelist.h"
 #include "views.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/dumpbdf.c
+++ b/fontforge/dumpbdf.c
@@ -29,6 +29,7 @@
 
 #include "bitmapchar.h"
 #include "bvedit.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include "splinefont.h"
 #include <gdraw.h>			/* for the defn of GClut for greymaps */

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -30,6 +30,7 @@
 #include "autohint.h"
 #include "bvedit.h"
 #include "fontforge.h"
+#include "fvfonts.h"
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -31,6 +31,7 @@
 #include "bvedit.h"
 #include "fontforge.h"
 #include "fvfonts.h"
+#include "http.h"
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "effects.h"
+
 #include "autohint.h"
 #include "cvundoes.h"
 #include "fontforgevw.h"

--- a/fontforge/effects.h
+++ b/fontforge/effects.h
@@ -1,0 +1,12 @@
+#ifndef FONTFORGE_EFFECTS_H
+#define FONTFORGE_EFFECTS_H
+
+#include "baseviews.h"
+#include "splinefont.h"
+
+extern SplineSet *SSShadow(SplineSet *spl, real angle, real outline_width, real shadow_length, SplineChar *sc, int wireframe);
+extern void FVInline(FontViewBase *fv, real width, real inset);
+extern void FVOutline(FontViewBase *fv, real width);
+extern void FVShadow(FontViewBase *fv, real angle, real outline_width, real shadow_length, int wireframe);
+
+#endif /* FONTFORGE_EFFECTS_H */

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -25,6 +25,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "encoding.h"
+
 #include "bitmapchar.h"
 #include "bvedit.h"
 #include "dumppfa.h"

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -31,6 +31,7 @@
 #include "bvedit.h"
 #include "dumppfa.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "splinefont.h"
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -32,6 +32,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "namelist.h"
 #include "splinefont.h"
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/encoding.h
+++ b/fontforge/encoding.h
@@ -1,5 +1,8 @@
-#ifndef _ENCODING_H
-#define _ENCODING_H
+#ifndef FONTFORGE_ENCODING_H
+#define FONTFORGE_ENCODING_H
+
+#include "baseviews.h"
+#include "splinefont.h"
 
 struct cidaltuni {
     struct cidaltuni *next;
@@ -23,4 +26,60 @@ extern struct cidmap *cidmaps;
 extern void DeleteEncoding(Encoding *me);
 extern void EncodingFree(Encoding *item);
 extern void RemoveMultiples(Encoding *item);
-#endif
+extern char *ParseEncodingFile(char *filename, char *encodingname);
+extern char *SFEncodingName(SplineFont *sf, EncMap *map);
+extern const char *FindUnicharName(void);
+extern EncMap *CompactEncMap(EncMap *map, SplineFont *sf);
+extern EncMap *EncMapFromEncoding(SplineFont *sf, Encoding *enc);
+extern Encoding *FindOrMakeEncoding(const char *name);
+extern Encoding *_FindOrMakeEncoding(const char *name, int make_it);
+extern int32 EncFromName(const char *name, enum uni_interp interp, Encoding *encname);
+extern int32 EncFromUni(int32 uni, Encoding *enc);
+extern int32 UniFromEnc(int enc, Encoding *encname);
+
+/* The "Encoding" here is a little different from what you normally see*/
+/*  It isn't a mapping from a byte stream to unicode, but from an int */
+/*  to unicode. If we have an 8/16 encoding (EUC or SJIS) then the */
+/*  single byte entries will be numbers less than <256 and the */
+/*  multibyte entries will be numbers >=256. So an encoding might be */
+/*  valid for the domain [0x20..0x7f] [0xa1a1..0xfefe] */
+/* In other words, we're interested in the ordering displayed in the */
+/*  fontview. Nothing else */
+/* The max value need not be exact (though it should be at least as big)*/
+/*  if you create a new font with the given encoding, then the font will */
+/*  have max slots in it by default */
+/* A return value of -1 (from an EncFunc) indicates no mapping */
+/* AddEncoding returns 1 if the encoding was added, 2 if it replaced */
+/*  an existing encoding, 0 if you attempt to replace a builtin */
+/*  encoding */
+typedef int (*EncFunc)(int);
+extern int AddEncoding(char *name, EncFunc enc_to_uni, EncFunc uni_to_enc, int max);
+
+extern int CID2NameUni(struct cidmap *map, int cid, char *buffer, int len);
+extern int CID2Uni(struct cidmap *map, int cid);
+extern int CIDFromName(char *name, SplineFont *cidmaster);
+extern int CountOfEncoding(Encoding *encoding_name);
+extern int MaxCID(struct cidmap *map);
+extern int NameUni2CID(struct cidmap *map, int uni, const char *name);
+extern int SFFlattenByCMap(SplineFont *sf, char *cmapname);
+extern int SFForceEncoding(SplineFont *sf, EncMap *old, Encoding *new_enc);
+extern int SFReencode(SplineFont *sf, const char *encname, int force);
+extern SplineFont *CIDFlatten(SplineFont *cidmaster, SplineChar **glyphs, int charcnt);
+extern SplineFont *MakeCIDMaster(SplineFont *sf, EncMap *oldmap, int bycmap, char *cmapfilename, struct cidmap *cidmap);
+extern struct altuni *CIDSetAltUnis(struct cidmap *map, int cid);
+extern struct cidmap *FindCidMap(char *registry, char *ordering, int supplement, SplineFont *sf);
+extern struct cidmap *LoadMapFromFile(char *file, char *registry, char *ordering, int supplement);
+extern void BDFOrigFixup(BDFFont *bdf, int orig_cnt, SplineFont *sf);
+extern void CIDMasterAsDes(SplineFont *sf);
+extern void DumpPfaEditEncodings(void);
+extern void FVAddEncodingSlot(FontViewBase *fv, int gid);
+extern void LoadPfaEditEncodings(void);
+extern void MMMatchGlyphs(MMSet *mm);
+extern void SFAddEncodingSlot(SplineFont *sf, int gid);
+extern void SFAddGlyphAndEncode(SplineFont *sf, SplineChar *sc, EncMap *basemap, int baseenc);
+extern void SFEncodeToMap(SplineFont *sf, struct cidmap *map);
+extern void SFExpandGlyphCount(SplineFont *sf, int newcnt);
+extern void SFMatchGlyphs(SplineFont *sf, SplineFont *target, int addempties);
+extern void SFRemoveGlyph(SplineFont *sf, SplineChar *sc);
+
+#endif /* FONTFORGE_ENCODING_H */

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -33,6 +33,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include "ttf.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -28,6 +28,7 @@
  */
 #include <fontforge-config.h>
 
+#include "encoding.h"
 #include "fontforgevw.h"
 #include "ttf.h"
 #include <stdio.h>

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -28,6 +28,8 @@
  */
 #include <fontforge-config.h>
 
+#include "featurefile.h"
+
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "ttf.h"

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -32,6 +32,7 @@
 
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "ttf.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -34,6 +34,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "namelist.h"
 #include "ttf.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/featurefile.h
+++ b/fontforge/featurefile.h
@@ -1,0 +1,12 @@
+#ifndef FONTFORGE_FEATUREFILE_H
+#define FONTFORGE_FEATUREFILE_H
+
+#include <stdio.h>
+
+#include "splinefont.h"
+
+extern void FeatDumpFontLookups(FILE *out, SplineFont *sf);
+extern void FeatDumpOneLookup(FILE *out, SplineFont *sf, OTLookup *otl);
+extern void SFApplyFeatureFilename(SplineFont *sf, char *filename);
+
+#endif /* FONTFORGE_FEATUREFILE_H */

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -30,6 +30,7 @@
 #include "bitmapchar.h"
 #include "bvedit.h"
 #include "cvundoes.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include "baseviews.h"
 #include "groups.h"

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -33,6 +33,7 @@
 #include "encoding.h"
 #include "fontforge.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include "baseviews.h"
 #include "groups.h"
 #include "psfont.h"

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -32,6 +32,7 @@
 #include "cvundoes.h"
 #include "encoding.h"
 #include "fontforge.h"
+#include "fvcomposite.h"
 #include "baseviews.h"
 #include "groups.h"
 #include "psfont.h"

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -34,6 +34,7 @@
 #include "fontforge.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "namelist.h"
 #include "baseviews.h"
 #include "groups.h"
 #include "psfont.h"

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -28,6 +28,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "fffreetype.h"
+#include "fvfonts.h"
 #include <math.h>
 
 FT_Library ff_ft_context;

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -33,6 +33,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "namelist.h"
 #include <chardata.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -30,6 +30,7 @@
 #include "bitmapchar.h"
 #include "bvedit.h"
 #include "cvundoes.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <chardata.h>
 #include <math.h>

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -32,6 +32,7 @@
 #include "cvundoes.h"
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <chardata.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforge/fvcomposite.h
+++ b/fontforge/fvcomposite.h
@@ -1,0 +1,20 @@
+#ifndef FONTFORGE_FVCOMPOSITE_H
+#define FONTFORGE_FVCOMPOSITE_H
+
+#include "splinefont.h"
+
+extern AnchorClass *AnchorClassCursMatch(SplineChar *sc1, SplineChar *sc2, AnchorPoint **_ap1, AnchorPoint **_ap2);
+extern AnchorClass *AnchorClassMatch(SplineChar *sc1, SplineChar *sc2, AnchorClass *restrict_, AnchorPoint **_ap1, AnchorPoint **_ap2);
+extern AnchorClass *AnchorClassMkMkMatch(SplineChar *sc1, SplineChar *sc2, AnchorPoint **_ap1, AnchorPoint **_ap2);
+extern const unichar_t *SFGetAlternate(SplineFont *sf, int base, SplineChar *sc, int nocheck);
+extern int CanonicalCombiner(int uni);
+extern int hascomposing(SplineFont *sf, int u, SplineChar *sc);
+extern int isaccent(int uni);
+extern int SCAppendAccent(SplineChar *sc, int layer, char *glyph_name, int uni, uint32 pos);
+extern int SFIsCompositBuildable(SplineFont *sf, int unicodeenc, SplineChar *sc, int layer);
+extern int SFIsRotatable(SplineFont *sf, SplineChar *sc);
+extern int SFIsSomethingBuildable(SplineFont *sf, SplineChar *sc, int layer, int onlyaccents);
+extern void _SCAddRef(SplineChar *sc, SplineChar *rsc, int layer, real transform[6]);
+extern void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *bdf, int disp_only);
+
+#endif /* FONTFORGE_FVCOMPOSITE_H */

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -29,6 +29,7 @@
 
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "lookups.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -24,6 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "encoding.h"
 #include "fontforgevw.h"
 #include "ustring.h"
 #include "utype.h"

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -30,6 +30,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "lookups.h"
+#include "namelist.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "fvfonts.h"
+
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "ustring.h"

--- a/fontforge/fvfonts.h
+++ b/fontforge/fvfonts.h
@@ -1,0 +1,34 @@
+#ifndef FONTFORGE_FVFONTS_H
+#define FONTFORGE_FVFONTS_H
+
+#include "baseviews.h"
+#include "splinefont.h"
+
+extern AnchorClass *MCConvertAnchorClass(struct sfmergecontext *mc, AnchorClass *ac);
+extern BDFChar *BDFCharCopy(BDFChar *bc);
+extern int SFCIDFindCID(SplineFont *sf, int unienc, const char *name);
+extern int SFCIDFindExistingChar(SplineFont *sf, int unienc, const char *name);
+extern int SFFindExistingSlot(SplineFont *sf, int unienc, const char *name);
+extern int SFFindGID(SplineFont *sf, int unienc, const char *name);
+extern int SFFindSlot(SplineFont *sf, EncMap *map, int unienc, const char *name);
+extern int SFHasChar(SplineFont *sf, int unienc, const char *name);
+extern int SFHasCID(SplineFont *sf, int cid);
+extern PST *PSTCopy(PST *base, SplineChar *sc, struct sfmergecontext *mc);
+extern RefChar *RefCharsCopy(RefChar *ref);
+extern SplineChar *SFGetChar(SplineFont *sf, int unienc, const char *name);
+extern SplineChar *SFGetOrMakeCharFromUnicodeBasic(SplineFont *sf, int ch);
+extern SplineChar *SFHashName(SplineFont *sf, const char *name);
+extern SplineChar *SplineCharCopy(SplineChar *sc, SplineFont *into, struct sfmergecontext *mc);
+extern SplineChar *SplineCharInterpolate(SplineChar *base, SplineChar *other, real amount, SplineFont *newfont);
+extern SplineFont *InterpolateFont(SplineFont *base, SplineFont *other, real amount, Encoding *enc);
+extern SplineSet *SplineSetsInterpolate(SplineSet *base, SplineSet *other, real amount, SplineChar *sc);
+extern struct altuni *AltUniCopy(struct altuni *altuni, SplineFont *noconflicts);
+extern struct lookup_subtable *MCConvertSubtable(struct sfmergecontext *mc, struct lookup_subtable *sub);
+extern void BitmapsCopy(SplineFont *to, SplineFont *from, int to_index, int from_index);
+extern void GlyphHashFree(SplineFont *sf);
+extern void __GlyphHashFree(struct glyphnamehash *hash);
+extern void MergeFont(FontViewBase *fv, SplineFont *other, int preserveCrossFontKerning);
+extern void SFFinishMergeContext(struct sfmergecontext *mc);
+extern void SFHashGlyph(SplineFont *sf, SplineChar *sc);
+
+#endif /* FONTFORGE_FVFONTS_H */

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -27,6 +27,7 @@
 #include "bitmapchar.h"
 #include "bvedit.h"
 #include "cvimages.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <gfile.h>
 #include <math.h>

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -29,6 +29,7 @@
 #include "cvimages.h"
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <gfile.h>
 #include <math.h>
 #include "utype.h"

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -34,6 +34,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "macbinary.h"
+#include "namelist.h"
 #include <gfile.h>
 #include <math.h>
 #include "utype.h"

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "fvimportbdf.h"
+
 #include "bitmapchar.h"
 #include "bvedit.h"
 #include "cvimages.h"

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -33,6 +33,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "macbinary.h"
 #include <gfile.h>
 #include <math.h>
 #include "utype.h"

--- a/fontforge/fvimportbdf.h
+++ b/fontforge/fvimportbdf.h
@@ -1,0 +1,14 @@
+#ifndef FONTFORGE_FVIMPORTBDF_H
+#define FONTFORGE_FVIMPORTBDF_H
+
+#include "baseviews.h"
+#include "splinefont.h"
+
+extern int FVImportBDF(FontViewBase *fv, char *filename, int ispk, int toback);
+extern int FVImportMult(FontViewBase *fv, char *filename, int toback, int bf);
+extern SplineFont *SFFromBDF(char *filename, int ispk, int toback);
+extern void SFCheckPSBitmap(SplineFont *sf);
+extern void SFDefaultAscent(SplineFont *sf);
+extern void SFSetFontName(SplineFont *sf, char *family, char *mods, char *fullname);
+
+#endif /* FONTFORGE_FVIMPORTBDF_H */

--- a/fontforge/fvmetrics.c
+++ b/fontforge/fvmetrics.c
@@ -24,13 +24,15 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "fvmetrics.h"
+
 #include "bitmapchar.h"
 #include "bvedit.h"
-#include "fontforgevw.h"
 #include "cvundoes.h"
+#include "fontforgevw.h"
 #include <math.h>
 #include <ustring.h>
-#include "fvmetrics.h"
 
 static void DoChar(SplineChar *sc,CreateWidthData *wd, FontViewBase *fv,
 	BDFChar *bc) {

--- a/fontforge/fvmetrics.h
+++ b/fontforge/fvmetrics.h
@@ -28,6 +28,8 @@
 #ifndef FONTFORGE_FVMETRICS_H
 #define FONTFORGE_FVMETRICS_H
 
+#include "baseviews.h"
+
 #include "fontforgeui.h"
 #include <math.h>
 #include <ustring.h>
@@ -49,5 +51,6 @@ typedef struct createwidthdata {
 extern void CVDoit(CreateWidthData *wd);
 extern void FVDoit(CreateWidthData *wd);
 extern void GenericVDoit(CreateWidthData *wd);
+extern void FVSetWidthScript(FontViewBase *fv, enum widthtype wtype, int val, int incr);
 
 #endif /* FONTFORGE_FVMETRICS_H */

--- a/fontforge/glyphcomp.c
+++ b/fontforge/glyphcomp.c
@@ -29,6 +29,7 @@
 #include "bvedit.h"
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "scriptfuncs.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/glyphcomp.c
+++ b/fontforge/glyphcomp.c
@@ -26,6 +26,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "glyphcomp.h"
+
 #include "bvedit.h"
 #include "cvundoes.h"
 #include "fontforgevw.h"

--- a/fontforge/glyphcomp.h
+++ b/fontforge/glyphcomp.h
@@ -1,0 +1,59 @@
+#ifndef FONTFORGE_GLYPHCOMP_H
+#define FONTFORGE_GLYPHCOMP_H
+
+#include "splinefont.h"
+#include "scripting.h"
+
+#include <stdio.h>
+
+enum font_compare_flags {
+	fcf_outlines             = 1,
+	fcf_exact                = 2,
+	fcf_warn_not_exact       = 4,
+	fcf_hinting              = 8,
+	fcf_hintmasks            = 0x10,
+	fcf_hmonlywithconflicts  = 0x20,
+	fcf_warn_not_ref_exact   = 0x40,
+	fcf_bitmaps              = 0x80,
+	fcf_names                = 0x100,
+	fcf_gpos                 = 0x200,
+	fcf_gsub                 = 0x400,
+	fcf_adddiff2sf1          = 0x800,
+	fcf_addmissing           = 0x1000
+};
+
+enum Compare_Ret {
+	SS_DiffContourCount     = 1,
+	SS_MismatchOpenClosed   = 2,
+	SS_DisorderedContours   = 4,
+	SS_DisorderedStart      = 8,
+	SS_DisorderedDirection  = 16,
+	SS_PointsMatch          = 32,
+	SS_ContourMatch         = 64,
+	SS_NoMatch              = 128,
+	SS_RefMismatch          = 256,
+	SS_WidthMismatch        = 512,
+	SS_VWidthMismatch       = 1024,
+	SS_HintMismatch         = 2048,
+	SS_HintMaskMismatch     = 4096,
+	SS_LayerCntMismatch     = 8192,
+	SS_ContourMismatch      = 16384,
+	SS_UnlinkRefMatch       = 32768,
+
+	BC_DepthMismatch        = 1<<16,
+	BC_BoundingBoxMismatch  = 2<<16,
+	BC_BitmapMismatch       = 4<<16,
+	BC_NoMatch              = 8<<16,
+	BC_Match                = 16<<16,
+
+	SS_RefPtMismatch        = 32<<16
+};
+
+extern enum Compare_Ret BitmapCompare(BDFChar *bc1, BDFChar *bc2, int err, int bb_err);
+extern enum Compare_Ret SSsCompare(const SplineSet *ss1, const SplineSet *ss2, real pt_err, real spline_err, SplinePoint **hmfail);
+extern int CompareFonts(SplineFont *sf1, EncMap *map1, SplineFont *sf2, FILE *diffs, int flags);
+extern int CompareGlyphs(Context *c, real pt_err, real spline_err, real pixel_off_frac, int bb_err, int comp_hints, int diffs_are_errors);
+extern int CompareLayer(Context *c, const SplineSet *ss1, const SplineSet *ss2, const RefChar *refs1, const RefChar *refs2, real pt_err, real spline_err, const char *name, int diffs_are_errors, SplinePoint **_hmfail);
+extern int LayersSimilar(Layer *ly1, Layer *ly2, double spline_err);
+
+#endif /* FONTFORGE_GLYPHCOMP_H */

--- a/fontforge/http.c
+++ b/fontforge/http.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "http.h"
+
 #include "fontforgevw.h"
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/http.h
+++ b/fontforge/http.h
@@ -1,0 +1,9 @@
+#ifndef FONTFORGE_HTTP_H
+#define FONTFORGE_HTTP_H
+
+#include <stdio.h>
+
+extern FILE *URLToTempFile(char *url, void *_lock);
+extern int URLFromFile(const char *url, FILE *from);
+
+#endif /* FONTFORGE_HTTP_H */

--- a/fontforge/ikarus.c
+++ b/fontforge/ikarus.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "ikarus.h"
+
 #include "fontforge.h"
 #include <utype.h>
 #include <string.h>

--- a/fontforge/ikarus.c
+++ b/fontforge/ikarus.c
@@ -28,6 +28,7 @@
 #include "ikarus.h"
 
 #include "fontforge.h"
+#include "namelist.h"
 #include <utype.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/ikarus.h
+++ b/fontforge/ikarus.h
@@ -1,0 +1,8 @@
+#ifndef FONTFORGE_IKARUS_H
+#define FONTFORGE_IKARUS_H
+
+#include "splinefont.h"
+
+extern SplineFont *SFReadIkarus(char *fontname);
+
+#endif /* FONTFORGE_IKARUS_H */

--- a/fontforge/langfreq.c
+++ b/fontforge/langfreq.c
@@ -1,5 +1,7 @@
 /* -*- coding: utf-8 -*- */
 
+#include "langfreq.h"
+
 #include "fvfonts.h"
 
 #include <stdio.h>
@@ -17,14 +19,7 @@
 #define MEDI	2
 #define FINA	3
 
-struct letter_frequencies {
-    const char *utf8_letter;
-    float frequency[4];
-    float *afters;
-};
-
 #define LETTER_FREQUENCIES_EMPTY { NULL, { 0, 0, 0, 0 }, NULL }
-
 
 /* This is over many languages, used when we have no specific info */
 static float word_lengths[] = {
@@ -1820,7 +1815,7 @@ static float WEL_vowel_run[] = {
     0.000000, 0.716191, 0.249052, 0.031673, 0.002959, 0.000125, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000
 };
 
-static struct lang_frequencies { uint32 script, lang; char *note; struct letter_frequencies *cnts; float *wordlens; char *vowels; float *consonant_run, *all_consonants, *vowel_run; } lang_frequencies[] = {
+static struct lang_frequencies lang_frequencies[] = {
     { CHR('l','a','t','n'), CHR('C','S','Y',' '), N_("Czech"),     CSY_counts, CSY_word_lens, "aeiouyráéíóúýěů", CSY_consonant_run, CSY_all_consonants, CSY_vowel_run },
     { CHR('l','a','t','n'), CHR('N','L','D',' '), N_("Dutch"),     NLD_counts, NLD_word_lens, "aeiouyàéêëïòó", NLD_consonant_run, NLD_all_consonants, NLD_vowel_run },
     { CHR('l','a','t','n'), CHR('E','N','G',' '), N_("English"),   ENG_counts, ENG_word_lens, "aeiouy", ENG_consonant_run, ENG_all_consonants, ENG_vowel_run },

--- a/fontforge/langfreq.c
+++ b/fontforge/langfreq.c
@@ -1,5 +1,7 @@
 /* -*- coding: utf-8 -*- */
 
+#include "fvfonts.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <basics.h>

--- a/fontforge/langfreq.h
+++ b/fontforge/langfreq.h
@@ -1,0 +1,28 @@
+#ifndef FONTFORGE_LANGFREQ_H
+#define FONTFORGE_LANGFREQ_H
+
+#include "splinefont.h"
+
+struct letter_frequencies {
+	const char *utf8_letter;
+	float frequency[4];
+	float *afters;
+};
+
+struct lang_frequencies {
+	uint32 script;
+	uint32 lang;
+	char *note;
+	struct letter_frequencies *cnts;
+	float *wordlens;
+	char *vowels;
+	float *consonant_run;
+	float *all_consonants;
+	float *vowel_run;
+};
+
+extern char *RandomParaFromScriptLang(uint32 script, uint32 lang, SplineFont *sf, struct lang_frequencies *freq);
+extern char **SFScriptLangs(SplineFont *sf, struct lang_frequencies ***_freq);
+extern int SF2Scripts(SplineFont *sf, uint32 scripts[100]);
+
+#endif /* FONTFORGE_LANGFREQ_H */

--- a/fontforge/libstamp.c
+++ b/fontforge/libstamp.c
@@ -27,6 +27,7 @@
 #include "fontforge.h"
 #include "baseviews.h"
 #include "libffstamp.h"			/* FontForge version# date time stamps */
+#include "libstamp.h"
 #include "uiinterface.h"
 
 struct library_version_configuration library_version_configuration = {

--- a/fontforge/libstamp.h
+++ b/fontforge/libstamp.h
@@ -1,0 +1,6 @@
+#ifndef FONTFORGE_LIBSTAMP_H
+#define FONTFORGE_LIBSTAMP_H
+
+extern int check_library_version(Library_Version_Configuration *exe_lib_version, int fatal, int quiet);
+
+#endif /* FONTFORGE_LIBSTAMP_H */

--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -25,6 +25,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "lookups.h"
+
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include <chardata.h>
@@ -35,7 +38,6 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include "ttf.h"
-#include "lookups.h"
 #include "xvasprintf.h"
 
 struct opentype_feature_friendlynames friendlies[] = {

--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -30,6 +30,7 @@
 
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "macenc.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/lookups.h
+++ b/fontforge/lookups.h
@@ -1,6 +1,19 @@
 #ifndef FONTFORGE_LOOKUPS_H
 #define FONTFORGE_LOOKUPS_H
 
+#include "splinefont.h"
+#include "uiinterface.h"
+
+struct sllk {
+	uint32 script;
+	int cnt;
+	int max;
+	OTLookup **lookups;
+	int lcnt;
+	int lmax;
+	uint32 *langs;
+};
+
 extern const char *lookup_type_names[2][10];
 extern void SortInsertLookup(SplineFont *sf, OTLookup *newotl);
 extern char *SuffixFromTags(FeatureScriptLangList *fl);
@@ -30,5 +43,60 @@ extern char *SuffixFromTags(FeatureScriptLangList *fl);
 extern int KernClassFindIndexContaining( char **firsts_or_seconds,
 					 int firsts_or_seconds_size,
 					 const char *name );
+
+extern char *FPSTRule_From_Str(SplineFont *sf, FPST *fpst, struct fpst_rule *rule, char *line, int *return_is_warning);
+extern char *FPSTRule_To_Str(SplineFont *sf, FPST *fpst, struct fpst_rule *rule);
+extern char *reverseGlyphNames(char *str);
+extern char *TagFullName(SplineFont *sf, uint32 tag, int ismac, int onlyifknown);
+extern FeatureScriptLangList *FeatureListCopy(FeatureScriptLangList *fl);
+extern FeatureScriptLangList *FindFeatureTagInFeatureScriptList(uint32 tag, FeatureScriptLangList *fl);
+extern FeatureScriptLangList *FLOrder(FeatureScriptLangList *fl);
+extern int DefaultLangTagInOneScriptList(struct scriptlanglist *sl);
+extern int FeatureOrderId(int isgpos, FeatureScriptLangList *fl);
+extern int _FeatureOrderId(int isgpos, uint32 tag);
+extern int FeatureScriptTagInFeatureScriptList(uint32 feature, uint32 script, FeatureScriptLangList *fl);
+extern int GlyphNameCnt(const char *pt);
+extern int IsAnchorClassUsed(SplineChar *sc, AnchorClass *an);
+extern int KCFindName(const char *name, char **classnames, int cnt, int allow_class0);
+extern int KernClassContains(KernClass *kc, const char *name1, const char *name2, int ordered);
+extern int LookupUsedNested(SplineFont *sf, OTLookup *checkme);
+extern int PSTContains(const char *components, const char *name);
+extern int ScriptInFeatureScriptList(uint32 script, FeatureScriptLangList *fl);
+extern int VerticalKernFeature(SplineFont *sf, OTLookup *otl, int ask);
+extern OTLookup *NewAALTLookup(SplineFont *sf, struct sllk *sllk, int sllk_cnt, int i);
+extern OTLookup *OTLookupCopyInto(SplineFont *into_sf, SplineFont *from_sf, OTLookup *from_otl);
+extern OTLookup *SFFindLookup(SplineFont *sf, char *name);
+extern OTLookup **SFLookupsInScriptLangFeature(SplineFont *sf, int gpos, uint32 script, uint32 lang, uint32 feature);
+extern SplineChar **SFGlyphsWithLigatureinLookup(SplineFont *sf, struct lookup_subtable *subtable);
+extern SplineChar **SFGlyphsWithPSTinSubtable(SplineFont *sf, struct lookup_subtable *subtable);
+extern struct lookup_subtable *SFFindLookupSubtableAndFreeName(SplineFont *sf, char *name);
+extern struct lookup_subtable *SFSubTableFindOrMake(SplineFont *sf, uint32 tag, uint32 script, int lookup_type);
+extern struct lookup_subtable *SFSubTableMake(SplineFont *sf, uint32 tag, uint32 script, int lookup_type);
+extern struct opentype_str *ApplyTickedFeatures(SplineFont *sf, uint32 *flist, uint32 script, uint32 lang, int pixelsize, SplineChar **glyphs);
+extern struct scriptlanglist *DefaultLangTagInScriptList(struct scriptlanglist *sl, int DFLT_ok);
+extern struct scriptlanglist *SLCopy(struct scriptlanglist *sl);
+extern struct scriptlanglist *SListCopy(struct scriptlanglist *sl);
+extern struct sllk *AddOTLToSllks(OTLookup *otl, struct sllk *sllk, int *_sllk_cnt, int *_sllk_max);
+extern uint32 *SFFeaturesInScriptLang(SplineFont *sf, int gpos, uint32 script, uint32 lang);
+extern uint32 *SFLangsInScript(SplineFont *sf, int gpos, uint32 script);
+extern uint32 *SFScriptsInLookups(SplineFont *sf, int gpos);
+extern void AddNewAALTFeatures(SplineFont *sf);
+extern void FF_SetFIInterface(struct fi_interface *fii);
+extern void FListAppendScriptLang(FeatureScriptLangList *fl, uint32 script_tag, uint32 lang_tag);
+extern void FListsAppendScriptLang(FeatureScriptLangList *fl, uint32 script_tag, uint32 lang_tag);
+extern void FLMerge(OTLookup *into, OTLookup *from);
+extern void LookupInit(void);
+extern void NameOTLookup(OTLookup *otl, SplineFont *sf);
+extern void OTLookupsCopyInto(SplineFont *into_sf, SplineFont *from_sf, OTLookup **from_list, OTLookup *before);
+extern void SFFindClearUnusedLookupBits(SplineFont *sf);
+extern void SFFindUnusedLookups(SplineFont *sf);
+extern void SFGlyphRenameFixup(SplineFont *sf, const char *old, const char *new, int rename_related_glyphs);
+extern void SFRemoveLookup(SplineFont *sf, OTLookup *otl, int remove_acs);
+extern void SFRemoveLookupSubTable(SplineFont *sf, struct lookup_subtable *sub, int remove_acs);
+extern void SFRemoveUnusedLookupSubTables(SplineFont *sf, int remove_incomplete_anchorclasses, int remove_unused_lookups);
+
+extern void SFSubTablesMerge(SplineFont *_sf, struct lookup_subtable *subfirst, struct lookup_subtable *subsecond);
+extern void SllkFree(struct sllk *sllk, int sllk_cnt);
+extern void SLMerge(FeatureScriptLangList *into, struct scriptlanglist *fsl);
 
 #endif /* FONTFORGE_LOOKUPS_H */

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -27,6 +27,7 @@
 #include "bvedit.h"
 #include "crctab.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <stdlib.h>
 #include <string.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "macbinary.h"
+
 #include "bvedit.h"
 #include "crctab.h"
 #include "dumppfa.h"

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -31,6 +31,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "http.h"
+#include "lookups.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -30,6 +30,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "http.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -29,6 +29,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/fontforge/macbinary.h
+++ b/fontforge/macbinary.h
@@ -1,0 +1,18 @@
+#ifndef FONTFORGE_MACBINARY_H
+#define FONTFORGE_MACBINARY_H
+
+#include "splinefont.h"
+
+extern char **NamesReadMacBinary(char *filename);
+extern int LoadKerningDataFromMacFOND(SplineFont *sf, char *filename, EncMap *map);
+extern int WriteMacBitmaps(char *filename, SplineFont *sf, int32 *sizes, int is_dfont, EncMap *enc);
+extern int WriteMacFamily(char *filename, struct sflist *sfs, enum fontformat format, enum bitmapformat bf, int flags, int layer);
+extern int WriteMacPSFont(char *filename, SplineFont *sf, enum fontformat format, int flags, EncMap *enc, int layer);
+extern int WriteMacTTFFont(char *filename, SplineFont *sf, enum fontformat format, int32 *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer);
+extern long mactime(void);
+extern SplineChar *SFFindExistingCharMac(SplineFont *sf, EncMap *map, int unienc);
+extern SplineFont *SFReadMacBinary(char *filename, int flags, enum openflags openflags);
+extern uint16 _MacStyleCode(const char *styles, SplineFont *sf, uint16 *psstylecode);
+extern void SfListFree(struct sflist *sfs);
+
+#endif /* FONTFORGE_MACBINARY_H */

--- a/fontforge/macenc.c
+++ b/fontforge/macenc.c
@@ -26,6 +26,7 @@
  */
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "macenc.h"
 #include <gkeysym.h>
 #include <ustring.h>
 #include "ttf.h"

--- a/fontforge/macenc.c
+++ b/fontforge/macenc.c
@@ -24,6 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <gkeysym.h>
 #include <ustring.h>

--- a/fontforge/macenc.h
+++ b/fontforge/macenc.h
@@ -1,0 +1,22 @@
+#ifndef FONTFORGE_MACENC_H
+#define FONTFORGE_MACENC_H
+
+#include "splinefont.h"
+
+extern char *FindEnglishNameInMacName(struct macname *mn);
+extern char *MacLanguageFromCode(int code);
+extern char *MacStrToUtf8(const char *str, int macenc, int maclang);
+extern char *PickNameFromMacName(struct macname *mn);
+extern char *Utf8ToMacStr(const char *ustr, int macenc, int maclang);
+extern const int32 *MacEncToUnicode(int script, int lang);
+extern int CanEncodingWinLangAsMac(int winlang);
+extern int MacLangFromLocale(void);
+extern int UserFeaturesDiffer(void);
+extern MacFeat *FindMacFeature(SplineFont *sf, int feat, MacFeat **secondary);
+extern struct macname *FindMacSettingName(SplineFont *sf, int feat, int set);
+extern struct macname *MacNameCopy(struct macname *mn);
+extern uint16 WinLangFromMac(int maclang);
+extern uint16 WinLangToMac(int winlang);
+extern uint8 MacEncFromMacLang(int maclang);
+
+#endif /* FONTFORGE_MACENC_H */

--- a/fontforge/mathconstants.c
+++ b/fontforge/mathconstants.c
@@ -26,6 +26,8 @@
  */
 
 #include "fontforgevw.h"
+#include "fvfonts.h"
+
 #ifdef __need_size_t
 /* This is a bug on the mac, someone defines this and leaves it defined */
 /*  that means when I load stddef.h it only defines size_t and doesn't */

--- a/fontforge/mathconstants.c
+++ b/fontforge/mathconstants.c
@@ -25,6 +25,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "mathconstants.h"
+
 #include "fontforgevw.h"
 #include "fvfonts.h"
 

--- a/fontforge/mathconstants.h
+++ b/fontforge/mathconstants.h
@@ -1,0 +1,9 @@
+#ifndef FONTFORGE_MATHCONSTANTS_H
+#define FONTFORGE_MATHCONSTANTS_H
+
+#include "splinefont.h"
+
+extern struct MATH *MathTableNew(SplineFont *sf);
+extern void MATHFree(struct MATH *math);
+
+#endif /* FONTFORGE_MATHCONSTANTS_H */

--- a/fontforge/mm.c
+++ b/fontforge/mm.c
@@ -27,6 +27,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "lookups.h"
+#include "macenc.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforge/mm.c
+++ b/fontforge/mm.c
@@ -26,6 +26,7 @@
  */
 #include "dumppfa.h"
 #include "fontforgevw.h"
+#include "lookups.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforge/mm.c
+++ b/fontforge/mm.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "mm.h"
+
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "lookups.h"
@@ -32,7 +35,6 @@
 #include <math.h>
 #include <utype.h>
 #include "ttf.h"
-#include "mm.h"
 
 const char *MMAxisAbrev(char *axis_name) {
     if ( strcmp(axis_name,"Weight")==0 )

--- a/fontforge/mm.h
+++ b/fontforge/mm.h
@@ -28,10 +28,24 @@
 #ifndef FONTFORGE_MM_H
 #define FONTFORGE_MM_H
 
+#include "baseviews.h"
+#include "splinefont.h"
+
 extern void MMWeightsUnMap(real weights[MmMax], real axiscoords[4],
 	int axis_count);
 extern bigreal MMAxisUnmap(MMSet *mm,int axis,bigreal ncv);
 extern SplineFont *_MMNewFont(MMSet *mm,int index,char *familyname,real *normalized);
 extern SplineFont *MMNewFont(MMSet *mm,int index,char *familyname);
+
+extern char *MMBlendChar(MMSet *mm, int gid);
+extern char *MMExtractArrayNth(char *pt, int ipos);
+extern char *MMExtractNth(char *pt, int ipos);
+extern char *MMGuessWeight(MMSet *mm, int ipos, char *def);
+extern char *MMMakeMasterFontname(MMSet *mm, int ipos, char **fullname);
+extern const char *MMAxisAbrev(char *axis_name);
+extern FontViewBase *MMCreateBlendedFont(MMSet *mm, FontViewBase *fv, real blends[MmMax], int tonew);
+extern int MMReblend(FontViewBase *fv, MMSet *mm);
+extern int MMValid(MMSet *mm, int complain);
+extern void MMKern(SplineFont *sf, SplineChar *first, SplineChar *second, int diff, struct lookup_subtable *sub, KernPair *oldkp);
 
 #endif /* FONTFORGE_MM_H */

--- a/fontforge/namehash.h
+++ b/fontforge/namehash.h
@@ -57,5 +57,4 @@ static __inline__ int hashname(const char *pt) {
 return( val );
 }
 
-extern void __GlyphHashFree(struct glyphnamehash *hash);
 #endif

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -28,6 +28,7 @@
 
 #include "fontforgevw.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include "ustring.h"
 #include <utype.h>
 #include "namehash.h"

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -27,6 +27,7 @@
  */
 
 #include "fontforgevw.h"
+#include "fvcomposite.h"
 #include "ustring.h"
 #include <utype.h>
 #include "namehash.h"

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -26,6 +26,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "namelist.h"
+
 #include "fontforgevw.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"

--- a/fontforge/namelist.h
+++ b/fontforge/namelist.h
@@ -1,0 +1,19 @@
+#ifndef FONTFORGE_NAMELIST_H
+#define FONTFORGE_NAMELIST_H
+
+#include "splinefont.h"
+
+extern char **AllGlyphNames(int uni, NameList *for_this_font, SplineChar *sc);
+extern char **AllNamelistNames(void);
+extern char **SFTemporaryRenameGlyphsToNamelist(SplineFont *sf, NameList *new);
+extern const char *RenameGlyphToNamelist(char *buffer, SplineChar *sc, NameList *old, NameList *new, char **sofar);
+extern const char *StdGlyphName(char *buffer, int uni, enum uni_interp interp, NameList *for_this_font);
+extern int UniFromName(const char *name, enum uni_interp interp, Encoding *encname);
+extern NameList *DefaultNameListForNewFonts(void);
+extern NameList *LoadNamelist(char *filename);
+extern NameList *NameListByName(const char *name);
+extern void LoadNamelistDir(char *dir);
+extern void SFRenameGlyphsToNamelist(SplineFont *sf, NameList *new);
+extern void SFTemporaryRestoreGlyphNames(SplineFont *sf, char **former);
+
+#endif /* FONTFORGE_NAMELIST_H */

--- a/fontforge/nonlineartrans.c
+++ b/fontforge/nonlineartrans.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "nonlineartrans.h"
+
 #include "cvundoes.h"
 #include "fontforgevw.h"
 #include <utype.h>
@@ -32,7 +35,6 @@
 #ifdef HAVE_IEEEFP_H
 # include <ieeefp.h>		/* Solaris defines isnan in ieeefp rather than math.h */
 #endif
-#include "nonlineartrans.h"
 
 static struct builtins { const char *name; enum operator op; } builtins[] = {
     { "x", op_x },
@@ -60,7 +62,7 @@ return;
     chunkfree(e,sizeof(*e));
 }
 
-static int gettoken(struct context *c, real *val) {
+static int gettoken(struct expr_context *c, real *val) {
     int ch, i;
     char *end, *pt;
     char buffer[40];
@@ -169,7 +171,7 @@ return( op_value );
     }
 }
 
-static void backup(struct context *c,enum operator op, real val ) {
+static void backup(struct expr_context *c,enum operator op, real val ) {
     if ( c->backed_token!=op_base ) {
 	IError( "Attempt to back up twice.\nnear ...%s\n", c->cur );
 	c->had_error = true;
@@ -179,9 +181,9 @@ static void backup(struct context *c,enum operator op, real val ) {
 	c->backed_val = val;
 }
 
-static struct expr *getexpr(struct context *c);
+static struct expr *getexpr(struct expr_context *c);
 
-static struct expr *gete0(struct context *c) {
+static struct expr *gete0(struct expr_context *c) {
     real val = 0;
     enum operator op = gettoken(c,&val);
     struct expr *ret;
@@ -244,7 +246,7 @@ return( ret );
     }
 }
 
-static struct expr *gete1(struct context *c) {
+static struct expr *gete1(struct expr_context *c) {
     real val = 0;
     enum operator op;
     struct expr *ret, *op1;
@@ -263,7 +265,7 @@ static struct expr *gete1(struct context *c) {
 return( op1 );
 }
 
-static struct expr *gete2(struct context *c) {
+static struct expr *gete2(struct expr_context *c) {
     real val = 0;
     enum operator op;
     struct expr *ret, *op1;
@@ -282,7 +284,7 @@ static struct expr *gete2(struct context *c) {
 return( op1 );
 }
 
-static struct expr *gete3(struct context *c) {
+static struct expr *gete3(struct expr_context *c) {
     real val = 0;
     enum operator op;
     struct expr *ret, *op1;
@@ -301,7 +303,7 @@ static struct expr *gete3(struct context *c) {
 return( op1 );
 }
 
-static struct expr *gete4(struct context *c) {
+static struct expr *gete4(struct expr_context *c) {
     real val = 0;
     enum operator op;
     struct expr *ret, *op1;
@@ -320,7 +322,7 @@ static struct expr *gete4(struct context *c) {
 return( op1 );
 }
 
-static struct expr *gete5(struct context *c) {
+static struct expr *gete5(struct expr_context *c) {
     real val = 0;
     enum operator op;
     struct expr *ret, *op1;
@@ -339,7 +341,7 @@ static struct expr *gete5(struct context *c) {
 return( op1 );
 }
 
-static struct expr *getexpr(struct context *c) {
+static struct expr *getexpr(struct expr_context *c) {
     real val = 0;
     enum operator op;
     struct expr *ret, *op1;
@@ -364,7 +366,7 @@ return( op1 );
     }
 }
 
-struct expr *nlt_parseexpr(struct context *c,char *str) {
+struct expr *nlt_parseexpr(struct expr_context *c, char *str) {
     struct expr *ret;
 
     c->backed_token = op_base;
@@ -381,7 +383,7 @@ return( NULL );
 return( ret );
 }
 
-static real evaluate_expr(struct context *c,struct expr *e) {
+static real evaluate_expr(struct expr_context *c, struct expr *e) {
     real val1, val2;
 
     switch ( e->operator ) {
@@ -489,7 +491,7 @@ return( 0 );
     }
 }
 
-static real NL_expr(struct context *c,struct expr *e) {
+static real NL_expr(struct expr_context *c, struct expr *e) {
     real val = evaluate_expr(c,e);
     if ( isnan(val))
 return( 0 );
@@ -501,7 +503,7 @@ return( -32768 );
 return( val );
 }
 
-static void NLTransPoint(SplinePoint *sp,struct context *c) {
+static void NLTransPoint(SplinePoint *sp, struct expr_context *c) {
     BasePoint old, off, delta;
     int fixup = true;
 
@@ -551,7 +553,7 @@ static void NLTransPoint(SplinePoint *sp,struct context *c) {
     }
 }
 
-static void SplineSetNLTrans(SplineSet *ss,struct context *c,
+static void SplineSetNLTrans(SplineSet *ss, struct expr_context *c,
 	int everything) {
     SplinePoint *first, *last, *next;
     SplinePoint *sp;
@@ -640,7 +642,7 @@ static void SplineSetNLTrans(SplineSet *ss,struct context *c,
     ss->last = last;
 }
 
-static void _SCNLTrans(SplineChar *sc,struct context *c,int layer) {
+static void _SCNLTrans(SplineChar *sc, struct expr_context *c, int layer) {
     SplineSet *ss;
     RefChar *ref;
     int i, last, first;
@@ -670,7 +672,7 @@ return;
     }
 }
 
-void _SFNLTrans(FontViewBase *fv,struct context *c) {
+void _SFNLTrans(FontViewBase *fv, struct expr_context *c) {
     SplineChar *sc;
     RefChar *ref;
     int i, gid;
@@ -697,7 +699,7 @@ void _SFNLTrans(FontViewBase *fv,struct context *c) {
 }
 
 int SFNLTrans(FontViewBase *fv,char *x_expr,char *y_expr) {
-    struct context c;
+    struct expr_context c;
 
     memset(&c,0,sizeof(c));
     if ( (c.x_expr = nlt_parseexpr(&c,x_expr))==NULL )
@@ -715,7 +717,7 @@ return( true );
 }
 
 int SSNLTrans(SplineSet *ss,char *x_expr,char *y_expr) {
-    struct context c;
+    struct expr_context c;
 
     memset(&c,0,sizeof(c));
     if ( (c.x_expr = nlt_parseexpr(&c,x_expr))==NULL )
@@ -736,7 +738,7 @@ return( true );
 }
 
 int SCNLTrans(SplineChar *sc, int layer,char *x_expr,char *y_expr) {
-    struct context c;
+    struct expr_context c;
 
     memset(&c,0,sizeof(c));
     if ( (c.x_expr = nlt_parseexpr(&c,x_expr))==NULL )
@@ -753,7 +755,7 @@ return( false );
 return( true );
 }
 
-void CVNLTrans(CharViewBase *cv,struct context *c) {
+void CVNLTrans(CharViewBase *cv, struct expr_context *c) {
     SplineSet *ss;
     RefChar *ref;
     int layer = CVLayer(cv);
@@ -797,7 +799,7 @@ void SPLPoV(SplineSet *base,struct pov_data *pov, int only_selected) {
     SplineSet *spl;
     real transform[6];
     bigreal si = sin( pov->direction ), co = cos( pov->direction );
-    struct context c;
+    struct expr_context c;
 
     if ( pov->z==0 )
 return;
@@ -889,7 +891,7 @@ static void VanishingTrans(BasePoint *me,void *_vanish) {
 
 void CVYPerspective(CharViewBase *cv,bigreal x_vanish, bigreal y_vanish) {
     SplineSet *spl;
-    struct context c;
+    struct expr_context c;
     struct vanishing_point vanish;
 
     if ( y_vanish==0 )		/* Leave things unchanged */

--- a/fontforge/nonlineartrans.h
+++ b/fontforge/nonlineartrans.h
@@ -25,10 +25,12 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _NONLINEARTRANS_H
-#define _NONLINEARTRANS_H
+#ifndef FONTFORGE_NONLINEARTRANS_H
+#define FONTFORGE_NONLINEARTRANS_H
 
-#include "fontforgeui.h"
+#include "baseviews.h"
+#include "splinefont.h"
+
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>
@@ -59,7 +61,7 @@ struct expr {
     real value;
 };
 
-struct context {
+struct expr_context {
     char *start, *cur;
     unsigned int had_error: 1;
     enum operator backed_token;
@@ -72,9 +74,15 @@ struct context {
     void (*pov_func)(BasePoint *me,void *);
 };
 
-extern void _SFNLTrans(FontViewBase *fv,struct context *c);
-extern struct expr *nlt_parseexpr(struct context *c,char *str);
+extern void _SFNLTrans(FontViewBase *fv, struct expr_context *c);
+extern struct expr *nlt_parseexpr(struct expr_context *c, char *str);
 extern void nlt_exprfree(struct expr *e);
-extern void CVNLTrans(CharViewBase *cv,struct context *c);
+extern void CVNLTrans(CharViewBase *cv,struct expr_context *c);
 extern void SPLPoV(SplineSet *spl,struct pov_data *pov, int only_selected);
-#endif
+
+extern int SCNLTrans(SplineChar *sc, int layer, char *x_expr, char *y_expr);
+extern int SSNLTrans(SplineSet *ss, char *x_expr, char *y_expr);
+extern void CVYPerspective(CharViewBase *cv, bigreal x_vanish, bigreal y_vanish);
+extern void FVPointOfView(FontViewBase *fv, struct pov_data *pov);
+
+#endif /* FONTFORGE_NONLINEARTRANS_H */

--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -28,6 +28,7 @@
 #include "encoding.h"
 #include "fontforge.h"
 #include "groups.h"
+#include "macenc.h"
 #include "plugins.h"
 #include <charset.h>
 #include <gfile.h>

--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -29,6 +29,7 @@
 #include "fontforge.h"
 #include "groups.h"
 #include "macenc.h"
+#include "namelist.h"
 #include "plugins.h"
 #include <charset.h>
 #include <gfile.h>

--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "autotrace.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include "groups.h"
 #include "plugins.h"

--- a/fontforge/palmfonts.c
+++ b/fontforge/palmfonts.c
@@ -27,6 +27,7 @@
 #include "bvedit.h"
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "macbinary.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforge/palmfonts.c
+++ b/fontforge/palmfonts.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "bvedit.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -27,6 +27,7 @@
  */
 #include "cvimages.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -29,6 +29,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforge.h"
+#include "namelist.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsepfa.c
+++ b/fontforge/parsepfa.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "cvundoes.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include "splinefont.h"
 #include <chardata.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "encoding.h"
 #include "fontforge.h"
+#include "fvimportbdf.h"
 #include "splinefont.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -32,6 +32,7 @@
 #include "splinefont.h"
 #include "macenc.h"
 #include "mm.h"
+#include "namelist.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -28,6 +28,7 @@
 #include "encoding.h"
 #include "fontforge.h"
 #include "fvimportbdf.h"
+#include "lookups.h"
 #include "splinefont.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -30,6 +30,7 @@
 #include "fvimportbdf.h"
 #include "lookups.h"
 #include "splinefont.h"
+#include "macenc.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -31,6 +31,7 @@
 #include "lookups.h"
 #include "splinefont.h"
 #include "macenc.h"
+#include "mm.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsettfatt.c
+++ b/fontforge/parsettfatt.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "lookups.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsettfvar.c
+++ b/fontforge/parsettfvar.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "fvfonts.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/plugins.h
+++ b/fontforge/plugins.h
@@ -74,24 +74,8 @@ extern int FontForgeInit(void);
  /* AddScriptingCommand is documented within */
 #include "scripting.h"
 
- /* AddEncoding is documented here */
-typedef int (*EncFunc)(int);
-extern int AddEncoding(char *name,EncFunc enc_to_uni,EncFunc uni_to_enc,int max);
-	/* The "Encoding" here is a little different from what you normally see*/
-	/*  It isn't a mapping from a byte stream to unicode, but from an int */
-	/*  to unicode. If we have an 8/16 encoding (EUC or SJIS) then the */
-	/*  single byte entries will be numbers less than <256 and the */
-	/*  multibyte entries will be numbers >=256. So an encoding might be */
-	/*  valid for the domain [0x20..0x7f] [0xa1a1..0xfefe] */
-	/* In other words, we're interested in the ordering displayed in the */
-	/*  fontview. Nothing else */
-	/* The max value need not be exact (though it should be at least as big)*/
-	/*  if you create a new font with the given encoding, then the font will */
-	/*  have max slots in it by default */
-	/* A return value of -1 (from an EncFunc) indicates no mapping */
-	/* AddEncoding returns 1 if the encoding was added, 2 if it replaced */
-	/*  an existing encoding, 0 if you attempt to replace a builtin */
-	/*  encoding */
+/* AddEncoding is documented within */
+#include "encoding.h"
 
  /* Internal routines. Plugins shouldn't need these */
 extern int LoadPlugin(const char *dynamic_lib_name);

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -28,6 +28,7 @@
 #include "cvexport.h"
 #include "dumppfa.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "sflayoutP.h"
 #include <stdlib.h>
 #include <math.h>

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -30,6 +30,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "langfreq.h"
+#include "mm.h"
 #include "sflayoutP.h"
 #include <stdlib.h>
 #include <math.h>

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -29,6 +29,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "langfreq.h"
 #include "sflayoutP.h"
 #include <stdlib.h>
 #include <math.h>

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -28,6 +28,7 @@
 #include "cvimages.h"
 #include "cvundoes.h"
 #include "fontforge.h"
+#include "namelist.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -55,6 +55,7 @@ extern int old_sfnt_flags;
 #include "cvundoes.h"
 #include "dumppfa.h"
 #include "encoding.h"
+#include "featurefile.h"
 #include "fontforgevw.h"
 #include "ttf.h"
 #include "plugins.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -60,6 +60,7 @@ extern int old_sfnt_flags;
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "fvimportbdf.h"
+#include "glyphcomp.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -62,6 +62,7 @@ extern int old_sfnt_flags;
 #include "fvimportbdf.h"
 #include "glyphcomp.h"
 #include "langfreq.h"
+#include "lookups.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -63,6 +63,7 @@ extern int old_sfnt_flags;
 #include "glyphcomp.h"
 #include "langfreq.h"
 #include "lookups.h"
+#include "mathconstants.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -57,6 +57,7 @@ extern int old_sfnt_flags;
 #include "encoding.h"
 #include "featurefile.h"
 #include "fontforgevw.h"
+#include "fvcomposite.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -64,6 +64,7 @@ extern int old_sfnt_flags;
 #include "langfreq.h"
 #include "lookups.h"
 #include "mathconstants.h"
+#include "namelist.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -61,6 +61,7 @@ extern int old_sfnt_flags;
 #include "fvfonts.h"
 #include "fvimportbdf.h"
 #include "glyphcomp.h"
+#include "langfreq.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -58,6 +58,7 @@ extern int old_sfnt_flags;
 #include "featurefile.h"
 #include "fontforgevw.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -54,6 +54,7 @@ extern int old_sfnt_flags;
 #include "cvimages.h"
 #include "cvundoes.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include "ttf.h"
 #include "plugins.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -59,6 +59,7 @@ extern int old_sfnt_flags;
 #include "fontforgevw.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "fvimportbdf.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -65,6 +65,7 @@ extern int old_sfnt_flags;
 #include "lookups.h"
 #include "mathconstants.h"
 #include "namelist.h"
+#include "nonlineartrans.h"
 #include "ttf.h"
 #include "plugins.h"
 #include "utype.h"

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -31,6 +31,7 @@
 #include "dumpbdf.h"
 #include "dumppfa.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -33,6 +33,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "http.h"
+#include "macbinary.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -34,6 +34,7 @@
 #include "fvfonts.h"
 #include "http.h"
 #include "macbinary.h"
+#include "namelist.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -32,6 +32,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "http.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/scriptfuncs.h
+++ b/fontforge/scriptfuncs.h
@@ -30,10 +30,6 @@
 
 #include "scripting.h"
 
-extern int CompareGlyphs(Context *c, real pt_err, real spline_err,
-	real pixel_off_frac, int bb_err, int comp_hints, int diffs_are_errors );
-extern int CompareLayer(Context *c, const SplineSet *ss1,const SplineSet *ss2,
-	const RefChar *refs1, const RefChar *refs2,
-	real pt_err, real spline_err, const char *name, int diffs_are_errors,
-	SplinePoint **_hmfail);
+#include "glyphcomp.h"
+
 #endif /* _SCRIPTFUNCS_H */

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -43,6 +43,7 @@
 #include "fontforge.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "fvimportbdf.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -48,6 +48,7 @@
 #include "lookups.h"
 #include "macbinary.h"
 #include "mm.h"
+#include "namelist.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -41,6 +41,7 @@
 #include "encoding.h"
 #include "featurefile.h"
 #include "fontforge.h"
+#include "fvcomposite.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -45,6 +45,7 @@
 #include "fvfonts.h"
 #include "fvimportbdf.h"
 #include "fvmetrics.h"
+#include "lookups.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -47,6 +47,7 @@
 #include "fvmetrics.h"
 #include "lookups.h"
 #include "macbinary.h"
+#include "mm.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -44,6 +44,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "fvimportbdf.h"
+#include "fvmetrics.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -37,6 +37,7 @@
 #include "cvimages.h"
 #include "cvundoes.h"
 #include "dumppfa.h"
+#include "effects.h"
 #include "fontforge.h"
 #include <gfile.h>
 #include <utype.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -42,6 +42,7 @@
 #include "featurefile.h"
 #include "fontforge.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -39,6 +39,7 @@
 #include "dumppfa.h"
 #include "effects.h"
 #include "encoding.h"
+#include "featurefile.h"
 #include "fontforge.h"
 #include <gfile.h>
 #include <utype.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -46,6 +46,7 @@
 #include "fvimportbdf.h"
 #include "fvmetrics.h"
 #include "lookups.h"
+#include "macbinary.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -38,6 +38,7 @@
 #include "cvundoes.h"
 #include "dumppfa.h"
 #include "effects.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include <gfile.h>
 #include <utype.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -31,6 +31,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "namelist.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -29,6 +29,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -30,6 +30,7 @@
 #include "fontforgevw.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -28,6 +28,7 @@
 #include "cvundoes.h"
 #include "dumppfa.h"
 #include "fontforgevw.h"
+#include "fvcomposite.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/search.c
+++ b/fontforge/search.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -28,6 +28,7 @@
 #include "bvedit.h"
 #include "cvimages.h"
 #include "cvundoes.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include "splinefont.h"
 #include "baseviews.h"

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -30,6 +30,7 @@
 #include "cvundoes.h"
 #include "encoding.h"
 #include "fontforge.h"
+#include "fvfonts.h"
 #include "splinefont.h"
 #include "baseviews.h"
 #include "views.h"

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -31,6 +31,7 @@
 #include "encoding.h"
 #include "fontforge.h"
 #include "fvfonts.h"
+#include "http.h"
 #include "splinefont.h"
 #include "baseviews.h"
 #include "views.h"

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -32,6 +32,7 @@
 #include "fontforge.h"
 #include "fvfonts.h"
 #include "http.h"
+#include "lookups.h"
 #include "splinefont.h"
 #include "baseviews.h"
 #include "views.h"

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -33,6 +33,7 @@
 #include "fvfonts.h"
 #include "http.h"
 #include "lookups.h"
+#include "namelist.h"
 #include "splinefont.h"
 #include "baseviews.h"
 #include "views.h"

--- a/fontforge/sfd1.c
+++ b/fontforge/sfd1.c
@@ -26,6 +26,7 @@
  */
 
 #include "fontforge.h"
+#include "fvfonts.h"
 #include "sfd1.h"
 #include <string.h>
 

--- a/fontforge/sfd1.c
+++ b/fontforge/sfd1.c
@@ -27,6 +27,7 @@
 
 #include "fontforge.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include "sfd1.h"
 #include <string.h>
 

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -30,6 +30,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <math.h>
 
 #include "sflayoutP.h"

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -29,6 +29,7 @@
 #include "bvedit.h"
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <math.h>
 
 #include "sflayoutP.h"

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -27,6 +27,7 @@
  */
 
 #include "bvedit.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <math.h>
 

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -30,6 +30,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <math.h>
 #include <locale.h>
 # include <ustring.h>

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -29,6 +29,7 @@
 #include "cvundoes.h"
 #include "dumppfa.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <locale.h>
 # include <ustring.h>

--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "fvfonts.h"
 #include <stdio.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -36,6 +36,7 @@
 #include "http.h"
 #include "ikarus.h"
 #include "macbinary.h"
+#include "namelist.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -35,6 +35,7 @@
 #include "fvimportbdf.h"
 #include "http.h"
 #include "ikarus.h"
+#include "macbinary.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -33,6 +33,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "fvimportbdf.h"
+#include "http.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -30,6 +30,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "fvcomposite.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -31,6 +31,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -34,6 +34,7 @@
 #include "fvfonts.h"
 #include "fvimportbdf.h"
 #include "http.h"
+#include "ikarus.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -28,6 +28,7 @@
 #include "autohint.h"
 #include "autotrace.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -32,6 +32,7 @@
 #include "fontforgevw.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "fvimportbdf.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -3135,14 +3135,9 @@ extern spiro_cp *SplineSet2SpiroCP(SplineSet *ss,uint16 *_cnt);
 extern spiro_cp *SpiroCPCopy(spiro_cp *spiros,uint16 *_cnt);
 extern void SSRegenerateFromSpiros(SplineSet *spl);
 
-struct lang_frequencies;
 extern unichar_t *PrtBuildDef( SplineFont *sf, void *tf,
 	void (*langsyscallback)(void *tf, int end, uint32 script, uint32 lang) );
-extern char *RandomParaFromScriptLang(uint32 script, uint32 lang, SplineFont *sf,
-	struct lang_frequencies *freq);
 extern char *RandomParaFromScript(uint32 script, uint32 *lang, SplineFont *sf);
-extern int   SF2Scripts(SplineFont *sf,uint32 scripts[100]);
-extern char **SFScriptLangs(SplineFont *sf,struct lang_frequencies ***freq);
 
 extern int SSHasClip(SplineSet *ss);
 extern int SSHasDrawn(SplineSet *ss);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2313,8 +2313,6 @@ int SFKerningGroupExistsSpecific(const struct splinefont *sf, const char *groupn
 extern struct jstf_lang *JstfLangsCopy(struct jstf_lang *jl);
 extern void JstfLangFree(struct jstf_lang *jl);
 extern void JustifyFree(Justify *just);
-extern void MATHFree(struct MATH *math);
-extern struct MATH *MathTableNew(SplineFont *sf);
 extern void OtfNameListFree(struct otfname *on);
 extern void OtfFeatNameListFree(struct otffeatname *fn);
 extern struct otffeatname *findotffeatname(uint32 tag,SplineFont *sf);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2167,7 +2167,6 @@ extern const char *_GetModifiers(const char *fontname, const char *familyname, c
 extern const char *SFGetModifiers(const SplineFont *sf);
 extern const unichar_t *_uGetModifiers(const unichar_t *fontname, const unichar_t *familyname,
 	const unichar_t *weight);
-extern void SFSetFontName(SplineFont *sf, char *family, char *mods, char *fullname);
 extern void ttfdumpbitmap(SplineFont *sf,struct alltabs *at,int32 *sizes);
 extern void ttfdumpbitmapscaling(SplineFont *sf,struct alltabs *at,int32 *sizes);
 extern void SplineFontSetUnChanged(SplineFont *sf);
@@ -2428,7 +2427,6 @@ extern BDFFont *SplineFontPieceMeal(SplineFont *sf,int layer,int ptsize, int dpi
 extern void BDFCharFree(BDFChar *bdfc);
 extern void BDFPropsFree(BDFFont *bdf);
 extern void BDFFontFree(BDFFont *bdf);
-extern void SFDefaultAscent(SplineFont *sf);
 extern int  FNTFontDump(char *filename,BDFFont *font, EncMap *map, int res);
 extern int  FONFontDump(char *filename,SplineFont *sf, int32 *sizes,int res,
 	EncMap *map);
@@ -2771,8 +2769,6 @@ extern int URLFromFile(const char *url,FILE *from);
 extern void ArchiveCleanup(char *archivedir);
 extern char *Unarchive(char *name, char **_archivedir);
 extern char *Decompress(char *name, int compression);
-extern SplineFont *SFFromBDF(char *filename,int ispk,int toback);
-extern void SFCheckPSBitmap(SplineFont *sf);
 extern uint16 _MacStyleCode( const char *styles, SplineFont *sf, uint16 *psstyle );
 extern uint16 MacStyleCode( SplineFont *sf, uint16 *psstyle );
 extern SplineFont *SFReadIkarus(char *fontname);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2073,10 +2073,7 @@ extern int LoadKerningDataFromOfm(SplineFont *sf, char *filename, EncMap *map);
 extern int LoadKerningDataFromPfm(SplineFont *sf, char *filename, EncMap *map);
 extern int LoadKerningDataFromMacFOND(SplineFont *sf, char *filename, EncMap *map);
 extern int LoadKerningDataFromMetricsFile(SplineFont *sf, char *filename, EncMap *map);
-extern void FeatDumpFontLookups(FILE *out,SplineFont *sf);
-extern void FeatDumpOneLookup(FILE *out,SplineFont *sf, OTLookup *otl);
 extern void SFApplyFeatureFile(SplineFont *sf,FILE *file,char *filename);
-extern void SFApplyFeatureFilename(SplineFont *sf,char *filename);
 extern void SubsNew(SplineChar *to,enum possub_type type,int tag,char *components,
 	    SplineChar *default_script);
 extern void PosNew(SplineChar *to,int tag,int dx, int dy, int dh, int dv);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2769,7 +2769,6 @@ extern char *Unarchive(char *name, char **_archivedir);
 extern char *Decompress(char *name, int compression);
 extern uint16 _MacStyleCode( const char *styles, SplineFont *sf, uint16 *psstyle );
 extern uint16 MacStyleCode( SplineFont *sf, uint16 *psstyle );
-extern SplineFont *SFReadIkarus(char *fontname);
 extern SplineFont *_SFReadPdfFont(FILE *ttf,char *filename,enum openflags openflags);
 extern SplineFont *SFReadPdfFont(char *filename, enum openflags openflags);
 extern char **GetFontNames(char *filename, int do_slow);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2210,7 +2210,6 @@ extern AnchorPoint *AnchorPointsCopy(AnchorPoint *alist);
 extern AnchorClass *SFFindOrAddAnchorClass(SplineFont *sf,char *name,struct lookup_subtable *sub);
 extern void SFRemoveAnchorClass(SplineFont *sf,AnchorClass *an);
 extern int AnchorClassesNextMerge(AnchorClass *ac);
-extern int IsAnchorClassUsed(SplineChar *sc,AnchorClass *an);
 extern AnchorPoint *APAnchorClassMerge(AnchorPoint *anchors,AnchorClass *into,AnchorClass *from);
 extern void AnchorClassMerge(SplineFont *sf,AnchorClass *into,AnchorClass *from);
 extern void AnchorClassesFree(AnchorClass *kp);
@@ -2224,7 +2223,6 @@ extern DeviceTable *DeviceTableCopy(DeviceTable *orig);
 extern void DeviceTableSet(DeviceTable *adjust, int size, int correction);
 extern void PSTFree(PST *lig);
 extern uint16 PSTDefaultFlags(enum possub_type type,SplineChar *sc );
-extern int PSTContains(const char *components,const char *name);
 extern StemInfo *StemInfoCopy(StemInfo *h);
 extern DStemInfo *DStemInfoCopy(DStemInfo *h);
 extern MinimumDistance *MinimumDistanceCopy(MinimumDistance *h);
@@ -2264,7 +2262,6 @@ extern void KernClassFreeContents(KernClass *kc);
 extern void KernClassClearSpecialContents(KernClass *kc);
 extern void KernClassListFree(KernClass *kc);
 extern void KernClassListClearSpecialContents(KernClass *kc);
-extern int KernClassContains(KernClass *kc, const char *name1, const char *name2, int ordered );
 extern void OTLookupFree(OTLookup *lookup);
 extern void OTLookupListFree(OTLookup *lookup );
 extern FPST *FPSTCopy(FPST *fpst);
@@ -2978,71 +2975,11 @@ extern int RefDepth(RefChar *ref,int layer);
 
 extern SplineChar *SCHasSubs(SplineChar *sc,uint32 tag);
 
-extern char *TagFullName(SplineFont *sf,uint32 tag, int ismac, int onlyifknown);
-
-extern uint32 *SFScriptsInLookups(SplineFont *sf,int gpos);
-extern uint32 *SFLangsInScript(SplineFont *sf,int gpos,uint32 script);
-extern uint32 *SFFeaturesInScriptLang(SplineFont *sf,int gpos,uint32 script,uint32 lang);
-extern OTLookup **SFLookupsInScriptLangFeature(SplineFont *sf,int gpos,uint32 script,uint32 lang, uint32 feature);
-extern SplineChar **SFGlyphsWithPSTinSubtable(SplineFont *sf,struct lookup_subtable *subtable);
-extern SplineChar **SFGlyphsWithLigatureinLookup(SplineFont *sf,struct lookup_subtable *subtable);
-extern void SFFindUnusedLookups(SplineFont *sf);
-extern void SFFindClearUnusedLookupBits(SplineFont *sf);
-extern int LookupUsedNested(SplineFont *sf,OTLookup *checkme);
-extern void SFRemoveUnusedLookupSubTables(SplineFont *sf,
-	int remove_incomplete_anchorclasses,
-	int remove_unused_lookups);
-extern void SFRemoveLookupSubTable(SplineFont *sf,struct lookup_subtable *sub,int remove_acs);
-extern void SFRemoveLookup(SplineFont *sf,OTLookup *otl,int remove_acs);
 extern struct lookup_subtable *SFFindLookupSubtable(SplineFont *sf,char *name);
-extern struct lookup_subtable *SFFindLookupSubtableAndFreeName(SplineFont *sf,char *name);
-extern OTLookup *SFFindLookup(SplineFont *sf,char *name);
-extern void NameOTLookup(OTLookup *otl,SplineFont *sf);
-extern int GlyphNameCnt(const char *pt);
-extern char *reverseGlyphNames(char *str);
-extern char *FPSTRule_From_Str(SplineFont *sf,FPST *fpst,struct fpst_rule *rule,
-	char *line, int *return_is_warning );
-extern char *FPSTRule_To_Str(SplineFont *sf,FPST *fpst,struct fpst_rule *rule);
-extern void FListAppendScriptLang(FeatureScriptLangList *fl,uint32 script_tag,uint32 lang_tag);
-extern void FListsAppendScriptLang(FeatureScriptLangList *fl,uint32 script_tag,uint32 lang_tag);
-struct scriptlanglist *SLCopy(struct scriptlanglist *sl);
-struct scriptlanglist *SListCopy(struct scriptlanglist *sl);
-extern FeatureScriptLangList *FeatureListCopy(FeatureScriptLangList *fl);
-extern void SLMerge(FeatureScriptLangList *into, struct scriptlanglist *fsl);
-extern void FLMerge(OTLookup *into, OTLookup *from);
-extern FeatureScriptLangList *FLOrder(FeatureScriptLangList *fl);
-extern int FeatureScriptTagInFeatureScriptList(uint32 tag, uint32 script, FeatureScriptLangList *fl);
-extern FeatureScriptLangList *FindFeatureTagInFeatureScriptList(uint32 tag, FeatureScriptLangList *fl);
 extern int FeatureTagInFeatureScriptList(uint32 tag, FeatureScriptLangList *fl);
-extern int DefaultLangTagInOneScriptList(struct scriptlanglist *sl);
-extern struct scriptlanglist *DefaultLangTagInScriptList(struct scriptlanglist *sl, int DFLT_ok);
-extern int ScriptInFeatureScriptList(uint32 script, FeatureScriptLangList *fl);
-extern int _FeatureOrderId( int isgpos,uint32 tag );
-extern int FeatureOrderId( int isgpos,FeatureScriptLangList *fl );
-extern void SFSubTablesMerge(SplineFont *_sf,struct lookup_subtable *subfirst,
-	struct lookup_subtable *subsecond);
-extern struct lookup_subtable *SFSubTableFindOrMake(SplineFont *sf,uint32 tag,uint32 script,
-	int lookup_type );
-extern struct lookup_subtable *SFSubTableMake(SplineFont *sf,uint32 tag,uint32 script,
-	int lookup_type );
-extern OTLookup *OTLookupCopyInto(SplineFont *into_sf,SplineFont *from_sf, OTLookup *from_otl);
-extern void OTLookupsCopyInto(SplineFont *into_sf,SplineFont *from_sf,
-	OTLookup **from_list, OTLookup *before);
-extern struct opentype_str *ApplyTickedFeatures(SplineFont *sf,uint32 *flist, uint32 script, uint32 lang,
-	int pixelsize, SplineChar **glyphs);
-extern int VerticalKernFeature(SplineFont *sf, OTLookup *otl, int ask);
-extern void SFGlyphRenameFixup(SplineFont *sf, const char *old, const char *new, int rename_related_glyphs);
-
-struct sllk { uint32 script; int cnt, max; OTLookup **lookups; int lcnt, lmax; uint32 *langs; };
-extern void SllkFree(struct sllk *sllk,int sllk_cnt);
-extern struct sllk *AddOTLToSllks( OTLookup *otl, struct sllk *sllk,
-	int *_sllk_cnt, int *_sllk_max );
-extern OTLookup *NewAALTLookup(SplineFont *sf,struct sllk *sllk, int sllk_cnt, int i);
-extern void AddNewAALTFeatures(SplineFont *sf);
 
 extern void SplinePointRound(SplinePoint *,real);
 
-extern int KCFindName(const char *name, char **classnames, int cnt, int allow_class0 );
 extern KernClass *SFFindKernClass(SplineFont *sf,SplineChar *first,SplineChar *last,
 	int *index,int allow_zero);
 extern KernClass *SFFindVKernClass(SplineFont *sf,SplineChar *first,SplineChar *last,

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2247,13 +2247,6 @@ struct sfmergecontext {
     int preserveCrossFontKerning;
     int lmax;
 };
-extern PST *PSTCopy(PST *base,SplineChar *sc,struct sfmergecontext *mc);
-extern struct lookup_subtable *MCConvertSubtable(struct sfmergecontext *mc,struct lookup_subtable *sub);
-extern AnchorClass *MCConvertAnchorClass(struct sfmergecontext *mc,AnchorClass *ac);
-extern void SFFinishMergeContext(struct sfmergecontext *mc);
-extern SplineChar *SplineCharCopy(SplineChar *sc,SplineFont *into,struct sfmergecontext *);
-extern BDFChar *BDFCharCopy(BDFChar *bc);
-extern void BitmapsCopy(SplineFont *to, SplineFont *from, int to_index, int from_index );
 extern void ImageListsFree(ImageList *imgs);
 extern void TTFLangNamesFree(struct ttflangname *l);
 extern void AltUniFree(struct altuni *altuni);
@@ -2266,8 +2259,6 @@ extern void LayerDefault(Layer *);
 extern SplineChar *SplineCharCreate(int layer_cnt);
 extern SplineChar *SFSplineCharCreate(SplineFont *sf);
 extern RefChar *RefCharCreate(void);
-extern RefChar *RefCharsCopy(RefChar *ref);	/* Still needs to be instanciated and have the dependency list adjusted */
-extern struct altuni *AltUniCopy(struct altuni *altuni,SplineFont *noconflicts);
 extern void SCAddRef(SplineChar *sc,SplineChar *rsc,int layer, real xoff, real yoff);
 extern KernClass *KernClassCopy(KernClass *kc);
 extern void KernClassFreeContents(KernClass *kc);
@@ -2488,10 +2479,6 @@ extern extended IterateSplineSolveFixup(const Spline1D *sp, extended tmin, exten
 extern void SplineFindExtrema(const Spline1D *sp, extended *_t1, extended *_t2 );
 extern int SSBoundsWithin(SplineSet *ss,bigreal z1, bigreal z2, bigreal *wmin, bigreal *wmax, int major );
 extern bigreal SplineMinDistanceToPoint(Spline *s, BasePoint *p);
-
-SplineSet *SplineSetsInterpolate(SplineSet *base, SplineSet *other, real amount, SplineChar *sc);
-SplineChar *SplineCharInterpolate(SplineChar *base, SplineChar *other, real amount, SplineFont *newfont);
-extern SplineFont *InterpolateFont(SplineFont *base, SplineFont *other, real amount, Encoding *enc);
 
 double SFSerifHeight(SplineFont *sf);
 
@@ -2841,20 +2828,8 @@ extern void MatMultiply(real m1[6], real m2[6], real to[6]);
 extern int MatIsIdentity(real transform[6]);
 
 extern int NameToEncoding(SplineFont *sf,EncMap *map,const char *uname);
-extern void GlyphHashFree(SplineFont *sf);
-extern void SFHashGlyph(SplineFont *sf,SplineChar *sc);
-extern SplineChar *SFHashName(SplineFont *sf,const char *name);
-extern int SFFindGID(SplineFont *sf, int unienc, const char *name );
-extern int SFFindSlot(SplineFont *sf, EncMap *map, int unienc, const char *name );
-extern int SFCIDFindCID(SplineFont *sf, int unienc, const char *name );
-extern SplineChar *SFGetChar(SplineFont *sf, int unienc, const char *name );
-extern int SFHasChar(SplineFont *sf, int unienc, const char *name );
 extern SplineChar *SFGetOrMakeChar(SplineFont *sf, int unienc, const char *name );
 extern SplineChar *SFGetOrMakeCharFromUnicode( SplineFont *sf, EncMap *map, int ch );
-extern SplineChar *SFGetOrMakeCharFromUnicodeBasic( SplineFont *sf, int ch );
-extern int SFFindExistingSlot(SplineFont *sf, int unienc, const char *name );
-extern int SFCIDFindExistingChar(SplineFont *sf, int unienc, const char *name );
-extern int SFHasCID(SplineFont *sf, int cid);
 
 extern int DoAutoRecovery(int);
 typedef void (*DoAutoRecoveryPostRecoverFunc)(SplineFont *sf);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2071,7 +2071,6 @@ extern int LoadKerningDataFromAfm(SplineFont *sf, char *filename);
 extern int LoadKerningDataFromTfm(SplineFont *sf, char *filename, EncMap *map);
 extern int LoadKerningDataFromOfm(SplineFont *sf, char *filename, EncMap *map);
 extern int LoadKerningDataFromPfm(SplineFont *sf, char *filename, EncMap *map);
-extern int LoadKerningDataFromMacFOND(SplineFont *sf, char *filename, EncMap *map);
 extern int LoadKerningDataFromMetricsFile(SplineFont *sf, char *filename, EncMap *map);
 extern void SFApplyFeatureFile(SplineFont *sf,FILE *file,char *filename);
 extern void SubsNew(SplineChar *to,enum possub_type type,int tag,char *components,
@@ -2119,9 +2118,6 @@ enum bitmapformat { bf_bdf, bf_ttf, bf_sfnt_dfont, bf_sfnt_ms, bf_otb,
 	bf_none };
 extern int32 filechecksum(FILE *file);
 extern const char *GetAuthor(void);
-extern SplineChar *SFFindExistingCharMac(SplineFont *,EncMap *map, int unienc);
-extern int WriteMacPSFont(char *fontname,SplineFont *sf,enum fontformat format,
-	int flags,EncMap *enc,int layer);
 extern int _WriteWOFFFont(FILE *ttf,SplineFont *sf, enum fontformat format,
 	int32 *bsizes, enum bitmapformat bf,int flags,EncMap *enc,int layer);
 extern int WriteWOFFFont(char *fontname,SplineFont *sf, enum fontformat format,
@@ -2132,20 +2128,12 @@ extern int WriteTTFFont(char *fontname,SplineFont *sf, enum fontformat format,
 	int32 *bsizes, enum bitmapformat bf,int flags,EncMap *enc,int layer);
 extern int _WriteType42SFNTS(FILE *type42,SplineFont *sf,enum fontformat format,
 	int flags,EncMap *enc,int layer);
-extern int WriteMacTTFFont(char *fontname,SplineFont *sf, enum fontformat format,
-	int32 *bsizes, enum bitmapformat bf,int flags,EncMap *enc,int layer);
-extern int WriteMacBitmaps(char *filename,SplineFont *sf, int32 *sizes,
-	int is_dfont,EncMap *enc);
 extern int WritePalmBitmaps(const char *filename,SplineFont *sf, int32 *sizes,EncMap *enc);
-extern int WriteMacFamily(char *filename,struct sflist *sfs,enum fontformat format,
-	enum bitmapformat bf,int flags,int layer);
 extern int WriteTTC(const char *filename,struct sflist *sfs,enum fontformat format,
 	enum bitmapformat bf,int flags,int layer,enum ttc_flags ttcflags);
-extern long mactime(void);
 extern int WriteSVGFont(const char *fontname,SplineFont *sf,enum fontformat format,int flags,EncMap *enc,int layer);
 extern int _WriteSVGFont(FILE *file,SplineFont *sf,int flags,EncMap *enc,int layer);
 extern int WriteUFOFont(const char *fontname, SplineFont *sf, enum fontformat format,int flags, const EncMap *enc,int layer);
-extern void SfListFree(struct sflist *sfs);
 extern void TTF_PSDupsDefault(SplineFont *sf);
 extern void DefaultTTFEnglishNames(struct ttflangname *dummy, SplineFont *sf);
 extern void TeXDefaultParams(SplineFont *sf);
@@ -2755,7 +2743,6 @@ extern SplineFont *SFReadSVGMem(char *data,int flags);
 extern SplineFont *SFReadUFO(char *filename,int flags);
 extern SplineFont *_CFFParse(FILE *temp,int len,char *fontsetname);
 extern SplineFont *CFFParse(char *filename);
-extern SplineFont *SFReadMacBinary(char *filename,int flags,enum openflags openflags);
 extern SplineFont *SFReadWinFON(char *filename,int toback);
 extern SplineFont *SFReadPalmPdb(char *filename);
 extern SplineFont *LoadSplineFont(const char *filename,enum openflags);
@@ -2764,7 +2751,6 @@ extern SplineFont *ReadSplineFont(const char *filename,enum openflags);	/* Don't
 extern void ArchiveCleanup(char *archivedir);
 extern char *Unarchive(char *name, char **_archivedir);
 extern char *Decompress(char *name, int compression);
-extern uint16 _MacStyleCode( const char *styles, SplineFont *sf, uint16 *psstyle );
 extern uint16 MacStyleCode( SplineFont *sf, uint16 *psstyle );
 extern SplineFont *_SFReadPdfFont(FILE *ttf,char *filename,enum openflags openflags);
 extern SplineFont *SFReadPdfFont(char *filename, enum openflags openflags);
@@ -2777,7 +2763,6 @@ extern char **NamesReadPostScript(char *filename);
 extern char **_NamesReadPostScript(FILE *ps);
 extern char **NamesReadSVG(char *filename);
 extern char **NamesReadUFO(char *filename);
-extern char **NamesReadMacBinary(char *filename);
 
 extern void SFSetOrder(SplineFont *sf,int order2);
 extern void SFLSetOrder(SplineFont *sf, int layerdest, int order2);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2084,7 +2084,6 @@ extern int SFOneWidth(SplineFont *sf);
 extern int CIDOneWidth(SplineFont *sf);
 extern int SFOneHeight(SplineFont *sf);
 extern int SFIsCJK(SplineFont *sf,EncMap *map);
-extern void CIDMasterAsDes(SplineFont *sf);
 enum fontformat { ff_pfa, ff_pfb, ff_pfbmacbin, ff_multiple, ff_mma, ff_mmb,
 	ff_ptype3, ff_ptype0, ff_cid, ff_cff, ff_cffcid,
 	ff_type42, ff_type42cid,
@@ -2168,11 +2167,6 @@ extern int SCRightToLeft(SplineChar *sc);
 extern int SLIContainsR2L(SplineFont *sf,int sli);
 extern void SFFindNearTop(SplineFont *);
 extern void SFRestoreNearTop(SplineFont *);
-extern int SFForceEncoding(SplineFont *sf,EncMap *old,Encoding *new_map);
-extern int CountOfEncoding(Encoding *encoding_name);
-extern int SFReencode(SplineFont *sf, const char *encname, int force);
-extern void SFMatchGlyphs(SplineFont *sf,SplineFont *target,int addempties);
-extern void MMMatchGlyphs(MMSet *mm);
 extern const char *_GetModifiers(const char *fontname, const char *familyname, const char *weight);
 extern const char *SFGetModifiers(const SplineFont *sf);
 extern const unichar_t *_uGetModifiers(const unichar_t *fontname, const unichar_t *familyname,
@@ -2314,12 +2308,9 @@ extern void LayerFreeContents(SplineChar *sc, int layer);
 extern void SplineCharFreeContents(SplineChar *sc);
 extern void SplineCharFree(SplineChar *sc);
 extern void EncMapFree(EncMap *map);
-extern EncMap *EncMapFromEncoding(SplineFont *sf,Encoding *enc);
-extern EncMap *CompactEncMap(EncMap *map, SplineFont *sf);
 extern EncMap *EncMapNew(int encmax, int backmax, Encoding *enc);
 extern EncMap *EncMap1to1(int enccount);
 extern EncMap *EncMapCopy(EncMap *map);
-extern void SFExpandGlyphCount(SplineFont *sf, int newcnt);
 extern void ScriptLangListFree(struct scriptlanglist *sl);
 extern void FeatureScriptLangListFree(FeatureScriptLangList *fl);
 extern void SFBaseSort(SplineFont *sf);
@@ -2515,9 +2506,6 @@ extern SplineFont *InterpolateFont(SplineFont *base, SplineFont *other, real amo
 
 double SFSerifHeight(SplineFont *sf);
 
-extern void DumpPfaEditEncodings(void);
-extern char *ParseEncodingFile(char *filename, char *encodingname);
-extern void LoadPfaEditEncodings(void);
 
 extern int GenerateScript(SplineFont *sf,char *filename, const char *bitmaptype,
 	int fmflags,int res, char *subfontdirectory,struct sflist *sfs,
@@ -2721,7 +2709,6 @@ extern int PfmSplineFont(FILE *pfm, SplineFont *sf,EncMap *map,int layer);
 extern int TfmSplineFont(FILE *tfm, SplineFont *sf,EncMap *map,int layer);
 extern int OfmSplineFont(FILE *afm, SplineFont *sf,EncMap *map,int layer);
 extern const char *EncodingName(Encoding *map);
-extern char *SFEncodingName(SplineFont *sf,EncMap *map);
 extern void SFLigaturePrepare(SplineFont *sf);
 extern void SFLigatureCleanup(SplineFont *sf);
 extern void SFKernClassTempDecompose(SplineFont *sf,int isv);
@@ -2771,9 +2758,6 @@ extern char* DumpSplineFontMetadata( SplineFont *sf );
 extern void SFD_DumpLookup( FILE *sfd, SplineFont *sf );
 extern enum uni_interp interp_from_encoding(Encoding *enc,enum uni_interp interp);
 extern const char *EncName(Encoding *encname);
-extern const char*FindUnicharName(void);
-extern Encoding *_FindOrMakeEncoding(const char *name,int make_it);
-extern Encoding *FindOrMakeEncoding(const char *name);
 extern void SFDDumpMacFeat(FILE *sfd,MacFeat *mf);
 extern MacFeat *SFDParseMacFeatures(FILE *sfd, char *tok);
 extern int SFDDoesAnyBackupExist(char* filename);
@@ -2911,22 +2895,7 @@ extern int SCRoundToCluster(SplineChar *sc,int layer,int sel,bigreal within,bigr
 extern int SplineSetsRemoveAnnoyingExtrema(SplineSet *ss,bigreal err);
 extern int hascomposing(SplineFont *sf,int u,SplineChar *sc);
 
-struct cidmap;			/* private structure to encoding.c */
-extern int CIDFromName(char *name,SplineFont *cidmaster);
-extern int CID2Uni(struct cidmap *map,int cid);
-extern int CID2NameUni(struct cidmap *map,int cid, char *buffer, int len);
-extern int NameUni2CID(struct cidmap *map,int uni, const char *name);
-extern struct altuni *CIDSetAltUnis(struct cidmap *map,int cid);
-extern int MaxCID(struct cidmap *map);
-extern struct cidmap *LoadMapFromFile(char *file,char *registry,char *ordering,
-	int supplement);
-extern struct cidmap *FindCidMap(char *registry,char *ordering,int supplement,
-	SplineFont *sf);
-extern void SFEncodeToMap(SplineFont *sf,struct cidmap *map);
-extern SplineFont *CIDFlatten(SplineFont *cidmaster,SplineChar **chars,int charcnt);
 extern void SFFlatten(SplineFont *cidmaster);
-extern int  SFFlattenByCMap(SplineFont *sf,char *cmapname);
-extern SplineFont *MakeCIDMaster(SplineFont *sf,EncMap *oldmap,int bycmap,char *cmapfilename,struct cidmap *cidmap);
 
 int getushort(FILE *ttf);
 int32 getlong(FILE *ttf);
@@ -3015,9 +2984,6 @@ extern MacFeat *FindMacFeature(SplineFont *sf, int feat,MacFeat **secondary);
 extern struct macsetting *FindMacSetting(SplineFont *sf, int feat, int set,struct macsetting **secondary);
 extern struct macname *FindMacSettingName(SplineFont *sf, int feat, int set);
 
-extern int32 UniFromEnc(int enc, Encoding *encname);
-extern int32 EncFromUni(int32 uni, Encoding *encname);
-extern int32 EncFromName(const char *name,enum uni_interp interp,Encoding *encname);
 
 extern void MatInverse(real into[6], real orig[6]);
 
@@ -3181,7 +3147,6 @@ extern void RevertedGlyphReferenceFixup(SplineChar *sc, SplineFont *sf);
 
 extern void SFUntickAll(SplineFont *sf);
 
-extern void BDFOrigFixup(BDFFont *bdf,int orig_cnt,SplineFont *sf);
 
 extern int HasSVG(void);
 extern int HasUFO(void);
@@ -3191,10 +3156,6 @@ extern void SCImportPDF(SplineChar *sc,int layer,char *path,int doclear, int fla
 extern int _ExportSVG(FILE *svg,SplineChar *sc,int layer);
 extern int _ExportGlif(FILE *glif,SplineChar *sc,int layer);
 
-extern EncMap *EncMapFromEncoding(SplineFont *sf,Encoding *enc);
-extern void SFRemoveGlyph(SplineFont *sf,SplineChar *sc);
-extern void SFAddEncodingSlot(SplineFont *sf,int gid);
-extern void SFAddGlyphAndEncode(SplineFont *sf,SplineChar *sc,EncMap *basemap, int baseenc);
 extern void SCCopyWidth(SplineChar *sc,enum undotype);
 extern void SCClearBackground(SplineChar *sc);
 extern void BackgroundImageTransform(SplineChar *sc, ImageList *img,real transform[6]);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2960,45 +2960,6 @@ extern char *EnforcePostScriptName(char *old);
 
 extern char *ToAbsolute(char *filename);
 
-enum Compare_Ret {	SS_DiffContourCount	= 1,
-			SS_MismatchOpenClosed	= 2,
-			SS_DisorderedContours	= 4,
-			SS_DisorderedStart	= 8,
-			SS_DisorderedDirection	= 16,
-			SS_PointsMatch		= 32,
-			SS_ContourMatch		= 64,
-			SS_NoMatch		= 128,
-			SS_RefMismatch		= 256,
-			SS_WidthMismatch	= 512,
-			SS_VWidthMismatch	= 1024,
-			SS_HintMismatch		= 2048,
-			SS_HintMaskMismatch	= 4096,
-			SS_LayerCntMismatch	= 8192,
-			SS_ContourMismatch	= 16384,
-			SS_UnlinkRefMatch	= 32768,
-
-			BC_DepthMismatch	= 1<<16,
-			BC_BoundingBoxMismatch	= 2<<16,
-			BC_BitmapMismatch	= 4<<16,
-			BC_NoMatch		= 8<<16,
-			BC_Match		= 16<<16,
-
-			SS_RefPtMismatch	= 32<<16
-		};
-
-extern enum Compare_Ret BitmapCompare(BDFChar *bc1, BDFChar *bc2, int err, int bb_err);
-extern enum Compare_Ret SSsCompare(const SplineSet *ss1, const SplineSet *ss2,
-	real pt_err, real spline_err, SplinePoint **hmfail);
-enum font_compare_flags { fcf_outlines=1, fcf_exact=2, fcf_warn_not_exact=4,
-	fcf_hinting=8, fcf_hintmasks=0x10, fcf_hmonlywithconflicts=0x20,
-	fcf_warn_not_ref_exact=0x40,
-	fcf_bitmaps=0x80, fcf_names = 0x100, fcf_gpos=0x200, fcf_gsub=0x400,
-	fcf_adddiff2sf1=0x800, fcf_addmissing=0x1000 };
-extern int CompareFonts(SplineFont *sf1, EncMap *map1, SplineFont *sf2,
-	FILE *diffs, int flags);
-extern int LayersSimilar(Layer *ly1, Layer *ly2, double spline_err);
-
-
 # if HANYANG
 extern void SFDDumpCompositionRules(FILE *sfd,struct compositionrules *rules);
 extern struct compositionrules *SFDReadCompositionRules(FILE *sfd);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2863,20 +2863,6 @@ extern void FreeType_FreeRaster(struct freetype_raster *raster);
 struct TT_ExecContextRec_;
 extern struct freetype_raster *DebuggerCurrentRaster(struct  TT_ExecContextRec_ *exc,int depth);
 
-extern int UniFromName(const char *name,enum uni_interp interp, Encoding *encname);
-extern const char *StdGlyphName(char *buffer, int uni, enum uni_interp interp, NameList *for_this_font);
-extern char **AllGlyphNames(int uni, NameList *for_this_font,SplineChar *sc/* May be NULL*/);
-extern char **AllNamelistNames(void);
-extern NameList *DefaultNameListForNewFonts(void);
-extern NameList *NameListByName(const char *name);
-extern NameList *LoadNamelist(char *filename);
-extern void LoadNamelistDir(char *dir);
-extern const char *RenameGlyphToNamelist(char *buffer, SplineChar *sc,NameList *old,
-	NameList *new, char **sofar);
-extern void SFRenameGlyphsToNamelist(SplineFont *sf,NameList *new);
-extern char **SFTemporaryRenameGlyphsToNamelist(SplineFont *sf,NameList *new);
-extern void SFTemporaryRestoreGlyphNames(SplineFont *sf, char **former);
-
 extern void doversion(const char *);
 
 extern AnchorPos *AnchorPositioning(SplineChar *sc,unichar_t *ustr,SplineChar **sstr );

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2258,7 +2258,6 @@ extern void FPSTClassesFree(FPST *fpst);
 extern void FPSTRulesFree(struct fpst_rule *r, enum fpossub_format format, int rcnt);
 extern void FPSTFree(FPST *fpst);
 extern void ASMFree(ASM *sm);
-extern struct macname *MacNameCopy(struct macname *mn);
 extern void MacNameListFree(struct macname *mn);
 extern void MacSettingListFree(struct macsetting *ms);
 extern void MacFeatListFree(MacFeat *mf);
@@ -2900,20 +2899,7 @@ extern int SFRemoveUnusedNestedFeatures(SplineFont *sf);
 
 extern char *utf8_verify_copy(const char *str);
 
-extern char *MacStrToUtf8(const char *str,int macenc,int maclang);
-extern char *Utf8ToMacStr(const char *ustr,int macenc,int maclang);
-extern uint8 MacEncFromMacLang(int maclang);
-extern uint16 WinLangFromMac(int maclang);
-extern uint16 WinLangToMac(int winlang);
-extern int CanEncodingWinLangAsMac(int winlang);
-extern const int32 *MacEncToUnicode(int script,int lang);
-extern int MacLangFromLocale(void);
-extern char *MacLanguageFromCode(int code);
-extern char *FindEnglishNameInMacName(struct macname *mn);
-extern char *PickNameFromMacName(struct macname *mn);
-extern MacFeat *FindMacFeature(SplineFont *sf, int feat,MacFeat **secondary);
 extern struct macsetting *FindMacSetting(SplineFont *sf, int feat, int set,struct macsetting **secondary);
-extern struct macname *FindMacSettingName(SplineFont *sf, int feat, int set);
 
 
 extern void MatInverse(real into[6], real orig[6]);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2764,8 +2764,6 @@ extern SplineFont *SFReadPalmPdb(char *filename);
 extern SplineFont *LoadSplineFont(const char *filename,enum openflags);
 extern SplineFont *_ReadSplineFont(FILE *file, const char *filename, enum openflags openflags);
 extern SplineFont *ReadSplineFont(const char *filename,enum openflags);	/* Don't use this, use LoadSF instead */
-extern FILE *URLToTempFile(char *url,void *lock);
-extern int URLFromFile(const char *url,FILE *from);
 extern void ArchiveCleanup(char *archivedir);
 extern char *Unarchive(char *name, char **_archivedir);
 extern char *Decompress(char *name, int compression);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2909,16 +2909,6 @@ extern int BpWithin(BasePoint *first, BasePoint *mid, BasePoint *last);
 enum psstrokeflags { /* sf_removeoverlap=2,*/ sf_handle_eraser=4,
 	sf_correctdir=8, sf_clearbeforeinput=16 };
 
-extern const char *MMAxisAbrev(char *axis_name);
-extern char *MMMakeMasterFontname(MMSet *mm,int ipos,char **fullname);
-extern char *MMGuessWeight(MMSet *mm,int ipos,char *def);
-extern char *MMExtractNth(char *pt,int ipos);
-extern char *MMExtractArrayNth(char *pt,int ipos);
-extern int MMValid(MMSet *mm,int complain);
-extern void MMKern(SplineFont *sf,SplineChar *first,SplineChar *second,int diff,
-	struct lookup_subtable *sub,KernPair *oldkp);
-extern char *MMBlendChar(MMSet *mm, int gid);
-
 extern char *EnforcePostScriptName(char *old);
 
 extern char *ToAbsolute(char *filename);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2089,7 +2089,6 @@ enum fontformat { ff_pfa, ff_pfb, ff_pfbmacbin, ff_multiple, ff_mma, ff_mmb,
 extern int CanWoff(void);
 extern struct pschars *SplineFont2ChrsSubrs(SplineFont *sf, int iscjk,
 	struct pschars *subrs,int flags,enum fontformat format,int layer);
-extern int CanonicalCombiner(int uni);
 struct cidbytes;
 struct fd2data;
 struct ttfinfo;
@@ -2218,12 +2217,6 @@ extern void AnchorClassMerge(SplineFont *sf,AnchorClass *into,AnchorClass *from)
 extern void AnchorClassesFree(AnchorClass *kp);
 extern void TtfTablesFree(struct ttf_table *tab);
 extern void SFRemoveSavedTable(SplineFont *sf, uint32 tag);
-extern AnchorClass *AnchorClassMatch(SplineChar *sc1,SplineChar *sc2,
-	AnchorClass *restrict_, AnchorPoint **_ap1,AnchorPoint **_ap2 );
-extern AnchorClass *AnchorClassMkMkMatch(SplineChar *sc1,SplineChar *sc2,
-	AnchorPoint **_ap1,AnchorPoint **_ap2 );
-extern AnchorClass *AnchorClassCursMatch(SplineChar *sc1,SplineChar *sc2,
-	AnchorPoint **_ap1,AnchorPoint **_ap2 );
 extern void SCInsertPST(SplineChar *sc,PST *new_);
 extern void ValDevFree(ValDevTab *adjust);
 extern ValDevTab *ValDevTabCopy(ValDevTab *orig);
@@ -2276,7 +2269,6 @@ extern RefChar *RefCharCreate(void);
 extern RefChar *RefCharsCopy(RefChar *ref);	/* Still needs to be instanciated and have the dependency list adjusted */
 extern struct altuni *AltUniCopy(struct altuni *altuni,SplineFont *noconflicts);
 extern void SCAddRef(SplineChar *sc,SplineChar *rsc,int layer, real xoff, real yoff);
-extern void _SCAddRef(SplineChar *sc,SplineChar *rsc,int layer, real transform[6]);
 extern KernClass *KernClassCopy(KernClass *kc);
 extern void KernClassFreeContents(KernClass *kc);
 extern void KernClassClearSpecialContents(KernClass *kc);
@@ -2824,13 +2816,6 @@ extern void SCLigCaretheck(SplineChar *sc,int clean);
 
 extern void SCUndoSetLBearingChange(SplineChar *sc,int lb);
 
-extern int isaccent(int uni);
-extern int SFIsCompositBuildable(SplineFont *sf,int unicodeenc,SplineChar *sc, int layer);
-extern int SFIsSomethingBuildable(SplineFont *sf,SplineChar *sc, int layer,int onlyaccents);
-extern int SFIsRotatable(SplineFont *sf,SplineChar *sc);
-extern void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *bmp, int disp_only);
-extern int SCAppendAccent(SplineChar *sc,int layer, char *glyph_name,int uni,uint32 pos);
-extern const unichar_t *SFGetAlternate(SplineFont *sf, int base,SplineChar *sc,int nocheck);
 
 
 extern void SFSplinesFromLayers(SplineFont *sf,int tostroke);
@@ -2890,7 +2875,6 @@ extern void SplineSetsRound2Int(SplineSet *spl,real factor,int inspiro,int onlys
 extern void SCRound2Int(SplineChar *sc,int layer, real factor);
 extern int SCRoundToCluster(SplineChar *sc,int layer,int sel,bigreal within,bigreal max);
 extern int SplineSetsRemoveAnnoyingExtrema(SplineSet *ss,bigreal err);
-extern int hascomposing(SplineFont *sf,int u,SplineChar *sc);
 
 extern void SFFlatten(SplineFont *cidmaster);
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2655,8 +2655,6 @@ extern enum PolyType PolygonIsConvex(BasePoint *poly,int n, int *badpointindex);
 extern SplineSet *UnitShape(int isrect);
 extern SplineSet *SplineSetStroke(SplineSet *spl,StrokeInfo *si,int order2);
 extern SplineSet *SplineSetRemoveOverlap(SplineChar *sc,SplineSet *base,enum overlap_type);
-extern SplineSet *SSShadow(SplineSet *spl,real angle, real outline_width,
-	real shadow_length,SplineChar *sc, int wireframe);
 
 extern double BlueScaleFigure(struct psdict *private_,real bluevalues[], real otherblues[]);
 extern double SFStdVW(SplineFont *sf);

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -27,6 +27,7 @@
 #include "autohint.h"
 #include "dumppfa.h"
 #include "fontforge.h"
+#include "fvfonts.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -32,6 +32,7 @@
 #include "lookups.h"
 #include "macbinary.h"
 #include "mm.h"
+#include "namelist.h"
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>
 #include "splinefont.h"

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -31,6 +31,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "macbinary.h"
+#include "mm.h"
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>
 #include "splinefont.h"

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "autohint.h"
+#include "featurefile.h"
 #include "fontforgevw.h"		/* For Error */
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -28,6 +28,7 @@
 #include "featurefile.h"
 #include "fontforgevw.h"		/* For Error */
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>
 #include "splinefont.h"

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -29,6 +29,7 @@
 #include "fontforgevw.h"		/* For Error */
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>
 #include "splinefont.h"

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -27,6 +27,7 @@
 #include "autohint.h"
 #include "featurefile.h"
 #include "fontforgevw.h"		/* For Error */
+#include "fvcomposite.h"
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>
 #include "splinefont.h"

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -30,6 +30,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "macbinary.h"
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>
 #include "splinefont.h"

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -26,9 +26,10 @@
  */
 #include "cvundoes.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
-#include "encoding.h"
+#include "fvimportbdf.h"
 #include <math.h>
 #include "psfont.h"
 #include "ustring.h"

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "dumppfa.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "encoding.h"
 #include <math.h>
 #include "psfont.h"

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -30,6 +30,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "fvimportbdf.h"
+#include "mm.h"
 #include <math.h>
 #include "psfont.h"
 #include "ustring.h"

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -31,6 +31,7 @@
 #include "fvfonts.h"
 #include "fvimportbdf.h"
 #include "mm.h"
+#include "namelist.h"
 #include <math.h>
 #include "psfont.h"
 #include "ustring.h"

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -28,6 +28,7 @@
 #include "autohint.h"
 #include "cvundoes.h"
 #include "fontforge.h"
+#include "namelist.h"
 #include <math.h>
 #include "ustring.h"
 #include "chardata.h"

--- a/fontforge/start.c
+++ b/fontforge/start.c
@@ -26,6 +26,7 @@
  */
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "namelist.h"
 #include "pluginloading.h"
 #include <gfile.h>
 #include <time.h>

--- a/fontforge/start.c
+++ b/fontforge/start.c
@@ -24,6 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "encoding.h"
 #include "fontforgevw.h"
 #include "pluginloading.h"
 #include <gfile.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -31,6 +31,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "http.h"
+#include "lookups.h"
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -32,6 +32,7 @@
 #include "fvfonts.h"
 #include "http.h"
 #include "lookups.h"
+#include "namelist.h"
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -30,6 +30,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "http.h"
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -29,6 +29,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -27,6 +27,7 @@
 #include "autohint.h"
 #include "cvimages.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgevw.h"
 #include <unistd.h>
 #include <math.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -27,6 +27,7 @@
 #include "autohint.h"
 #include "dumpbdf.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include <math.h>
 #include <unistd.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -32,6 +32,7 @@
 #include "fvfonts.h"
 #include "http.h"
 #include "lookups.h"
+#include "macenc.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -33,6 +33,7 @@
 #include "http.h"
 #include "lookups.h"
 #include "macenc.h"
+#include "mm.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -31,6 +31,7 @@
 #include "fontforge.h"
 #include "fvfonts.h"
 #include "http.h"
+#include "lookups.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -29,6 +29,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforge.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -30,6 +30,7 @@
 #include "encoding.h"
 #include "fontforge.h"
 #include "fvfonts.h"
+#include "http.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforge.h"
+#include "fvfonts.h"
 #include "asmfpst.h"
 #include <utype.h>
 

--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -26,6 +26,7 @@
  */
 #include "fontforge.h"
 #include "fvfonts.h"
+#include "macenc.h"
 #include "asmfpst.h"
 #include <utype.h>
 

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include "asmfpst.h"
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgevw.h"
+#include "fvfonts.h"
 #include "asmfpst.h"
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -27,6 +27,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "namelist.h"
 #include "asmfpst.h"
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -35,6 +35,7 @@
 
 #include "autohint.h"
 #include "dumppfa.h"
+#include "featurefile.h"
 #include "fontforgevw.h"
 #include <unistd.h>
 #include <math.h>

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -39,6 +39,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <unistd.h>
 #include <math.h>
 #include <time.h>

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -37,6 +37,8 @@
 #include "dumppfa.h"
 #include "featurefile.h"
 #include "fontforgevw.h"
+#include "fvfonts.h"
+#include "fvfonts.h"
 #include <unistd.h>
 #include <math.h>
 #include <time.h>

--- a/fontforge/uiinterface.h
+++ b/fontforge/uiinterface.h
@@ -356,8 +356,6 @@ extern struct fi_interface *fi_interface;
 #define FIOTLookupCopyInto			(fi_interface->copy_into)
 #define FontInfo_Destroy			(fi_interface->destroy)
 
-void FF_SetFIInterface(struct fi_interface *fii);
-
 /* ************************************************************************** */
 /*                           Updating font windows                            */
 /* ************************************************************************** */

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "bvedit.h"
+#include "encoding.h"
 #include "fontforge.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -30,6 +30,7 @@
 /* Basically sfnts with compressed tables and some more metadata */
 
 #include "fontforge.h"
+#include "http.h"
 #include <math.h>
 #include <ctype.h>
 

--- a/fontforgeexe/acorn2sfd.c
+++ b/fontforgeexe/acorn2sfd.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 
 #include "lookups.h"
+#include "namelist.h"
 #include "splinefont.h"
 #include <ustring.h>
 

--- a/fontforgeexe/acorn2sfd.c
+++ b/fontforgeexe/acorn2sfd.c
@@ -27,6 +27,7 @@
 #include <dirent.h>
 #include <errno.h>
 
+#include "lookups.h"
 #include "splinefont.h"
 #include <ustring.h>
 

--- a/fontforgeexe/anchorsaway.c
+++ b/fontforgeexe/anchorsaway.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <gkeysym.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -30,6 +30,7 @@
 #include "cvundoes.h"
 #include "encoding.h"
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <gkeysym.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -28,6 +28,7 @@
 #include "bitmapchar.h"
 #include "bvedit.h"
 #include "cvundoes.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -32,6 +32,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "namelist.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -31,6 +31,7 @@
 #include "fontforgeui.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -30,6 +30,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -29,6 +29,7 @@
 #include "autowidth2.h"
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "fvcomposite.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -39,6 +39,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "mm.h"
+#include "namelist.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -36,6 +36,7 @@
 #include "encoding.h"
 #include "fontforgeui.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -33,6 +33,7 @@
 #include "cvruler.h"
 #include "cvundoes.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #include <math.h>
 #include <locale.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -35,6 +35,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforgeui.h"
+#include "fvcomposite.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -37,6 +37,7 @@
 #include "fontforgeui.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -38,6 +38,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "mm.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/combinations.c
+++ b/fontforgeexe/combinations.c
@@ -27,6 +27,7 @@
  */
 #include "fontforgeui.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include "psfont.h"
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/combinations.c
+++ b/fontforgeexe/combinations.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "fvcomposite.h"
 #include "psfont.h"
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/combinations.c
+++ b/fontforgeexe/combinations.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include "psfont.h"
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -26,6 +26,7 @@
  */
 #include "asmfpst.h"
 #include "fontforgeui.h"
+#include "lookups.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "lookups.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/cvimportdlg.c
+++ b/fontforgeexe/cvimportdlg.c
@@ -28,6 +28,7 @@
 #include "cvimages.h"
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "fvimportbdf.h"
 #include <math.h>
 #include <sys/types.h>
 #include <dirent.h>

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforgeexe/cvtranstools.c
+++ b/fontforgeexe/cvtranstools.c
@@ -26,6 +26,8 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "nonlineartrans.h"
+
 #include <math.h>
 
 void CVMouseDownTransform(CharView *cv) {

--- a/fontforgeexe/displayfonts.c
+++ b/fontforgeexe/displayfonts.c
@@ -29,6 +29,7 @@
 #include "autotrace.h"
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "lookups.h"
 #include "sftextfieldP.h"
 #include <stdlib.h>
 #include <math.h>

--- a/fontforgeexe/effectsui.c
+++ b/fontforgeexe/effectsui.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "cvundoes.h"
+#include "effects.h"
 #include "fontforgeui.h"
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -28,6 +28,7 @@
 #include "autowidth.h"
 #include "bitmapchar.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #include "ofl.h"
 #include <ustring.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -31,13 +31,13 @@
 #include "encoding.h"
 #include "featurefile.h"
 #include "fontforgeui.h"
+#include "lookups.h"
 #include "ofl.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>
 #include "unicoderange.h"
 #include <locale.h>
-#include "lookups.h"
 #include "sfundo.h"
 #include "collabclientui.h"
 

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -29,6 +29,7 @@
 #include "bitmapchar.h"
 #include "dumppfa.h"
 #include "encoding.h"
+#include "featurefile.h"
 #include "fontforgeui.h"
 #include "ofl.h"
 #include <ustring.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -32,6 +32,7 @@
 #include "featurefile.h"
 #include "fontforgeui.h"
 #include "lookups.h"
+#include "namelist.h"
 #include "ofl.h"
 #include <ustring.h>
 #include <chardata.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -45,6 +45,7 @@
 #include "groups.h"
 #include "mm.h"
 #include "namelist.h"
+#include "nonlineartrans.h"
 #include "psfont.h"
 #include "scripting.h"
 #include <gfile.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -40,6 +40,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforgeui.h"
+#include "fvcomposite.h"
 #include "groups.h"
 #include "psfont.h"
 #include "scripting.h"

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -44,6 +44,7 @@
 #include "fvfonts.h"
 #include "groups.h"
 #include "mm.h"
+#include "namelist.h"
 #include "psfont.h"
 #include "scripting.h"
 #include <gfile.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -38,6 +38,7 @@
 #include "bvedit.h"
 #include "cvundoes.h"
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #include "groups.h"
 #include "psfont.h"

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -43,6 +43,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "groups.h"
+#include "mm.h"
 #include "psfont.h"
 #include "scripting.h"
 #include <gfile.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -41,6 +41,7 @@
 #include "encoding.h"
 #include "fontforgeui.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include "groups.h"
 #include "psfont.h"
 #include "scripting.h"

--- a/fontforgeexe/fvfontsdlg.c
+++ b/fontforgeexe/fvfontsdlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforgeexe/gotodlg.c
+++ b/fontforgeexe/gotodlg.c
@@ -26,6 +26,7 @@
  */
 
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <utype.h>
 #include <ustring.h>
 #include "unicoderange.h"

--- a/fontforgeexe/groupsdlg.c
+++ b/fontforgeexe/groupsdlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include "groups.h"
 #include <unistd.h>
 #include <ustring.h>

--- a/fontforgeexe/groupsdlg.c
+++ b/fontforgeexe/groupsdlg.c
@@ -27,6 +27,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "groups.h"
+#include "namelist.h"
 #include <unistd.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/justifydlg.c
+++ b/fontforgeexe/justifydlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "lookups.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/kernclass.c
+++ b/fontforgeexe/kernclass.c
@@ -27,6 +27,7 @@
 #include "autowidth2.h"
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <gkeysym.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/kernclass.c
+++ b/fontforgeexe/kernclass.c
@@ -26,6 +26,7 @@
  */
 #include "autowidth2.h"
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <gkeysym.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/layer2layer.c
+++ b/fontforgeexe/layer2layer.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "glyphcomp.h"
 #include <ustring.h>
 #include <gkeysym.h>
 

--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -27,6 +27,7 @@
  */
 #include "autowidth2.h"
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -28,6 +28,7 @@
 #include "autowidth2.h"
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "lookups.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>
@@ -36,7 +37,6 @@
 #include <stdlib.h>
 #include "ttf.h"
 #include <gkeysym.h>
-#include "lookups.h"
 #include "gfile.h"
 #include "sfundo.h"
 

--- a/fontforgeexe/macencui.c
+++ b/fontforgeexe/macencui.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "macenc.h"
 #include <gkeysym.h>
 #include <ustring.h>
 #include "ttf.h"

--- a/fontforgeexe/math.c
+++ b/fontforgeexe/math.c
@@ -26,6 +26,7 @@
  */
 
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <stddef.h>
 #include <gkeysym.h>

--- a/fontforgeexe/math.c
+++ b/fontforgeexe/math.c
@@ -27,6 +27,7 @@
 
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "mathconstants.h"
 #include <math.h>
 #include <stddef.h>
 #include <gkeysym.h>

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -34,6 +34,7 @@
 #include "fvcomposite.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "mm.h"
 #include <gkeysym.h>
 #include <gresource.h>
 #include <gresedit.h>

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -31,6 +31,7 @@
 #include "bvedit.h"
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "fvcomposite.h"
 #include "lookups.h"
 #include <gkeysym.h>
 #include <gresource.h>

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -32,6 +32,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "fvcomposite.h"
+#include "fvfonts.h"
 #include "lookups.h"
 #include <gkeysym.h>
 #include <gresource.h>

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -27,6 +27,7 @@
 #include "dumppfa.h"
 #include "encoding.h"
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <ustring.h>
 #include <math.h>
 #include <gkeysym.h>

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -28,6 +28,7 @@
 #include "encoding.h"
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "macenc.h"
 #include <ustring.h>
 #include <math.h>
 #include <gkeysym.h>

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "dumppfa.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #include <ustring.h>
 #include <math.h>

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -29,6 +29,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "macenc.h"
+#include "mm.h"
 #include <ustring.h>
 #include <math.h>
 #include <gkeysym.h>

--- a/fontforgeexe/nonlineartransui.c
+++ b/fontforgeexe/nonlineartransui.c
@@ -27,9 +27,9 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "nonlineartrans.h"
 #include <utype.h>
 #include <ustring.h>
-#include "nonlineartrans.h"
 
 struct nldlg {
     GWindow gw;
@@ -57,7 +57,7 @@ void NonLinearDlg(FontView *fv,CharView *cv) {
     GWindowAttrs wattrs;
     GGadgetCreateData gcd[8], boxes[4], *hvarray[3][3], *barray[9], *varray[3][2];
     GTextInfo label[8];
-    struct context c;
+    struct expr_context c;
     char *expstr;
 
     memset(&d,'\0',sizeof(d));

--- a/fontforgeexe/openfontdlg.c
+++ b/fontforgeexe/openfontdlg.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "namelist.h"
 #include <stdlib.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -29,6 +29,7 @@
 #include "encoding.h"
 #include "fontforgeui.h"
 #include "groups.h"
+#include "macenc.h"
 #include "plugins.h"
 #include <charset.h>
 #include <gfile.h>

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -30,6 +30,7 @@
 #include "fontforgeui.h"
 #include "groups.h"
 #include "macenc.h"
+#include "namelist.h"
 #include "plugins.h"
 #include <charset.h>
 #include <gfile.h>

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "autotrace.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #include "groups.h"
 #include "plugins.h"

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -29,6 +29,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "namelist.h"
 #include "ttf.h"
 #include <gwidget.h>
 #include <ustring.h>

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -28,6 +28,7 @@
 #include "autohint.h"
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include "ttf.h"
 #include <gwidget.h>
 #include <ustring.h>

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -29,6 +29,7 @@
 #include "fontforgeui.h"
 #include "macbinary.h"
 #include "mm.h"
+#include "namelist.h"
 #include <ustring.h>
 #include <locale.h>
 #include <gfile.h>

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -27,6 +27,7 @@
  */
 #include "encoding.h"
 #include "fontforgeui.h"
+#include "macbinary.h"
 #include <ustring.h>
 #include <locale.h>
 #include <gfile.h>

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -28,6 +28,7 @@
 #include "encoding.h"
 #include "fontforgeui.h"
 #include "macbinary.h"
+#include "mm.h"
 #include <ustring.h>
 #include <locale.h>
 #include <gfile.h>

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -25,6 +25,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "encoding.h"
 #include "fontforgeui.h"
 #include <ustring.h>
 #include <locale.h>

--- a/fontforgeexe/searchview.c
+++ b/fontforgeexe/searchview.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/sftextfield.c
+++ b/fontforgeexe/sftextfield.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "langfreq.h"
 #include <gkeysym.h>
 #include <math.h>
 

--- a/fontforgeexe/sfundo.c
+++ b/fontforgeexe/sfundo.c
@@ -27,6 +27,8 @@
 ******************************************************************************/
 
 #include "sfundo.h"
+
+#include "fvfonts.h"
 #include "views.h"
 #include <string.h>
 #include "uiinterface.h"

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -27,6 +27,7 @@
  */
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "glyphcomp.h"
 #include <utype.h>
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "glyphcomp.h"
+#include "lookups.h"
 #include <utype.h>
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "fvfonts.h"
 #include <utype.h>
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -31,6 +31,7 @@
 #include "autosave.h"
 #include "bitmapchar.h"
 #include "clipnoui.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #ifndef _NO_LIBUNICODENAMES
 #include <libunicodenames.h>	/* need to open a database when we start */

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -33,6 +33,7 @@
 #include "clipnoui.h"
 #include "encoding.h"
 #include "fontforgeui.h"
+#include "lookups.h"
 #ifndef _NO_LIBUNICODENAMES
 #include <libunicodenames.h>	/* need to open a database when we start */
 extern uninm_names_db names_db; /* Unicode character names and annotations database */

--- a/fontforgeexe/statemachine.c
+++ b/fontforgeexe/statemachine.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "lookups.h"
 #include "ttf.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -28,6 +28,8 @@
 ******************************************************************************/
 #include <fontforge-config.h>
 
+#include "fvfonts.h"
+
 #include <string.h>
 #include <ctype.h>
 

--- a/plugins/gb12345.c
+++ b/plugins/gb12345.c
@@ -5,6 +5,7 @@
 #define FontForgeInit gb12345_LTX_FontForgeInit
 
 #include "plugins.h"
+#include "encoding.h"
 
 static const unsigned short __gb12345_to_ucs[] =
 {


### PR DESCRIPTION
The second bunch of standalone cleanups for the headers in `fontforge/`, a followup to PR #2878. I made this PR smaller than previously stated in the hope it will be easier to review.

Similary to the previous PR, these commits all the `extern` prototypes of non-static functions of various `.c` files to their respective `.h` files. In this second PR, the headers of the files from `fontforge/effects.c` to `fontforge/nonlineartrans.c` (in alphabetical order) have been consolidated. `splinefont.h` and `baseview.h` getting smaller and smaller. The most important thing is that many implicit dependencies are now explicit, hinting at where the future code clean-ups and refactorings should start from.

No implementation code has been touched and this PR. Comments, where available, have been preserved and moved near to the function declarations.