### PR TITLE
Honor SOURCE_DATE_EPOCH in more cases

### DIFF
--- a/contrib/admintools/copyright.c
+++ b/contrib/admintools/copyright.c
@@ -69,7 +69,11 @@ return;
     fclose(src);
     if ( IsCopyright(lines[0],buffer)) {
 	stat(filename,&sb);
-	tm = localtime(&sb.st_mtime);
+	if (!getenv("SOURCE_DATE_EPOCH")) {
+	    tm = localtime(&sb.st_mtime);
+	} else {
+	    tm = gmtime(&sb.st_mtime);
+	}
 	fprintf( output, "*** %s~\t%d-%0d-%0d %02d:%02d:%02d.000000000 -0800\n", filename,
 	    tm->tm_year+1900, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec );
 	now = GetTime();

--- a/contrib/admintools/copyright.c
+++ b/contrib/admintools/copyright.c
@@ -6,8 +6,8 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
 #include <stdlib.h>
+#include <time.h>
 
 /* Update copyright notices to a new year */
 

--- a/contrib/admintools/copyright.c
+++ b/contrib/admintools/copyright.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <errno.h>
+#include <gutils.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -71,7 +72,7 @@ return;
 	tm = localtime(&sb.st_mtime);
 	fprintf( output, "*** %s~\t%d-%0d-%0d %02d:%02d:%02d.000000000 -0800\n", filename,
 	    tm->tm_year+1900, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec );
-	time(&now);
+	now = GetTime();
 	tm = localtime(&now);
 	fprintf( output, "--- %s\t%d-%0d-%0d %02d:%02d:%02d.000000000 -0800\n", filename,
 	    tm->tm_year+1900, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec );

--- a/contrib/fonttools/Makefile.am
+++ b/contrib/fonttools/Makefile.am
@@ -35,6 +35,8 @@ noinst_PROGRAMS = findtable pfadecrypt rmligamarks stripttc woff	\
 
 woff_LDADD = $(ZLIB_LIBS)
 dewoff_LDADD = $(ZLIB_LIBS)
+ttf2eps_LDADD = $(top_builddir)/Unicode/libgunicode.la \
+                $(top_builddir)/gutils/libgutils.la
 
 EXTRA_DIST = README-ttf2eps
 

--- a/contrib/fonttools/ttf2eps.c
+++ b/contrib/fonttools/ttf2eps.c
@@ -797,7 +797,11 @@ static void DumpEpsHeader(FILE *eps, struct ttfinfo *info, int glyph,
     fprintf( eps, "\n" );
     fprintf( eps, "%%%%Creator: ttf2eps\n" );
     now = GetTime();
-    tm = localtime(&now);
+    if (!getenv("SOURCE_DATE_EPOCH")) {
+	tm = localtime(&now);
+    } else {
+	tm = gmtime(&now);
+    }
     fprintf( eps, "%%%%CreationDate: %d:%02d %d-%d-%d\n", tm->tm_hour, tm->tm_min,
 	    tm->tm_mday, tm->tm_mon+1, 1900+tm->tm_year );
     fprintf( eps, "%%%%EndComments\n" );

--- a/contrib/fonttools/ttf2eps.c
+++ b/contrib/fonttools/ttf2eps.c
@@ -24,6 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <gutils.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -795,7 +796,7 @@ static void DumpEpsHeader(FILE *eps, struct ttfinfo *info, int glyph,
 	fprintf(eps, " Unicode %04x", info->glyph_unicode[glyph]);
     fprintf( eps, "\n" );
     fprintf( eps, "%%%%Creator: ttf2eps\n" );
-    time(&now);
+    now = GetTime();
     tm = localtime(&now);
     fprintf( eps, "%%%%CreationDate: %d:%02d %d-%d-%d\n", tm->tm_hour, tm->tm_min,
 	    tm->tm_mday, tm->tm_mon+1, 1900+tm->tm_year );

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -39,6 +39,7 @@
 #include <locale.h>
 #include <string.h>
 #include "gfile.h"
+#include <gutils.h>
 #include <time.h>
 #include "ustring.h"
 #include "gio.h"
@@ -100,7 +101,7 @@ int _ExportEPS(FILE *eps,SplineChar *sc, int layer, int preview) {
     fprintf( eps, "%%%%Creator: FontForge\n" );
     if ( author!=NULL )
 	fprintf( eps, "%%%%Author: %s\n", author);
-    time(&now);
+    now = GetTime();
     tm = localtime(&now);
     fprintf( eps, "%%%%CreationDate: %d:%02d %d-%d-%d\n", tm->tm_hour, tm->tm_min,
 	    tm->tm_mday, tm->tm_mon+1, 1900+tm->tm_year );
@@ -218,7 +219,7 @@ int _ExportPDF(FILE *pdf,SplineChar *sc,int layer) {
     fprintf( pdf, "6 0 obj\n" );
     fprintf( pdf, " <<\n" );
     fprintf( pdf, "    /Creator (FontForge)\n" );
-    time(&now);
+    now = GetTime();
     tm = localtime(&now);
     fprintf( pdf, "    /CreationDate (D:%04d%02d%02d%02d%02d%02d",
 	    1900+tm->tm_year, tm->tm_mon+1, tm->tm_mday,

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -102,7 +102,11 @@ int _ExportEPS(FILE *eps,SplineChar *sc, int layer, int preview) {
     if ( author!=NULL )
 	fprintf( eps, "%%%%Author: %s\n", author);
     now = GetTime();
-    tm = localtime(&now);
+    if (!getenv("SOURCE_DATE_EPOCH")) {
+	tm = localtime(&now);
+    } else {
+	tm = gmtime(&now);
+    }
     fprintf( eps, "%%%%CreationDate: %d:%02d %d-%d-%d\n", tm->tm_hour, tm->tm_min,
 	    tm->tm_mday, tm->tm_mon+1, 1900+tm->tm_year );
     if ( sc->parent->multilayer ) {
@@ -220,7 +224,11 @@ int _ExportPDF(FILE *pdf,SplineChar *sc,int layer) {
     fprintf( pdf, " <<\n" );
     fprintf( pdf, "    /Creator (FontForge)\n" );
     now = GetTime();
-    tm = localtime(&now);
+    if (!getenv("SOURCE_DATE_EPOCH")) {
+	tm = localtime(&now);
+    } else {
+	tm = gmtime(&now);
+    }
     fprintf( pdf, "    /CreationDate (D:%04d%02d%02d%02d%02d%02d",
 	    1900+tm->tm_year, tm->tm_mon+1, tm->tm_mday,
 	    tm->tm_hour, tm->tm_min, tm->tm_sec );
@@ -228,7 +236,7 @@ int _ExportPDF(FILE *pdf,SplineChar *sc,int layer) {
     fprintf( pdf, "Z)\n" );
 #else
     tzset();
-    if ( timezone==0 )
+    if ( timezone==0  || getenv("SOURCE_DATE_EPOCH") )
 	fprintf( pdf, "Z)\n" );
     else {
 	if ( timezone<0 ) /* fprintf bug - this is a kludge to print +/- in front of a %02d-padded value */

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -45,6 +45,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <ustring.h>
 #include <utype.h>
 #include <unistd.h>

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -1423,7 +1423,6 @@ static int DumpMacBinaryHeader(FILE *res,struct macbinaryheader *mb) {
 
 	/* Creation time, (seconds from 1/1/1904) */
     now = mactime();
-    time(&now);
     *hpt++ = now>>24; *hpt++ = now>>16; *hpt++ = now>>8; *hpt++ = now;
 	/* Modification time, (seconds from 1/1/1904) */
     *hpt++ = now>>24; *hpt++ = now>>16; *hpt++ = now>>8; *hpt++ = now;

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -51,8 +51,8 @@
 #include <math.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <time.h>
 #include <ustring.h>
+#include <gutils.h>
 #include "ttf.h"
 #include "psfont.h"
 #if __Mac
@@ -1359,9 +1359,8 @@ static void DumpResourceMap(FILE *res,struct resourcetype *rtypes,enum fontforma
 }
 
 long mactime(void) {
-    time_t now;
+    time_t now = GetTime();
 
-    time(&now);
     /* convert from 1970 based time to 1904 based time */
     now += (1970-1904)*365L*24*60*60+((1970-1904)>>2)*24*60*60;
     /* Ignore any leap seconds -- Sorry Steve */

--- a/fontforge/parsepfa.c
+++ b/fontforge/parsepfa.c
@@ -29,6 +29,7 @@
 #include "fontforge.h"
 #include "parsettf.h"
 #include "psread.h"
+#include <gutils.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2645,8 +2646,8 @@ return(NULL);
     fclose(temp);
 
     if ( fstat(fileno(in),&b)!=-1 ) {
-	fp.fd->modificationtime = b.st_mtime;
-	fp.fd->creationtime = b.st_mtime;
+	fp.fd->modificationtime = GetST_MTime(b);
+	fp.fd->creationtime = GetST_MTime(b);
     }
 return( fp.fd );
 }

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -1157,13 +1157,17 @@ static void dump_pdfprologue(PI *pi) {
     fprintf( pi->out, "  /Creator (FontForge)\n" );
     fprintf( pi->out, "  /Producer (FontForge)\n" );
     now = GetTime();
-    tm = localtime(&now);
+    if (!getenv("SOURCE_DATE_EPOCH")) {
+	tm = localtime(&now);
+    } else {
+	tm = gmtime(&now);
+    }
     fprintf( pi->out, "    /CreationDate (D:%04d%02d%02d%02d%02d%02d",
 	    tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec );
 #ifdef _NO_TZSET
     fprintf( pi->out, "Z)\n" );
 #else
-    if ( timezone==0 )
+    if ( timezone==0 || getenv("SOURCE_DATE_EPOCH") )
 	fprintf( pi->out, "Z)\n" );
     else {
 	if ( timezone<0 ) /* fprintf bug - this is a kludge to print +/- in front of a %02d-padded value */

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -39,6 +39,7 @@
 #include "splinesaveafm.h"
 #include "splineutil.h"
 #include "tottf.h"
+#include <gutils.h>
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>
@@ -1155,7 +1156,7 @@ static void dump_pdfprologue(PI *pi) {
 	fprintf( pi->out, "  /Title (Character Displays from %s)\n", pi->mainsf->fullname );
     fprintf( pi->out, "  /Creator (FontForge)\n" );
     fprintf( pi->out, "  /Producer (FontForge)\n" );
-    time(&now);
+    now = GetTime();
     tm = localtime(&now);
     fprintf( pi->out, "    /CreationDate (D:%04d%02d%02d%02d%02d%02d",
 	    tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec );
@@ -1369,7 +1370,7 @@ return;
     fprintf( pi->out, "%%!PS-Adobe-3.0\n" );
     fprintf( pi->out, "%%%%BoundingBox: 20 20 %d %d\n", pi->pagewidth-30, pi->pageheight-20 );
     fprintf( pi->out, "%%%%Creator: FontForge\n" );
-    time(&now);
+    now = GetTime();
     fprintf( pi->out, "%%%%CreationDate: %s", ctime(&now) );
     fprintf( pi->out, "%%%%DocumentData: Binary\n" );
     if ( author!=NULL )

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -75,6 +75,7 @@
 #include "tottfgpos.h"
 #include "ttfinstrs.h"
 #include <gfile.h>
+#include <gutils.h>
 #include <utype.h>
 #include <ustring.h>
 #include <ffglib.h>
@@ -817,7 +818,7 @@ static void bStrftime(Context *c) {
     if ( c->a.argc>=4 )
 	oldloc = setlocale(LC_TIME, c->a.vals[3].u.sval); // TODO
 
-    time(&now);
+    now = GetTime();
     if ( isgmt )
 	tm = gmtime(&now);
     else

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -50,6 +50,7 @@
 #include "baseviews.h"
 #include "views.h"
 #include <gdraw.h>
+#include <gutils.h>
 #include <ustring.h>
 #include <math.h>
 #include <utype.h>
@@ -8836,8 +8837,8 @@ return( sf );
 void SFTimesFromFile(SplineFont *sf,FILE *file) {
     struct stat b;
     if ( fstat(fileno(file),&b)!=-1 ) {
-	sf->modificationtime = b.st_mtime;
-	sf->creationtime = b.st_mtime;
+	sf->modificationtime = GetST_MTime(b);
+	sf->creationtime = GetST_MTime(b);
     }
 }
 

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -45,6 +45,7 @@
 #include "splinefont.h"
 #include "splinesave.h"
 #include "splineutil.h"
+#include <time.h>
 #include <utype.h>
 #include <ustring.h>
 #include <gutils.h>

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -41,6 +41,7 @@
 #include <math.h>
 #include "ustring.h"
 #include "chardata.h"
+#include <gutils.h>
 #include <unistd.h>
 #include <time.h>
 #include <stdlib.h>
@@ -3808,7 +3809,6 @@ return( copy(buffer));
 
 SplineFont *SplineFontEmpty(void) {
     extern int default_fv_row_count, default_fv_col_count;
-    time_t now;
     SplineFont *sf;
 
     sf = calloc(1,sizeof(SplineFont));
@@ -3832,8 +3832,7 @@ SplineFont *SplineFontEmpty(void) {
     else
 	memcpy(sf->pfminfo.os2_vendor,"PfEd",4);
     sf->for_new_glyphs = DefaultNameListForNewFonts();
-    time(&now);
-    sf->creationtime = sf->modificationtime = now;
+    sf->creationtime = sf->modificationtime = GetTime();
 
     sf->layer_cnt = 2;
     sf->layers = calloc(2,sizeof(LayerInfo));
@@ -3860,7 +3859,7 @@ SplineFont *SplineFontBlank(int charcnt) {
     sprintf( buffer, "%s.sfd", sf->fontname);
     sf->origname = ToAbsolute(buffer);
     sf->weight = copy("Regular");
-    time(&now);
+    now = GetTime();
     tm = localtime(&now);
     if ( author!=NULL )
 	sprintf( buffer, "Copyright (c) %d, %.50s", tm->tm_year+1900, author );

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -3860,7 +3860,11 @@ SplineFont *SplineFontBlank(int charcnt) {
     sf->origname = ToAbsolute(buffer);
     sf->weight = copy("Regular");
     now = GetTime();
-    tm = localtime(&now);
+    if (!getenv("SOURCE_DATE_EPOCH")) {
+	tm = localtime(&now);
+    } else {
+	tm = gmtime(&now);
+    }
     if ( author!=NULL )
 	sprintf( buffer, "Copyright (c) %d, %.50s", tm->tm_year+1900, author );
     else

--- a/fontforge/stamper.c
+++ b/fontforge/stamper.c
@@ -2,6 +2,7 @@
  * This program is used to create a 'release date' time stamp when it is time for the
  * next fontforge release build. See fontforge/GNUmakefile.in
  */
+#include <gutils.h>
 #include <stdio.h>
 #include <time.h>
 
@@ -9,11 +10,9 @@ static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
 	"Aug", "Sep", "Oct", "Nov", "Dec", NULL };
 
 int main( int argc, char **argv ) {
-    time_t now;
-    struct tm *tm;
+    time_t now = GetTime();
+    struct tm *tm = gmtime(&now);
 
-    time(&now);
-    tm = gmtime(&now);
     /* Let the user or developer know that this resulting output is generated rather than edited */
     printf( "/* This file was generated using stamper.c to create the next version release.          */\n" );
     printf( "/* If you need to update this to the next release version, see fontforge/GNUmakefile.in */\n\n" );

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -49,6 +49,7 @@
 #include <locale.h>
 #include <utype.h>
 #include <chardata.h>
+#include <time.h>
 #include <ustring.h>
 #include <unistd.h>
 #include <sys/types.h>

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -44,6 +44,7 @@
 #include "splineutil2.h"
 #include "tottf.h"
 #include "tottfgpos.h"
+#include <gutils.h>
 #include <unistd.h>
 #include <math.h>
 #include <locale.h>
@@ -3609,8 +3610,8 @@ return( NULL );
 	SFSetOrder(sf,sf->layers[ly_fore].order2);
 	sf->chosenname = chosenname;
 	if ( stat(filename,&b)!=-1 ) {
-	    sf->modificationtime = b.st_mtime;
-	    sf->creationtime = b.st_mtime;
+	    sf->modificationtime = GetST_MTime(b);
+	    sf->creationtime = GetST_MTime(b);
 	}
     }
 return( sf );

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -54,6 +54,7 @@
 #include <unistd.h>
 #include <gutils.h>
 #include <locale.h>
+#include <time.h>
 #include <utype.h>
 #include <ustring.h>
 #include <chardata.h>

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -43,6 +43,7 @@
 #include "splineutil.h"
 #include "splineutil2.h"
 #include "tottf.h"
+#include <gutils.h>
 #include <ustring.h>
 #include <chardata.h>
 #include <utype.h>
@@ -3263,7 +3264,7 @@ static int GFI_AddOFL(GGadget *g, GEvent *e) {
 	time_t now;
 	struct tm *tm;
 
-	time(&now);
+	now = GetTime();
 	tm = localtime(&now);
 
 	tns = GMatrixEditGet(tng, &rows); newtns = NULL;

--- a/gdraw/gpsdraw.c
+++ b/gdraw/gpsdraw.c
@@ -24,6 +24,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <gutils.h>
 #include <stdio.h>
 #include <math.h>
 #include <time.h>
@@ -930,7 +931,7 @@ static void PSInitJob(GPSWindow ps, unichar_t *title) {
 	    72.0*gdisp->lmargin, 72.0*gdisp->bmargin,
 	    72.0*(gdisp->xwidth-gdisp->rmargin), 72.0*(gdisp->yheight-gdisp->tmargin));
     fprintf( ps->init_file, "%%%%Creator: %s\n", GResourceProgramName );
-    time(&now);
+    now = GetTime();
     fprintf( ps->init_file, "%%%%CreationDate: %s", ctime(&now) );
     if ( title!=NULL )
 	fprintf( ps->init_file, "%%%%Title: %s\n", u2def_strncpy(buf,title,sizeof(buf)) );

--- a/gutils/gutils.c
+++ b/gutils/gutils.c
@@ -100,3 +100,14 @@ time_t GetTime(void) {
 
 	return now;
 }
+
+time_t GetST_MTime(struct stat s) {
+	time_t st_time;
+	if (getenv("SOURCE_DATE_EPOCH")) {
+		st_time = atol(getenv("SOURCE_DATE_EPOCH"));
+	} else {
+		st_time = s.st_mtime;
+	}
+
+	return st_time;
+}

--- a/gutils/gutils.c
+++ b/gutils/gutils.c
@@ -63,14 +63,19 @@ const char *GetAuthor(void) {
 #else
     struct passwd *pwd;
     static char author[200] = { '\0' };
-    const char *ret = NULL, *pt;
+    const char *ret = NULL, *username;
 
     if ( author[0]!='\0' )
 return( author );
 
 /* Can all be commented out if no pwd routines */
     pwd = getpwuid(getuid());
-    if ( pwd!=NULL && pwd->pw_gecos!=NULL && *pwd->pw_gecos!='\0' ) {
+    username = getenv("USER");
+    if (getenv("SOURCE_DATE_EPOCH") && username) {
+	strncpy(author, username, sizeof(author));
+	author[sizeof(author)-1] = '\0';
+	ret = author;
+    } else if ( pwd!=NULL && pwd->pw_gecos!=NULL && *pwd->pw_gecos!='\0' ) {
 	strncpy(author,pwd->pw_gecos,sizeof(author));
 	author[sizeof(author)-1] = '\0';
 	ret = author;
@@ -78,8 +83,8 @@ return( author );
 	strncpy(author,pwd->pw_name,sizeof(author));
 	author[sizeof(author)-1] = '\0';
 	ret = author;
-    } else if ( (pt=getenv("USER"))!=NULL ) {
-	strncpy(author,pt,sizeof(author));
+    } else if ( username !=NULL ) {
+	strncpy(author, username, sizeof(author));
 	author[sizeof(author)-1] = '\0';
 	ret = author;
     }

--- a/inc/gutils.h
+++ b/inc/gutils.h
@@ -28,8 +28,10 @@
 #define _GUTILS_H
 
 #include <time.h>
+#include <sys/stat.h>
 
 extern const char *GetAuthor(void);
 extern time_t GetTime(void);
+extern time_t GetST_MTime(struct stat s);
 
 #endif


### PR DESCRIPTION
This PR is an extension of the merged PR #3152, making sure that SOURCE_DATE_EPOCH is used everywhere the current time is serialized in a file.

@volth, @bmwiedemann: could you please test this to see if further reduces or eliminate problems with reproducible build on Linux?

@volth: The MacOS issues will need to be taken care of separately.

WRT Author names, `GetAuthor` already honors the user-configurable env variable `USER`.

Closes #3134
Fixes #2711