### PR TITLE
Fix public headers

### DIFF
--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -96,7 +96,7 @@ noinst_HEADERS = \
 	winfonts.h \
 	woff.h \
 	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
-	flaglist.h strlist.h charview_private.h cvundoes.h tables.h
+	strlist.h charview_private.h cvundoes.h tables.h
 
 pkginclude_HEADERS = autowidth2.h configure-fontforge.h fontforge.h		\
 	libffstamp.h psfont.h stemdb.h autowidth.h delta.h fontforgevw.h	\
@@ -106,6 +106,7 @@ pkginclude_HEADERS = autowidth2.h configure-fontforge.h fontforge.h		\
 	sd.h unicoderange.h bitmapcontrol.h encoding.h ofl.h search.h		\
 	usermenu.h fffreetype.h PfEd.h sfd1.h ffpython.h			\
 	plugins.h sflayoutP.h print.h splinefont.h cvruler.h ffglib.h           \
+	flaglist.h \
 	glif_name_hash.h \
 	mem.h
 

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -55,7 +55,6 @@ noinst_HEADERS = \
 	fvcomposite.h \
 	fvfonts.h \
 	fvimportbdf.h \
-	glyphcomp.h\
 	http.h\
 	ikarus.h\
 	langfreq.h\
@@ -108,6 +107,7 @@ pkginclude_HEADERS = autowidth2.h configure-fontforge.h fontforge.h		\
 	plugins.h sflayoutP.h print.h splinefont.h cvruler.h ffglib.h           \
 	flaglist.h \
 	glif_name_hash.h \
+	glyphcomp.h \
 	mem.h
 
 #--------------------------------------------------------------------------

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -94,7 +94,7 @@ noinst_HEADERS = \
 	ttfspecial.h \
 	winfonts.h \
 	woff.h \
-	fontforgeui.h sftextfieldP.h configure-fontforge.h views.h 	\
+	fontforgeui.h sftextfieldP.h configure-fontforge.h \
 	strlist.h charview_private.h cvundoes.h tables.h
 
 pkginclude_HEADERS = autowidth2.h configure-fontforge.h fontforge.h		\
@@ -108,7 +108,8 @@ pkginclude_HEADERS = autowidth2.h configure-fontforge.h fontforge.h		\
 	flaglist.h \
 	glif_name_hash.h \
 	glyphcomp.h \
-	mem.h
+	mem.h \
+	views.h
 
 #--------------------------------------------------------------------------
 

--- a/fontforge/fvmetrics.h
+++ b/fontforge/fvmetrics.h
@@ -29,8 +29,8 @@
 #define FONTFORGE_FVMETRICS_H
 
 #include "baseviews.h"
+#include "splinefont.h"
 
-#include "fontforgeui.h"
 #include <math.h>
 #include <ustring.h>
 

--- a/fontforge/mem.h
+++ b/fontforge/mem.h
@@ -1,8 +1,8 @@
 #ifndef FONTFORGE_MEM_H
 #define FONTFORGE_MEM_H
 
-#include "../inc/basics.h"
-#include <inc/fontforge-config.h>
+#include "basics.h"
+#include "fontforge-config.h"
 
 // FIXME: move from splinefont.h to a separate header
 #ifdef FONTFORGE_CONFIG_USE_DOUBLE


### PR DESCRIPTION
Some headers installed by `make install` refer to other FontForge headers that are not installed. This breaks external C and C++ applications that use FontForge as a library.

This PR fixes all the issues of this kind that I have found.

Side note: some of the fixed problems are now, but some have been around for years. I wonder how (or if) people manage to compile applications that depend on FontForge.