### PR TITLE
GDK: Remove gdk_display_close calls

### DIFF
--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -2466,7 +2466,6 @@ GDisplay *_GGDKDraw_CreateDisplay(char *displayname, char *UNUSED(programname)) 
 
     gdisp = (GGDKDisplay *)calloc(1, sizeof(GGDKDisplay));
     if (gdisp == NULL) {
-        gdk_display_close(display);
         return NULL;
     }
 
@@ -2531,7 +2530,6 @@ GDisplay *_GGDKDraw_CreateDisplay(char *displayname, char *UNUSED(programname)) 
     if (groot == NULL) {
         g_object_unref(gdisp->pangoc_context);
         free(gdisp);
-        gdk_display_close(display);
         return NULL;
     }
 
@@ -2631,7 +2629,6 @@ void _GGDKDraw_DestroyDisplay(GDisplay *disp) {
 
     // Close the display
     if (gdisp->display != NULL) {
-        gdk_display_close(gdisp->display);
         gdisp->display = NULL;
     }
 

--- a/travis-scripts/ffosxbuild.sh
+++ b/travis-scripts/ffosxbuild.sh
@@ -33,8 +33,8 @@ cp -r $workdir/share $outdir/Contents/Resources/opt/local/
 rm -r $outdir/Contents/Resources/opt/local/share/fontforge/osx
 # This may not work if collab isn't built
 cp -r $workdir/libexec $outdir/Contents/Resources/opt/local/ || true
-mkdir $outdir/Contents/Resources/opt/local/lib
 cp -r $workdir/lib/python2.7 $outdir/Contents/Resources/opt/local/lib/python2.7
+mkdir -p $outdir/Contents/Resources/opt/local/lib
 
 pushd $outdir/Contents/MacOS
 rm FontForge && cp $BASE/_FontForge FontForge

--- a/travis-scripts/ffosxbuild.sh
+++ b/travis-scripts/ffosxbuild.sh
@@ -33,8 +33,8 @@ cp -r $workdir/share $outdir/Contents/Resources/opt/local/
 rm -r $outdir/Contents/Resources/opt/local/share/fontforge/osx
 # This may not work if collab isn't built
 cp -r $workdir/libexec $outdir/Contents/Resources/opt/local/ || true
-cp -r $workdir/lib/python2.7 $outdir/Contents/Resources/opt/local/lib/python2.7
 mkdir -p $outdir/Contents/Resources/opt/local/lib
+cp -r $workdir/lib/python2.7 $outdir/Contents/Resources/opt/local/lib/python2.7
 
 pushd $outdir/Contents/MacOS
 rm FontForge && cp $BASE/_FontForge FontForge


### PR DESCRIPTION
Classic GDK - the GdkDisplay objects returned are transfer-none.

Calling this function on the GdkDisplay's on osx results in a
segfault, complaining that an object being freed was never malloc'ed
in the first place.
