### PR TITLE
Fixup dist target included/cleaned files

### DIFF
--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -34,10 +34,11 @@ DISTCLEANFILES=fontforge-config.h stamp-h1 stamp-h2
 # they should require a "fontforge/" prefix.
 
 pkginclude_HEADERS = basics.h chardata.h charset.h dynamic.h	\
-	fileutil.h fontforge-config.h gdraw.h gfile.h ggadget.h gicons.h gimage.h gio.h		\
+	fileutil.h gdraw.h gfile.h ggadget.h gicons.h gimage.h gio.h		\
 	gkeysym.h gprogress.h gresedit.h gresource.h gwidget.h gwwiconv.h	\
 	intl.h ustring.h utype.h dlist.h carbon.h gnetwork.h gutils.h
 
+nodist_pkginclude_HEADERS = fontforge-config.h
 noinst_HEADERS = pluginloading.h
 
 -include $(top_srcdir)/git.mk

--- a/osx/FontForge.app/Contents/Makefile.am
+++ b/osx/FontForge.app/Contents/Makefile.am
@@ -27,12 +27,12 @@
 include $(top_srcdir)/mk/layout.am
 
 SUBDIRS = Resources MacOS Frameworks
-FFAPP_FILES = Info.plist PkgInfo
-EXTRA_DIST = $(FFAPP_FILES)
+EXTRA_DIST = PkgInfo
 
 if PLATFORM_OSX
   ffappdir = $(pkgdatadir)/osx/FontForge.app/Contents
