### PR TITLE
Fix many of the free() calls to PyMem_Free() for the python3.6 requirement

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1045,7 +1045,7 @@ static PyObject *PyFF_OpenFont(PyObject *UNUSED(self), PyObject *args) {
     if ( !PyArg_ParseTuple(args,"es|i", "UTF-8", &filename, &openflags ))
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     /* The actual filename opened may be different from the one passed
      * to LoadSplineFont, so we can't report the filename on an
@@ -1072,7 +1072,7 @@ static PyObject *PyFF_FontsInFile(PyObject *UNUSED(self), PyObject *args) {
     if ( !PyArg_ParseTuple(args,"es","UTF-8",&filename) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
     ret = GetFontNames(locfilename, 1);
     free(locfilename);
     cnt = 0;
@@ -4128,7 +4128,7 @@ static PyObject *PyFFLayer_export(PyFF_Layer *self, PyObject *args) {
     if ( !PyArg_ParseTuple(args,"es","UTF-8",&filename) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     pt = strrchr(locfilename,'.');
     if ( pt==NULL ) pt=locfilename;
@@ -7785,7 +7785,7 @@ static PyObject *PyFFGlyph_import(PyObject *self, PyObject *args) {
     if ( !PyArg_ParseTuple(args,"es|O","UTF-8",&filename, &flags) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     /* Check if the file exists and is readable */
     if ( access(locfilename,R_OK)!=0 ) {
@@ -7854,7 +7854,7 @@ static PyObject *PyFFGlyph_export(PyObject *self, PyObject *args) {
     if ( !PyArg_ParseTuple(args,"es|OO","UTF-8",&filename,&foo,&bar) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     pt = strrchr(locfilename,'.');
     if ( pt==NULL ) pt=locfilename;
@@ -13549,7 +13549,7 @@ return (NULL);
 	    &to_background) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     ext = strrchr(locfilename,'.');
     if ( ext==NULL ) {
@@ -13623,7 +13623,7 @@ return (NULL);
     if ( !PyArg_ParseTuple(args,"OesO", &other, "UTF-8", &filename, &flagstuple ))
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     if ( !PyType_IsSubtype(&PyFF_FontType, Py_TYPE(other)) ) {
 	PyErr_Format(PyExc_TypeError,"First argument must be a fontforge font");
@@ -15690,7 +15690,7 @@ return( NULL );
 	}
     }
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
     if ( !GenerateScript(fv->sf,locfilename,bitmaptype,iflags,resolution,subfontdirectory,
 	    NULL,fv->normal==NULL?fv->map:fv->normal,rename_to,layer) ) {
 	PyErr_Format(PyExc_EnvironmentError, "Font generation failed");
@@ -15846,7 +15846,7 @@ return( NULL );
     }
 
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     if ( !WriteTTC(locfilename,head,ff_ttc,bf,iflags,layer,ittcflags)) {
 	PyErr_Format(PyExc_EnvironmentError, "Font generation failed");
@@ -15874,7 +15874,7 @@ return (NULL);
     if ( !PyArg_ParseTuple(args,"es|s","UTF-8",&filename,&lookup_name) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
 
     if ( lookup_name!=NULL ) {
 	otl = SFFindLookup(fv->sf,lookup_name);
@@ -15914,7 +15914,8 @@ return (NULL);
     if ( !PyArg_ParseTuple(args,"es","UTF-8",&filename) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
+
     if ( !LoadKerningDataFromMetricsFile(fv->sf,locfilename,fv->map)) {
 	PyErr_Format(PyExc_EnvironmentError, "No metrics data found");
 return( NULL );
@@ -15938,7 +15939,7 @@ return (NULL);
 	    &preserveCrossFontKerning, &openflags) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
     sf = LoadSplineFont(locfilename,openflags);
     if ( sf==NULL ) {
 	PyErr_Format(PyExc_EnvironmentError, "No font found in file \"%s\"", locfilename);
@@ -15966,7 +15967,7 @@ return (NULL);
     if ( !PyArg_ParseTuple(args,"des|i",&fraction,"UTF-8",&filename, &openflags) )
 return( NULL );
     locfilename = utf82def_copy(filename);
-    free(filename);
+    PyMem_Free(filename);
     sf = LoadSplineFont(locfilename,openflags);
     if ( sf==NULL ) {
 	PyErr_Format(PyExc_EnvironmentError, "No font found in file \"%s\"", locfilename);


### PR DESCRIPTION
This is also based on the discussion happened in upstream issue
https://github.com/fontforge/fontforge/issues/2992

This commit is a fix for the reported two problems in issue
https://github.com/fontforge/fontforge/issues/3042

The upstream documentation says
PyArg_ParseTuple() will allocate a buffer of the needed size, copy the
encoded data into this buffer and adjust *buffer to reference the newly
allocated storage. The caller is responsible for calling PyMem_Free()
to free the allocated buffer after use.

