### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ os:
 
 env:
   global:
+    - MAKEFLAGS="-j4"
     # For Coverity
     - secure: "MeTS1Pqa5gzx1nn/peW/9a5kq84bba3XYUljOfkCUqzuyGiERk/nmok+RW7skrgzboBlKxnNG8+ykKqHMwK9s9M83ezFxvEWXBcKEpmEQKkqXPI5hpMs6jGLTgpeuheSIzqHA3danV8iircp1GOiTLWA0pt/AOsNLZiaYBh0OiE="
   matrix:
@@ -93,11 +94,11 @@ install:
         wget --tries 1 "http://download.savannah.gnu.org/releases/freetype/freetype-$FTVER.tar.gz" || \
           wget "https://sourceforge.net/projects/freetype/files/freetype2/$SFFTVER/freetype-$FTVER.tar.gz"
 
-        pushd zeromq-4.1.5 && ./configure --prefix=$DEPSPREFIX && make -j4 && make install && popd
-        pushd czmq-3.0.2 && CFLAGS="-Wno-format-truncation" ./configure --prefix=$DEPSPREFIX && make -j4 && make install && popd
-        pushd libspiro-0.5.20150702 && ./configure --prefix=$DEPSPREFIX && make -j4 && make install && popd
-        pushd libuninameslist-20160701 && ./configure --prefix=$DEPSPREFIX && make -j4 && make install && popd
-        pushd libunicodenames-1.1.0_beta1 && ./configure --prefix=$DEPSPREFIX && make -j4 && make install && popd
+        pushd zeromq-4.1.5 && ./configure --prefix=$DEPSPREFIX && make && make install && popd
+        pushd czmq-3.0.2 && CFLAGS="-Wno-format-truncation" ./configure --prefix=$DEPSPREFIX && make && make install && popd
+        pushd libspiro-0.5.20150702 && ./configure --prefix=$DEPSPREFIX && make && make install && popd
+        pushd libuninameslist-20160701 && ./configure --prefix=$DEPSPREFIX && make && make install && popd
+        pushd libunicodenames-1.1.0_beta1 && ./configure --prefix=$DEPSPREFIX && make && make install && popd
         tar -zxf freetype-$FTVER.tar.gz -C $DEPSPREFIX
         popd
       fi
@@ -136,11 +137,11 @@ install:
 script:
   - ./bootstrap
   - ./configure $FFCONFIG
-  - make -j4
-  - make -C contrib/fonttools -j4
+  - make
+  - make -C contrib/fonttools
   - make install
   - if [ ! -z "$TRACE_CODE_COVERAGE" ]; then make check ; coveralls --gcov-options '\-bulp' --gcov $(which $GCOV) ; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make distcheck -j4; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make distcheck; fi
   - fontforge -version
   - $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version()); fontforge.font();"
   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ install:
       # These are FF-specific mods (set here so it runs also in Coverity)
       export PYTHON=python3.6
       export PYTHONPATH=$PYTHONPATH:$PREFIX/lib/python$($PYTHON -c "import sys; print('{0}.{1}'.format(sys.version_info.major, sys.version_info.minor))")/site-packages
-      export CFLAGS="-fdiagnostics-color=always -Wall -Wno-switch"
+      export CFLAGS="-fdiagnostics-color=always -Wall -Wno-switch -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wnull-dereference -Wjump-misses-init -Wdouble-promotion -Wshadow"
     else
       export PATH=/opt/local/bin:$PATH
       export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:/opt/X11/lib/pkgconfig:/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/pkgconfig:$PKG_CONFIG_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,26 +9,20 @@ branches:
     - master
     - travis
     - coverity_scan
