### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ cache:
   directories:
     - $TRAVIS_BUILD_DIR/travisdeps
 
-before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update || brew update; fi
+#before_install:
+#  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update || brew update; fi
 
 install:
   - |
@@ -77,28 +77,31 @@ install:
       export PYTHON=python3.5
       export PYTHONPATH=$PYTHONPATH:$PREFIX/lib/python$($PYTHON -c "import sys; print('{0}.{1}'.format(sys.version_info.major, sys.version_info.minor))")/site-packages
       export CFLAGS="-fdiagnostics-color=auto -Wall -Wno-switch"
-      #Why.
-      export LIBSPIRO_CFLAGS=`pkg-config --cflags libspiro` && export LIBSPIRO_LIBS=`pkg-config --libs libspiro`
-      export LIBUNINAMESLIST_CFLAGS=`pkg-config --cflags libuninameslist` && export LIBUNINAMESLIST_LIBS=`pkg-config --libs libuninameslist`
     else
-      export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig
-      export MSGFMT=/usr/local/opt/gettext/bin/msgfmt
-      export PYTHON=python
+      export PATH=/opt/local/bin:$PATH
+      export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:/opt/X11/lib/pkgconfig:/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/pkgconfig:$PKG_CONFIG_PATH
       export PYTHONPATH=$PYTHONPATH:$PREFIX/lib/python2.7/site-packages
+      export PYTHON=python
+      wget https://github.com/macports/macports-base/releases/download/v2.4.1/MacPorts-2.4.1-10.11-ElCapitan.pkg
+      sudo installer -pkg MacPorts-2.4.1-10.11-ElCapitan.pkg -target /
+      sudo port selfupdate
 
-      # IPython??
-      # pip install ipython
-      # Disable fc-cache on fontconfig install. Because it's slow.
-      sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb"
-      # Install cairo and pango, using cached bottles if possible
-      pushd $DEPSPREFIX
-      brew install *cairo*bottle* || (brew install --build-bottle cairo --with-x11 && brew bottle cairo)
-      brew install *pango*bottle* || (brew install --build-bottle pango --with-x11 && brew bottle pango)
-      brew outdated | grep -q cairo && rm *cairo*bottle* || true
-      brew outdated | grep -q pango && rm *pango*bottle* || true
-      popd
-      brew install ./travis-scripts/fontforge.rb --HEAD --with-x11 --only-dependencies
+      PORTDEFS=$(pushd osx >/dev/null && port deps | \
+        grep '^Build\|^Library' | \
+        sed -e 's/Build Dependencies://' -e 's/Library Dependencies://' | \
+        tr , '\n' | \
+        sed -e 's/^[[:space:]]*//' && \
+        popd >/dev/null \
+      )
+      echo "Installing dependencies: $PORTDEFS"
+      COLUMNS=80 sudo port install $PORTDEFS
+      sudo port select --set python python27
+      sudo port select --set python2 python27
     fi
+
+    #Why.
+    export LIBSPIRO_CFLAGS=`pkg-config --cflags libspiro` && export LIBSPIRO_LIBS=`pkg-config --libs libspiro`
+    export LIBUNINAMESLIST_CFLAGS=`pkg-config --cflags libuninameslist` && export LIBUNINAMESLIST_LIBS=`pkg-config --libs libuninameslist`
     set +e
 
 script:
@@ -109,7 +112,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make distcheck -j4; fi
   - fontforge -version
   - $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version())"
-  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
+  #- if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
 
 deploy:
   provider: bintray

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
         popd >/dev/null \
       )
       echo "Installing dependencies: $PORTDEFS"
-      COLUMNS=80 sudo port install $PORTDEFS
+      COLUMNS=80 sudo port install $PORTDEFS 2>&1 | tee /dev/null
       sudo port select --set python python27
       sudo port select --set python2 python27
     fi
@@ -112,7 +112,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make distcheck -j4; fi
   - fontforge -version
   - $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version())"
-  #- if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
 
 deploy:
   provider: bintray
@@ -130,4 +130,4 @@ deploy:
 env:
   global:
    # For Coverity
-   - secure: "MeTS1Pqa5gzx1nn/peW/9a5kq84bba3XYUljOfkCUqzuyGiERk/nmok+RW7skrgzboBlKxnNG8+ykKqHMwK9s9M83ezFxvEWXBcKEpmEQKkqXPI5hpMs6jGLTgpeuheSIzqHA3danV8iircp1GOiTLWA0pt/AOsNLZiaYBh0OiE="
+   - secure: "YBvK5QLZ4LNE3WQPXjDYalLsTgmiGyRGYY87ep5knQ0YGyt3Q9OiBCtQ3GvhHNKOa2L2QlctJi2VWcUu+ftrS72mi5j2tvse9wRF3V8EVFIPb3bxjnN6E11FjXtLIqU8WR7HlAHJpOL2bhO+RleIhSVZm0MsiSjekFOoA5tfll4="

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ deploy:
   user: "fontforge-ci-bot"
   dry-run: false
   key:
