### PR TITLE
Stop specifying architecture for Macintosh builds.

### DIFF
--- a/m4/fontforge_platform_specifics.m4
+++ b/m4/fontforge_platform_specifics.m4
@@ -23,7 +23,7 @@ AS_CASE([$host],
        MACAPP=""
       fi
 
-      RAW_COMPILE_PLATFORM_CFLAGS=" $CFLAGS -arch x86_64 -arch i386 "
+      RAW_COMPILE_PLATFORM_CFLAGS=" $CFLAGS "
       AC_SUBST([RAW_COMPILE_PLATFORM_CFLAGS])
 
       dnl fink puts stuff under /sw


### PR DESCRIPTION
This replaces and closes #3023 and closes #3001.
