### PR TITLE
Consolidate fontforge headers, part 4

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -79,6 +79,7 @@ noinst_HEADERS = \
 	spiro.h \
 	splinefill.h \
 	splineorder2.h \
+	splineoverlap.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -83,6 +83,7 @@ noinst_HEADERS = \
 	splinerefigure.h \
 	splinesaveafm.h \
 	splinesave.h \
+	splinestroke.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -78,6 +78,7 @@ noinst_HEADERS = \
 	sfd.h \
 	spiro.h \
 	splinefill.h \
+	splineorder2.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -80,6 +80,7 @@ noinst_HEADERS = \
 	splinefill.h \
 	splineorder2.h \
 	splineoverlap.h \
+	splinerefigure.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -81,6 +81,7 @@ noinst_HEADERS = \
 	splineorder2.h \
 	splineoverlap.h \
 	splinerefigure.h \
+	splinesaveafm.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -84,6 +84,7 @@ noinst_HEADERS = \
 	splinesaveafm.h \
 	splinesave.h \
 	splinestroke.h \
+	splineutil2.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -77,6 +77,7 @@ noinst_HEADERS = \
 	scstyles.h \
 	sfd.h \
 	spiro.h \
+	splinefill.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -86,6 +86,7 @@ noinst_HEADERS = \
 	splinestroke.h \
 	splineutil.h \
 	splineutil2.h \
+	start.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -82,6 +82,7 @@ noinst_HEADERS = \
 	splineoverlap.h \
 	splinerefigure.h \
 	splinesaveafm.h \
+	splinesave.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -84,6 +84,7 @@ noinst_HEADERS = \
 	splinesaveafm.h \
 	splinesave.h \
 	splinestroke.h \
+	splineutil.h \
 	splineutil2.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
 	flaglist.h strlist.h charview_private.h cvundoes.h tables.h

--- a/fontforge/asmfpst.c
+++ b/fontforge/asmfpst.c
@@ -30,6 +30,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "ttf.h"
+#include "splineutil.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -36,6 +36,7 @@
 #include "splinefont.h"
 #include "splinefill.h"
 #include "splinesave.h"
+#include "splineutil2.h"
 #include "views.h"
 #include "stemdb.h"
 #include <utype.h>

--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -36,6 +36,7 @@
 #include "splinefont.h"
 #include "splinefill.h"
 #include "splinesave.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "views.h"
 #include "stemdb.h"

--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"
+#include "splinefill.h"
 #include "views.h"
 #include "stemdb.h"
 #include <utype.h>

--- a/fontforge/autohint.c
+++ b/fontforge/autohint.c
@@ -35,6 +35,7 @@
 #include <math.h>
 #include "splinefont.h"
 #include "splinefill.h"
+#include "splinesave.h"
 #include "views.h"
 #include "stemdb.h"
 #include <utype.h>

--- a/fontforge/autotrace.c
+++ b/fontforge/autotrace.c
@@ -33,6 +33,7 @@
 #include "psread.h"
 #include "splineorder2.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autotrace.c
+++ b/fontforge/autotrace.c
@@ -32,6 +32,7 @@
 #include "fvimportbdf.h"
 #include "psread.h"
 #include "splineorder2.h"
+#include "splinestroke.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autotrace.c
+++ b/fontforge/autotrace.c
@@ -33,6 +33,7 @@
 #include "psread.h"
 #include "splineorder2.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/autotrace.c
+++ b/fontforge/autotrace.c
@@ -31,6 +31,7 @@
 #include "fontforgevw.h"
 #include "fvimportbdf.h"
 #include "psread.h"
+#include "splineorder2.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -34,6 +34,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -33,6 +33,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "splinesaveafm.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth2.c
+++ b/fontforge/autowidth2.c
@@ -30,6 +30,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "splineoverlap.h"
+#include "splineutil.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/autowidth2.c
+++ b/fontforge/autowidth2.c
@@ -29,6 +29,7 @@
 #include "cvundoes.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "splineoverlap.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -325,7 +325,6 @@ extern void TransHints(StemInfo *stem,real mul1, real off1, real mul2, real off2
 extern void TransDStemHints(DStemInfo *ds,real xmul, real xoff, real ymul, real yoff, int round_to_int );
 extern void VrTrans(struct vr *vr,real transform[6]);
 extern int SFNLTrans(FontViewBase *fv,char *x_expr,char *y_expr);