-    secure: Uf8EJV4m5uCicRQmn5eEnP/LSYzW0By9iI2vID/qS5zo3787qCtqWeovBJEUgkRk7aU6OlnIQ0w9WVBxGlElAkoaqbZs+RWYnv5JS/mX98+fFTYhtz9u0A5GTo8+IOgv1jho28Yrt9HaFRfFhBOSqNucGvDKeS3RMRywEaQmzMQ=
+    secure: "YBvK5QLZ4LNE3WQPXjDYalLsTgmiGyRGYY87ep5knQ0YGyt3Q9OiBCtQ3GvhHNKOa2L2QlctJi2VWcUu+ftrS72mi5j2tvse9wRF3V8EVFIPb3bxjnN6E11FjXtLIqU8WR7HlAHJpOL2bhO+RleIhSVZm0MsiSjekFOoA5tfll4="
   on:
     condition: $TRAVIS_OS_NAME = osx
     branch:
@@ -130,4 +130,4 @@ deploy:
 env:
   global:
    # For Coverity
-   - secure: "YBvK5QLZ4LNE3WQPXjDYalLsTgmiGyRGYY87ep5knQ0YGyt3Q9OiBCtQ3GvhHNKOa2L2QlctJi2VWcUu+ftrS72mi5j2tvse9wRF3V8EVFIPb3bxjnN6E11FjXtLIqU8WR7HlAHJpOL2bhO+RleIhSVZm0MsiSjekFOoA5tfll4="
+   - secure: "MeTS1Pqa5gzx1nn/peW/9a5kq84bba3XYUljOfkCUqzuyGiERk/nmok+RW7skrgzboBlKxnNG8+ykKqHMwK9s9M83ezFxvEWXBcKEpmEQKkqXPI5hpMs6jGLTgpeuheSIzqHA3danV8iircp1GOiTLWA0pt/AOsNLZiaYBh0OiE="

--- a/travis-scripts/bintray_descriptor.json
+++ b/travis-scripts/bintray_descriptor.json
@@ -16,9 +16,9 @@
     },
 
     "version": {
-        "name": "ci",
+        "name": "ci-2017-06-08",
         "desc": "This is a CI build",
-        "released": "2016-10-16",
+        "released": "2017-06-08",
         "gpgSign": false
     },
 

--- a/travis-scripts/bintray_descriptor.json
+++ b/travis-scripts/bintray_descriptor.json
@@ -16,9 +16,9 @@
     },
 
     "version": {
-        "name": "ci-2017-06-08",
+        "name": "ciXXXX",
         "desc": "This is a CI build",
-        "released": "2017-06-08",
+        "released": "releaseXXXX",
         "gpgSign": false
     },
 

--- a/travis-scripts/ffosxbuild.sh
+++ b/travis-scripts/ffosxbuild.sh
@@ -113,5 +113,12 @@ hdiutil create -size 800m   \
    -ov        -format UDBZ  \
    $outdir.dmg
 
+# Update the bintray descriptor... sigh. If this fails, then oh well, no bintray
+echo "Updating the bintray descriptor..."
+sed -i '' s/ciXXXX/$(date +mac-ci-%Y-%M-%d)/g $BASE/bintray_descriptor.json || true
+sed -i '' s/releaseXXXX/$(date +%Y-%M-%d)/g $BASE/bintray_descriptor.json || true
+echo "Bintray descriptor:"
+cat $BASE/bintray_descriptor.json
+
 echo "Done."
 

--- a/travis-scripts/ffosxbuild.sh
+++ b/travis-scripts/ffosxbuild.sh
@@ -47,11 +47,13 @@ popd
 
 # Now we bundle the Python libraries
 echo "Bundling Python libraries..."
-pylib=$(otool -L $workdir/bin/fontforge | grep python | sed -e 's/ \(.*\)//')
+otool -L $workdir/bin/fontforge
+
+pylib=$(otool -L $workdir/bin/fontforge | grep -i python | sed -e 's/ \(.*\)//')
 pycruft=$(dirname $pylib)/../../..
 cp -a $pycruft/Python.framework $outdir/Contents/Frameworks
 pushd $outdir/Contents/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
-rm site-packages
+rm site-packages || rm -rf site-packages
 ln -s ../../../../../../Resources/opt/local/lib/python2.7/site-packages
 popd
 pushd $outdir/Contents/Frameworks/Python.framework && \


### PR DESCRIPTION
Get Travis working again by using macports instead of homebrew. Closes #3001, closes #3077 

Homebrew support can be revisited, perhaps if/when #2782 gets merged?

Oh yeah, the [bintray binaries](http://dl.bintray.com/fontforge/fontforge/) do run on Sierra. No collab though