-  ffapp_DATA = $(FFAPP_FILES)
+  ffapp_DATA = PkgInfo
+  nodist_ffapp_DATA = Info.plist
 endif
 
 -include $(top_srcdir)/git.mk

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,21 +45,21 @@ $(srcdir)/package.m4: $(top_srcdir)/configure.ac
 
 noinst_FILES = * fonts/* results/* results
 
+TESTSUITE = $(srcdir)/testsuite
 EXTRA_DIST = testsuite.at $(srcdir)/package.m4 $(TESTSUITE) atlocal.in
-TESTSUITE = $(builddir)/testsuite
 
 FONTFORGE = $(top_builddir)/fontforgeexe/fontforge
 
-check-local: $(builddir)/fonts atconfig atlocal $(TESTSUITE) $(FONTFORGE)
+check-local: $(builddir)/fonts atconfig atlocal $(TESTSUITE) $(FONTFORGE) $(GENERATED_INPUTS) $(FETCHED_INPUTS)
 	$(MKDIR_P) $(builddir)/results
 	$(SHELL) '$(TESTSUITE)' $(TESTSUITEFLAGS)
 
-installcheck-local: atconfig atlocal $(TESTSUITE)
+installcheck-local: atconfig atlocal $(TESTSUITE)  $(GENERATED_INPUTS) $(FETCHED_INPUTS)
 	$(MKDIR_P) $(builddir)/results
 	$(SHELL) '$(TESTSUITE)' AUTOTEST_PATH='$(bindir)' $(TESTSUITEFLAGS)
 
 clean-local:
-	rm -fR $(builddir)/results/ $(builddir)/fetched-fonts/
+	rm -fR $(builddir)/results/ $(builddir)/testsuite.dir/
 
 # test ! -f '$(abs_builddir)/testsuite' || bash -x '$(abs_builddir)/testsuite' --clean
 # The previous line breaks the build in parallel mode sometimes.
@@ -70,7 +70,7 @@ clean-local:
 
 AUTOM4TE = $(SHELL) $(srcdir)/build-aux/missing --run autom4te
 AUTOTEST = $(AUTOM4TE) --language=autotest
-$(TESTSUITE): $(srcdir)/testsuite.at $(srcdir)/package.m4 $(GENERATED_INPUTS) $(FETCHED_INPUTS)
+$(TESTSUITE): $(srcdir)/testsuite.at $(srcdir)/package.m4
 	$(AUTOTEST) -I '$(srcdir)' -o $@.tmp $@.at
 	mv $@.tmp $@
 
@@ -86,51 +86,43 @@ EXTRA_DIST += fonts/AddExtremaTest2.sfd fonts/AddExtremumTest.sfd	\
 	fonts/OmittedCharBugs.sfd fonts/OverlapBugs.sfd			\
 	fonts/QuadOverlapBugs.sfd fonts/QuadraticConversionBug.sfd	\
 	fonts/SimplifyBugs.sfd fonts/SplineOverlapBug1.sfd		\
-	fonts/StrokeTests.sfd fonts/VKern.sfd README
+	fonts/StrokeTests.sfd fonts/VKern.sfd fonts/MunhwaGothic-Bold \
+	README
 
 # generated test inputs
-GENERATED_INPUTS =							\
-	fonts/MunhwaGothic-Bold						\
-	fonts/Ambrosia.pt3
-
 FETCHED_INPUTS =							\
-	$(srcdir)/fetched-fonts/MunhwaGothic-Bold
+	fonts/MunhwaGothic-Bold
+
+FETCHED_INPUTS_NONFREE =					\
+	fonts/mingliu.ttc
+
+GENERATED_INPUTS =							\
+	fonts/Ambrosia.pt3
 
 MAYBE_GENERATED_INPUTS =						\
 	fonts/MinionPro-Regular.fea
 
 .PHONY: prefetch-fonts
+.PHONY: prefetch-nonfree-fonts
 
 prefetch-fonts: $(FETCHED_INPUTS)
+prefetch-nonfree-fonts: $(FETCHED_INPUTS_NONFREE)
 
 # Inputs we can generate from files in git
 fonts/Ambrosia.pt3: fonts/Ambrosia.sfd
 	$(MKDIR_P) $(builddir)/fonts
 	$(FONTFORGE) -c 'open(argv[1]).generate(argv[2])' $< $@
 
-# Inputs we can download
-$(srcdir)/fetched-fonts/MunhwaGothic-Bold:
-	$(MKDIR_P) $(srcdir)/fetched-fonts
-	if [ ! -e $@ ] ; then $(WGET) https://github.com/fontforge/debugfonts/raw/master/MunhwaGothic-Bold -O $@ ; fi ;
-
 fonts/MunhwaGothic-Bold:
 	$(MKDIR_P) $(builddir)/fonts
 	if [ ! -e $@ ] ; then \
-	if [ -e $(srcdir)/fetched-fonts/MunhwaGothic-Bold ]; then \
-	cp -pRP $(srcdir)/fetched-fonts/MunhwaGothic-Bold $@ ; \
-	else \
 	$(WGET) https://github.com/fontforge/debugfonts/raw/master/MunhwaGothic-Bold -O $@ ; \
-	fi ; \
 	fi ;
 
 fonts/mingliu.ttc:
 	$(MKDIR_P) $(builddir)/fonts
 	if [ ! -e $@ ] ; then \
-	if [ -e $(srcdir)/fetched-fonts/mingliu.ttc ]; then \
-	cp -pRP $(srcdir)/fetched-fonts/mingliu.ttc $@ ; \
-	else \
 	$(WGET) http://www.fontsupply.com/fonts/mingliu.ttc -O $@ ; \
-	fi ; \
 	fi ;
 
 # Inputs we can generate from files that aren't available
@@ -160,9 +152,10 @@ EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
 
 EXTRA_DIST += link_test.c randomtest.c build-aux/missing
 
-DISTCLEANFILES = atconfig randomtest $(GENERATED_INPUTS) fonts/*.afm testsuite.log
+DISTCLEANFILES = atconfig randomtest fonts/*.afm testsuite.log $(GENERATED_INPUTS)
 
-MAINTAINERCLEANFILES = package.m4 testsuite.dir testsuite.log results $(TESTSUITE)
+MAINTAINERCLEANFILES = package.m4 testsuite.dir testsuite.log	\
+	results $(TESTSUITE) $(FETCHED_INPUTS) $(FETCHED_INPUTS_NONFREE)
 
 GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/Zapfino-4.0d3.dfont				\
@@ -173,7 +166,6 @@ GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/merged.cff					\
 	fonts/MinionPro-Regular.otf				\
 	fonts/LucidaGrande.ttc					\
-	fonts/nuvo-medium-woff-demo.woff			\
-	fetched-fonts/*
+	fonts/nuvo-medium-woff-demo.woff
 
 -include $(top_srcdir)/git.mk

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -87,11 +87,12 @@ EXTRA_DIST += fonts/AddExtremaTest2.sfd fonts/AddExtremumTest.sfd	\
 	fonts/QuadOverlapBugs.sfd fonts/QuadraticConversionBug.sfd	\
 	fonts/SimplifyBugs.sfd fonts/SplineOverlapBug1.sfd		\
 	fonts/StrokeTests.sfd fonts/VKern.sfd fonts/MunhwaGothic-Bold \
-	README
+	fonts/NotoSans-Regular.ttc README
 
 # generated test inputs
 FETCHED_INPUTS =							\
-	fonts/MunhwaGothic-Bold
+	fonts/MunhwaGothic-Bold					\
+	fonts/NotoSans-Regular.ttc
 
 FETCHED_INPUTS_NONFREE =					\
 	fonts/mingliu.ttc
@@ -117,6 +118,12 @@ fonts/MunhwaGothic-Bold:
 	$(MKDIR_P) $(builddir)/fonts
 	if [ ! -e $@ ] ; then \
 	$(WGET) https://github.com/fontforge/debugfonts/raw/master/MunhwaGothic-Bold -O $@ ; \
+	fi ;
+
+fonts/NotoSans-Regular.ttc:
+	$(MKDIR_P) $(builddir)/fonts
+	if [ ! -e $@ ] ; then \
+	$(WGET) https://github.com/fontforge/debugfonts/raw/master/NotoSans-Regular.ttc -O $@ ; \
 	fi ;
 
 fonts/mingliu.ttc:
@@ -166,6 +173,8 @@ GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/merged.cff					\
 	fonts/MinionPro-Regular.otf				\
 	fonts/LucidaGrande.ttc					\
-	fonts/nuvo-medium-woff-demo.woff
+	fonts/nuvo-medium-woff-demo.woff		\
+	$(FETCHED_INPUTS)						\
+	$(FETCHED_INPUTS_NONFREE)
 
 -include $(top_srcdir)/git.mk

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,7 +59,7 @@ installcheck-local: atconfig atlocal $(TESTSUITE)
 	$(SHELL) '$(TESTSUITE)' AUTOTEST_PATH='$(bindir)' $(TESTSUITEFLAGS)
 
 clean-local:
-	rm -fR $(builddir)/results/*
+	rm -fR $(builddir)/results/ $(builddir)/fetched-fonts/
 
 # test ! -f '$(abs_builddir)/testsuite' || bash -x '$(abs_builddir)/testsuite' --clean
 # The previous line breaks the build in parallel mode sometimes.
@@ -160,9 +160,9 @@ EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
 
 EXTRA_DIST += link_test.c randomtest.c build-aux/missing
 
-DISTCLEANFILES = atconfig randomtest $(GENERATED_INPUTS) fonts/*.afm $(TESTSUITE) testsuite.log
+DISTCLEANFILES = atconfig randomtest $(GENERATED_INPUTS) fonts/*.afm testsuite.log
 
-MAINTAINERCLEANFILES = package.m4 testsuite.dir testsuite.log results
+MAINTAINERCLEANFILES = package.m4 testsuite.dir testsuite.log results $(TESTSUITE)
 
 GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/Zapfino-4.0d3.dfont				\

--- a/tests/test0101.py
+++ b/tests/test0101.py
@@ -1,4 +1,4 @@
-#Needs: fonts/LucidaGrande.ttc
+#Needs: fonts/NotoSans-Regular.ttc
 
 #Test the fontforge module (but not its types)
 import sys, fontforge

--- a/tests/test130.pe
+++ b/tests/test130.pe
@@ -1,0 +1,11 @@
+#Needs: fonts/NotoSans-Regular.ttc
+# but any other ttc file would do
+
+Open($1+"(Noto Sans)");
+Print( "...Read NotoSans-Regular.ttc(Noto Sans)")
+Close();
+
+Open($1+"(Noto Sans UI)");
+Print( "...Read NotoSans-Regular.ttc(Noto Sans UI)")
+Close();
+Quit()

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -97,11 +97,12 @@ check_pedit([Test generation of TrueType instructions],[test127.pe],[Ambrosia.sf
 #check_pedit([],[svg2ttf.pe])
 check_pedit([Test StrSplit overrun],[test128.pe])
 check_pedit([Ligatures and Fractions Table Lookups],[test129.pe])
+check_pedit([TTC loading],[test130.pe],[NotoSans-Regular.ttc])
 
 AT_BANNER([FontForge Python Scripting Tests])
 
 check_python([FontForge .sfd file open check],[test0001.py],[Ambrosia.sfd])
-check_python([FontForge .ttc file open check],[test0101.py],[LucidaGrande.ttc])
+check_python([FontForge .ttc file open check],[test0101.py],[NotoSans-Regular.ttc])
 check_python([Generate several font files],[test1001.py],[Caliban.sfd])
 check_python([Point count check],[test1001a.py],[Zapfino-4.0d3.dfont])
 check_python([Odd morx test without crashing],[test1001b.py],[Zapfino-4.1d6.dfont])


### PR DESCRIPTION
* Don't include `fontforge-config.h` and `Info.plist` in the dist package (these are generated files)
* Testsuite: Don't delete `testsuite` on `make distclean` - otherwise you'd need autoconf to regenerate it
* Bundle fetched fonts when `make dist` is called. Fixes the files being re-downloaded anyway when running `make check` from a dist tarball. 
* Separate fetched fonts from generated fonts; remove generated fonts on `make distclean`, only remove fetched fonts on `make maintainer-clean`
* Add in simple TTC loading check

Closes #3110.

<strike>I also noticed that the test that depends on mingliu.ttc fails now; something's changed that's causing FontForge to no longer be able to read the names of the fonts within the mingliu ttc.</strike> actually no, it looks like the source for that mingliu.ttc is not good.