-os:
-  - linux
-  - osx
 
 env:
   global:
     - MAKEFLAGS="-j4"
     # For Coverity
     - secure: "MeTS1Pqa5gzx1nn/peW/9a5kq84bba3XYUljOfkCUqzuyGiERk/nmok+RW7skrgzboBlKxnNG8+ykKqHMwK9s9M83ezFxvEWXBcKEpmEQKkqXPI5hpMs6jGLTgpeuheSIzqHA3danV8iircp1GOiTLWA0pt/AOsNLZiaYBh0OiE="
-  matrix:
-    - BUILD_EXTRA_FLAGS="--without-x"
-    - TRACE_CODE_COVERAGE=true
-    - OSX_ONLY=true
+
 matrix:
-  exclude:
-    - os: osx
-      env: BUILD_EXTRA_FLAGS="--without-x"
-    - os: osx
-      env: TRACE_CODE_COVERAGE=true
+  include:
     - os: linux
+      env: LINUX_NOX=true
+    - os: linux
+      env: LINUX_FULL=true
+    - os: osx
       env: OSX_ONLY=true
 
 addons:
@@ -53,9 +47,7 @@ cache:
     - $TRAVIS_BUILD_DIR/travisdeps
 
 before_install:
-  - if [ ! -z "$TRACE_CODE_COVERAGE" ]; then pip --quiet install --user cpp-coveralls==0.3.12 ; fi
-
-#before_install:
+  - if [ ! -z "$LINUX_FULL" ]; then pip --quiet install --user cpp-coveralls==0.3.12 ; fi
 #  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update || brew update; fi
 
 install:
@@ -66,10 +58,12 @@ install:
     export PATH=$PATH:$DEPSPREFIX/bin:$PREFIX/bin
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DEPSPREFIX/lib:$PREFIX/lib
     export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$DEPSPREFIX/lib/pkgconfig
-    export FFCONFIG="--prefix=$PREFIX $BUILD_EXTRA_FLAGS"
+    export FFCONFIG="--prefix=$PREFIX"
 
-    if [ ! -z "$TRACE_CODE_COVERAGE" ] ; then
-        FFCONFIG="$FFCONFIG --enable-code-coverage --enable-debug"
+    if [ ! -z "$LINUX_FULL" ] ; then
+      export FFCONFIG="$FFCONFIG --enable-code-coverage --enable-debug"
+    elif [ ! -z "$LINUX_NOX" ]; then
+      export FFCONFIG="$FFCONFIG --without-x"
     fi
 
     # For some inane reason Travis defines this to '-g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
@@ -137,14 +131,16 @@ install:
 script:
   - ./bootstrap
   - ./configure $FFCONFIG
-  - make
-  - make -C contrib/fonttools
+  - make && make -C contrib/fonttools
   - make install
-  - if [ ! -z "$TRACE_CODE_COVERAGE" ]; then make check ; coveralls --gcov-options '\-bulp' --gcov $(which $GCOV) ; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then make distcheck; fi
+  - make check
+  - if [ ! -z "$LINUX_FULL" ]; then make distcheck; fi
   - fontforge -version
   - $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version()); fontforge.font();"
-  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
+
+after_success:
+  - if [ ! -z "$LINUX_FULL" ]; then coveralls --gcov-options '\-bulp' --gcov $(which $GCOV) || true; fi
 
 after_failure:
   - cat config.log


### PR DESCRIPTION
This supersedes #3168.

We always want to run `make check`, which runs the test suite against that matrix build's configured/built version.

Picked up from #3168, we only run distcheck on one of the branches, which means that the nox build is sped up to around 7-9 minutes (depending on if the build cache is present). That's good enough for me, if you're after a quick indicator of if the full build will fail (actually, since they more or less do the same thing up until the distcheck step, then they're likely to fail at around the same time into the build).

Yes, the full build is still around 15 minutes, but I'd say having two linux builds vs. four is better, especially given the concurrency limits. We can revisit this if ever it becomes slower than the mac build.

I've also separated out the 'upload coverage' step to the `after_success` event, and made it always succeed, so it works when built on forked travis builds.