### PR TITLE
psread.c: dictfree: NULL entries after freeing

### DIFF
--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -90,8 +90,10 @@ static void dictfree(struct pskeydict *dict) {
 
     for ( i=0; i<dict->cnt; ++i ) {
 	if ( dict->entries[i].type==ps_string || dict->entries[i].type==ps_instr ||
-		dict->entries[i].type==ps_lit )
+		dict->entries[i].type==ps_lit ) {
 	    free(dict->entries[i].u.str);
+	    dict->entries[i].u.str = NULL;
+    }
 	else if ( dict->entries[i].type==ps_array || dict->entries[i].type==ps_dict )
 	    dictfree(&dict->entries[i].u.dict);
     }


### PR DESCRIPTION
This prevents a double-free condition if the entry is also in the 'tofrees' garbage list.
