### PR TITLE
Add an option to not generate duplicated Mac names

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -15737,6 +15737,7 @@ struct flaglist gen_flags[] = {
     { "no-hints", 0x80000 },
     { "round", 0x200000 },
     { "composites-in-afm", 0x400000 },
+    { "no-mac-names", 0x8000000},
     FLAGLIST_EMPTY /* Sentinel */
 };
 /* Generate TrueType Collection flags: see 'enum ttc_flags' in splinefont.h */

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -1171,6 +1171,7 @@ int GenerateScript(SplineFont *sf,char *filename,const char *bitmaptype, int fmf
 		if ( fmflags&0x1000000 ) old_sfnt_flags |= ttf_flag_pfed_guides;
 		if ( fmflags&0x2000000 ) old_sfnt_flags |= ttf_flag_pfed_layers;
 		if ( fmflags&0x4000000 ) old_sfnt_flags |= ttf_flag_oldkernmappedonly;
+		if ( fmflags&0x8000000 ) old_sfnt_flags |= ttf_flag_nomacnames;
 	    }
 	} else {
 	    old_sfnt_flags = 0;
@@ -1214,6 +1215,7 @@ int GenerateScript(SplineFont *sf,char *filename,const char *bitmaptype, int fmf
 	    if ( fmflags&0x1000000 ) old_sfnt_flags |= ttf_flag_pfed_guides;
 	    if ( fmflags&0x2000000 ) old_sfnt_flags |= ttf_flag_pfed_layers;
 	    if ( fmflags&0x4000000 ) old_sfnt_flags |= ttf_flag_oldkernmappedonly;
+	    if ( fmflags&0x8000000 ) old_sfnt_flags |= ttf_flag_nomacnames;
 	}
     }
 

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2013,7 +2013,8 @@ enum ttf_flags { ttf_flag_shortps = 1, ttf_flag_nohints = 2,
 		    ttf_flag_symbol=0x4000,
 		    ttf_flag_dummyDSIG=0x8000,
 		    ttf_native_kern=0x10000, // This applies mostly to U. F. O. right now.
-		    ttf_flag_oldkernmappedonly=0x20000000 // Allow only mapped glyphs in the old-style "kern" table, required for Windows compatibility
+		    ttf_flag_oldkernmappedonly=0x20000000, // Allow only mapped glyphs in the old-style "kern" table, required for Windows compatibility
+                    ttf_flag_nomacnames=0x40000 // Don't autogenerate mac name entries
 		};
 enum ttc_flags { ttc_flag_trymerge=0x1, ttc_flag_cff=0x2 };
 enum openflags { of_fstypepermitted=1, of_askcmap=2, of_all_glyphs_in_ttc=4,

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3886,7 +3886,7 @@ return( mn1->lang - mn2->lang );
 return( mn1->strid-mn2->strid );
 }
 
