### PR TITLE
Check for a non-null familyname before outputting to svg.

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -118,6 +118,8 @@ static int svg_outfontheader(FILE *file, SplineFont *sf,int layer) {
 	fprintf( file, "    font-family=\"");
 	latin1ToUtf8Out(file, sf->familyname_with_timestamp ? sf->familyname_with_timestamp : sf->familyname );
 	fprintf( file, "\"\n");
+    } else {
+	LogError(_("An SVG font without a familyname value might not be usable."));
     }
     fprintf( file, "    font-weight=\"%d\"\n", info.weight );
     if ( strstrmatch(sf->fontname,"obli") || strstrmatch(sf->fontname,"slanted") )

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -114,9 +114,11 @@ static int svg_outfontheader(FILE *file, SplineFont *sf,int layer) {
 	fprintf( file, "vert-adv-y=\"%d\" ", sf->ascent+sf->descent );
     putc('>',file); putc('\n',file);
     fprintf( file, "  <font-face \n" );
-    fprintf( file, "    font-family=\"");
-    latin1ToUtf8Out(file, sf->familyname_with_timestamp ? sf->familyname_with_timestamp : sf->familyname );
-    fprintf( file, "\"\n");
+    if (sf->familyname_with_timestamp != NULL || sf->familyname != NULL) {
+	fprintf( file, "    font-family=\"");
+	latin1ToUtf8Out(file, sf->familyname_with_timestamp ? sf->familyname_with_timestamp : sf->familyname );
+	fprintf( file, "\"\n");
+    }
     fprintf( file, "    font-weight=\"%d\"\n", info.weight );
     if ( strstrmatch(sf->fontname,"obli") || strstrmatch(sf->fontname,"slanted") )
 	fprintf( file, "    font-style=\"oblique\"\n" );


### PR DESCRIPTION
This closes #3115.