-extern void FVStrokeItScript(void *fv, StrokeInfo *si,int pointless);
 
 struct smallcaps {
     double lc_stem_width, uc_stem_width;

--- a/fontforge/bezctx_ff.c
+++ b/fontforge/bezctx_ff.c
@@ -27,6 +27,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #include <basics.h>
 #include <stdio.h>
 
+#include "splineutil.h"
+
 #ifndef _NO_LIBSPIRO
 #include "bezctx_ff.h"
 #include "fontforgevw.h"	/* For LogError, else splinefont.h */

--- a/fontforge/bitmapchar.c
+++ b/fontforge/bitmapchar.c
@@ -33,6 +33,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <string.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/bitmapchar.c
+++ b/fontforge/bitmapchar.c
@@ -32,6 +32,7 @@
 #include "dumpbdf.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "splinefill.h"
 #include <string.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/bitmapcontrol.c
+++ b/fontforge/bitmapcontrol.c
@@ -30,6 +30,7 @@
 #include "autohint.h"
 #include "bvedit.h"
 #include "fontforgevw.h"
+#include "splinefill.h"
 #include "ustring.h"
 #include <math.h>
 #include "bitmapcontrol.h"

--- a/fontforge/bitmapcontrol.c
+++ b/fontforge/bitmapcontrol.c
@@ -31,6 +31,7 @@
 #include "bvedit.h"
 #include "fontforgevw.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include "ustring.h"
 #include <math.h>
 #include "bitmapcontrol.h"

--- a/fontforge/bvedit.c
+++ b/fontforge/bvedit.c
@@ -29,6 +29,7 @@
 
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "splinefill.h"
 #include <math.h>
 #include "ustring.h"
 

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -32,6 +32,7 @@
 #include "dumppfa.h"
 #include "fontforgevw.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include <math.h>
 #include <locale.h>
 #include <string.h>

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -33,6 +33,7 @@
 #include "fontforgevw.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include <math.h>
 #include <locale.h>
 #include <string.h>

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -34,6 +34,7 @@
 #include "psread.h"
 #include "spiro.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <sys/types.h>
 #include <dirent.h>

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -34,6 +34,7 @@
 #include "psread.h"
 #include "spiro.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <sys/types.h>

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -33,6 +33,7 @@
 #include "parsepdf.h"
 #include "psread.h"
 #include "spiro.h"
+#include "splineorder2.h"
 #include <math.h>
 #include <sys/types.h>
 #include <dirent.h>

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -40,6 +40,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "views.h"
 #include <math.h>

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -39,6 +39,7 @@
 #include "sfd.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include "views.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -38,6 +38,7 @@
 #include "namelist.h"
 #include "sfd.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include "views.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -40,6 +40,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include "views.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/dumpbdf.c
+++ b/fontforge/dumpbdf.c
@@ -32,6 +32,7 @@
 #include "encoding.h"
 #include "fontforge.h"
 #include "splinefont.h"
+#include "splinefill.h"
 #include <gdraw.h>			/* for the defn of GClut for greymaps */
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/dumpbdf.c
+++ b/fontforge/dumpbdf.c
@@ -33,6 +33,7 @@
 #include "fontforge.h"
 #include "splinefont.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <gdraw.h>			/* for the defn of GClut for greymaps */
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -37,6 +37,7 @@
 #include "splineorder2.h"
 #include "splinesave.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -37,6 +37,7 @@
 #include "splineorder2.h"
 #include "splinesave.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -34,6 +34,7 @@
 #include "http.h"
 #include "parsepfa.h"
 #include "psread.h"
+#include "splineorder2.h"
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -35,6 +35,7 @@
 #include "parsepfa.h"
 #include "psread.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -35,6 +35,7 @@
 #include "parsepfa.h"
 #include "psread.h"
 #include "splineorder2.h"
+#include "splinesave.h"
 #include "splinesaveafm.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/edgelist.h
+++ b/fontforge/edgelist.h
@@ -78,12 +78,6 @@ typedef struct edgelist {
     DBounds bbox;		/* Not always set. {m,o}{min,max} a provide scaled bbox, this is in glyph units */
 } EdgeList;
 
-extern void FreeEdges(EdgeList *es);
-extern bigreal TOfNextMajor(Edge *e, EdgeList *es, bigreal sought_y );
-extern void FindEdgesSplineSet(SplinePointList *spl, EdgeList *es, int ignore_clip);
-extern Edge *ActiveEdgesInsertNew(EdgeList *es, Edge *active,int i);
-extern Edge *ActiveEdgesRefigure(EdgeList *es, Edge *active,real i);
-extern Edge *ActiveEdgesFindStem(Edge *apt, Edge **prev, real i);
 
 /* Version which is better for everything other than rasterization */
 /*  (I think) */

--- a/fontforge/edgelist2.h
+++ b/fontforge/edgelist2.h
@@ -79,9 +79,4 @@ typedef struct monotonic {
     struct preintersection *pending;
 } Monotonic;
 
-extern void FreeMonotonics(Monotonic *m);
-extern Monotonic *SSsToMContours(SplineSet *spl, enum overlap_type ot);
-	/* overlap_type controls whether we look at selected splinesets or all splinesets */
-extern int MonotonicFindAt(Monotonic *ms,int which, extended test, Monotonic **space );
-
 #endif /* _EDGELIST2_H */

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -32,6 +32,7 @@
 #include "fontforgevw.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -30,6 +30,7 @@
 #include "autohint.h"
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "splineoverlap.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -31,6 +31,7 @@
 #include "cvundoes.h"
 #include "fontforgevw.h"
 #include "splineoverlap.h"
+#include "splinestroke.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -32,6 +32,7 @@
 #include "fontforgevw.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -37,6 +37,7 @@
 #include "splinefont.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -35,6 +35,7 @@
 #include "namelist.h"
 #include "psread.h"
 #include "splinefont.h"
+#include "splinefill.h"
 #include <ustring.h>
 #include <utype.h>
 #include <math.h>

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -37,6 +37,7 @@
 #include "splinefont.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <utype.h>
 #include <math.h>

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -36,6 +36,7 @@
 #include "psread.h"
 #include "splinefont.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <ustring.h>
 #include <utype.h>
 #include <math.h>

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -36,6 +36,7 @@
 #include "lookups.h"
 #include "namelist.h"
 #include "ttf.h"
+#include "splineutil.h"
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -43,6 +43,7 @@
 #include "spiro.h"
 #include "splineoverlap.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <gfile.h>
 #include <gio.h>
 #include <ustring.h>

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -42,6 +42,7 @@
 #include "sfd.h"
 #include "spiro.h"
 #include "splineoverlap.h"
+#include "splinesaveafm.h"
 #include <gfile.h>
 #include <gio.h>
 #include <ustring.h>

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -41,6 +41,7 @@
 #include "scripting.h"
 #include "sfd.h"
 #include "spiro.h"
+#include "splineoverlap.h"
 #include <gfile.h>
 #include <gio.h>
 #include <ustring.h>

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -43,6 +43,7 @@
 #include "spiro.h"
 #include "splineoverlap.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <gfile.h>
 #include <gio.h>

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -31,6 +31,7 @@
 #include "fvfonts.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include <math.h>
 
 FT_Library ff_ft_context;

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -30,6 +30,7 @@
 #include "fffreetype.h"
 #include "fvfonts.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include <math.h>
 
 FT_Library ff_ft_context;

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -29,6 +29,7 @@
 #include "fontforgevw.h"
 #include "fffreetype.h"
 #include "fvfonts.h"
+#include "splinefill.h"
 #include <math.h>
 
 FT_Library ff_ft_context;

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -32,6 +32,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splinestroke.h"
 #include <math.h>
 
 FT_Library ff_ft_context;

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -33,6 +33,7 @@
 #include "splineorder2.h"
 #include "splinesaveafm.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include <math.h>
 
 FT_Library ff_ft_context;

--- a/fontforge/ftdelta.c
+++ b/fontforge/ftdelta.c
@@ -27,6 +27,7 @@
 #include "fontforgevw.h"
 #include "fffreetype.h"
 #include "delta.h"
+#include "splineutil.h"
 #include <math.h>
 
 static int NearestPt(Spline *s,BasePoint *bp) {

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -35,6 +35,7 @@
 #include "fvfonts.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "namelist.h"
 #include <chardata.h>
 #include <math.h>

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -34,6 +34,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include "namelist.h"
 #include <chardata.h>
 #include <math.h>

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -33,6 +33,7 @@
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "splinefill.h"
 #include "namelist.h"
 #include <chardata.h>
 #include <math.h>

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -34,6 +34,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "ustring.h"
 #include "utype.h"

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -32,6 +32,7 @@
 #include "lookups.h"
 #include "namelist.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -34,6 +34,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -33,6 +33,7 @@
 #include "namelist.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -31,6 +31,7 @@
 #include "fontforgevw.h"
 #include "lookups.h"
 #include "namelist.h"
+#include "splinefill.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -39,6 +39,7 @@
 #include "palmfonts.h"
 #include "parsettf.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <gfile.h>
 #include <math.h>

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -38,6 +38,7 @@
 #include "namelist.h"
 #include "palmfonts.h"
 #include "parsettf.h"
+#include "splinefill.h"
 #include <gfile.h>
 #include <math.h>
 #include "utype.h"

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -39,6 +39,7 @@
 #include "palmfonts.h"
 #include "parsettf.h"
 #include "splinefill.h"
+#include "splineutil2.h"
 #include <gfile.h>
 #include <math.h>
 #include "utype.h"

--- a/fontforge/fvmetrics.c
+++ b/fontforge/fvmetrics.c
@@ -31,6 +31,7 @@
 #include "bvedit.h"
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "splineutil.h"
 #include <math.h>
 #include <ustring.h>
 

--- a/fontforge/glyphcomp.c
+++ b/fontforge/glyphcomp.c
@@ -35,6 +35,7 @@
 #include "scriptfuncs.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/glyphcomp.c
+++ b/fontforge/glyphcomp.c
@@ -35,6 +35,7 @@
 #include "scriptfuncs.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>
 

--- a/fontforge/glyphcomp.c
+++ b/fontforge/glyphcomp.c
@@ -33,6 +33,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "scriptfuncs.h"
+#include "splinefill.h"
 #include <math.h>
 #include <ustring.h>
 

--- a/fontforge/glyphcomp.c
+++ b/fontforge/glyphcomp.c
@@ -34,6 +34,7 @@
 #include "fvfonts.h"
 #include "scriptfuncs.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include <math.h>
 #include <ustring.h>
 

--- a/fontforge/ikarus.c
+++ b/fontforge/ikarus.c
@@ -30,6 +30,7 @@
 #include "fontforge.h"
 #include "namelist.h"
 #include "mem.h"
+#include "splineorder2.h"
 #include <utype.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/ikarus.c
+++ b/fontforge/ikarus.c
@@ -31,6 +31,7 @@
 #include "namelist.h"
 #include "mem.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <utype.h>
 #include <string.h>

--- a/fontforge/ikarus.c
+++ b/fontforge/ikarus.c
@@ -31,6 +31,7 @@
 #include "namelist.h"
 #include "mem.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include <utype.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/langfreq.c
+++ b/fontforge/langfreq.c
@@ -3,6 +3,7 @@
 #include "langfreq.h"
 
 #include "fvfonts.h"
+#include "splinesaveafm.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -32,6 +32,7 @@
 #include "fvfonts.h"
 #include "macenc.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -31,6 +31,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "macenc.h"
+#include "splinesaveafm.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -39,6 +39,7 @@
 #include "parsepfa.h"
 #include "parsettf.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -41,6 +41,7 @@
 #include "splinefill.h"
 #include "splinesave.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <stdlib.h>
 #include <string.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -38,6 +38,7 @@
 #include "mem.h"
 #include "parsepfa.h"
 #include "parsettf.h"
+#include "splinefill.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -39,6 +39,7 @@
 #include "parsepfa.h"
 #include "parsettf.h"
 #include "splinefill.h"
+#include "splinesave.h"
 #include "splinesaveafm.h"
 #include <stdlib.h>
 #include <string.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -41,6 +41,7 @@
 #include "splinefill.h"
 #include "splinesave.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/fontforge/mathconstants.c
+++ b/fontforge/mathconstants.c
@@ -29,6 +29,7 @@
 
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "splineutil.h"
 
 #ifdef __need_size_t
 /* This is a bug on the mac, someone defines this and leaves it defined */

--- a/fontforge/mm.c
+++ b/fontforge/mm.c
@@ -32,6 +32,7 @@
 #include "lookups.h"
 #include "macenc.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforge/mm.c
+++ b/fontforge/mm.c
@@ -31,6 +31,7 @@
 #include "fontforgevw.h"
 #include "lookups.h"
 #include "macenc.h"
+#include "splinesaveafm.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforge/mm.c
+++ b/fontforge/mm.c
@@ -32,6 +32,7 @@
 #include "lookups.h"
 #include "macenc.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/nonlineartrans.c
+++ b/fontforge/nonlineartrans.c
@@ -29,6 +29,7 @@
 
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/nonlineartrans.c
+++ b/fontforge/nonlineartrans.c
@@ -29,6 +29,7 @@
 
 #include "cvundoes.h"
 #include "fontforgevw.h"
+#include "splineutil2.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -33,6 +33,7 @@
 #include "othersubrs.h"
 #include "plugins.h"
 #include "sfd.h"
+#include "splineutil.h"
 #include <charset.h>
 #include <gfile.h>
 #include <ustring.h>

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -36,6 +36,7 @@
 #include "ttf.h"
 #include "splinefont.h"
 #include "stemdb.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 
 extern int autohint_before_generate;

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -38,6 +38,7 @@
 #include "stemdb.h"
 #include "splineutil.h"
 #include "splineutil2.h"
+#include "stemdb.h"
 
 extern int autohint_before_generate;
 

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -36,6 +36,7 @@
 #include "ttf.h"
 #include "splinefont.h"
 #include "stemdb.h"
+#include "splineutil2.h"
 
 extern int autohint_before_generate;
 

--- a/fontforge/palmfonts.c
+++ b/fontforge/palmfonts.c
@@ -32,6 +32,7 @@
 #include "fontforgevw.h"
 #include "macbinary.h"
 #include "mem.h"
+#include "splinefill.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforge/palmfonts.c
+++ b/fontforge/palmfonts.c
@@ -34,6 +34,7 @@
 #include "mem.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/palmfonts.c
+++ b/fontforge/palmfonts.c
@@ -34,6 +34,7 @@
 #include "mem.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforge/palmfonts.c
+++ b/fontforge/palmfonts.c
@@ -33,6 +33,7 @@
 #include "macbinary.h"
 #include "mem.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -36,6 +36,7 @@
 #include "parsepfa.h"
 #include "parsettf.h"
 #include "psread.h"
+#include "splineutil2.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -36,6 +36,7 @@
 #include "parsepfa.h"
 #include "parsettf.h"
 #include "psread.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -44,6 +44,7 @@
 #include "psread.h"
 #include "sfd1.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <chardata.h>
 #include <utype.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -43,6 +43,7 @@
 #include "parsettfvar.h"
 #include "psread.h"
 #include "sfd1.h"
+#include "splineorder2.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -44,6 +44,7 @@
 #include "psread.h"
 #include "sfd1.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsettfatt.c
+++ b/fontforge/parsettfatt.c
@@ -31,6 +31,7 @@
 #include "lookups.h"
 #include "mem.h"
 #include "parsettf.h"
+#include "splineutil.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/parsettfbmf.c
+++ b/fontforge/parsettfbmf.c
@@ -32,6 +32,7 @@
 #include "fontforge.h"
 #include "chardata.h"
 #include "mem.h"
+#include "splinefill.h"
 #include "utype.h"
 #include "ustring.h"
 #include <math.h>

--- a/fontforge/parsettfvar.c
+++ b/fontforge/parsettfvar.c
@@ -31,6 +31,7 @@
 #include "fvfonts.h"
 #include "mem.h"
 #include "parsettf.h"
+#include "splineutil.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -36,6 +36,7 @@
 #include "mm.h"
 #include "psread.h"
 #include "sflayoutP.h"
+#include "splinesaveafm.h"
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -37,6 +37,7 @@
 #include "psread.h"
 #include "sflayoutP.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -31,6 +31,7 @@
 #include "namelist.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -30,6 +30,7 @@
 #include "fontforge.h"
 #include "namelist.h"
 #include "splineoverlap.h"
+#include "splinestroke.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -31,6 +31,7 @@
 #include "namelist.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <locale.h>

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -29,6 +29,7 @@
 #include "cvundoes.h"
 #include "fontforge.h"
 #include "namelist.h"
+#include "splineoverlap.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -73,6 +73,7 @@ extern int old_sfnt_flags;
 #include "print.h"
 #include "psread.h"
 #include "savefont.h"
+#include "splineorder2.h"
 #include "utype.h"
 #include "ustring.h"
 #include "flaglist.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -87,6 +87,7 @@ extern int old_sfnt_flags;
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineoverlap.h"
+#include "splinestroke.h"
 #include "ffpython.h"
 
 #include <math.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -85,6 +85,7 @@ extern int old_sfnt_flags;
 #include "sfd.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineoverlap.h"
 #include "ffpython.h"
 
 #include <math.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -88,6 +88,7 @@ extern int old_sfnt_flags;
 #include "splinefill.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "ffpython.h"
 

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -74,6 +74,7 @@ extern int old_sfnt_flags;
 #include "psread.h"
 #include "savefont.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include "utype.h"
 #include "ustring.h"
 #include "flaglist.h"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -90,6 +90,7 @@ extern int old_sfnt_flags;
 #include "splinestroke.h"
 #include "splineutil.h"
 #include "splineutil2.h"
+#include "start.h"
 #include "ffpython.h"
 
 #include <math.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -88,6 +88,7 @@ extern int old_sfnt_flags;
 #include "splinefill.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include "ffpython.h"
 
 #include <math.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -83,6 +83,7 @@ extern int old_sfnt_flags;
 #include "search.h"
 #include "sfd.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include "ffpython.h"
 
 #include <math.h>

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -41,6 +41,7 @@
 #include "splinefill.h"
 #include "splineoverlap.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -40,6 +40,7 @@
 #include "palmfonts.h"
 #include "splinefill.h"
 #include "splineoverlap.h"
+#include "splinesaveafm.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -38,6 +38,7 @@
 #include "macbinary.h"
 #include "namelist.h"
 #include "palmfonts.h"
+#include "splinefill.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -39,6 +39,7 @@
 #include "namelist.h"
 #include "palmfonts.h"
 #include "splinefill.h"
+#include "splineoverlap.h"
 #include "ustring.h"
 #include "gfile.h"
 #include "gresource.h"

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -64,6 +64,7 @@
 #include "search.h"
 #include "sfd.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -66,6 +66,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -65,6 +65,7 @@
 #include "sfd.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -68,6 +68,7 @@
 #include "splineorder2.h"
 #include "splinesaveafm.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <gfile.h>
 #include <utype.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -68,6 +68,7 @@
 #include "splineorder2.h"
 #include "splinesaveafm.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -67,6 +67,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splinestroke.h"
 #include <gfile.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -36,6 +36,7 @@
 #include "splineorder2.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -33,6 +33,7 @@
 #include "lookups.h"
 #include "namelist.h"
 #include "scstyles.h"
+#include "splineorder2.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -34,6 +34,7 @@
 #include "namelist.h"
 #include "scstyles.h"
 #include "splineorder2.h"
+#include "splineoverlap.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -35,6 +35,7 @@
 #include "scstyles.h"
 #include "splineorder2.h"
 #include "splineoverlap.h"
+#include "splinestroke.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -36,6 +36,7 @@
 #include "splineorder2.h"
 #include "splineoverlap.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforge/search.c
+++ b/fontforge/search.c
@@ -30,6 +30,7 @@
 #include "cvundoes.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforge/search.c
+++ b/fontforge/search.c
@@ -30,6 +30,7 @@
 #include "cvundoes.h"
 #include "fontforgevw.h"
 #include "fvfonts.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -43,6 +43,7 @@
 #include "splinefont.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "baseviews.h"
 #include "views.h"

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -42,6 +42,7 @@
 #include "psread.h"
 #include "splinefont.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include "baseviews.h"
 #include "views.h"
 #include <gdraw.h>

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -41,6 +41,7 @@
 #include "parsettf.h"
 #include "psread.h"
 #include "splinefont.h"
+#include "splinefill.h"
 #include "baseviews.h"
 #include "views.h"
 #include <gdraw.h>

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -43,6 +43,7 @@
 #include "splinefont.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include "baseviews.h"
 #include "views.h"
 #include <gdraw.h>

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -32,6 +32,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include <math.h>
 
 #include "sflayoutP.h"

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -31,6 +31,7 @@
 #include "fontforgevw.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "splinefill.h"
 #include <math.h>
 
 #include "sflayoutP.h"

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -33,6 +33,7 @@
 #include "lookups.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include <math.h>
 
 #include "sflayoutP.h"

--- a/fontforge/spiro.c
+++ b/fontforge/spiro.c
@@ -31,6 +31,7 @@
 #include "spiro.h"
 
 #include "fontforgevw.h"
+#include "splineutil.h"
 
 /* Access to Raph Levien's spiro splines */
 /* See http://www.levien.com/spiro/ */

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -36,6 +36,7 @@
 #include "spiro.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <locale.h>
 # include <ustring.h>

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -34,6 +34,7 @@
 #include "mem.h"
 #include "parsettf.h"
 #include "spiro.h"
+#include "splineorder2.h"
 #include <math.h>
 #include <locale.h>
 # include <ustring.h>

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -36,6 +36,7 @@
 #include "spiro.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <locale.h>

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -35,6 +35,7 @@
 #include "parsettf.h"
 #include "spiro.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include <math.h>
 #include <locale.h>
 # include <ustring.h>

--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -30,6 +30,7 @@
 #include "fvfonts.h"
 #include "psread.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <stdio.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -29,6 +29,7 @@
 #include "fontforge.h"
 #include "fvfonts.h"
 #include "psread.h"
+#include "splinesaveafm.h"
 #include <stdio.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -24,6 +24,8 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "splinefill.h"
+
 #include "fontforge.h"
 #include "fvfonts.h"
 #include "psread.h"

--- a/fontforge/splinefill.h
+++ b/fontforge/splinefill.h
@@ -1,0 +1,37 @@
+#ifndef FONTFORGE_SPLINEFILL_H
+#define FONTFORGE_SPLINEFILL_H
+
+#include "edgelist.h"
+#include "splinefont.h"
+
+#include <gdraw.h>
+
+enum piecemeal_flags { pf_antialias=1, pf_bbsized=2, pf_ft_nohints=4, pf_ft_recontext=8 };
+
+extern BDFChar *BDFPieceMeal(BDFFont *bdf, int index);
+extern BDFChar *BDFPieceMealCheck(BDFFont *bdf, int index);
+extern BDFChar *SplineCharAntiAlias(SplineChar *sc, int layer, int pixelsize, int linear_scale);
+extern BDFChar *SplineCharRasterize(SplineChar *sc, int layer, bigreal pixelsize);
+extern BDFFont *SplineFontAntiAlias(SplineFont *_sf, int layer, int pixelsize, int linear_scale);
+extern BDFFont *SplineFontPieceMeal(SplineFont *sf, int layer, int ptsize, int dpi, int flags, void *freetype_context);
+extern BDFFont *SplineFontRasterize(SplineFont *_sf, int layer, int pixelsize, int indicate);
+extern BDFFont *SplineFontToBDFHeader(SplineFont *_sf, int pixelsize, int indicate);
+extern bigreal TOfNextMajor(Edge *e, EdgeList *es, bigreal sought_m);
+extern Edge *ActiveEdgesFindStem(Edge *apt, Edge **prev, real i);
+extern Edge *ActiveEdgesInsertNew(EdgeList *es, Edge *active, int i);
+extern Edge *ActiveEdgesRefigure(EdgeList *es, Edge *active, real i);
+extern GClut *_BDFClut(int linear_scale);
+extern int BDFDepth(BDFFont *bdf);
+extern int GradientHere(bigreal scale, DBounds *bbox, int iy, int ix, struct gradient *grad, struct pattern *pat, int defgrey);
+extern void BCCompressBitmap(BDFChar *bdfc);
+extern void BCRegularizeBitmap(BDFChar *bdfc);
+extern void BCRegularizeGreymap(BDFChar *bdfc);
+extern void BDFCAntiAlias(BDFChar *bc, int linear_scale);
+extern void BDFCharFree(BDFChar *bdfc);
+extern void BDFFontFree(BDFFont *bdf);
+extern void BDFPropsFree(BDFFont *bdf);
+extern void FindEdgesSplineSet(SplinePointList *spl, EdgeList *es, int ignore_clip);
+extern void FreeEdges(EdgeList *es);
+extern void PatternPrep(SplineChar *sc, struct brush *brush, bigreal scale);
+
+#endif /* FONTFORGE_SPLINEFILL_H */

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -43,6 +43,7 @@
 #include "parsettf.h"
 #include "sfd.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -42,6 +42,7 @@
 #include "parsepfa.h"
 #include "parsettf.h"
 #include "sfd.h"
+#include "splinefill.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -44,6 +44,7 @@
 #include "sfd.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <utype.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2528,30 +2528,8 @@ extern int PointListIsSelected(SplinePointList *spl);
 extern void SplineSetsUntick(SplineSet *spl);
 extern void SFOrderBitmapList(SplineFont *sf);
 
-extern SplinePoint *SplineTtfApprox(Spline *ps);
-extern SplineSet *SSttfApprox(SplineSet *ss);
-extern SplineSet *SplineSetsTTFApprox(SplineSet *ss);
-extern SplineSet *SSPSApprox(SplineSet *ss);
-extern SplineSet *SplineSetsPSApprox(SplineSet *ss);
-extern SplineSet *SplineSetsConvertOrder(SplineSet *ss, int to_order2);
-extern void SplineRefigure2(Spline *spline);
-extern void SplineRefigureFixup(Spline *spline);
-extern Spline *SplineMake2(SplinePoint *from, SplinePoint *to);
 extern Spline *SplineMake(SplinePoint *from, SplinePoint *to, int order2);
 extern Spline *SFSplineMake(SplineFont *sf,SplinePoint *from, SplinePoint *to);
-extern void SCConvertToOrder2(SplineChar *sc);
-extern void SFConvertToOrder2(SplineFont *sf);
-extern void SCConvertToOrder3(SplineChar *sc);
-extern void SFConvertToOrder3(SplineFont *sf);
-extern void SFConvertGridToOrder2(SplineFont *_sf);
-extern void SCConvertLayerToOrder2(SplineChar *sc,int layer);
-extern void SFConvertLayerToOrder2(SplineFont *sf,int layer);
-extern void SFConvertGridToOrder3(SplineFont *_sf);
-extern void SCConvertLayerToOrder3(SplineChar *sc,int layer);
-extern void SFConvertLayerToOrder3(SplineFont *sf,int layer);
-extern void SCConvertOrder(SplineChar *sc, int to_order2);
-extern void SplinePointPrevCPChanged2(SplinePoint *sp);
-extern void SplinePointNextCPChanged2(SplinePoint *sp);
 extern int IntersectLinesSlopes(BasePoint *inter,
 	BasePoint *line1, BasePoint *slope1,
 	BasePoint *line2, BasePoint *slope2);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2130,16 +2130,8 @@ extern const unichar_t *_uGetModifiers(const unichar_t *fontname, const unichar_
 extern void ttfdumpbitmap(SplineFont *sf,struct alltabs *at,int32 *sizes);
 extern void SplineFontSetUnChanged(SplineFont *sf);
 
-extern int Within4RoundingErrors(bigreal v1, bigreal v2);
-extern int Within16RoundingErrors(bigreal v1, bigreal v2);
-extern int Within64RoundingErrors(bigreal v1, bigreal v2);
 extern int RealNear(real a,real b);
-extern int RealNearish(real a,real b);
-extern int RealApprox(real a,real b);
-extern int RealWithin(real a,real b,real fudge);
-extern int RealRatio(real a,real b,real fudge);
 
-extern int PointsDiagonalable(SplineFont *sf,BasePoint **bp,BasePoint *unit);
 
 extern void LineListFree(LineList *ll);
 extern void LinearApproxFree(LinearApprox *la);
@@ -2294,7 +2286,6 @@ extern void SFRemoveUndoes(SplineFont *sf,uint8 *selected,EncMap *map);
 extern void SplineRefigure(Spline *spline);
 extern Spline *SplineMake3(SplinePoint *from, SplinePoint *to);
 extern LinearApprox *SplineApproximate(Spline *spline, real scale);
-extern int SplinePointListIsClockwise(const SplineSet *spl);
 extern void SplineSetFindBounds(const SplinePointList *spl, DBounds *bounds);
 extern void SplineCharLayerFindBounds(SplineChar *sc,int layer,DBounds *bounds);
 extern void SplineCharFindBounds(SplineChar *sc,DBounds *bounds);
@@ -2343,7 +2334,6 @@ extern SplinePointList *SPLCopyTranslatedHintMasks(SplinePointList *base,
 extern SplinePointList *SPLCopyTransformedHintMasks(RefChar *r,
 	SplineChar *basesc, BasePoint *trans,int layer);
 extern SplinePointList *SplinePointListRemoveSelected(SplineChar *sc,SplinePointList *base);
-extern void SplinePointListSet(SplinePointList *tobase, SplinePointList *frombase);
 extern void SplinePointListSelect(SplinePointList *spl,int sel);
 extern void SCRefToSplines(SplineChar *sc,RefChar *rf,int layer);
 extern void RefCharFindBounds(RefChar *rf);
@@ -2425,79 +2415,9 @@ extern SplinePoint *SplineBisect(Spline *spline, extended t);
 extern Spline *SplineSplit(Spline *spline, extended ts[3]);
 extern Spline *ApproximateSplineFromPoints(SplinePoint *from, SplinePoint *to,
 	TPoint *mid, int cnt,int order2);
-extern Spline *ApproximateSplineFromPointsSlopes(SplinePoint *from, SplinePoint *to,
-	TPoint *mid, int cnt,int order2);
 extern bigreal SplineLength(Spline *spline);
-extern bigreal SplineLengthRange(Spline *spline, real from_t, real to_t);
-extern bigreal PathLength(SplineSet *ss);
-extern Spline *PathFindDistance(SplineSet *path,bigreal d,bigreal *_t);
-extern SplineSet *SplineSetBindToPath(SplineSet *ss,int doscale, int glyph_as_unit,
-	int align,real offset, SplineSet *path);
 extern int SplineIsLinear(Spline *spline);
-extern int SplineIsLinearMake(Spline *spline);
-extern int SplineInSplineSet(Spline *spline, SplineSet *spl);
 extern int SSPointWithin(SplineSet *spl,BasePoint *pt);
-extern SplineSet *SSRemoveZeroLengthSplines(SplineSet *base);
-extern void SSRemoveStupidControlPoints(SplineSet *base);
-extern void SSOverlapClusterCpAngles(SplineSet *base,bigreal within);
-extern void SplinesRemoveBetween(SplineChar *sc, SplinePoint *from, SplinePoint *to,int type);
-extern void SplineCharMerge(SplineChar *sc,SplineSet **head,int type);
-extern void SPLNearlyHvCps(SplineChar *sc,SplineSet *ss,bigreal err);
-extern void SPLNearlyHvLines(SplineChar *sc,SplineSet *ss,bigreal err);
-extern int  SPLNearlyLines(SplineChar *sc,SplineSet *ss,bigreal err);
-extern int SPInterpolate(const SplinePoint *sp);
-extern void SplinePointListSimplify(SplineChar *sc,SplinePointList *spl,
-	struct simplifyinfo *smpl);
-extern SplineSet *SplineCharSimplify(SplineChar *sc,SplineSet *head,
-	struct simplifyinfo *smpl);
-extern void SPLStartToLeftmost(SplineChar *sc,SplinePointList *spl, int *changed);
-extern void SPLsStartToLeftmost(SplineChar *sc,int layer);
-extern void CanonicalContours(SplineChar *sc,int layer);
-extern void SplineSetJoinCpFixup(SplinePoint *sp);
-extern SplineSet *SplineSetJoin(SplineSet *start,int doall,real fudge,int *changed);
-enum ae_type { ae_all, ae_between_selected, ae_only_good, ae_only_good_rm_later };
-extern int SpIsExtremum(SplinePoint *sp);
-extern int Spline1DCantExtremeX(const Spline *s);
-extern int Spline1DCantExtremeY(const Spline *s);
-extern Spline *SplineAddExtrema(Spline *s,int always,real lenbound,
-	real offsetbound,DBounds *b);
-extern void SplineSetAddExtrema(SplineChar *sc,SplineSet *ss,enum ae_type between_selected, int emsize);
-extern void SplineCharAddExtrema(SplineChar *sc,SplineSet *head,enum ae_type between_selected,int emsize);
-extern SplineSet *SplineCharRemoveTiny(SplineChar *sc,SplineSet *head);
-extern SplineFont *SplineFontNew(void);
-extern char *GetNextUntitledName(void);
-extern SplineFont *SplineFontEmpty(void);
-extern SplineFont *SplineFontBlank(int charcnt);
-extern void SFIncrementXUID(SplineFont *sf);
-extern void SFRandomChangeXUID(SplineFont *sf);
-extern SplineSet *SplineSetReverse(SplineSet *spl);
-extern SplineSet *SplineSetsExtractOpen(SplineSet **tbase);
-extern void SplineSetsInsertOpen(SplineSet **tbase,SplineSet *open);
-extern SplineSet *SplineSetsCorrect(SplineSet *base,int *changed);
-extern SplineSet *SplineSetsAntiCorrect(SplineSet *base);
-extern SplineSet *SplineSetsDetectDir(SplineSet **_base, int *lastscan);
-extern void SPAverageCps(SplinePoint *sp);
-extern void SPLAverageCps(SplinePointList *spl);
-extern void SPWeightedAverageCps(SplinePoint *sp);
-extern void BP_HVForce(BasePoint *vector);
-extern void SplineCharDefaultPrevCP(SplinePoint *base);
-extern void SplineCharDefaultNextCP(SplinePoint *base);
-extern void SplineCharTangentNextCP(SplinePoint *sp);
-extern void SplineCharTangentPrevCP(SplinePoint *sp);
-/**
- * This is like SPAdjustControl but you have not wanting to move the
- * BCP at all, but you would like the current location of the passed
- * BCP to reshape the spline through the splinepoint. For example, if
- * you drag the spline between two points then you might like to touch
- * the inside BCP between the two splinepoints to reshape the whole
- * curve through a curve point.
- */
-extern void SPTouchControl(SplinePoint *sp,BasePoint *which, int order2);
-extern void SPAdjustControl(SplinePoint *sp,BasePoint *cp, BasePoint *to,int order2);
-extern void SPHVCurveForce(SplinePoint *sp);
-extern void SPSmoothJoint(SplinePoint *sp);
-extern int PointListIsSelected(SplinePointList *spl);
-extern void SplineSetsUntick(SplineSet *spl);
 extern void SFOrderBitmapList(SplineFont *sf);
 
 extern Spline *SplineMake(SplinePoint *from, SplinePoint *to, int order2);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2080,7 +2080,6 @@ typedef struct growbuf {
 extern void GrowBuffer(GrowBuf *gb);
 
 struct glyphdata;
-extern int UnitsParallel(BasePoint *u1,BasePoint *u2,int strict);
 extern struct pschars *CID2ChrsSubrs(SplineFont *cidmaster,struct cidbytes *cidbytes,int flags,int layer);
 enum bitmapformat { bf_bdf, bf_ttf, bf_sfnt_dfont, bf_sfnt_ms, bf_otb,
 	bf_nfntmacbin, /*bf_nfntdfont, */bf_fon, bf_fnt, bf_palm,

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2057,10 +2057,7 @@ struct enc;
 #define chunkfree(item,size)	free(item)
 
 extern char *strconcat(const char *str, const char *str2);
-extern char *strconcat3(const char *str, const char *str2, const char *str3);
 
-extern char *XUIDFromFD(int xuid[20]);
-extern SplineFont *SplineFontFromPSFont(struct fontdict *fd);
 extern void SFApplyFeatureFile(SplineFont *sf,FILE *file,char *filename);
 enum fontformat { ff_pfa, ff_pfb, ff_pfbmacbin, ff_multiple, ff_mma, ff_mmb,
 	ff_ptype3, ff_ptype0, ff_cid, ff_cff, ff_cffcid,
@@ -2081,8 +2078,6 @@ typedef struct growbuf {
     unsigned char *end;
 } GrowBuf;
 extern void GrowBuffer(GrowBuf *gb);
-extern void GrowBufferAdd(GrowBuf *gb,int ch);
-extern void GrowBufferAddStr(GrowBuf *gb,char *str);
 
 struct glyphdata;
 extern int UnitsParallel(BasePoint *u1,BasePoint *u2,int strict);
@@ -2133,49 +2128,16 @@ extern void SplineFontSetUnChanged(SplineFont *sf);
 extern int RealNear(real a,real b);
 
 
-extern void LineListFree(LineList *ll);
-extern void LinearApproxFree(LinearApprox *la);
-extern void SplineFree(Spline *spline);
-extern SplinePoint *SplinePointCreate(real x, real y);
-extern void SplinePointFree(SplinePoint *sp);
-extern void SplinePointMDFree(SplineChar *sc,SplinePoint *sp);
-extern void SplinePointsFree(SplinePointList *spl);
-extern void SplinePointListFree(SplinePointList *spl);
-extern void SplinePointListMDFree(SplineChar *sc,SplinePointList *spl);
-extern void SplinePointListsMDFree(SplineChar *sc,SplinePointList *spl);
-extern void SplinePointListsFree(SplinePointList *head);
-extern void SplineSetSpirosClear(SplineSet *spl);
-extern void SplineSetBeziersClear(SplineSet *spl);
-extern void RefCharFree(RefChar *ref);
-extern void RefCharsFree(RefChar *ref);
 extern void UndoesFree(Undoes *undo);
 extern void StemInfosFree(StemInfo *h);
 extern void StemInfoFree(StemInfo *h);
-extern void DStemInfosFree(DStemInfo *h);
-extern void DStemInfoFree(DStemInfo *h);
-extern void KernPairsFree(KernPair *kp);
 extern void SCOrderAP(SplineChar *sc);
-extern void AnchorPointsFree(AnchorPoint *ap);
-extern AnchorPoint *AnchorPointsCopy(AnchorPoint *alist);
-extern AnchorClass *SFFindOrAddAnchorClass(SplineFont *sf,char *name,struct lookup_subtable *sub);
-extern void SFRemoveAnchorClass(SplineFont *sf,AnchorClass *an);
 extern int AnchorClassesNextMerge(AnchorClass *ac);
-extern AnchorPoint *APAnchorClassMerge(AnchorPoint *anchors,AnchorClass *into,AnchorClass *from);
 extern void AnchorClassMerge(SplineFont *sf,AnchorClass *into,AnchorClass *from);
-extern void AnchorClassesFree(AnchorClass *kp);
-extern void TtfTablesFree(struct ttf_table *tab);
-extern void SFRemoveSavedTable(SplineFont *sf, uint32 tag);
 extern void SCInsertPST(SplineChar *sc,PST *new_);
-extern void ValDevFree(ValDevTab *adjust);
-extern ValDevTab *ValDevTabCopy(ValDevTab *orig);
-extern void DeviceTableFree(DeviceTable *adjust);
-extern DeviceTable *DeviceTableCopy(DeviceTable *orig);
-extern void DeviceTableSet(DeviceTable *adjust, int size, int correction);
 extern void PSTFree(PST *lig);
 extern uint16 PSTDefaultFlags(enum possub_type type,SplineChar *sc );
 extern StemInfo *StemInfoCopy(StemInfo *h);
-extern DStemInfo *DStemInfoCopy(DStemInfo *h);
-extern MinimumDistance *MinimumDistanceCopy(MinimumDistance *h);
 extern void SPChangePointType(SplinePoint *sp, int pointtype);
 
 struct lookup_cvt { OTLookup *from, *to; int old;};
@@ -2194,56 +2156,14 @@ struct sfmergecontext {
     int preserveCrossFontKerning;
     int lmax;
 };
-extern void ImageListsFree(ImageList *imgs);
-extern void TTFLangNamesFree(struct ttflangname *l);
-extern void AltUniFree(struct altuni *altuni);
 extern void AltUniRemove(SplineChar *sc,int uni);
 extern void AltUniAdd(SplineChar *sc,int uni);
 extern void AltUniAdd_DontCheckDups(SplineChar *sc,int uni);
-extern void MinimumDistancesFree(MinimumDistance *md);
-extern void LayerDefault(Layer *);
 extern SplineChar *SplineCharCreate(int layer_cnt);
-extern SplineChar *SFSplineCharCreate(SplineFont *sf);
-extern RefChar *RefCharCreate(void);
 extern void SCAddRef(SplineChar *sc,SplineChar *rsc,int layer, real xoff, real yoff);
-extern KernClass *KernClassCopy(KernClass *kc);
-extern void KernClassFreeContents(KernClass *kc);
-extern void KernClassClearSpecialContents(KernClass *kc);
-extern void KernClassListFree(KernClass *kc);
-extern void KernClassListClearSpecialContents(KernClass *kc);
-extern void OTLookupFree(OTLookup *lookup);
-extern void OTLookupListFree(OTLookup *lookup );
-extern FPST *FPSTCopy(FPST *fpst);
-extern void FPSTRuleContentsFree(struct fpst_rule *r, enum fpossub_format format);
-extern void FPSTClassesFree(FPST *fpst);
-extern void FPSTRulesFree(struct fpst_rule *r, enum fpossub_format format, int rcnt);
-extern void FPSTFree(FPST *fpst);
-extern void ASMFree(ASM *sm);
-extern void MacNameListFree(struct macname *mn);
-extern void MacSettingListFree(struct macsetting *ms);
-extern void MacFeatListFree(MacFeat *mf);
-extern void GlyphVariantsFree(struct glyphvariants *gv);
-extern struct glyphvariants *GlyphVariantsCopy(struct glyphvariants *gv);
-extern void MathKernVContentsFree(struct mathkernvertex *mk);
-extern void MathKernFree(struct mathkern *mk);
-extern struct mathkern *MathKernCopy(struct mathkern *mk);
-extern void SplineCharListsFree(struct splinecharlist *dlist);
-extern void LayerFreeContents(SplineChar *sc, int layer);
-extern void SplineCharFreeContents(SplineChar *sc);
 extern void SplineCharFree(SplineChar *sc);
-extern void EncMapFree(EncMap *map);
-extern EncMap *EncMapNew(int encmax, int backmax, Encoding *enc);
-extern EncMap *EncMap1to1(int enccount);
-extern EncMap *EncMapCopy(EncMap *map);
 extern void ScriptLangListFree(struct scriptlanglist *sl);
-extern void FeatureScriptLangListFree(FeatureScriptLangList *fl);
 extern void SFBaseSort(SplineFont *sf);
-extern struct baselangextent *BaseLangCopy(struct baselangextent *extent);
-extern void BaseLangFree(struct baselangextent *extent);
-extern void BaseScriptFree(struct basescript *bs);
-extern void BaseFree(struct Base *base);
-extern void SplineFontFree(SplineFont *sf);
-extern void SplineFontClearSpecial(SplineFont *sf);
 
 #if 1
 // These relate to experimental support for U. F. O. groups.
@@ -2251,66 +2171,13 @@ extern void SplineFontClearSpecial(SplineFont *sf);
 #define GROUP_NAME_KERNING_FEATURE 2
 #define GROUP_NAME_VERTICAL 4 // Otherwise horizontal.
 #define GROUP_NAME_RIGHT 8 // Otherwise left (or above).
-
-void GlyphGroupFree(struct ff_glyphclasses* group);
-void GlyphGroupsFree(struct ff_glyphclasses* root);
-int GroupNameType(const char *input);
-void GlyphGroupKernFree(struct ff_rawoffsets* groupkern);
-void GlyphGroupKernsFree(struct ff_rawoffsets* root);
-int CountKerningClasses(SplineFont *sf);
-#ifdef FF_UTHASH_GLIF_NAMES
-struct glif_name_index;
-int HashKerningClassNamesFlex(SplineFont *sf, struct glif_name_index * class_name_hash, int capitalize);
-int HashKerningClassNames(SplineFont *sf, struct glif_name_index * class_name_hash);
-int HashKerningClassNamesCaps(SplineFont *sf, struct glif_name_index * class_name_hash);
-#endif
-int KerningClassSeekByAbsoluteIndex(const struct splinefont *sf, int seek_index, struct kernclass **okc, int *oisv, int *oisr, int *ooffset);
-struct ff_glyphclasses *SFGetGroup(const struct splinefont *sf, int index, const char *name);
-int StringInStrings(char const* const* space, int length, const char *target);
-char **StringExplode(const char *input, char delimiter);
-void ExplodedStringFree(char **input);
-int SFKerningGroupExistsSpecific(const struct splinefont *sf, const char *groupname, int isv, int isr);
 #endif // 1
-extern struct jstf_lang *JstfLangsCopy(struct jstf_lang *jl);
-extern void JstfLangFree(struct jstf_lang *jl);
-extern void JustifyFree(Justify *just);
-extern void OtfNameListFree(struct otfname *on);
-extern void OtfFeatNameListFree(struct otffeatname *fn);
 extern struct otffeatname *findotffeatname(uint32 tag,SplineFont *sf);
-extern void MarkSetFree(int cnt,char **classes,char **names);
-extern void MarkClassFree(int cnt,char **classes,char **names);
-extern void MMSetFreeContents(MMSet *mm);
 extern void MMSetFree(MMSet *mm);
-extern void MMSetClearSpecial(MMSet *mm);
 extern void SFRemoveUndoes(SplineFont *sf,uint8 *selected,EncMap *map);
 extern void SplineRefigure(Spline *spline);
-extern Spline *SplineMake3(SplinePoint *from, SplinePoint *to);
-extern LinearApprox *SplineApproximate(Spline *spline, real scale);
-extern void SplineSetFindBounds(const SplinePointList *spl, DBounds *bounds);
-extern void SplineCharLayerFindBounds(SplineChar *sc,int layer,DBounds *bounds);
-extern void SplineCharFindBounds(SplineChar *sc,DBounds *bounds);
-extern void SplineFontLayerFindBounds(SplineFont *sf,int layer,DBounds *bounds);
-extern void SplineFontFindBounds(SplineFont *sf,DBounds *bounds);
-extern void CIDLayerFindBounds(SplineFont *sf,int layer,DBounds *bounds);
-extern void SplineSetQuickBounds(SplineSet *ss,DBounds *b);
-extern void SplineCharLayerQuickBounds(SplineChar *sc,int layer,DBounds *bounds);
-extern void SplineCharQuickBounds(SplineChar *sc, DBounds *b);
-extern void SplineSetQuickConservativeBounds(SplineSet *ss,DBounds *b);
-extern void SplineCharQuickConservativeBounds(SplineChar *sc, DBounds *b);
-extern void SplineFontQuickConservativeBounds(SplineFont *sf,DBounds *b);
-extern void SplinePointCategorize(SplinePoint *sp);
-extern int SplinePointIsACorner(SplinePoint *sp);
 extern void SPLCategorizePoints(SplinePointList *spl);
-extern void SPLCategorizePointsKeepCorners(SplinePointList *spl);
-extern void SCCategorizePoints(SplineChar *sc);
-extern SplinePointList *SplinePointListCopy1(const SplinePointList *spl);
 extern SplinePointList *SplinePointListCopy(const SplinePointList *base);
-extern SplinePointList *SplinePointListCopySelected(SplinePointList *base);
-extern SplinePointList *SplinePointListCopySpiroSelected(SplinePointList *base);
-extern ImageList *ImageListCopy(ImageList *cimg);
-extern ImageList *ImageListTransform(ImageList *cimg,real transform[6],int everything);
-extern void BpTransform(BasePoint *to, BasePoint *from, real transform[6]);
-extern void ApTransform(AnchorPoint *ap, real transform[6]);
 /* The order of the enum elements below doesn't make much sense, but it's done*/
 /*  this way to preserve binary compatibility */
 enum transformPointType { tpt_OnlySelected, tpt_AllPoints, tpt_OnlySelectedInterpCPs };
@@ -2323,28 +2190,8 @@ enum transformPointMask {
     tpmask_operateOnSelectedBCP = 1 << 2
 };
 extern SplinePointList *SplinePointListTransform(SplinePointList *base, real transform[6], enum transformPointType allpoints );
-extern SplinePointList *SplinePointListTransformExtended(SplinePointList *base, real transform[6],
-							 enum transformPointType tpt, enum transformPointMask tpmask );
-extern SplinePointList *SplinePointListSpiroTransform(SplinePointList *base, real transform[6], int allpoints );
-extern SplinePointList *SplinePointListShift(SplinePointList *base, real xoff, enum transformPointType allpoints );
-extern HintMask *HintMaskFromTransformedRef(RefChar *ref,BasePoint *trans,
-	SplineChar *basesc,HintMask *hm);
-extern SplinePointList *SPLCopyTranslatedHintMasks(SplinePointList *base,
-	SplineChar *basesc, SplineChar *subsc, BasePoint *trans);
-extern SplinePointList *SPLCopyTransformedHintMasks(RefChar *r,
-	SplineChar *basesc, BasePoint *trans,int layer);
-extern SplinePointList *SplinePointListRemoveSelected(SplineChar *sc,SplinePointList *base);
-extern void SplinePointListSelect(SplinePointList *spl,int sel);
-extern void SCRefToSplines(SplineChar *sc,RefChar *rf,int layer);
-extern void RefCharFindBounds(RefChar *rf);
-extern void SCReinstanciateRefChar(SplineChar *sc,RefChar *rf,int layer);
 extern void SCReinstanciateRef(SplineChar *sc,SplineChar *rsc,int layer);
-extern void SFReinstanciateRefs(SplineFont *sf);
-extern void SFInstanciateRefs(SplineFont *sf);
 extern SplineChar *MakeDupRef(SplineChar *base, int local_enc, int uni_enc);
-extern void SCRemoveDependent(SplineChar *dependent,RefChar *rf,int layer);
-extern void SCRemoveLayerDependents(SplineChar *dependent,int layer);
-extern void SCRemoveDependents(SplineChar *dependent);
 extern void BDFClut(BDFFont *bdf, int linear_scale);
 extern int  FNTFontDump(char *filename,BDFFont *font, EncMap *map, int res);
 extern int  FONFontDump(char *filename,SplineFont *sf, int32 *sizes,int res,
@@ -2373,64 +2220,25 @@ struct std_bdf_props {
 };
 #define STD_BDF_PROPS_EMPTY { NULL, 0, 0 }
 
-/* Two lines intersect in at most 1 point */
-/* Two quadratics intersect in at most 4 points */
-/* Two cubics intersect in at most 9 points */ /* Plus an extra space for a trailing -1 */
-extern int SplinesIntersect(const Spline *s1, const Spline *s2, BasePoint pts[9],
-	extended t1s[10], extended t2s[10]);
-extern SplineSet *LayerAllSplines(Layer *layer);
-extern SplineSet *LayerUnAllSplines(Layer *layer);
-extern int SplineSetIntersect(SplineSet *spl, Spline **_spline, Spline **_spline2 );
-extern int LineTangentToSplineThroughPt(Spline *s, BasePoint *pt, extended ts[4],
-	extended tmin, extended tmax);
-extern int _CubicSolve(const Spline1D *sp,bigreal sought,extended ts[3]);
 extern int CubicSolve(const Spline1D *sp,bigreal sought,extended ts[3]);
 /* Uses an algebraic solution */
 extern extended SplineSolve(const Spline1D *sp, real tmin, real tmax, extended sought_y);
 /* Tries to fixup rounding errors that crept in to the solution */
 extern extended SplineSolveFixup(const Spline1D *sp, real tmin, real tmax, extended sought_y);
 /* Uses an iterative approximation */
-extern extended IterateSplineSolve(const Spline1D *sp, extended tmin, extended tmax, extended sought_y);
 /* Uses an iterative approximation and then tries to fix things up */
-extern extended IterateSplineSolveFixup(const Spline1D *sp, extended tmin, extended tmax, extended sought_y);
-extern void SplineFindExtrema(const Spline1D *sp, extended *_t1, extended *_t2 );
-extern int SSBoundsWithin(SplineSet *ss,bigreal z1, bigreal z2, bigreal *wmin, bigreal *wmax, int major );
-extern bigreal SplineMinDistanceToPoint(Spline *s, BasePoint *p);
 
 
 #define CURVATURE_ERROR	-1e9
-extern bigreal SplineCurvature(Spline *s, bigreal t);
 
-extern double CheckExtremaForSingleBitErrors(const Spline1D *sp, double t, double othert);
-extern int Spline2DFindExtrema(const Spline *sp, extended extrema[4] );
-extern int Spline2DFindPointsOfInflection(const Spline *sp, extended poi[2] );
-extern int SplineAtInflection(Spline1D *sp, bigreal t );
-extern int SplineAtMinMax(Spline1D *sp, bigreal t );
-extern void SplineRemoveExtremaTooClose(Spline1D *sp, extended *_t1, extended *_t2 );
-extern int NearSpline(struct findsel *fs, Spline *spline);
-extern real SplineNearPoint(Spline *spline, BasePoint *bp, real fudge);
-extern int SplineT2SpiroIndex(Spline *spline,bigreal t,SplineSet *spl);
-extern void SCMakeDependent(SplineChar *dependent,SplineChar *base);
-extern SplinePoint *SplineBisect(Spline *spline, extended t);
-extern Spline *SplineSplit(Spline *spline, extended ts[3]);
 extern Spline *ApproximateSplineFromPoints(SplinePoint *from, SplinePoint *to,
 	TPoint *mid, int cnt,int order2);
 extern bigreal SplineLength(Spline *spline);
 extern int SplineIsLinear(Spline *spline);
-extern int SSPointWithin(SplineSet *spl,BasePoint *pt);
 extern void SFOrderBitmapList(SplineFont *sf);
 
 extern Spline *SplineMake(SplinePoint *from, SplinePoint *to, int order2);
 extern Spline *SFSplineMake(SplineFont *sf,SplinePoint *from, SplinePoint *to);
-extern int IntersectLinesSlopes(BasePoint *inter,
-	BasePoint *line1, BasePoint *slope1,
-	BasePoint *line2, BasePoint *slope2);
-extern int IntersectLines(BasePoint *inter,
-	BasePoint *line1_1, BasePoint *line1_2,
-	BasePoint *line2_1, BasePoint *line2_2);
-extern int IntersectLinesClip(BasePoint *inter,
-	BasePoint *line1_1, BasePoint *line1_2,
-	BasePoint *line2_1, BasePoint *line2_2);
 
 
 extern double BlueScaleFigure(struct psdict *private_,real bluevalues[], real otherblues[]);
@@ -2549,8 +2357,6 @@ extern void SFLayerSetBackground(SplineFont *sf,int layer,int is_back);
 
 extern void SplineSetsRound2Int(SplineSet *spl,real factor,int inspiro,int onlysel);
 extern void SCRound2Int(SplineChar *sc,int layer, real factor);
-extern int SCRoundToCluster(SplineChar *sc,int layer,int sel,bigreal within,bigreal max);
-extern int SplineSetsRemoveAnnoyingExtrema(SplineSet *ss,bigreal err);
 
 extern void SFFlatten(SplineFont *cidmaster);
 
@@ -2696,9 +2502,6 @@ extern void doinitFontForgeMain(void);
 
 extern void InitSimpleStuff(void);
 
-extern int SSExistsInLayer(SplineSet *ss,SplineSet *lots );
-extern int SplineExistsInSS(Spline *s,SplineSet *ss);
-extern int SpExistsInSS(SplinePoint *sp,SplineSet *ss);
 
 
 extern struct math_constants_descriptor {
@@ -2726,14 +2529,6 @@ extern int VSMaskFromFormat(SplineFont *sf, int layer, enum fontformat format);
 
 extern char *RandomParaFromScript(uint32 script, uint32 *lang, SplineFont *sf);
 
-extern int SSHasClip(SplineSet *ss);
-extern int SSHasDrawn(SplineSet *ss);
-extern struct gradient *GradientCopy(struct gradient *old,real transform[6]);
-extern void GradientFree(struct gradient *grad);
-extern struct pattern *PatternCopy(struct pattern *old,real transform[6]);
-extern void PatternFree(struct pattern *pat);
-extern void BrushCopy(struct brush *into, struct brush *from,real transform[6]);
-extern void PenCopy(struct pen *into, struct pen *from,real transform[6]);
 extern void PatternSCBounds(SplineChar *sc,DBounds *b);
 
 extern char *SFDefaultImage(SplineFont *sf,char *filename);
@@ -2844,16 +2639,7 @@ extern SplinePoint* SplinePointListContainsPointAtXY( SplinePointList* container
 extern bool isSplinePointPartOfGuide( SplineFont *sf, SplinePoint *sp );
 
 
-extern bigreal DistanceBetweenPoints( BasePoint *p1, BasePoint *p2 );
-
-
 extern void debug_printHint( StemInfo *h, char* msg );
-
-// The following functions are in splineutil.c at present.
-size_t count_caps(const char * input);
-char * upper_case(const char * input);
-char * same_case(const char * input);
-char * delimit_null(const char * input, char delimiter);
 
 #include "ustring.h"
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2066,10 +2066,6 @@ extern char *strconcat3(const char *str, const char *str2, const char *str3);
 extern char *XUIDFromFD(int xuid[20]);
 extern SplineFont *SplineFontFromPSFont(struct fontdict *fd);
 extern void SFApplyFeatureFile(SplineFont *sf,FILE *file,char *filename);
-extern int SFOneWidth(SplineFont *sf);
-extern int CIDOneWidth(SplineFont *sf);
-extern int SFOneHeight(SplineFont *sf);
-extern int SFIsCJK(SplineFont *sf,EncMap *map);
 enum fontformat { ff_pfa, ff_pfb, ff_pfbmacbin, ff_multiple, ff_mma, ff_mmb,
 	ff_ptype3, ff_ptype0, ff_cid, ff_cff, ff_cffcid,
 	ff_type42, ff_type42cid,
@@ -2094,14 +2090,7 @@ extern void GrowBufferAddStr(GrowBuf *gb,char *str);
 
 struct glyphdata;
 extern int UnitsParallel(BasePoint *u1,BasePoint *u2,int strict);
-extern int CvtPsStem3(struct growbuf *gb, SplineChar *scs[MmMax], int instance_count,
-	int ishstem, int round);
 extern struct pschars *CID2ChrsSubrs(SplineFont *cidmaster,struct cidbytes *cidbytes,int flags,int layer);
-extern struct pschars *SplineFont2ChrsSubrs2(SplineFont *sf, int nomwid,
-	int defwid, const int *bygid, int cnt, int flags,
-	struct pschars **_subrs,int layer);
-extern struct pschars *CID2ChrsSubrs2(SplineFont *cidmaster,struct fd2data *fds,
-	int flags, struct pschars **_glbls,int layer);
 enum bitmapformat { bf_bdf, bf_ttf, bf_sfnt_dfont, bf_sfnt_ms, bf_otb,
 	bf_nfntmacbin, /*bf_nfntdfont, */bf_fon, bf_fnt, bf_palm,
 	bf_ptype3,
@@ -2171,7 +2160,6 @@ extern void SplineSetSpirosClear(SplineSet *spl);
 extern void SplineSetBeziersClear(SplineSet *spl);
 extern void RefCharFree(RefChar *ref);
 extern void RefCharsFree(RefChar *ref);
-extern void RefCharsFreeRef(RefChar *ref);
 extern void UndoesFree(Undoes *undo);
 extern void StemInfosFree(StemInfo *h);
 extern void StemInfoFree(StemInfo *h);
@@ -2947,14 +2935,6 @@ extern bigreal DistanceBetweenPoints( BasePoint *p1, BasePoint *p2 );
 
 
 extern void debug_printHint( StemInfo *h, char* msg );
-extern void debug_printHintInstance( HintInstance* hi, int hin, char* msg );
-
-
-/**
- * It is like a == b, but also true if a is within
- * tolerence of b.
- */
-extern bool equalWithTolerence( real a, real b, real tolerence );
 
 // The following functions are in splineutil.c at present.
 size_t count_caps(const char * input);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2065,17 +2065,7 @@ extern char *strconcat3(const char *str, const char *str2, const char *str3);
 
 extern char *XUIDFromFD(int xuid[20]);
 extern SplineFont *SplineFontFromPSFont(struct fontdict *fd);
-extern int CheckAfmOfPostScript(SplineFont *sf,char *psname);
-extern int LoadKerningDataFromAmfm(SplineFont *sf, char *filename);
-extern int LoadKerningDataFromAfm(SplineFont *sf, char *filename);
-extern int LoadKerningDataFromTfm(SplineFont *sf, char *filename, EncMap *map);
-extern int LoadKerningDataFromOfm(SplineFont *sf, char *filename, EncMap *map);
-extern int LoadKerningDataFromPfm(SplineFont *sf, char *filename, EncMap *map);
-extern int LoadKerningDataFromMetricsFile(SplineFont *sf, char *filename, EncMap *map);
 extern void SFApplyFeatureFile(SplineFont *sf,FILE *file,char *filename);
-extern void SubsNew(SplineChar *to,enum possub_type type,int tag,char *components,
-	    SplineChar *default_script);
-extern void PosNew(SplineChar *to,int tag,int dx, int dy, int dh, int dv);
 extern int SFOneWidth(SplineFont *sf);
 extern int CIDOneWidth(SplineFont *sf);
 extern int SFOneHeight(SplineFont *sf);
@@ -2134,7 +2124,6 @@ extern int WriteSVGFont(const char *fontname,SplineFont *sf,enum fontformat form
 extern int _WriteSVGFont(FILE *file,SplineFont *sf,int flags,EncMap *enc,int layer);
 extern int WriteUFOFont(const char *fontname, SplineFont *sf, enum fontformat format,int flags, const EncMap *enc,int layer);
 extern void DefaultTTFEnglishNames(struct ttflangname *dummy, SplineFont *sf);
-extern void TeXDefaultParams(SplineFont *sf);
 extern int AlreadyMSSymbolArea(SplineFont *sf,EncMap *map);
 extern void OS2FigureCodePages(SplineFont *sf, uint32 CodePage[2]);
 extern void OS2FigureUnicodeRanges(SplineFont *sf, uint32 Ranges[4]);
@@ -2593,24 +2582,6 @@ extern void CVT_ImportPrivate(SplineFont *sf);
 
 extern void SplineFontAutoHint( SplineFont *sf, int layer);
 extern int SCDrawsSomething(SplineChar *sc);
-extern int SCDrawsSomethingOnLayer(SplineChar *sc, int layer);
-extern int SCWorthOutputting(SplineChar *sc);
-extern int SCHasData(SplineChar *sc);
-extern int LayerWorthOutputting(SplineFont *sf, int layer);
-extern int SCLWorthOutputtingOrHasData(SplineChar *sc, int layer);
-extern int SFFindNotdef(SplineFont *sf, int fixed);
-extern int doesGlyphExpandHorizontally(SplineChar *sc);
-extern int CIDWorthOutputting(SplineFont *cidmaster, int enc); /* Returns -1 on failure, font number on success */
-extern int AmfmSplineFont(FILE *afm, MMSet *mm,int formattype,EncMap *map,int layer);
-extern int AfmSplineFont(FILE *afm, SplineFont *sf,int formattype,EncMap *map, int docc, SplineFont *fullsf,int layer);
-extern int PfmSplineFont(FILE *pfm, SplineFont *sf,EncMap *map,int layer);
-extern int TfmSplineFont(FILE *tfm, SplineFont *sf,EncMap *map,int layer);
-extern int OfmSplineFont(FILE *afm, SplineFont *sf,EncMap *map,int layer);
-extern const char *EncodingName(Encoding *map);
-extern void SFLigaturePrepare(SplineFont *sf);
-extern void SFLigatureCleanup(SplineFont *sf);
-extern void SFKernClassTempDecompose(SplineFont *sf,int isv);
-extern void SFKernCleanup(SplineFont *sf,int isv);
 extern int SCSetMetaData(SplineChar *sc,const char *name,int unienc,
 	const char *comment);
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2540,11 +2540,9 @@ extern int IntersectLinesClip(BasePoint *inter,
 	BasePoint *line1_1, BasePoint *line1_2,
 	BasePoint *line2_1, BasePoint *line2_2);
 
-extern void SSRemoveBacktracks(SplineSet *ss);
 extern enum PolyType PolygonIsConvex(BasePoint *poly,int n, int *badpointindex);
 extern SplineSet *UnitShape(int isrect);
 extern SplineSet *SplineSetStroke(SplineSet *spl,StrokeInfo *si,int order2);
-extern SplineSet *SplineSetRemoveOverlap(SplineChar *sc,SplineSet *base,enum overlap_type);
 
 extern double BlueScaleFigure(struct psdict *private_,real bluevalues[], real otherblues[]);
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2318,7 +2318,6 @@ extern void MMSetFreeContents(MMSet *mm);
 extern void MMSetFree(MMSet *mm);
 extern void MMSetClearSpecial(MMSet *mm);
 extern void SFRemoveUndoes(SplineFont *sf,uint8 *selected,EncMap *map);
-extern void SplineRefigure3(Spline *spline);
 extern void SplineRefigure(Spline *spline);
 extern Spline *SplineMake3(SplinePoint *from, SplinePoint *to);
 extern LinearApprox *SplineApproximate(Spline *spline, real scale);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -229,10 +229,6 @@ typedef struct strokeinfo {
     bigreal (*factor)(void *data,struct spline *spline,real t);
 } StrokeInfo;
 
-enum PolyType { Poly_Convex, Poly_Concave, Poly_PointOnEdge,
-    Poly_TooFewPoints, Poly_Line };
-
-
 enum overlap_type { over_remove, over_rmselected, over_intersect, over_intersel,
 	over_exclude, over_findinter, over_fisel };
 
@@ -2516,9 +2512,6 @@ extern int IntersectLinesClip(BasePoint *inter,
 	BasePoint *line1_1, BasePoint *line1_2,
 	BasePoint *line2_1, BasePoint *line2_2);
 
-extern enum PolyType PolygonIsConvex(BasePoint *poly,int n, int *badpointindex);
-extern SplineSet *UnitShape(int isrect);
-extern SplineSet *SplineSetStroke(SplineSet *spl,StrokeInfo *si,int order2);
 
 extern double BlueScaleFigure(struct psdict *private_,real bluevalues[], real otherblues[]);
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2393,7 +2393,6 @@ extern void FreeType_FreeRaster(struct freetype_raster *raster);
 struct TT_ExecContextRec_;
 extern struct freetype_raster *DebuggerCurrentRaster(struct  TT_ExecContextRec_ *exc,int depth);
 
-extern void doversion(const char *);
 
 extern AnchorPos *AnchorPositioning(SplineChar *sc,unichar_t *ustr,SplineChar **sstr );
 
@@ -2498,9 +2497,7 @@ extern void *PyFF_UnPickleMeToObjects(char *str);
 struct _object;		/* Python Object */
 extern void PyFF_CallDictFunc(struct _object *dict,const char *key,const char *argtypes, ... );
 #endif
-extern void doinitFontForgeMain(void);
 
-extern void InitSimpleStuff(void);
 
 
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2383,28 +2383,7 @@ extern SplineChar *MakeDupRef(SplineChar *base, int local_enc, int uni_enc);
 extern void SCRemoveDependent(SplineChar *dependent,RefChar *rf,int layer);
 extern void SCRemoveLayerDependents(SplineChar *dependent,int layer);
 extern void SCRemoveDependents(SplineChar *dependent);
-extern void BCCompressBitmap(BDFChar *bdfc);
-extern void BCRegularizeBitmap(BDFChar *bdfc);
-extern void BCRegularizeGreymap(BDFChar *bdfc);
-extern int GradientHere(bigreal scale,DBounds *bbox,int iy,int ix,
-	struct gradient *grad,struct pattern *pat, int defgrey);
-extern void PatternPrep(SplineChar *sc,struct brush *brush,bigreal scale);
-extern BDFChar *SplineCharRasterize(SplineChar *sc, int layer, bigreal pixelsize);
-extern BDFFont *SplineFontToBDFHeader(SplineFont *_sf, int pixelsize, int indicate);
-extern BDFFont *SplineFontRasterize(SplineFont *sf, int layer, int pixelsize, int indicate);
-extern void BDFCAntiAlias(BDFChar *bc, int linear_scale);
-extern BDFChar *SplineCharAntiAlias(SplineChar *sc, int layer, int pixelsize,int linear_scale);
-extern BDFFont *SplineFontAntiAlias(SplineFont *sf, int layer, int pixelsize,int linear_scale);
-extern struct clut *_BDFClut(int linear_scale);
 extern void BDFClut(BDFFont *bdf, int linear_scale);
-extern int BDFDepth(BDFFont *bdf);
-extern BDFChar *BDFPieceMeal(BDFFont *bdf, int index);
-extern BDFChar *BDFPieceMealCheck(BDFFont *bdf, int index);
-enum piecemeal_flags { pf_antialias=1, pf_bbsized=2, pf_ft_nohints=4, pf_ft_recontext=8 };
-extern BDFFont *SplineFontPieceMeal(SplineFont *sf,int layer,int ptsize, int dpi,int flags,void *freetype_context);
-extern void BDFCharFree(BDFChar *bdfc);
-extern void BDFPropsFree(BDFFont *bdf);
-extern void BDFFontFree(BDFFont *bdf);
 extern int  FNTFontDump(char *filename,BDFFont *font, EncMap *map, int res);
 extern int  FONFontDump(char *filename,SplineFont *sf, int32 *sizes,int res,
 	EncMap *map);

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -29,6 +29,7 @@
 
 #include "fontforge.h"
 #include "splinerefigure.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <unistd.h>

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -28,6 +28,7 @@
 #include "splineorder2.h"
 
 #include "fontforge.h"
+#include "splinerefigure.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -29,6 +29,7 @@
 
 #include "fontforge.h"
 #include "splinerefigure.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splineorder2.h"
+
 #include "fontforge.h"
 #include <math.h>
 #include <unistd.h>

--- a/fontforge/splineorder2.h
+++ b/fontforge/splineorder2.h
@@ -1,0 +1,29 @@
+#ifndef FONTFORGE_SPLINEORDER2_H
+#define FONTFORGE_SPLINEORDER2_H
+
+#include "splinefont.h"
+
+extern SplinePoint *SplineTtfApprox(Spline *ps);
+extern SplineSet *SplineSetsConvertOrder(SplineSet *ss, int to_order2);
+extern SplineSet *SplineSetsPSApprox(SplineSet *ss);
+extern SplineSet *SplineSetsTTFApprox(SplineSet *ss);
+extern SplineSet *SSPSApprox(SplineSet *ss);
+extern SplineSet *SSttfApprox(SplineSet *ss);
+extern Spline *SplineMake2(SplinePoint *from, SplinePoint *to);
+extern void SCConvertLayerToOrder2(SplineChar *sc, int layer);
+extern void SCConvertLayerToOrder3(SplineChar *sc, int layer);
+extern void SCConvertOrder(SplineChar *sc, int to_order2);
+extern void SCConvertToOrder2(SplineChar *sc);
+extern void SCConvertToOrder3(SplineChar *sc);
+extern void SFConvertGridToOrder2(SplineFont *_sf);
+extern void SFConvertGridToOrder3(SplineFont *_sf);
+extern void SFConvertLayerToOrder2(SplineFont *_sf, int layer);
+extern void SFConvertLayerToOrder3(SplineFont *_sf, int layer);
+extern void SFConvertToOrder2(SplineFont *_sf);
+extern void SFConvertToOrder3(SplineFont *_sf);
+extern void SplinePointNextCPChanged2(SplinePoint *sp);
+extern void SplinePointPrevCPChanged2(SplinePoint *sp);
+extern void SplineRefigure2(Spline *spline);
+extern void SplineRefigureFixup(Spline *spline);
+
+#endif /* FONTFORGE_SPLINEORDER2_H */

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -30,6 +30,7 @@
 #include "fontforge.h"
 #include "splinefont.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include "edgelist2.h"
 #include <math.h>
 #ifdef HAVE_IEEEFP_H

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -30,6 +30,7 @@
 #include "fontforge.h"
 #include "splinefont.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "edgelist2.h"
 #include <math.h>

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splineoverlap.h"
+
 #include "fontforge.h"
 #include "splinefont.h"
 #include "splineorder2.h"

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -26,6 +26,7 @@
  */
 #include "fontforge.h"
 #include "splinefont.h"
+#include "splineorder2.h"
 #include "edgelist2.h"
 #include <math.h>
 #ifdef HAVE_IEEEFP_H

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -129,7 +129,7 @@ static void ValidateMListTs(struct mlist * input) {
 #define ValidateMListTs_IF_VERBOSE(input) 
 #endif
 
-extended evalSpline(Spline *s, extended t, int dim) {
+static extended evalSpline(Spline *s, extended t, int dim) {
   return ((s->splines[dim].a*t+s->splines[dim].b)*t+s->splines[dim].c)*t+s->splines[dim].d;
 }
 

--- a/fontforge/splineoverlap.h
+++ b/fontforge/splineoverlap.h
@@ -1,0 +1,15 @@
+#ifndef FONTFORGE_SPLINEOVERLAP_H
+#define FONTFORGE_SPLINEOVERLAP_H
+
+#include "edgelist2.h"
+#include "splinefont.h"
+
+extern int CheckMonotonicClosed(struct monotonic *ms);
+extern int MonotonicFindAt(Monotonic *ms, int which, extended test, Monotonic **space);
+/* overlap_type controls whether we look at selected splinesets or all splinesets */
+extern Monotonic *SSsToMContours(SplineSet *spl, enum overlap_type ot);
+extern SplineSet *SplineSetRemoveOverlap(SplineChar *sc, SplineSet *base, enum overlap_type ot);
+extern void FreeMonotonics(Monotonic *m);
+extern void SSRemoveBacktracks(SplineSet *ss);
+
+#endif /* FONTFORGE_SPLINEOVERLAP_H */

--- a/fontforge/splinerefigure.c
+++ b/fontforge/splinerefigure.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splinerefigure.h"
+
 #include "fontforge.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/splinerefigure.c
+++ b/fontforge/splinerefigure.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #ifdef HAVE_IEEEFP_H
 # include <ieeefp.h>		/* Solaris defines isnan in ieeefp rather than math.h */

--- a/fontforge/splinerefigure.c
+++ b/fontforge/splinerefigure.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"
+#include "splineutil2.h"
 #ifdef HAVE_IEEEFP_H
 # include <ieeefp.h>		/* Solaris defines isnan in ieeefp rather than math.h */
 #endif

--- a/fontforge/splinerefigure.h
+++ b/fontforge/splinerefigure.h
@@ -1,0 +1,8 @@
+#ifndef FONTFORGE_SPLINEREFIGURE_H
+#define FONTFORGE_SPLINEREFIGURE_H
+
+#include "splinefont.h"
+
+extern void SplineRefigure3(Spline *spline);
+
+#endif /* FONTFORGE_SPLINEREFIGURE_H */

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"
+#include "splineorder2.h"
 #include "psfont.h"
 #include <ustring.h>
 #include <string.h>

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splinesave.h"
+
 #include "autohint.h"
 #include "dumppfa.h"
 #include "fontforge.h"

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -37,6 +37,7 @@
 #include "splinefont.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include "psfont.h"
 #include <ustring.h>
 #include <string.h>

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -33,6 +33,7 @@
 #include <math.h>
 #include "splinefont.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include "psfont.h"
 #include <ustring.h>
 #include <string.h>

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -37,6 +37,7 @@
 #include "splinefont.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "psfont.h"
 #include <ustring.h>

--- a/fontforge/splinesave.h
+++ b/fontforge/splinesave.h
@@ -1,0 +1,21 @@
+#ifndef FONTFORGE_SPLINESAVE_H
+#define FONTFORGE_SPLINESAVE_H
+
+#include "splinefont.h"
+
+/**
+ * It is like a == b, but also true if a is within tolerence of b.
+ */
+extern bool equalWithTolerence(real a, real b, real tolerence);
+
+extern int CIDOneWidth(SplineFont *_sf);
+extern int CvtPsStem3(GrowBuf *gb, SplineChar *scs[MmMax], int instance_count, int ishstem, int round);
+extern int SFIsCJK(SplineFont *sf, EncMap *map);
+extern int SFOneHeight(SplineFont *sf);
+extern int SFOneWidth(SplineFont *sf);
+extern struct pschars *CID2ChrsSubrs2(SplineFont *cidmaster, struct fd2data *fds, int flags, struct pschars **_glbls, int layer);
+extern struct pschars *SplineFont2ChrsSubrs2(SplineFont *sf, int nomwid, int defwid, const int *bygid, int cnt, int flags, struct pschars **_subrs, int layer);
+extern void debug_printHintInstance(HintInstance* hi, int hin, char* msg);
+extern void RefCharsFreeRef(RefChar *ref);
+
+#endif /* FONTFORGE_SPLINESAVE_H */

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splinesaveafm.h"
+
 #include "autohint.h"
 #include "featurefile.h"
 #include "fontforgevw.h"		/* For Error */

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -40,6 +40,7 @@
 #include "ttf.h"		/* For AnchorClassDecompose */
 #include <stdio.h>
 #include "splinefont.h"
+#include "splinesave.h"
 #include <utype.h>
 #include <ustring.h>
 #include <time.h>

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -41,6 +41,7 @@
 #include <stdio.h>
 #include "splinefont.h"
 #include "splinesave.h"
+#include "splineutil.h"
 #include <utype.h>
 #include <ustring.h>
 #include <time.h>

--- a/fontforge/splinesaveafm.h
+++ b/fontforge/splinesaveafm.h
@@ -1,0 +1,35 @@
+#ifndef FONTFORGE_SPLINESAVEAFM_H
+#define FONTFORGE_SPLINESAVEAFM_H
+
+#include "splinefont.h"
+
+extern const char *EncodingName(Encoding *map);
+extern int AfmSplineFont(FILE *afm, SplineFont *sf, int formattype, EncMap *map, int docc, SplineFont *fullsf, int layer);
+extern int AmfmSplineFont(FILE *amfm, MMSet *mm, int formattype, EncMap *map, int layer);
+extern int CheckAfmOfPostScript(SplineFont *sf, char *psname);
+extern int CIDWorthOutputting(SplineFont *cidmaster, int enc);
+extern int doesGlyphExpandHorizontally(SplineChar *UNUSED(sc));
+extern int LayerWorthOutputting(SplineFont *sf, int layer);
+extern int LoadKerningDataFromAfm(SplineFont *sf, char *filename);
+extern int LoadKerningDataFromAmfm(SplineFont *sf, char *filename);
+extern int LoadKerningDataFromMetricsFile(SplineFont *sf, char *filename, EncMap *map);
+extern int LoadKerningDataFromOfm(SplineFont *sf, char *filename, EncMap *map);
+extern int LoadKerningDataFromPfm(SplineFont *sf, char *filename, EncMap *map);
+extern int LoadKerningDataFromTfm(SplineFont *sf, char *filename, EncMap *map);
+extern int OfmSplineFont(FILE *tfm, SplineFont *sf, EncMap *map, int layer);
+extern int PfmSplineFont(FILE *pfm, SplineFont *sf, EncMap *map, int layer);
+extern int SCDrawsSomethingOnLayer(SplineChar *sc, int layer);
+extern int SCHasData(SplineChar *sc);
+extern int SCLWorthOutputtingOrHasData(SplineChar *sc, int layer);
+extern int SCWorthOutputting(SplineChar *sc);
+extern int SFFindNotdef(SplineFont *sf, int fixed);
+extern int TfmSplineFont(FILE *tfm, SplineFont *sf, EncMap *map, int layer);
+extern void PosNew(SplineChar *to, int tag, int dx, int dy, int dh, int dv);
+extern void SFKernClassTempDecompose(SplineFont *sf, int isv);
+extern void SFKernCleanup(SplineFont *sf, int isv);
+extern void SFLigatureCleanup(SplineFont *sf);
+extern void SFLigaturePrepare(SplineFont *sf);
+extern void SubsNew(SplineChar *to, enum possub_type type, int tag, char *components, SplineChar *default_script);
+extern void TeXDefaultParams(SplineFont *sf);
+
+#endif /* FONTFORGE_SPLINESAVEAFM_H */

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splinestroke.h"
+
 #include "cvundoes.h"
 #include "fontforge.h"
 #include "splinefont.h"

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforge.h"
 #include "splinefont.h"
+#include "splineorder2.h"
 #include <math.h>
 #define PI      3.1415926535897932
 

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -32,6 +32,7 @@
 #include "splinefont.h"
 #include "splineorder2.h"
 #include "splineoverlap.h"
+#include "splineutil2.h"
 #include <math.h>
 #define PI      3.1415926535897932
 

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -32,6 +32,7 @@
 #include "splinefont.h"
 #include "splineorder2.h"
 #include "splineoverlap.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #define PI      3.1415926535897932

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -28,6 +28,7 @@
 #include "fontforge.h"
 #include "splinefont.h"
 #include "splineorder2.h"
+#include "splineoverlap.h"
 #include <math.h>
 #define PI      3.1415926535897932
 

--- a/fontforge/splinestroke.h
+++ b/fontforge/splinestroke.h
@@ -1,0 +1,19 @@
+#ifndef FONTFORGE_SPLINESTROKE_H
+#define FONTFORGE_SPLINESTROKE_H
+
+#include "splinefont.h"
+
+enum PolyType {
+	Poly_Convex,
+	Poly_Concave,
+	Poly_PointOnEdge,
+	Poly_TooFewPoints,
+	Poly_Line
+};
+
+extern enum PolyType PolygonIsConvex(BasePoint *poly, int n, int *badpointindex);
+extern SplineSet *SplineSetStroke(SplineSet *ss, StrokeInfo *si, int order2);
+extern SplineSet *UnitShape(int n);
+extern void FVStrokeItScript(void *_fv, StrokeInfo *si, int pointless_argument);
+
+#endif /* FONTFORGE_SPLINESTROKE_H */

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -38,6 +38,7 @@
 #include <math.h>
 #include "psfont.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include "ustring.h"
 #include "utype.h"
 #include "views.h"		/* for FindSel structure */

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -2973,7 +2973,7 @@ static void LayerToRefLayer(struct reflayer *rl,Layer *layer, real transform[6])
     rl->fillfirst = layer->fillfirst;
 }
 
-int RefLayerFindBaseLayerIndex(RefChar *rf, int layer) {
+static int RefLayerFindBaseLayerIndex(RefChar *rf, int layer) {
 	// Note that most of the logic below is copied and lightly modified from SCReinstanciateRefChar.
 	SplineChar *rsc = rf->sc;
 	int i = 0, j = 0, cnt = 0;

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -39,6 +39,7 @@
 #include "psfont.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include "ustring.h"
 #include "utype.h"
 #include "views.h"		/* for FindSel structure */

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -41,6 +41,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splinerefigure.h"
+#include "splineutil2.h"
 #include "ustring.h"
 #include "utype.h"
 #include "views.h"		/* for FindSel structure */

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splineutil.h"
+
 #include "cvundoes.h"
 #include "dumppfa.h"
 #include "encoding.h"

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -40,6 +40,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splinerefigure.h"
 #include "ustring.h"
 #include "utype.h"
 #include "views.h"		/* for FindSel structure */

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -1,0 +1,216 @@
+#ifndef FONTFORGE_SPLINEUTIL_H
+#define FONTFORGE_SPLINEUTIL_H
+
+#include "psfont.h"
+#include "splinefont.h"
+#include "views.h"
+
+extern AnchorClass *SFFindOrAddAnchorClass(SplineFont *sf, char *name, struct lookup_subtable *sub);
+extern AnchorPoint *AnchorPointsCopy(AnchorPoint *alist);
+extern AnchorPoint *APAnchorClassMerge(AnchorPoint *anchors, AnchorClass *into, AnchorClass *from);
+extern bigreal DistanceBetweenPoints(BasePoint *p1, BasePoint *p2);
+extern bigreal SplineCurvature(Spline *s, bigreal t);
+extern bigreal SplineMinDistanceToPoint(Spline *s, BasePoint *p);
+
+extern size_t count_caps(const char * input);
+extern char *upper_case(const char * input);
+extern char *same_case(const char * input);
+extern char *delimit_null(const char * input, char delimiter);
+
+extern char *strconcat3(const char *str1, const char *str2, const char *str3);
+extern char **StringExplode(const char *input, char delimiter);
+extern char *XUIDFromFD(int xuid[20]);
+extern DeviceTable *DeviceTableCopy(DeviceTable *orig);
+extern double CheckExtremaForSingleBitErrors(const Spline1D *sp, double t, double othert);
+extern DStemInfo *DStemInfoCopy(DStemInfo *h);
+extern EncMap *EncMap1to1(int enccount);
+extern EncMap *EncMapCopy(EncMap *map);
+extern EncMap *EncMapNew(int enccount, int backmax, Encoding *enc);
+
+/* Uses an iterative approximation */
+extern extended IterateSplineSolve(const Spline1D *sp, extended tmin, extended tmax, extended sought_y);
+/* Uses an iterative approximation and then tries to fix things up */
+extern extended IterateSplineSolveFixup(const Spline1D *sp, extended tmin, extended tmax, extended sought_y);
+
+extern FPST *FPSTCopy(FPST *fpst);
+extern HintMask *HintMaskFromTransformedRef(RefChar *ref, BasePoint *trans, SplineChar *basesc,HintMask *hm);
+extern ImageList *ImageListCopy(ImageList *cimg);
+extern ImageList *ImageListTransform(ImageList *img, real transform[6], int everything);
+extern int CountKerningClasses(SplineFont *sf);
+extern int _CubicSolve(const Spline1D *sp, bigreal sought, extended ts[3]);
+extern int GroupNameType(const char *input);
+extern int IntersectLines(BasePoint *inter, BasePoint *line1_1, BasePoint *line1_2, BasePoint *line2_1, BasePoint *line2_2);
+extern int IntersectLinesClip(BasePoint *inter, BasePoint *line1_1, BasePoint *line1_2, BasePoint *line2_1, BasePoint *line2_2);
+extern int IntersectLinesSlopes(BasePoint *inter, BasePoint *line1, BasePoint *slope1, BasePoint *line2, BasePoint *slope2);
+extern int LineTangentToSplineThroughPt(Spline *s, BasePoint *pt, extended ts[4], extended tmin, extended tmax);
+extern int NearSpline(FindSel *fs, Spline *spline);
+extern int SCRoundToCluster(SplineChar *sc, int layer, int sel, bigreal within, bigreal max);
+extern int SFKerningGroupExistsSpecific(const struct splinefont *sf, const char *groupname, int isv, int isr);
+extern int SpExistsInSS(SplinePoint *sp, SplineSet *ss);
+extern int Spline2DFindExtrema(const Spline *sp, extended extrema[4]);
+extern int Spline2DFindPointsOfInflection(const Spline *sp, extended poi[2]);
+extern int SplineAtInflection(Spline1D *sp, bigreal t);
+extern int SplineAtMinMax(Spline1D *sp, bigreal t);
+extern int SplineExistsInSS(Spline *s, SplineSet *ss);
+extern int SplinePointIsACorner(SplinePoint *sp);
+extern int SplineSetIntersect(SplineSet *spl, Spline **_spline, Spline **_spline2);
+extern int SplineSetsRemoveAnnoyingExtrema(SplineSet *ss, bigreal err);
+
+/* Two lines intersect in at most 1 point */
+/* Two quadratics intersect in at most 4 points */
+/* Two cubics intersect in at most 9 points */ /* Plus an extra space for a trailing -1 */
+extern int SplinesIntersect(const Spline *s1, const Spline *s2, BasePoint pts[9], extended t1s[10], extended t2s[10]);
+
+extern int SplineT2SpiroIndex(Spline *spline, bigreal t, SplineSet *spl);
+extern int SSBoundsWithin(SplineSet *ss, bigreal z1, bigreal z2, bigreal *wmin, bigreal *wmax, int major);
+extern int SSExistsInLayer(SplineSet *ss, SplineSet *lots);
+extern int SSHasClip(SplineSet *ss);
+extern int SSHasDrawn(SplineSet *ss);
+extern int SSPointWithin(SplineSet *spl, BasePoint *pt);
+extern int StringInStrings(char const* const* space, int length, const char *target);
+extern KernClass *KernClassCopy(KernClass *kc);
+extern LinearApprox *SplineApproximate(Spline *spline, real scale);
+extern MinimumDistance *MinimumDistanceCopy(MinimumDistance *md);
+extern real SplineNearPoint(Spline *spline, BasePoint *bp, real fudge);
+extern RefChar *RefCharCreate(void);
+extern SplineChar *SFSplineCharCreate(SplineFont *sf);
+extern SplineFont *SplineFontFromPSFont(FontDict *fd);
+extern SplinePointList *SPLCopyTransformedHintMasks(RefChar *r, SplineChar *basesc, BasePoint *trans,int layer);
+extern SplinePointList *SPLCopyTranslatedHintMasks(SplinePointList *base, SplineChar *basesc, SplineChar *subsc, BasePoint *trans);
+extern SplinePointList *SplinePointListCopy1(const SplinePointList *spl);
+extern SplinePointList *SplinePointListCopySelected(SplinePointList *base);
+extern SplinePointList *SplinePointListCopySpiroSelected(SplinePointList *base);
+extern SplinePointList *SplinePointListRemoveSelected(SplineChar *sc, SplinePointList *base);
+extern SplinePointList *SplinePointListShift(SplinePointList *base, real xoff, enum transformPointType allpoints);
+extern SplinePointList *SplinePointListSpiroTransform(SplinePointList *base, real transform[6], int allpoints);
+extern SplinePointList *SplinePointListTransformExtended(SplinePointList *base, real transform[6], enum transformPointType tpt, enum transformPointMask tpmask);
+
+extern SplinePoint *SplineBisect(Spline *spline, extended t);
+extern SplinePoint *SplinePointCreate(real x, real y);
+extern SplineSet *LayerAllSplines(Layer *layer);
+extern SplineSet *LayerUnAllSplines(Layer *layer);
+extern Spline *SplineMake3(SplinePoint *from, SplinePoint *to);
+extern Spline *SplineSplit(Spline *spline, extended ts[3]);
+extern struct baselangextent *BaseLangCopy(struct baselangextent *extent);
+extern struct ff_glyphclasses *SFGetGroup(const struct splinefont *sf, int index, const char *name);
+extern struct glyphvariants *GlyphVariantsCopy(struct glyphvariants *gv);
+extern struct gradient *GradientCopy(struct gradient *old, real transform[6]);
+extern struct jstf_lang *JstfLangsCopy(struct jstf_lang *jl);
+extern struct mathkern *MathKernCopy(struct mathkern *mk);
+extern struct pattern *PatternCopy(struct pattern *old, real transform[6]);
+extern ValDevTab *ValDevTabCopy(ValDevTab *orig);
+extern void AltUniFree(struct altuni *altuni);
+extern void AnchorClassesFree(AnchorClass *an);
+extern void AnchorPointsFree(AnchorPoint *ap);
+extern void ApTransform(AnchorPoint *ap, real transform[6]);
+extern void ASMFree(ASM *sm);
+extern void BaseFree(struct Base *base);
+extern void BaseLangFree(struct baselangextent *extent);
+extern void BaseScriptFree(struct basescript *bs);
+extern void BpTransform(BasePoint *to, BasePoint *from, real transform[6]);
+extern void BrushCopy(struct brush *into, struct brush *from, real transform[6]);
+extern void CIDLayerFindBounds(SplineFont *cidmaster, int layer, DBounds *bounds);
+extern void DeviceTableFree(DeviceTable *dt);
+extern void DeviceTableSet(DeviceTable *adjust, int size, int correction);
+extern void DStemInfoFree(DStemInfo *h);
+extern void DStemInfosFree(DStemInfo *h);
+extern void EncMapFree(EncMap *map);
+extern void ExplodedStringFree(char **input);
+extern void FeatureScriptLangListFree(FeatureScriptLangList *fl);
+extern void FPSTClassesFree(FPST *fpst);
+extern void FPSTFree(FPST *fpst);
+extern void FPSTRuleContentsFree(struct fpst_rule *r, enum fpossub_format format);
+extern void FPSTRulesFree(struct fpst_rule *r, enum fpossub_format format, int rcnt);
+extern void GlyphGroupFree(struct ff_glyphclasses* group);
+extern void GlyphGroupKernFree(struct ff_rawoffsets* groupkern);
+extern void GlyphGroupKernsFree(struct ff_rawoffsets* root);
+extern void GlyphGroupsFree(struct ff_glyphclasses* root);
+extern void GlyphVariantsFree(struct glyphvariants *gv);
+extern void GradientFree(struct gradient *grad);
+extern void GrowBufferAdd(GrowBuf *gb, int ch);
+extern void GrowBufferAddStr(GrowBuf *gb, char *str);
+extern void ImageListsFree(ImageList *imgs);
+extern void JstfLangFree(struct jstf_lang *jl);
+extern void JustifyFree(Justify *just);
+extern void KernClassClearSpecialContents(KernClass *kc);
+extern void KernClassFreeContents(KernClass *kc);
+extern void KernClassListClearSpecialContents(KernClass *kc);
+extern void KernClassListFree(KernClass *kc);
+extern void KernPairsFree(KernPair *kp);
+extern void LayerDefault(Layer *layer);
+extern void LayerFreeContents(SplineChar *sc, int layer);
+extern void LinearApproxFree(LinearApprox *la);
+extern void LineListFree(LineList *ll);
+extern void MacFeatListFree(MacFeat *mf);
+extern void MacNameListFree(struct macname *mn);
+extern void MacSettingListFree(struct macsetting *ms);
+extern void MarkClassFree(int cnt, char **classes, char **names);
+extern void MarkSetFree(int cnt, char **classes, char **names);
+extern void MathKernFree(struct mathkern *mk);
+extern void MathKernVContentsFree(struct mathkernvertex *mk);
+extern void MinimumDistancesFree(MinimumDistance *md);
+extern void MMSetClearSpecial(MMSet *mm);
+extern void MMSetFreeContents(MMSet *mm);
+extern void OtfFeatNameListFree(struct otffeatname *fn);
+extern void OtfNameListFree(struct otfname *on);
+extern void OTLookupFree(OTLookup *lookup);
+extern void OTLookupListFree(OTLookup *lookup);
+extern void PatternFree(struct pattern *pat);
+extern void PenCopy(struct pen *into, struct pen *from, real transform[6]);
+extern void RefCharFindBounds(RefChar *rf);
+extern void RefCharFree(RefChar *ref);
+extern void RefCharsFree(RefChar *ref);
+extern void SCCategorizePoints(SplineChar *sc);
+extern void SCMakeDependent(SplineChar *dependent, SplineChar *base);
+extern void SCRefToSplines(SplineChar *sc, RefChar *rf, int layer);
+extern void SCReinstanciateRefChar(SplineChar *sc, RefChar *rf, int layer);
+extern void SCRemoveDependent(SplineChar *dependent, RefChar *rf, int layer);
+extern void SCRemoveDependents(SplineChar *dependent);
+extern void SCRemoveLayerDependents(SplineChar *dependent, int layer);
+extern void SFInstanciateRefs(SplineFont *sf);
+extern void SFReinstanciateRefs(SplineFont *sf);
+extern void SFRemoveAnchorClass(SplineFont *sf, AnchorClass *an);
+extern void SFRemoveSavedTable(SplineFont *sf, uint32 tag);
+extern void SPLCategorizePointsKeepCorners(SplinePointList *spl);
+extern void SplineCharFindBounds(SplineChar *sc, DBounds *bounds);
+extern void SplineCharFreeContents(SplineChar *sc);
+extern void SplineCharLayerFindBounds(SplineChar *sc, int layer, DBounds *bounds);
+extern void SplineCharLayerQuickBounds(SplineChar *sc, int layer, DBounds *bounds);
+extern void SplineCharListsFree(struct splinecharlist *dlist);
+extern void SplineCharQuickBounds(SplineChar *sc, DBounds *b);
+extern void SplineCharQuickConservativeBounds(SplineChar *sc, DBounds *b);
+extern void SplineFindExtrema(const Spline1D *sp, extended *_t1, extended *_t2);
+extern void SplineFontClearSpecial(SplineFont *sf);
+extern void SplineFontFindBounds(SplineFont *sf, DBounds *bounds);
+extern void SplineFontFree(SplineFont *sf);
+extern void SplineFontLayerFindBounds(SplineFont *sf, int layer, DBounds *bounds);
+extern void SplineFontQuickConservativeBounds(SplineFont *sf, DBounds *b);
+extern void SplineFree(Spline *spline);
+extern void SplinePointCategorize(SplinePoint *sp);
+extern void SplinePointFree(SplinePoint *sp);
+extern void SplinePointListFree(SplinePointList *spl);
+extern void SplinePointListMDFree(SplineChar *sc, SplinePointList *spl);
+extern void SplinePointListSelect(SplinePointList *spl, int sel);
+extern void SplinePointListsFree(SplinePointList *spl);
+extern void SplinePointListsMDFree(SplineChar *sc, SplinePointList *spl);
+extern void SplinePointMDFree(SplineChar *sc, SplinePoint *sp);
+extern void SplinePointsFree(SplinePointList *spl);
+extern void SplineRemoveExtremaTooClose(Spline1D *sp, extended *_t1, extended *_t2);
+extern void SplineSetBeziersClear(SplinePointList *spl);
+extern void SplineSetFindBounds(const SplinePointList *spl, DBounds *bounds);
+extern void SplineSetQuickBounds(SplineSet *ss, DBounds *b);
+extern void SplineSetQuickConservativeBounds(SplineSet *ss, DBounds *b);
+extern void SplineSetSpirosClear(SplineSet *spl);
+extern void TTFLangNamesFree(struct ttflangname *l);
+extern void TtfTablesFree(struct ttf_table *tab);
+extern void ValDevFree(ValDevTab *adjust);
+
+#ifdef FF_UTHASH_GLIF_NAMES
+struct glif_name_index;
+extern int KerningClassSeekByAbsoluteIndex(const struct splinefont *sf, int seek_index, struct kernclass **okc, int *oisv, int *oisr, int *ooffset);
+extern int HashKerningClassNames(SplineFont *sf, struct glif_name_index * class_name_hash);
+extern int HashKerningClassNamesCaps(SplineFont *sf, struct glif_name_index * class_name_hash);
+extern int HashKerningClassNamesFlex(SplineFont *sf, struct glif_name_index * class_name_hash, int capitalize);
+#endif /* FF_UTHASH_GLIF_NAMES */
+
+#endif /* FONTFORGE_SPLINEUTIL_H */

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -37,6 +37,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splineoverlap.h"
+#include "splineutil.h"
 #include <math.h>
 #include "ustring.h"
 #include "chardata.h"

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -32,6 +32,7 @@
 #include "psread.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include <math.h>
 #include "ustring.h"
 #include "chardata.h"

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -31,6 +31,7 @@
 #include "namelist.h"
 #include "psread.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include <math.h>
 #include "ustring.h"
 #include "chardata.h"

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -25,6 +25,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "splineutil2.h"
+
 #include "autohint.h"
 #include "cvundoes.h"
 #include "fontforge.h"

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -33,6 +33,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineoverlap.h"
 #include <math.h>
 #include "ustring.h"
 #include "chardata.h"

--- a/fontforge/splineutil2.h
+++ b/fontforge/splineutil2.h
@@ -1,0 +1,85 @@
+#ifndef FONTFORGE_SPLINEUTIL2_H
+#define FONTFORGE_SPLINEUTIL2_H
+
+#include "splinefont.h"
+
+enum ae_type { ae_all, ae_between_selected, ae_only_good, ae_only_good_rm_later };
+
+extern bigreal PathLength(SplineSet *ss);
+extern bigreal SplineLengthRange(Spline *spline, real from_t, real to_t);
+extern char *GetNextUntitledName(void);
+extern int PointListIsSelected(SplinePointList *spl);
+extern int PointsDiagonalable(SplineFont *sf, BasePoint **bp, BasePoint *unit);
+extern int RealApprox(real a, real b);
+extern int RealNearish(real a, real b);
+extern int RealRatio(real a, real b, real fudge);
+extern int RealWithin(real a, real b, real fudge);
+extern int SPInterpolate(const SplinePoint *sp);
+extern int SpIsExtremum(SplinePoint *sp);
+extern int Spline1DCantExtremeX(const Spline *s);
+extern int Spline1DCantExtremeY(const Spline *s);
+extern int SplineInSplineSet(Spline *spline, SplineSet *spl);
+extern int SplineIsLinearMake(Spline *spline);
+extern int SplinePointListIsClockwise(const SplineSet *spl);
+extern int SPLNearlyLines(SplineChar *sc, SplineSet *ss, bigreal err);
+extern int Within16RoundingErrors(bigreal v1, bigreal v2);
+extern int Within4RoundingErrors(bigreal v1, bigreal v2);
+extern int Within64RoundingErrors(bigreal v1, bigreal v2);
+extern Spline *ApproximateSplineFromPointsSlopes(SplinePoint *from, SplinePoint *to, TPoint *mid, int cnt, int order2);
+extern SplineFont *SplineFontBlank(int charcnt);
+extern SplineFont *SplineFontEmpty(void);
+extern SplineFont *SplineFontNew(void);
+extern Spline *PathFindDistance(SplineSet *path, bigreal d, bigreal *_t);
+extern SplineSet *SplineCharRemoveTiny(SplineChar *sc, SplineSet *head);
+extern SplineSet *SplineCharSimplify(SplineChar *sc, SplineSet *head, struct simplifyinfo *smpl);
+extern SplineSet *SplineSetBindToPath(SplineSet *ss, int doscale, int glyph_as_unit, int align, real offset, SplineSet *path);
+extern SplineSet *SplineSetJoin(SplineSet *start, int doall, real fudge, int *changed);
+extern SplineSet *SplineSetReverse(SplineSet *spl);
+extern SplineSet *SplineSetsAntiCorrect(SplineSet *base);
+extern SplineSet *SplineSetsCorrect(SplineSet *base, int *changed);
+extern SplineSet *SplineSetsDetectDir(SplineSet **_base, int *_lastscan);
+extern SplineSet *SplineSetsExtractOpen(SplineSet **tbase);
+extern SplineSet *SSRemoveZeroLengthSplines(SplineSet *base);
+extern Spline *SplineAddExtrema(Spline *s, int always, real lenbound, real offsetbound, DBounds *b);
+extern void BP_HVForce(BasePoint *vector);
+extern void CanonicalContours(SplineChar *sc, int layer);
+extern void SFIncrementXUID(SplineFont *sf);
+extern void SFRandomChangeXUID(SplineFont *sf);
+extern void SPAdjustControl(SplinePoint *sp, BasePoint *cp, BasePoint *to, int order2);
+extern void SPAverageCps(SplinePoint *sp);
+extern void SPHVCurveForce(SplinePoint *sp);
+extern void SPLAverageCps(SplinePointList *spl);
+extern void SplineCharAddExtrema(SplineChar *sc, SplineSet *head, enum ae_type between_selected, int emsize);
+extern void SplineCharDefaultNextCP(SplinePoint *base);
+extern void SplineCharDefaultPrevCP(SplinePoint *base);
+extern void SplineCharMerge(SplineChar *sc, SplineSet **head, int type);
+extern void SplineCharTangentNextCP(SplinePoint *sp);
+extern void SplineCharTangentPrevCP(SplinePoint *sp);
+extern void SplinePointListSet(SplinePointList *tobase, SplinePointList *frombase);
+extern void SplinePointListSimplify(SplineChar *sc, SplinePointList *spl, struct simplifyinfo *smpl);
+extern void SplineSetAddExtrema(SplineChar *sc, SplineSet *ss, enum ae_type between_selected, int emsize);
+extern void SplineSetJoinCpFixup(SplinePoint *sp);
+extern void SplineSetsInsertOpen(SplineSet **tbase, SplineSet *open);
+extern void SplineSetsUntick(SplineSet *spl);
+extern void SplinesRemoveBetween(SplineChar *sc, SplinePoint *from, SplinePoint *to, int type);
+extern void SPLNearlyHvCps(SplineChar *sc, SplineSet *ss, bigreal err);
+extern void SPLNearlyHvLines(SplineChar *sc, SplineSet *ss, bigreal err);
+extern void SPLsStartToLeftmost(SplineChar *sc, int layer);
+extern void SPLStartToLeftmost(SplineChar *sc, SplinePointList *spl, int *changed);
+extern void SPSmoothJoint(SplinePoint *sp);
+
+/**
+ * This is like SPAdjustControl but you have not wanting to move the
+ * BCP at all, but you would like the current location of the passed
+ * BCP to reshape the spline through the splinepoint. For example, if
+ * you drag the spline between two points then you might like to touch
+ * the inside BCP between the two splinepoints to reshape the whole
+ * curve through a curve point.
+ */
+extern void SPTouchControl(SplinePoint *sp, BasePoint *which, int order2);
+
+extern void SPWeightedAverageCps(SplinePoint *sp);
+extern void SSOverlapClusterCpAngles(SplineSet *base, bigreal within);
+extern void SSRemoveStupidControlPoints(SplineSet *base);
+
+#endif /* FONTFORGE_SPLINEUTIL2_H */

--- a/fontforge/start.c
+++ b/fontforge/start.c
@@ -24,6 +24,9 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "start.h"
+
 #include "encoding.h"
 #include "fontforgevw.h"
 #include "namelist.h"

--- a/fontforge/start.h
+++ b/fontforge/start.h
@@ -1,0 +1,8 @@
+#ifndef FONTFORGE_START_H
+#define FONTFORGE_START_H
+
+extern void doinitFontForgeMain(void);
+extern void doversion(const char *source_version_str);
+extern void InitSimpleStuff(void);
+
+#endif /* FONTFORGE_START_H */

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -29,6 +29,7 @@
 #include "fontforge.h"
 #include "edgelist2.h"
 #include "stemdb.h"
+#include "splineoverlap.h"
 
 #include <math.h>
 #include <utype.h>

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -30,6 +30,7 @@
 #include "edgelist2.h"
 #include "stemdb.h"
 #include "splineoverlap.h"
+#include "splineutil2.h"
 
 #include <math.h>
 #include <utype.h>

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -24,11 +24,13 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include "stemdb.h"
+
 #include "autohint.h"
 #include "dumppfa.h"
 #include "fontforge.h"
 #include "edgelist2.h"
-#include "stemdb.h"
 #include "splineoverlap.h"
 #include "splineutil.h"
 #include "splineutil2.h"

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -30,6 +30,7 @@
 #include "edgelist2.h"
 #include "stemdb.h"
 #include "splineoverlap.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 
 #include <math.h>

--- a/fontforge/stemdb.h
+++ b/fontforge/stemdb.h
@@ -216,4 +216,6 @@ extern struct glyphdata *DStemInfoToStemData( struct glyphdata *gd,DStemInfo *ds
 extern int IsStemAssignedToPoint( struct pointdata *pd,struct stemdata *stem,int is_next );
 extern void GlyphDataFree(struct glyphdata *gd);
 
+extern int UnitsParallel(BasePoint *u1, BasePoint *u2, int strict);
+
 #endif		/* _STEMDB_H_ */

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -35,6 +35,7 @@
 #include "namelist.h"
 #include "parsettf.h"
 #include "psread.h"
+#include "splineorder2.h"
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -37,6 +37,7 @@
 #include "psread.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -37,6 +37,7 @@
 #include "psread.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <unistd.h>
 #include <math.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -36,6 +36,7 @@
 #include "parsettf.h"
 #include "psread.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -38,6 +38,7 @@
 #include "parsepfa.h"
 #include "parsettfbmf.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -39,6 +39,7 @@
 #include "parsettfbmf.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -37,6 +37,7 @@
 #include "mm.h"
 #include "parsepfa.h"
 #include "parsettfbmf.h"
+#include "splinefill.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -40,6 +40,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splinesave.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -41,6 +41,7 @@
 #include "splineorder2.h"
 #include "splinesaveafm.h"
 #include "splinesave.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <unistd.h>

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -41,6 +41,7 @@
 #include "splineorder2.h"
 #include "splinesaveafm.h"
 #include "splinesave.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <unistd.h>
 #include <time.h>

--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -29,6 +29,7 @@
 #include "macenc.h"
 #include "asmfpst.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <utype.h>
 
 #include "ttf.h"

--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -28,6 +28,7 @@
 #include "fvfonts.h"
 #include "macenc.h"
 #include "asmfpst.h"
+#include "splinesaveafm.h"
 #include <utype.h>
 
 #include "ttf.h"

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -30,6 +30,7 @@
 #include "mem.h"
 #include "namelist.h"
 #include "asmfpst.h"
+#include "splinesaveafm.h"
 #include <utype.h>
 #include <ustring.h>
 

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -31,6 +31,7 @@
 #include "namelist.h"
 #include "asmfpst.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <utype.h>
 #include <ustring.h>
 

--- a/fontforge/tottfvar.c
+++ b/fontforge/tottfvar.c
@@ -27,6 +27,7 @@
 #include "fontforge.h"
 #include "mem.h"
 #include "ttf.h"
+#include "splinesaveafm.h"
 #include <math.h>
 #include <ustring.h>
 

--- a/fontforge/ttfspecial.c
+++ b/fontforge/ttfspecial.c
@@ -27,6 +27,7 @@
 #include "fontforge.h"
 #include "mem.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <time.h>

--- a/fontforge/ttfspecial.c
+++ b/fontforge/ttfspecial.c
@@ -26,6 +26,7 @@
  */
 #include "fontforge.h"
 #include "mem.h"
+#include "splinefill.h"
 #include <math.h>
 #include <time.h>
 #include <utype.h>

--- a/fontforge/ttfspecial.c
+++ b/fontforge/ttfspecial.c
@@ -27,6 +27,7 @@
 #include "fontforge.h"
 #include "mem.h"
 #include "splinefill.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <time.h>
 #include <utype.h>

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -41,6 +41,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <unistd.h>
 #include <math.h>

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -41,6 +41,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <unistd.h>
 #include <math.h>
 #include <time.h>

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -40,6 +40,7 @@
 #include "fvfonts.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "splinesaveafm.h"
 #include <unistd.h>
 #include <math.h>
 #include <time.h>

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -29,6 +29,7 @@
 #include "fontforge.h"
 #include "mem.h"
 #include "splinefill.h"
+#include "splineutil2.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -29,6 +29,7 @@
 #include "fontforge.h"
 #include "mem.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <stdio.h>
 #include <math.h>

--- a/fontforge/winfonts.c
+++ b/fontforge/winfonts.c
@@ -28,6 +28,7 @@
 #include "encoding.h"
 #include "fontforge.h"
 #include "mem.h"
+#include "splinefill.h"
 #include <stdio.h>
 #include <math.h>
 #include "splinefont.h"

--- a/fontforgeexe/acorn2sfd.c
+++ b/fontforgeexe/acorn2sfd.c
@@ -31,6 +31,7 @@
 #include "mem.h"
 #include "namelist.h"
 #include "splinefont.h"
+#include "splineutil2.h"
 #include <ustring.h>
 
 static int includestrokes = false;

--- a/fontforgeexe/acorn2sfd.c
+++ b/fontforgeexe/acorn2sfd.c
@@ -31,6 +31,7 @@
 #include "mem.h"
 #include "namelist.h"
 #include "splinefont.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 

--- a/fontforgeexe/acorn2sfd.c
+++ b/fontforgeexe/acorn2sfd.c
@@ -33,6 +33,7 @@
 #include "splinefont.h"
 #include "splineutil.h"
 #include "splineutil2.h"
+#include "start.h"
 #include <ustring.h>
 
 static int includestrokes = false;

--- a/fontforgeexe/anchorsaway.c
+++ b/fontforgeexe/anchorsaway.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "splinefill.h"
 #include <gkeysym.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/anchorsaway.c
+++ b/fontforgeexe/anchorsaway.c
@@ -27,6 +27,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include <gkeysym.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/basedlg.c
+++ b/fontforgeexe/basedlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/bdfinfo.c
+++ b/fontforgeexe/bdfinfo.c
@@ -30,6 +30,7 @@
 #include "bitmapchar.h"
 #include "fontforgeui.h"
 #include "splinefont.h"
+#include "splinefill.h"
 #include <string.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/bitmapdlg.c
+++ b/fontforgeexe/bitmapdlg.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgeui.h"
 #include "gwidget.h"
+#include "splinefill.h"
 #include "ustring.h"
 #include <gkeysym.h>
 #include <math.h>

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -32,6 +32,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <gkeysym.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -31,6 +31,7 @@
 #include "encoding.h"
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "splinefill.h"
 #include <gkeysym.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -33,6 +33,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "namelist.h"
+#include "splinefill.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -34,6 +34,7 @@
 #include "lookups.h"
 #include "namelist.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -46,6 +46,7 @@
 #include "splineorder2.h"
 #include "splineoverlap.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -42,6 +42,7 @@
 #include "namelist.h"
 #include "sfd.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -45,6 +45,7 @@
 #include "splinefill.h"
 #include "splineorder2.h"
 #include "splineoverlap.h"
+#include "splinesaveafm.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -43,6 +43,7 @@
 #include "sfd.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -44,6 +44,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineoverlap.h"
 #include <math.h>
 #include <locale.h>
 #include <ustring.h>

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -46,6 +46,7 @@
 #include "splineorder2.h"
 #include "splineoverlap.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <locale.h>

--- a/fontforgeexe/combinations.c
+++ b/fontforgeexe/combinations.c
@@ -31,6 +31,7 @@
 #include "lookups.h"
 #include "psfont.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforgeexe/combinations.c
+++ b/fontforgeexe/combinations.c
@@ -30,6 +30,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "psfont.h"
+#include "splinefill.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -27,6 +27,7 @@
 #include "asmfpst.h"
 #include "fontforgeui.h"
 #include "lookups.h"
+#include "splineutil.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/cvaddpoints.c
+++ b/fontforgeexe/cvaddpoints.c
@@ -30,6 +30,7 @@
 #include "spiro.h"
 #include "splinefont.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include "ustring.h"
 
 int CVOneThingSel(CharView *cv, SplinePoint **sp, SplinePointList **_spl,

--- a/fontforgeexe/cvaddpoints.c
+++ b/fontforgeexe/cvaddpoints.c
@@ -30,6 +30,7 @@
 #include "spiro.h"
 #include "splinefont.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "ustring.h"
 

--- a/fontforgeexe/cvaddpoints.c
+++ b/fontforgeexe/cvaddpoints.c
@@ -29,6 +29,7 @@
 #include <math.h>
 #include "spiro.h"
 #include "splinefont.h"
+#include "splineorder2.h"
 #include "ustring.h"
 
 int CVOneThingSel(CharView *cv, SplinePoint **sp, SplinePointList **_spl,

--- a/fontforgeexe/cvdebug.c
+++ b/fontforgeexe/cvdebug.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "splineorder2.h"
 #include <math.h>
 #include <gkeysym.h>
 #include <ustring.h>

--- a/fontforgeexe/cvdebug.c
+++ b/fontforgeexe/cvdebug.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include <math.h>
 #include <gkeysym.h>
 #include <ustring.h>

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "splineorder2.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "splineorder2.h"
 #include <math.h>
 
 #undef DEBUG_FREEHAND

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "splineorder2.h"
+#include "splinestroke.h"
 #include <math.h>
 
 #undef DEBUG_FREEHAND

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "splineorder2.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <math.h>
 
 #undef DEBUG_FREEHAND

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -29,6 +29,7 @@
 #include "lookups.h"
 #include "parsettf.h"
 #include "spiro.h"
+#include "splineorder2.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -30,6 +30,7 @@
 #include "parsettf.h"
 #include "spiro.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -30,6 +30,7 @@
 #include "parsettf.h"
 #include "spiro.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <math.h>

--- a/fontforgeexe/cvgridfit.c
+++ b/fontforgeexe/cvgridfit.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <math.h>

--- a/fontforgeexe/cvimportdlg.c
+++ b/fontforgeexe/cvimportdlg.c
@@ -30,6 +30,7 @@
 #include "fontforgeui.h"
 #include "fvimportbdf.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include <math.h>
 #include <sys/types.h>
 #include <dirent.h>

--- a/fontforgeexe/cvknife.c
+++ b/fontforgeexe/cvknife.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "spiro.h"
 #include "collabclientui.h"
+#include "splineutil.h"
 #include <math.h>
 
 #if defined(KNIFE_CONTINUOUS)	/* Use this code to do cuts as we move along. Probably a bad idea, let's wait till the end */

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "spiro.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include "collabclientui.h"
 
 int palettes_docked=1;

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "spiro.h"
+#include "splinefill.h"
 #include "collabclientui.h"
 
 int palettes_docked=1;

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -29,6 +29,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include "collabclientui.h"
 

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -29,6 +29,7 @@
 #include "spiro.h"
 #include "splinefill.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include "collabclientui.h"
 
 int palettes_docked=1;

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -28,6 +28,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "spiro.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <utype.h>
 #include <math.h>

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -28,6 +28,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "spiro.h"
+#include "splineutil2.h"
 #include <utype.h>
 #include <math.h>
 #include "collabclient.h"

--- a/fontforgeexe/cvruler.c
+++ b/fontforgeexe/cvruler.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>
 

--- a/fontforgeexe/cvruler.c
+++ b/fontforgeexe/cvruler.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforgeexe/cvshapes.c
+++ b/fontforgeexe/cvshapes.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "spiro.h"
 #include "splineorder2.h"
+#include "splineutil2.h"
 #include <math.h>
 
 static struct shapedescrip {

--- a/fontforgeexe/cvshapes.c
+++ b/fontforgeexe/cvshapes.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "spiro.h"
 #include "splineorder2.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 

--- a/fontforgeexe/cvshapes.c
+++ b/fontforgeexe/cvshapes.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "spiro.h"
+#include "splineorder2.h"
 #include <math.h>
 
 static struct shapedescrip {

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "splinestroke.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "splinestroke.h"
 #include <ustring.h>
 #include <utype.h>
 #include <gkeysym.h>

--- a/fontforgeexe/displayfonts.c
+++ b/fontforgeexe/displayfonts.c
@@ -33,6 +33,7 @@
 #include "print.h"
 #include "sftextfieldP.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>

--- a/fontforgeexe/displayfonts.c
+++ b/fontforgeexe/displayfonts.c
@@ -32,6 +32,7 @@
 #include "lookups.h"
 #include "print.h"
 #include "sftextfieldP.h"
+#include "splinesaveafm.h"
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>

--- a/fontforgeexe/effectsui.c
+++ b/fontforgeexe/effectsui.c
@@ -28,6 +28,7 @@
 #include "effects.h"
 #include "fontforgeui.h"
 #include "splinestroke.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforgeexe/effectsui.c
+++ b/fontforgeexe/effectsui.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "effects.h"
 #include "fontforgeui.h"
+#include "splinestroke.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -38,6 +38,7 @@
 #include "parsettf.h"
 #include "psread.h"
 #include "sfd.h"
+#include "splineorder2.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -39,6 +39,7 @@
 #include "psread.h"
 #include "sfd.h"
 #include "splineorder2.h"
+#include "splinesaveafm.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -40,6 +40,7 @@
 #include "sfd.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -40,6 +40,7 @@
 #include "sfd.h"
 #include "splineorder2.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <chardata.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -51,6 +51,7 @@
 #include "splinefill.h"
 #include "search.h"
 #include "sfd.h"
+#include "splinesaveafm.h"
 #include <gfile.h>
 #include <gio.h>
 #include <gresedit.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -48,6 +48,7 @@
 #include "nonlineartrans.h"
 #include "psfont.h"
 #include "scripting.h"
+#include "splinefill.h"
 #include "search.h"
 #include "sfd.h"
 #include <gfile.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -52,6 +52,7 @@
 #include "search.h"
 #include "sfd.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <gfile.h>
 #include <gio.h>

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -52,6 +52,7 @@
 #include "search.h"
 #include "sfd.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <gfile.h>
 #include <gio.h>
 #include <gresedit.h>

--- a/fontforgeexe/fvfontsdlg.c
+++ b/fontforgeexe/fvfontsdlg.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "splineutil.h"
 #include "ustring.h"
 #include "utype.h"
 #include "gfile.h"

--- a/fontforgeexe/fvmetricsdlg.c
+++ b/fontforgeexe/fvmetricsdlg.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "bvedit.h"
+#include "splineutil.h"
 #include "fontforgeui.h"
 #include <math.h>
 #include <ustring.h>

--- a/fontforgeexe/groupsdlg.c
+++ b/fontforgeexe/groupsdlg.c
@@ -28,6 +28,7 @@
 #include "fvfonts.h"
 #include "groups.h"
 #include "namelist.h"
+#include "splineutil.h"
 #include <unistd.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/histograms.c
+++ b/fontforgeexe/histograms.c
@@ -28,6 +28,7 @@
 #include "dumppfa.h"
 #include "fontforgeui.h"
 #include "psfont.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <gkeysym.h>
 #include <utype.h>

--- a/fontforgeexe/justifydlg.c
+++ b/fontforgeexe/justifydlg.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgeui.h"
 #include "lookups.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>

--- a/fontforgeexe/kernclass.c
+++ b/fontforgeexe/kernclass.c
@@ -29,6 +29,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include <gkeysym.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/kernclass.c
+++ b/fontforgeexe/kernclass.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "lookups.h"
+#include "splinefill.h"
 #include <gkeysym.h>
 #include <string.h>
 #include <ustring.h>

--- a/fontforgeexe/layer2layer.c
+++ b/fontforgeexe/layer2layer.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "glyphcomp.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <gkeysym.h>
 

--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -32,6 +32,7 @@
 #include "sfd.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -30,6 +30,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "sfd.h"
+#include "splinefill.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -31,6 +31,7 @@
 #include "lookups.h"
 #include "sfd.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <chardata.h>
 #include <utype.h>
 #include <ustring.h>

--- a/fontforgeexe/macencui.c
+++ b/fontforgeexe/macencui.c
@@ -27,6 +27,7 @@
  */
 #include "fontforgeui.h"
 #include "macenc.h"
+#include "splineutil.h"
 #include <gkeysym.h>
 #include <ustring.h>
 #include "ttf.h"

--- a/fontforgeexe/math.c
+++ b/fontforgeexe/math.c
@@ -28,6 +28,7 @@
 #include "fontforgeui.h"
 #include "fvfonts.h"
 #include "mathconstants.h"
+#include "splineutil.h"
 #include <math.h>
 #include <stddef.h>
 #include <gkeysym.h>

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -37,6 +37,7 @@
 #include "mm.h"
 #include "splinefill.h"
 #include "splineoverlap.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <gkeysym.h>
 #include <gresource.h>

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -37,6 +37,7 @@
 #include "mm.h"
 #include "splinefill.h"
 #include "splineoverlap.h"
+#include "splineutil2.h"
 #include <gkeysym.h>
 #include <gresource.h>
 #include <gresedit.h>

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -36,6 +36,7 @@
 #include "lookups.h"
 #include "mm.h"
 #include "splinefill.h"
+#include "splineoverlap.h"
 #include <gkeysym.h>
 #include <gresource.h>
 #include <gresedit.h>

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -35,6 +35,7 @@
 #include "fvfonts.h"
 #include "lookups.h"
 #include "mm.h"
+#include "splinefill.h"
 #include <gkeysym.h>
 #include <gresource.h>
 #include <gresedit.h>

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -35,6 +35,7 @@
 #include "psread.h"
 #include "sfd.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <ustring.h>
 #include <math.h>

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -34,6 +34,7 @@
 #include "parsettf.h"
 #include "psread.h"
 #include "sfd.h"
+#include "splinefill.h"
 #include <ustring.h>
 #include <math.h>
 #include <gkeysym.h>

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -35,6 +35,7 @@
 #include "psread.h"
 #include "sfd.h"
 #include "splinefill.h"
+#include "splineutil2.h"
 #include <ustring.h>
 #include <math.h>
 #include <gkeysym.h>

--- a/fontforgeexe/nonlineartransui.c
+++ b/fontforgeexe/nonlineartransui.c
@@ -28,6 +28,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "nonlineartrans.h"
+#include "splineutil.h"
 #include <utype.h>
 #include <ustring.h>
 

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -34,6 +34,7 @@
 #include "othersubrs.h"
 #include "plugins.h"
 #include "sfd.h"
+#include "splineutil.h"
 #include <charset.h>
 #include <gfile.h>
 #include <gresource.h>

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -32,6 +32,7 @@
 #include "namelist.h"
 #include "ttf.h"
 #include "splineorder2.h"
+#include "splineoverlap.h"
 #include <gwidget.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -34,6 +34,7 @@
 #include "splineorder2.h"
 #include "splineoverlap.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <gwidget.h>
 #include <ustring.h>

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -31,6 +31,7 @@
 #include "fvfonts.h"
 #include "namelist.h"
 #include "ttf.h"
+#include "splineorder2.h"
 #include <gwidget.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -33,6 +33,7 @@
 #include "ttf.h"
 #include "splineorder2.h"
 #include "splineoverlap.h"
+#include "splinesaveafm.h"
 #include <gwidget.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -34,6 +34,7 @@
 #include "splineorder2.h"
 #include "splineoverlap.h"
 #include "splinesaveafm.h"
+#include "splineutil2.h"
 #include <gwidget.h>
 #include <ustring.h>
 #include <math.h>

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -31,6 +31,7 @@
 #include "mm.h"
 #include "namelist.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <ustring.h>
 #include <locale.h>
 #include <gfile.h>

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -30,6 +30,7 @@
 #include "macbinary.h"
 #include "mm.h"
 #include "namelist.h"
+#include "splinefill.h"
 #include <ustring.h>
 #include <locale.h>
 #include <gfile.h>

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -32,6 +32,7 @@
 #include "namelist.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <ustring.h>
 #include <locale.h>
 #include <gfile.h>

--- a/fontforgeexe/searchview.c
+++ b/fontforgeexe/searchview.c
@@ -27,6 +27,7 @@
 #include "cvundoes.h"
 #include "fontforgeui.h"
 #include "fvfonts.h"
+#include "splineutil.h"
 #include <math.h>
 #include <ustring.h>
 #include <utype.h>

--- a/fontforgeexe/sftextfield.c
+++ b/fontforgeexe/sftextfield.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgeui.h"
 #include "langfreq.h"
+#include "splinefill.h"
 #include <gkeysym.h>
 #include <math.h>
 

--- a/fontforgeexe/sftextfield.c
+++ b/fontforgeexe/sftextfield.c
@@ -27,6 +27,7 @@
 #include "fontforgeui.h"
 #include "langfreq.h"
 #include "splinefill.h"
+#include "splineutil.h"
 #include <gkeysym.h>
 #include <math.h>
 

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -29,6 +29,7 @@
 #include "fvfonts.h"
 #include "glyphcomp.h"
 #include "lookups.h"
+#include "splinefill.h"
 #include <utype.h>
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -30,6 +30,7 @@
 #include "glyphcomp.h"
 #include "lookups.h"
 #include "splinefill.h"
+#include "splinesaveafm.h"
 #include <utype.h>
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -31,6 +31,7 @@
 #include "lookups.h"
 #include "splinefill.h"
 #include "splinesaveafm.h"
+#include "splineutil.h"
 #include <utype.h>
 #include <ustring.h>
 #include <gkeysym.h>

--- a/fontforgeexe/startnoui.c
+++ b/fontforgeexe/startnoui.c
@@ -26,6 +26,7 @@
  */
 #include "fontforgevw.h"
 #include "scripting.h"
+#include "start.h"
 
 #ifndef _NO_LIBUNICODENAMES
 #include <libunicodenames.h>	/* need to open a database when we start */

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -34,6 +34,7 @@
 #include "encoding.h"
 #include "fontforgeui.h"
 #include "lookups.h"
+#include "start.h"
 
 #ifndef _NO_LIBUNICODENAMES
 #include <libunicodenames.h>	/* need to open a database when we start */

--- a/fontforgeexe/tilepath.c
+++ b/fontforgeexe/tilepath.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "splineutil2.h"
 #include <math.h>
 #include <gkeysym.h>
 

--- a/fontforgeexe/tilepath.c
+++ b/fontforgeexe/tilepath.c
@@ -25,6 +25,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "fontforgeui.h"
+#include "splineutil.h"
 #include "splineutil2.h"
 #include <math.h>
 #include <gkeysym.h>

--- a/fontforgeexe/ttfinstrsui.c
+++ b/fontforgeexe/ttfinstrsui.c
@@ -26,6 +26,7 @@
  */
 #include "cvundoes.h"
 #include "fontforgeui.h"
+#include "splineutil.h"
 #include <gkeysym.h>
 #include <ustring.h>
 #include <utype.h>

--- a/tests/link_test.c
+++ b/tests/link_test.c
@@ -1,4 +1,5 @@
 #include "fontforge.h"
+#include "start.h"
 
 int main()
 {


### PR DESCRIPTION
The fourth installation of the cleanups of the headers in `fontforge/`, a followup to PR #2975 (part 3), #2969 (part 2) and #2878 (part 1).

Just like the previous PRs, this PR is quite "uneventful": only declarations have been moved and the comments (where available) preserved. The only things to note are two drive-by commits that mark some functions as static (both functions have never been exported and are only used inside the same file in which they are found).