### PR TITLE
Fix "Unicode 2.0, full repertoire" cmap encoding.

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -4939,17 +4939,13 @@ static void dumpcmap(struct alltabs *at, SplineFont *sf,enum fontformat format) 
     if ( hasmac&1 ) {
 	/* big mac table, just a copy of the ms table */
 	putshort(at->cmap,0);	/* mac unicode platform */
-	putshort(at->cmap,3);	/* Unicode 2.0 */
+	putshort(at->cmap,3);	/* Unicode 2.0, BMP only */
 	putlong(at->cmap,mspos);
     }
     if ( format12!=NULL ) {
 	/* full unicode mac table, just a copy of the ms table */
 	putshort(at->cmap,0);	/* mac unicode platform */
-        if( map->enc->is_unicodefull ) {
-	    putshort(at->cmap,10);	/* Unicode 2.0, unicode beyond BMP */
-	} else {
-	    putshort(at->cmap,4);	/* Unicode 2.0, unicode BMP */
-	}
+	putshort(at->cmap,4);	/* Unicode 2.0, full repertoire */
 	putlong(at->cmap,ucs4pos);
     }
     if ( format14!=NULL ) {


### PR DESCRIPTION
Previously, FontForge would emit a cmap table with Platform ID = 0,
Platform Specific Encoding ID = 10. The 0/10 combination is bogus. It
should be 0/4 instead.

Both these specs:
  - https://www.microsoft.com/typography/otspec/name.htm
  - https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6cmap.html
lists 0/4 and 3/10 as valid combinations, but not 0/10. The first number
is the PID, and means Unicode (0) or Microsoft (3). The second number is
the PSID, but its meaning depends on the PID.

Fixes #2728.