### PR TITLE
Reduce configure-fontforge.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,11 @@ FONTFORGE_ARG_ENABLE([tile-path],
                 [enable a 'tile path' command (a variant of 'expand stroke')])],
         [FONTFORGE_CONFIG_TILEPATH])
 
+FONTFORGE_ARG_ENABLE([write-pfm],
+        [AS_HELP_STRING([--enable-write-pfm],
+                [add the ability to save a PFM file without creating the associated font file])],
+        [FONTFORGE_CONFIG_WRITE_PFM])
+
 #--------------------------------------------------------------------------
 # Theme pixmap ICON selection.
 # Go with tango by default. Retain older 2012 theme for those who like it.

--- a/fontforge/configure-fontforge.h
+++ b/fontforge/configure-fontforge.h
@@ -82,14 +82,6 @@
 /*									      */
 
 
-/* Werner wants to be able to see the raw (unscaled) data for the location of */
-/*  points (in the points window of the debugger). I'm not sure that is       */
-/*  generally a good idea (I think it makes the dlg look unsymetric).         */
-/*									      */
-/* #define FONTFORGE_CONFIG_SHOW_RAW_POINTS				      */
-/*									      */
-
-
 /* ************************************************************************** */
 /* **************************** Numeric Settings **************************** */
 /* ************************************************************************** */

--- a/fontforge/configure-fontforge.h
+++ b/fontforge/configure-fontforge.h
@@ -78,10 +78,6 @@
 /* **************************** Numeric Settings **************************** */
 /* ************************************************************************** */
 
-
-/* The number of files displayed in the "File->Recent" menu */
-#define RECENT_MAX	10
-
 /* The number of tabs allowed in the outline glyph view of former glyphs */
 #define FORMER_MAX	10
 

--- a/fontforge/configure-fontforge.h
+++ b/fontforge/configure-fontforge.h
@@ -78,9 +78,4 @@
 /* **************************** Numeric Settings **************************** */
 /* ************************************************************************** */
 
-/* The maximum number of layers allowed in a normal font (this includes the */
-/*  default foreground and background layers) -- this does not limit type3  */
-/*  fonts */
-#define BACK_LAYER_MAX	256
-
 #endif

--- a/fontforge/configure-fontforge.h
+++ b/fontforge/configure-fontforge.h
@@ -53,14 +53,6 @@
 /*									      */
 
 
-/* Harald Harders would like to be able to generate a PFM file without        */
-/*  creating a font along with it. I don't see the need for this, but he pro- */
-/*  vided a patch. Setting this flag will enable his patch		      */
-/*									      */
-/* #define FONTFORGE_CONFIG_WRITE_PFM					      */
-/*									      */
-
-
 /* Prior to late Sept of 2003 FontForge converted certain mac feature/settings*/
 /*  into opentype-like tags. Some features could be converted directly but for*/
 /*  a few I made up tags.  Now FontForge is capable of using the mac feature  */

--- a/fontforge/configure-fontforge.h
+++ b/fontforge/configure-fontforge.h
@@ -78,9 +78,6 @@
 /* **************************** Numeric Settings **************************** */
 /* ************************************************************************** */
 
-/* The number of tabs allowed in the outline glyph view of former glyphs */
-#define FORMER_MAX	10
-
 /* The maximum number of layers allowed in a normal font (this includes the */
 /*  default foreground and background layers) -- this does not limit type3  */
 /*  fonts */

--- a/fontforge/fontforgeui.h
+++ b/fontforge/fontforgeui.h
@@ -161,6 +161,9 @@ extern struct clip_interface gdraw_clip_interface;
 extern int ItalicConstrained;
 extern unichar_t *script_menu_names[SCRIPT_MENU_MAX];
 extern char *script_filenames[SCRIPT_MENU_MAX];
+
+/* The number of files displayed in the "File->Recent" menu */
+#define RECENT_MAX	10
 extern char *RecentFiles[RECENT_MAX];
 
 /* I would like these to be const ints, but gcc doesn't treat them as consts */

--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -142,6 +142,8 @@ static int  gridfit_x_sameas_y=true;		/* in cvgridfit.c */
 static int default_font_filter_index=0;
 static unichar_t *script_menu_names[SCRIPT_MENU_MAX];
 static char *script_filenames[SCRIPT_MENU_MAX];
+/* defined in fontforgeui.h */
+#define RECENT_MAX 10
 static char *RecentFiles[RECENT_MAX];
 static int ItalicConstrained = true;
 extern int clear_tt_instructions_when_needed;	/* cvundoes.c */

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -26,6 +26,8 @@
  */
 /*			   Yet another interpreter			      */
 
+#include <fontforge-config.h>
+
 #include "autohint.h"
 #include "autotrace.h"
 #include "autowidth.h"

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -55,6 +55,13 @@
 #define MmMax		16	/* PS says at most this many instances for type1/2 mm fonts */
 #define AppleMmMax	26	/* Apple sort of has a limit of 4095, but we only support this many */
 
+
+/* The maximum number of layers allowed in a normal font (this includes the */
+/*  default foreground and background layers) -- this does not limit type3  */
+/*  fonts */
+#define BACK_LAYER_MAX 256
+
+
 typedef struct ipoint {
     int x;
     int y;

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -126,6 +126,11 @@ typedef struct debugview {
     int layer;
 } DebugView;
 
+
+/* The number of tabs allowed in the outline glyph view of former glyphs */
+#define FORMER_MAX	10
+
+
 enum dv_coderange { cr_none=0, cr_fpgm, cr_prep, cr_glyph };	/* cleverly chosen to match ttobjs.h */
 
 struct freehand {

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -27,6 +27,8 @@
 #ifndef _VIEWS_H
 #define _VIEWS_H
 
+#include <fontforge-config.h>
+
 #include "ffglib.h"
 #include "baseviews.h"
 

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -130,7 +130,6 @@ typedef struct debugview {
 /* The number of tabs allowed in the outline glyph view of former glyphs */
 #define FORMER_MAX	10
 
-
 enum dv_coderange { cr_none=0, cr_fpgm, cr_prep, cr_glyph };	/* cleverly chosen to match ttobjs.h */
 
 struct freehand {
@@ -153,9 +152,12 @@ typedef struct charviewtab
 enum { charview_cvtabssz = 100 };
 
 
+ /* approximately BACK_LAYER_MAX / 32 */
+#define BACK_LAYERS_VIEW_MAX 8
+
 typedef struct charview {
     CharViewBase b;
-    uint32 showback[BACK_LAYER_MAX/32];
+    uint32 showback[BACK_LAYERS_VIEW_MAX];
     unsigned int showfore:1;
     unsigned int showgrids:1;
     unsigned int showhhints:1;


### PR DESCRIPTION
While we sort out how what is the best way to go about removing `configure-fontforge.h` in PR #2945, I isolated in this smaller PR a couple of low-hanging fruits: turning the last still used configuration option to a proper autoconf option and moving some constants near other similar constants in the appropriate headers.

A reminder about the duplicated constant in `fontforge/noprefs.c`: that file contains, on purpose, hundreds of duplicated declarations. Life is interesting in fontforge's land. ;)