### PR TITLE
Compiler

### DIFF
--- a/fontforge/autowidth2.c
+++ b/fontforge/autowidth2.c
@@ -444,7 +444,7 @@ SplineChar ***GlyphClassesFromNames(SplineFont *sf,char **classnames,
 	    else
 		classes[i] = malloc((clen+1)*sizeof(SplineChar *));
 	}
-	if ( cn != NULL ) free( cn ) ; cn = NULL ;
+	if ( cn != NULL ) { free( cn ) ; cn = NULL ; }
     }
 return( classes );
 }

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -1431,8 +1431,10 @@ return;
     unit.x = from->nextcp.x-from->me.x;
     unit.y = from->nextcp.y-from->me.y;
     len = sqrt(unit.x*unit.x + unit.y*unit.y);
-    if ( len!=0 )
-	unit.x /= len; unit.y /= len;
+    if ( len!=0 ) {
+        unit.x /= len;
+        unit.y /= len;
+    }
 
     if ( (fpt = from->pointtype)==pt_hvcurve ) fpt = pt_curve;
     if ( (tpt =   to->pointtype)==pt_hvcurve ) tpt = pt_curve;

--- a/fontforgeexe/groupsdlg.c
+++ b/fontforgeexe/groupsdlg.c
@@ -1040,7 +1040,7 @@ return( true );
 	GDrawRequestExpose(grp->v,NULL,false);
 	if ( grp->oldsel==NULL )
 return( true );
-	if ( grp->oldsel->glyphs!=NULL && grp->oldsel->glyphs!='\0' ) {
+	if ( grp->oldsel->glyphs!=NULL && grp->oldsel->glyphs[0]!='\0' ) {
 	    GGadgetSetEnabled(grp->newsub,false);
 return( true );
 	}

--- a/gdraw/gxcdraw.c
+++ b/gdraw/gxcdraw.c
@@ -909,7 +909,7 @@ void _GXPDraw_NewWindow(GXWindow nw) {
     {
 	if ( gdisp->pango_context==NULL ) {
 	    gdisp->pango_fontmap = pango_xft_get_font_map(gdisp->display,gdisp->screen);
-	    gdisp->pango_context = pango_xft_get_context(gdisp->display,gdisp->screen);
+	    gdisp->pango_context = pango_font_map_create_context(gdisp->pango_fontmap);
 	    /* No obvious way to get or set the resolution of pango_xft */
 	}
 	nw->xft_w = XftDrawCreate(gdisp->display,nw->w,gdisp->visual,gdisp->cmap);

--- a/gdraw/gxdraw.c
+++ b/gdraw/gxdraw.c
@@ -4384,6 +4384,9 @@ void _GXDraw_DestroyDisplay(GDisplay * gdisp) {
     if (gdispc->fence_stipple != BadAlloc && gdispc->fence_stipple != BadDrawable && gdispc->fence_stipple != BadValue) {
       XFreePixmap(gdispc->display, gdispc->fence_stipple); gdispc->fence_stipple = BadAlloc;
     }
+    if (gdispc->pango_context != NULL) {
+        g_object_unref(gdispc->pango_context); gdispc->pango_context = NULL;
+    }
     if (gdispc->groot != NULL) {
       if (gdispc->groot->ggc != NULL) { free(gdispc->groot->ggc); gdispc->groot->ggc = NULL; }
       free(gdispc->groot); gdispc->groot = NULL;


### PR DESCRIPTION
Fix some compiler warnings (on misleading indentation)

Swap the deprecated `pango_xft_get_context` for `pango_font_map_create_context`