### PR TITLE
Improve TrueType parsing safety.

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3551,7 +3551,7 @@ static void readcffset(FILE *ttf,struct topdicts *dict,struct ttfinfo *info) {
 	    for ( i = 1; i<len; ) {
 		first = dict->charset[i++] = getushort(ttf);
 		cnt = getushort(ttf);
-		for ( j=0; j<cnt; ++j )
+		for ( j=0; j<cnt && i<len; ++j )
 		    dict->charset[i++] = ++first;
 	    }
 	} else {
@@ -4720,13 +4720,16 @@ return;
 	    enc = FindOrMakeEncoding("UnicodeFull");
 
 	if ( format==0 ) {
+	    if (len > 256 + 6) {
+		IError("Table too large; truncated to 256 entries.");
+	    }
 	    if ( justinuse==git_normal && map!=NULL && map->enccount<256 ) {
 		map->map = realloc(map->map,256*sizeof(int));
-		memset(map->map,-1,(256-map->enccount)*sizeof(int));
+		memset(map->map+map->enccount,-1,(256-map->enccount)*sizeof(int));
 		map->enccount = map->encmax = 256;
 	    }
 	    for ( i=0; i<len-6; ++i )
-		table[i] = getc(ttf);
+		if (i < 256) table[i] = getc(ttf); else getc(ttf);
 	    trans = enc->unicode;
 	    if ( trans==NULL && dcmap[dc].platform==1 )
 		trans = MacEncToUnicode(dcmap[dc].specific,dcmap[dc].lang-1);
@@ -4741,6 +4744,7 @@ return;
 		} else if ( table[i]<info->glyph_cnt && info->chars[table[i]]!=NULL )
 		    info->inuse[table[i]] = 1;
 	} else if ( format==4 ) {
+	    int rlen = len;
 	    segCount = getushort(ttf)/2;
 	    /* searchRange = */ getushort(ttf);
 	    /* entrySelector = */ getushort(ttf);
@@ -4765,8 +4769,12 @@ return;
 	    /* that's the amount of space left in the subtable and it must */
 	    /*  be filled with glyphIDs */
 	    if ( len<0 ) {
-		IError("This font has an illegal format 4 subtable with too little space for all the segments.\nThis error is not recoverable.\nBye" );
-		exit(1);
+		IError("This font has an illegal format 4 subtable with too little space for all the segments (%d).\nThis error is not recoverable.\nBye", rlen);
+		// exit(1);
+		// Exiting abruptly is not a desirable behavior.
+		// Even if continuing to load would result in a totally broken font,
+		// that is still better than closing completely.
+		len = 0;
 	    }
 	    glyphs = malloc(len);
 	    glyph_tot = len/2;


### PR DESCRIPTION
Cap TrueType format 0 table size at 256, fix an overrun crash reading CFF, and keep FontForge open when trying to load a corrupt OpenType file.

This supersedes #3211.

This closes #3094, #3095, #3208, and #3209.
