### PR TITLE
contrib: Remove unneeded header includes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,7 @@ script:
   - ./bootstrap
   - ./configure $FFCONFIG
   - make -j4
+  - make -C contrib/fonttools -j4
   - make install
   - if [ ! -z "$TRACE_CODE_COVERAGE" ]; then make check ; coveralls --gcov-options '\-bulp' --gcov $(which $GCOV) ; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make distcheck -j4; fi

--- a/contrib/fonttools/dewoff.c
+++ b/contrib/fonttools/dewoff.c
@@ -4,9 +4,6 @@
 #include <stdlib.h>
 #include <zlib.h>
 
-#include "mem.h"
-#include "tottf.h"
-
 /* Compile with: $ cc -o dewoff dewoff.c -lz */
 
 /* http://people.mozilla.com/~jkew/woff/woff-2009-09-16.html */

--- a/contrib/fonttools/findtable.c
+++ b/contrib/fonttools/findtable.c
@@ -2,8 +2,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "mem.h"
-
 typedef unsigned int uint32;
 typedef int int32;
 typedef short int16;

--- a/contrib/fonttools/pcl2ttf.c
+++ b/contrib/fonttools/pcl2ttf.c
@@ -36,9 +36,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "mem.h"
-#include "tottf.h"
-
 #define true	1
 #define false	0
 #define CHR(ch1,ch2,ch3,ch4) (((ch1)<<24)|((ch2)<<16)|((ch3)<<8)|(ch4))

--- a/contrib/fonttools/showttf.c
+++ b/contrib/fonttools/showttf.c
@@ -11,8 +11,6 @@ typedef unsigned char uint8;
 #define false	0
 #include <string.h>
 
-#include "mem.h"
-
 static int verbose = false;
 static int max_lig_nest = 10000;
 static int just_headers = false;

--- a/contrib/fonttools/stripttc.c
+++ b/contrib/fonttools/stripttc.c
@@ -2,9 +2,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "mem.h"
-#include "tottf.h"
-
 /* This program takes a ttc file and turns it into its component ttf files */
 /* The makes two changes to the data:                                      */
 /*	* The tables are placed a different offsets                        */

--- a/contrib/fonttools/ttf2eps.c
+++ b/contrib/fonttools/ttf2eps.c
@@ -29,8 +29,6 @@
 #include <stdio.h>
 #include <time.h>
 
-#include "mem.h"
-
 typedef struct basepoint {
     double x, y;
 } BasePoint;

--- a/contrib/fonttools/woff.c
+++ b/contrib/fonttools/woff.c
@@ -4,9 +4,6 @@
 #include <stdlib.h>
 #include <zlib.h>
 
-#include "mem.h"
-#include "tottf.h"
-
 /* Compile with: $ cc -o woff woff.c -lz */
 
 /* http://people.mozilla.com/~jkew/woff/woff-2009-09-16.html */


### PR DESCRIPTION
These were introduced with 0b8be8d93f5bd68473ed739b63a3c8bdf14d23e4 and
ae657bca203ecdac7a508aec0e43dec6b0b31883, likely with a script.

They aren't actually needed, because all the required definitions
are redefined/copied into the contrib files.

Fixes #3155 