### PR TITLE
stemdb.c: Zero-initialise glyphdata members on init in GlyphDataBuild

### DIFF
--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -5975,10 +5975,10 @@ return( gd );
     /* Figure out active zones at the first order (as they are needed to */
     /* determine which stems are undesired and they don't depend from */
     /* the "potential" state of left/right points in chunks */
-    gd->lspace = malloc(gd->pcnt*sizeof(struct segment));
-    gd->rspace = malloc(gd->pcnt*sizeof(struct segment));
-    gd->bothspace = malloc(3*gd->pcnt*sizeof(struct segment));
-    gd->activespace = malloc(3*gd->pcnt*sizeof(struct segment));
+    gd->lspace = calloc(gd->pcnt, sizeof(struct segment));
+    gd->rspace = calloc(gd->pcnt, sizeof(struct segment));
+    gd->bothspace = calloc(3 * gd->pcnt, sizeof(struct segment));
+    gd->activespace = calloc(3 * gd->pcnt, sizeof(struct segment));
 #if GLYPH_DATA_DEBUG
     fprintf( stderr,"Going to calculate stem active zones for %s\n",gd->sc->name );
 #endif


### PR DESCRIPTION
Fixes #3059. This resolves undefined behaviour (specifically `gd->activespace[acnt].start` was uninitialized - the fact that it worked on any other platform/build was probably only because it was zero by chance) as identified by Valgrind:

```
==1686== Conditional jump or move depends on uninitialised value(s)
==1686==    at 0x47ED9F7: FigureStemActive (stemdb.c:3513)
==1686==    by 0x47F0AF7: GlyphDataBuild (stemdb.c:5986)
==1686==    by 0x460F0B6: _SplineCharAutoHint (autohint.c:2953)
==1686==    by 0x460F228: __SplineCharAutoHint (autohint.c:2980)
==1686==    by 0x47A86C5: SplineFont2ChrsSubrs2 (splinesave.c:3241)
==1686==    by 0x48200D5: dumptype2glyphs (tottf.c:2624)
==1686==    by 0x4826990: initTables (tottf.c:5726)
==1686==    by 0x4826D08: _WriteTTFFont (tottf.c:6119)
==1686==    by 0x4827334: WriteTTFFont (tottf.c:6152)
==1686==    by 0x470C6EE: _DoSave (savefont.c:836)
==1686==    by 0x470DC78: GenerateScript (savefont.c:1245)
==1686==    by 0x4726693: bGenerate (scripting.c:2006)
```