### PR TITLE
Fix OS/2.fsSelection field calculation

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3377,7 +3377,6 @@ static void setos2(struct os2 *os2,struct alltabs *at, SplineFont *sf,
 	os2->fsSel |= 8;
     if ( os2->version>=4 ) {
 	if ( strstrmatch(sf->fontname,"Obli")!=NULL ) {
-	    os2->fsSel &= ~1;		/* Turn off Italic */
 	    os2->fsSel |= 512;		/* Turn on Oblique */
 	}
 	if ( sf->use_typo_metrics )


### PR DESCRIPTION
Currently, when exporting a TTF font, FontForge will analyze the font name, and if it contains the "Obli" substring, it will set the OBLIQUE bit (bit 9) and clear the ITALIC bit (bit 0) of the fsSelection field of the OS/2 table. However, the OpenType specification suggests that both ITALIC and OBLIQUE bits are set for oblique fonts (see https://www.microsoft.com/typography/otspec/os2.htm#fss).

This behavior creates issues on Windows, where if a family contains Oblique fonts, not all fonts from the family will be displayed in the Control Panel.