### PR TITLE
Fix typo in python.c and sflayout.c.

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -3268,7 +3268,7 @@ return( NULL );
 	}
     } else {
 	if ( start!=0 ) {
-	    points = malloc(self->pt_cnt*sizeof(struct PyFF_Point *));
+	    points = malloc(self->pt_cnt*sizeof(PyFF_Point *));
 	    for ( i=start; i<self->pt_cnt; ++i )
 		points[i-start] = self->points[i];
 	    off = self->pt_cnt - start;

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -402,7 +402,7 @@ void LayoutInfoRefigureLines(LayoutInfo *li, int start_of_change,
     double scale;
 
     if ( li->lines==NULL ) {
-	li->lines = malloc(10*sizeof(struct opentype_str *));
+	li->lines = malloc(10*sizeof(struct opentype_str **));
 	li->lineheights = malloc(10*sizeof(struct lineheights));
 	li->lines[0] = NULL;
 	li->lmax = 10;

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -504,7 +504,7 @@ void LayoutInfoRefigureLines(LayoutInfo *li, int start_of_change,
     li->pcnt += pdiff;
 
     if ( li->lmax <= li->lcnt+lcnt - (le-ls) + 1 ) {
-	li->lines = realloc(li->lines,(li->lmax = li->lcnt+30+lcnt-(le-ls+1))*sizeof(struct openfont_str **));
+	li->lines = realloc(li->lines,(li->lmax = li->lcnt+30+lcnt-(le-ls+1))*sizeof(struct opentype_str **));
 	li->lineheights = realloc(li->lineheights,li->lmax*sizeof(struct lineheights));
     }
     /* move any old lines around */


### PR DESCRIPTION
1.The 'struct PyFF_Point' in 'points = malloc(self->pt_cnt*sizeof(struct PyFF_Point *))' is a forward declaration, which is different from the 'PyFF_Point'(typedef ff_point). 2.I believe that 'openfont_str' is a typo and there is no definition of 'openfont_str' in fontforge.
