### PR TITLE
startnoui.c: Include header that defines FindOrMakeEncoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 compiler: gcc
 sudo: false
-dist: precise
+dist: trusty
 osx_image: xcode8
 
 branches:
@@ -18,20 +18,24 @@ env:
     # For Coverity
     - secure: "MeTS1Pqa5gzx1nn/peW/9a5kq84bba3XYUljOfkCUqzuyGiERk/nmok+RW7skrgzboBlKxnNG8+ykKqHMwK9s9M83ezFxvEWXBcKEpmEQKkqXPI5hpMs6jGLTgpeuheSIzqHA3danV8iircp1GOiTLWA0pt/AOsNLZiaYBh0OiE="
   matrix:
-    - TRACE_CODE_COVERAGE=false
+    - BUILD_EXTRA_FLAGS="--without-x"
     - TRACE_CODE_COVERAGE=true
-
+    - OSX_ONLY=true
 matrix:
   exclude:
     - os: osx
+      env: BUILD_EXTRA_FLAGS="--without-x"
+    - os: osx
       env: TRACE_CODE_COVERAGE=true
+    - os: linux
+      env: OSX_ONLY=true
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
       - deadsnakes
-    packages: [autoconf, automake, autotools-dev, bzip2, gcc-4.9, libtool,
+    packages: [autoconf, automake, autotools-dev, bzip2, gcc-7, libtool,
       libjpeg-dev, libtiff4-dev, libpng12-dev, libfreetype6-dev, libgif-dev,
       libx11-dev, libxml2-dev, libpango1.0-dev, libcairo2-dev, python3.5-dev, lcov]
   coverity_scan:
@@ -48,7 +52,7 @@ cache:
     - $TRAVIS_BUILD_DIR/travisdeps
 
 before_install:
-  - if $TRACE_CODE_COVERAGE ; then pip --quiet install --user cpp-coveralls==0.3.12 ; fi
+  - if [ ! -z "$TRACE_CODE_COVERAGE" ]; then pip --quiet install --user cpp-coveralls==0.3.12 ; fi
 
 #before_install:
 #  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update || brew update; fi
@@ -61,18 +65,22 @@ install:
     export PATH=$PATH:$DEPSPREFIX/bin:$PREFIX/bin
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DEPSPREFIX/lib:$PREFIX/lib
     export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$DEPSPREFIX/lib/pkgconfig
-    export FFCONFIG="--prefix=$PREFIX"
+    export FFCONFIG="--prefix=$PREFIX $BUILD_EXTRA_FLAGS"
 
-    if $TRACE_CODE_COVERAGE ; then
+    if [ ! -z "$TRACE_CODE_COVERAGE" ] ; then
         FFCONFIG="$FFCONFIG --enable-code-coverage --enable-debug"
     fi
+
+    # For some inane reason Travis defines this to '-g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
+    # This prevents pkg-config from setting the CFLAGS properly.
+    unset PYTHON_CFLAGS
 
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       export FTVER=`dpkg -s libfreetype6-dev | perl -ne 'print $1 if /^Version: (\d+(?:\.\d+)+)/'`
       export SFFTVER=`echo $FTVER | perl -ne 'print $1 if /^(\d+(?:\.\d+){1,2})/'`
       export FFCONFIG="$FFCONFIG --with-freetype-source=$DEPSPREFIX/freetype-$FTVER"
-      export CC=gcc-4.9
-      export GCOV=gcov-4.9
+      export CC=gcc-7
+      export GCOV=gcov-7
 
       # This block only runs if the cache isn't present.
       if [ ! "$(ls -A $DEPSPREFIX)" ]; then
@@ -97,7 +105,7 @@ install:
       # These are FF-specific mods (set here so it runs also in Coverity)
       export PYTHON=python3.5
       export PYTHONPATH=$PYTHONPATH:$PREFIX/lib/python$($PYTHON -c "import sys; print('{0}.{1}'.format(sys.version_info.major, sys.version_info.minor))")/site-packages
-      export CFLAGS="-fdiagnostics-color=auto -Wall -Wno-switch"
+      export CFLAGS="-fdiagnostics-color=always -Wall -Wno-switch"
     else
       export PATH=/opt/local/bin:$PATH
       export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:/opt/X11/lib/pkgconfig:/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/pkgconfig:$PKG_CONFIG_PATH
@@ -130,11 +138,16 @@ script:
   - ./configure $FFCONFIG
   - make -j4
   - make install
-  - if $TRACE_CODE_COVERAGE ; then make check ; coveralls --gcov-options '\-bulp' --gcov $(which gcov-4.9) ; fi
+  - if [ ! -z "$TRACE_CODE_COVERAGE" ]; then make check ; coveralls --gcov-options '\-bulp' --gcov $(which $GCOV) ; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make distcheck -j4; fi
   - fontforge -version
-  - $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version())"
+  - $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version()); fontforge.font();"
   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
+
+after_failure:
+  - cat config.log
+  - cat Makefile
+  - which python
 
 deploy:
   provider: bintray

--- a/configure.ac
+++ b/configure.ac
@@ -425,6 +425,10 @@ AC_C_BIGENDIAN
 AC_TYPE_PID_T
 AX_PTHREAD
 
+# Error out under certain conditions, please.
+gl_WARN_ADD([-Werror=implicit-function-declaration])
+gl_WARN_ADD([-Werror=int-conversion])
+
 #--------------------------------------------------------------------------
 # Check to see if "this" compiler can use these flags, errors, or warnings.
 # Enable the flags that can be used and skip flags that are unknown.

--- a/fontforgeexe/startnoui.c
+++ b/fontforgeexe/startnoui.c
@@ -27,6 +27,7 @@
 #include "fontforgevw.h"
 #include "scripting.h"
 #include "start.h"
+#include "encoding.h"
 
 #ifndef _NO_LIBUNICODENAMES
 #include <libunicodenames.h>	/* need to open a database when we start */


### PR DESCRIPTION
Failure to include this was causing an implicit pointer to int conversion
which results in an invalid pointer address on 64-bit builds.

Fixes #3145.