-static void AddEncodedName(NamTab *nt,char *utf8name,uint16 lang,uint16 strid) {
+static void AddEncodedName(NamTab *nt,char *utf8name,uint16 lang,uint16 strid, int nomacnames) {
     NameEntry *ne;
     int maclang, macenc= -1, specific;
     char *macname = NULL;
@@ -3921,7 +3921,7 @@ return;		/* Should not happen, but it did */
     maclang = WinLangToMac(lang);
     if ( !nt->applemode && lang!=0x409 )
 	maclang = 0xffff;
-    if ( maclang!=0xffff ) {
+    if ( !nomacnames && maclang!=0xffff ) {
 #ifdef FONTFORGE_CONFIG_APPLE_UNICODE_NAMES
 	if ( strid!=ttf_postscriptname ) {
 	    *ne = ne[-1];
@@ -4038,6 +4038,7 @@ static void dumpnames(struct alltabs *at, SplineFont *sf,enum fontformat format)
     NamTab nt;
     struct otfname *otfn;
     struct otffeatname *fn;
+    int nomacnames = at->gi.flags&ttf_flag_nomacnames;
 
     memset(&nt,0,sizeof(nt));
     nt.encoding_name = at->map->enc;
@@ -4058,12 +4059,12 @@ static void dumpnames(struct alltabs *at, SplineFont *sf,enum fontformat format)
     DefaultTTFEnglishNames(&dummy, sf);
 
     for ( i=0; i<ttf_namemax; ++i ) if ( dummy.names[i]!=NULL )
-	AddEncodedName(&nt,dummy.names[i],0x409,i);
+	AddEncodedName(&nt,dummy.names[i],0x409,i, nomacnames);
     for ( cur=sf->names; cur!=NULL; cur=cur->next ) {
 	if ( cur->lang!=0x409 )
 	    for ( i=0; i<ttf_namemax; ++i )
 		if ( cur->names[i]!=NULL )
-		    AddEncodedName(&nt,cur->names[i],cur->lang,i);
+		    AddEncodedName(&nt,cur->names[i],cur->lang,i, nomacnames);
     }
 
     /* The examples I've seen of the feature table only contain platform==mac */
@@ -4089,12 +4090,12 @@ static void dumpnames(struct alltabs *at, SplineFont *sf,enum fontformat format)
     /* Wow, the GPOS 'size' feature uses the name table in a very mac-like way*/
     if ( at->fontstyle_name_strid!=0 && sf->fontstyle_name!=NULL ) {
 	for ( otfn = sf->fontstyle_name; otfn!=NULL; otfn = otfn->next )
-	    AddEncodedName(&nt,otfn->name,otfn->lang,at->fontstyle_name_strid);
+	    AddEncodedName(&nt,otfn->name,otfn->lang,at->fontstyle_name_strid, nomacnames);
     }
     /* As do some other features now */
     for ( fn = sf->feat_names; fn!=NULL; fn=fn->next ) {
 	for ( otfn = fn->names; otfn!=NULL; otfn = otfn->next )
-	    AddEncodedName(&nt,otfn->name,otfn->lang,fn->nid);
+	    AddEncodedName(&nt,otfn->name,otfn->lang,fn->nid, nomacnames);
     }
 
     qsort(nt.entries,nt.cur,sizeof(NameEntry),compare_entry);

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -87,6 +87,7 @@ static int nfnt_warned = false, post_warned = false;
 #define CID_TTF_OldKern		1109
 #define CID_TTF_GlyphMap	1110
 #define CID_TTF_OFM		1111
+#define CID_TTF_NoMacNames	1112
 #define CID_TTF_PfEdLookups	1113
 #define CID_TTF_PfEdGuides	1114
 #define CID_TTF_PfEdLayers	1115
@@ -363,6 +364,8 @@ return( false );
 		    d->sfnt_flags |= ttf_native_kern; // This applies mostly to U. F. O. right now.
 		if ( GGadgetIsChecked(GWidgetGetControl(gw,CID_TTF_OldKernMappedOnly)) )
 		    d->sfnt_flags |= ttf_flag_oldkernmappedonly;
+		if ( GGadgetIsChecked(GWidgetGetControl(gw,CID_TTF_NoMacNames)) )
+		    d->sfnt_flags |= ttf_flag_nomacnames;
 	    } else {				/* PS + OpenType Bitmap */
 		d->ps_flags = d->psotb_flags = 0;
 		if ( GGadgetIsChecked(GWidgetGetControl(gw,CID_PS_AFMmarks)) )
@@ -398,6 +401,8 @@ return( false );
 		    d->psotb_flags |= ttf_flag_glyphmap;
 		if ( GGadgetIsChecked(GWidgetGetControl(gw,CID_TTF_OFM)) )
 		    d->psotb_flags |= ttf_flag_ofm;
+		if ( GGadgetIsChecked(GWidgetGetControl(gw,CID_TTF_NoMacNames)) )
+		    d->psotb_flags |= ttf_flag_nomacnames;
 	    }
 	    d->sod_invoked = true;
 	}
@@ -459,6 +464,7 @@ static void OptSetDefaults(GWindow gw,struct gfc_data *d,int which,int iscid) {
     GGadgetSetChecked(GWidgetGetControl(gw,CID_FontLog),flags&ps_flag_outputfontlog);
     GGadgetSetChecked(GWidgetGetControl(gw,CID_NativeKern),flags&ttf_native_kern);
     GGadgetSetChecked(GWidgetGetControl(gw,CID_TTF_OldKernMappedOnly),flags&ttf_flag_oldkernmappedonly);
+    GGadgetSetChecked(GWidgetGetControl(gw,CID_TTF_NoMacNames),flags&ttf_flag_nomacnames);
 
     GGadgetSetEnabled(GWidgetGetControl(gw,CID_PS_Hints),which!=1);
     GGadgetSetEnabled(GWidgetGetControl(gw,CID_PS_Flex),which!=1);
@@ -492,6 +498,7 @@ static void OptSetDefaults(GWindow gw,struct gfc_data *d,int which,int iscid) {
     GGadgetSetEnabled(GWidgetGetControl(gw,CID_TTF_OFM),which!=0);
     
     GGadgetSetEnabled(GWidgetGetControl(gw,CID_TTF_OldKernMappedOnly),which!=0 );
+    GGadgetSetEnabled(GWidgetGetControl(gw,CID_TTF_NoMacNames),which!=0 );
 
     d->optset[which] = true;
 }
@@ -503,10 +510,10 @@ static void SaveOptionsDlg(struct gfc_data *d,int which,int iscid) {
     int k,fontlog_k,group,group2;
     GWindow gw;
     GWindowAttrs wattrs;
-    GGadgetCreateData gcd[34];
-    GTextInfo label[34];
+    GGadgetCreateData gcd[35];
+    GTextInfo label[35];
     GRect pos;
-    GGadgetCreateData *hvarray1[21], *hvarray2[42], *hvarray3[6], *harray[7], *varray[11];
+    GGadgetCreateData *hvarray1[21], *hvarray2[42], *hvarray3[8], *harray[7], *varray[11];
     GGadgetCreateData boxes[6];
 
     d->sod_done = false;
@@ -860,9 +867,19 @@ static void SaveOptionsDlg(struct gfc_data *d,int which,int iscid) {
     gcd[k].gd.label = &label[k];
     gcd[k].gd.cid = CID_TTF_OldKernMappedOnly;
     gcd[k++].creator = GCheckBoxCreate;
-    hvarray3[3] = &gcd[k-1];
+    hvarray3[3] = &gcd[k-1]; hvarray3[4] = NULL;
 
-    hvarray3[4] = NULL; hvarray3[5] = NULL;
+    gcd[k].gd.pos.x = gcd[k-1].gd.pos.x; gcd[k].gd.pos.y = gcd[k-1].gd.pos.y;
+    gcd[k].gd.flags = gg_visible | gg_enabled | gg_utf8_popup;
+    label[k].text = (unichar_t *) _("No Mac Names");
+    label[k].text_is_1byte = true;
+    gcd[k].gd.popup_msg = (unichar_t *) _("Do not add duplicated name entries for legacy Mac platform. These name entries are only needed for some legacy Mac applications.");
+    gcd[k].gd.label = &label[k];
+    gcd[k].gd.cid = CID_TTF_NoMacNames;
+    gcd[k++].creator = GCheckBoxCreate;
+    hvarray3[5] = &gcd[k-1];
+
+    hvarray3[6] = NULL; hvarray3[7] = NULL;
 
     boxes[4].gd.flags = gg_enabled|gg_visible;
     boxes[4].gd.u.boxelements = hvarray3;


### PR DESCRIPTION
### Motivation and Context
Most macOS applications will use name entries from MS platform if the Mac platform is missing.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
This option to not generate the legacy Mac names especially that they use 8-bit encodings that does not cover the whole Unicode.