### PR TITLE
Don’t mark UFO fonts with layers multilayer

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -4193,10 +4193,8 @@ return( NULL );
 											bg = 0;
 										} else if (strcmp(layernames[2*lcount],"public.background")==0) {
 											layerdest = ly_back;
-											sf->multilayer |= 1;
 										} else {
 											layerdest = auxpos++;
-											sf->multilayer |= 1;
 										}
 
 										// We ensure that the splinefont layer list has sufficient space.

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -2281,7 +2281,7 @@ return( 0 );
 	formattypes[ff_otf].disabled = true;
 	formattypes[ff_otfcid].disabled = true;
 	formattypes[ff_cffcid].disabled = true;
-	// formattypes[ff_ufo].disabled = true;
+	formattypes[ff_ufo].disabled = true;
 	if ( ofs!=ff_svg )
 	    ofs = ff_ptype3;
     } else if ( sf->strokedfont ) {


### PR DESCRIPTION
All fonts in FontForge can have layers, so there is no need to do any thing special for UFO here. More importantly, FontForge’s multilayer mode means something very different:
https://fontforge.github.io/multilayer.html

One consequence of marking a font multilayer is that it can’t be hinted, which is wrong for UFO.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)