### PR TITLE
Force MacOS builds to target only x86_64

### DIFF
--- a/m4/fontforge_platform_specifics.m4
+++ b/m4/fontforge_platform_specifics.m4
@@ -23,7 +23,7 @@ AS_CASE([$host],
        MACAPP=""
       fi
 
-      RAW_COMPILE_PLATFORM_CFLAGS=" $CFLAGS -arch x86_64 -arch i386 "
+      RAW_COMPILE_PLATFORM_CFLAGS=" $CFLAGS -arch x86_64 "
       AC_SUBST([RAW_COMPILE_PLATFORM_CFLAGS])
 
       dnl fink puts stuff under /sw


### PR DESCRIPTION
Commit 25c51f592df2c69f12ed5fc1d39c7917ef829dcf introduced in 2014 the following compile flags on MacOS

    -arch x86_64 -arch i386

These flags were used to create universal binaries for OS X up to version 10.12. In the current MacOS version and, it seems, in the current Travis + Homebrew installations, only x86_64 makes sense.

This PR fixes all the recent Travis failures, as described in issue #3001.