### PR TITLE
Skip Apple ‘head’ table fields in OpenType mode

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -2854,23 +2854,24 @@ static void sethead(struct head *head,SplineFont *sf,struct alltabs *at,
     /*  a different advance width from that expected by scaling, then windows */
     /*  will only notice the fact if the 0x10 bit is set (even though this has*/
     /*  nothing to do with instructions) */
-/* Apple flags */
-    if ( sf->hasvmetrics )
-	head->flags |= (1<<5);		/* designed to be layed out vertically */
-    /* Bit 6 must be zero */
-    if ( arabic )
-	head->flags |= (1<<7);
-    if ( sf->sm )
-	head->flags |= (1<<8);		/* has metamorphesis effects */
-    if ( rl )
-	head->flags |= (1<<9);
-    indic_rearrange = 0;
-    for ( sm = sf->sm; sm!=NULL; sm=sm->next )
-	if ( sm->type == asm_indic )
-	    indic_rearrange = true;
-    if ( indic_rearrange )
-	head->flags |= (1<<10);
-/* End apple flags */
+    if ( at->applemode ) {
+	/* Apple flags */
+	if ( sf->hasvmetrics )
+	    head->flags |= (1<<5);		/* designed to be layed out vertically */
+	/* Bit 6 must be zero */
+	if ( arabic )
+	    head->flags |= (1<<7);
+	if ( sf->sm )
+	    head->flags |= (1<<8);		/* has metamorphesis effects */
+	if ( rl )
+	    head->flags |= (1<<9);
+	indic_rearrange = 0;
+	for ( sm = sf->sm; sm!=NULL; sm=sm->next )
+	    if ( sm->type == asm_indic )
+		indic_rearrange = true;
+	if ( indic_rearrange )
+	    head->flags |= (1<<10);
+    }
     if ( sf->head_optimized_for_cleartype )
 	head->flags |= (1<<13);
     head->emunits = sf->ascent+sf->descent;
@@ -2880,16 +2881,23 @@ static void sethead(struct head *head,SplineFont *sf,struct alltabs *at,
     if ( at->gi.glyph_len<0x20000 )
 	head->locais32 = 0;
 
-    /* I assume we've always got some neutrals (spaces, punctuation) */
-    if ( lr && rl )
-	head->dirhint = 0;
-    else if ( rl )
-	head->dirhint = -2;
-    else
-	head->dirhint = 2;
-    if ( rl )
-	head->flags |= (1<<9);		/* Apple documents this */
-    /* if there are any indic characters, set bit 10 */
+    if ( !at->applemode ) {
+      /* "Deprecated (Set to 2)":
+       * https://www.microsoft.com/typography/otspec/head.htm#fontDirectionHint
+       */
+      head->dirhint = 2;
+    } else {
+      /* I assume we've always got some neutrals (spaces, punctuation) */
+      if ( lr && rl )
+          head->dirhint = 0;
+      else if ( rl )
+          head->dirhint = -2;
+      else
+          head->dirhint = 2;
+      if ( rl )
+          head->flags |= (1<<9);		/* Apple documents this */
+      /* if there are any indic characters, set bit 10 */
+    }
 
     cvt_unix_to_1904(sf->creationtime,head->createtime);
     cvt_unix_to_1904(sf->modificationtime,head->modtime);


### PR DESCRIPTION
### Motivation and Context

Some parts of the ‘head’ table are specific to Apple and either deprecated or should not be set for OpenType fonts.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
From https://www.microsoft.com/typography/otspec/head.htm#flags:
> Bit 5: This bit is not used in OpenType, and should not be set in order to ensure compatible behavior on all platforms. If set, it may result in different behavior for vertical layout in some platforms. (See Apple's specification for details regarding behavior in Apple platforms.)
> Bits 6–10: These bits are not used in Opentype and should always be cleared. (See Apple's specification for details regarding legacy used in Apple platforms.)

From https://www.microsoft.com/typography/otspec/head.htm#fontDirectionHint
> Deprecated (Set to 2).