### PR TITLE
clarify python-dev requirement and force a halt if user wants python-scripting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -916,7 +916,7 @@ Summary of optional features:
 			UseIt?	HaveIt?
   real (floating pt)		${my_real_type}
   programs		yes	${i_do_have_programs}
-  native scripting	yes	${i_do_have_native_scripting}
+  native scripting	yes	${i_do_have_native_scripting}${i_want_python_dev}
   python scripting	${enable_python_scripting}	${i_do_have_python_scripting}
   python extension	${enable_python_extension}	${i_do_have_python_extension}
   freetype debugger		${i_do_have_freetype_debugger}

--- a/configure.ac
+++ b/configure.ac
@@ -916,8 +916,8 @@ Summary of optional features:
 			UseIt?	HaveIt?
   real (floating pt)		${my_real_type}
   programs		yes	${i_do_have_programs}
-  native scripting	yes	${i_do_have_native_scripting}${i_want_python_dev}
-  python scripting	${enable_python_scripting}	${i_do_have_python_scripting}
+  native scripting	yes	${i_do_have_native_scripting}
+  python scripting	${enable_python_scripting}	${i_do_have_python_scripting}${i_want_python_ver}
   python extension	${enable_python_extension}	${i_do_have_python_extension}
   freetype debugger		${i_do_have_freetype_debugger}
   raw points mode		${i_do_have_debug_raw_points}

--- a/configure.ac
+++ b/configure.ac
@@ -270,8 +270,7 @@ FONTFORGE_ARG_DISABLE([native-scripting],
         [_NO_FFSCRIPT])
 AM_CONDITIONAL([NATIVE_SCRIPTING],[test x"${i_do_have_native_scripting}" = xyes])
 
-FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING
-FONTFORGE_ARG_DISABLE_PYTHON_EXTENSION
+FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING_AND_EXTENSION
 
 AC_ARG_ENABLE([freetype-debugger],
         [AS_HELP_STRING([--enable-freetype-debugger[[=DIR]]],
@@ -914,12 +913,12 @@ Configuration:
 
 Summary of optional features:
 
-			HaveIt?	UseIt?
+			UseIt?	HaveIt?
   real (floating pt)		${my_real_type}
   programs		yes	${i_do_have_programs}
   native scripting	yes	${i_do_have_native_scripting}
   python scripting	${enable_python_scripting}	${i_do_have_python_scripting}
-  python extension		${i_do_have_python_extension}
+  python extension	${enable_python_extension}	${i_do_have_python_extension}
   freetype debugger		${i_do_have_freetype_debugger}
   raw points mode		${i_do_have_debug_raw_points}
   tile path			${i_do_have_tile_path}
@@ -929,7 +928,7 @@ Summary of optional features:
 
 Summary of optional dependencies:
 
-Optional Library	HaveIt?	UseIt?	WebsiteURL
+Optional Library	UseIt?	HaveIt?	WebsiteURL
   cairo			${with_cairo}	${i_do_have_cairo}	${cairo_url}
   giflib		${with_giflib}	${i_do_have_giflib}	${giflib_url}
   libjpeg		${with_libjpeg}	${i_do_have_libjpeg}	${libjpeg_url}

--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,7 @@ libuninameslist_url="https://github.com/fontforge/libuninameslist"
 libzmq_url="http://www.zeromq.org/"
 libreadline_url="http://www.gnu.org/software/readline"
 libxorg_url="http://www.x.org/"
+python_url="https://www.python.org/"
 gdk_url="http://www.gtk.org/"
 
 # Point to the Wikipedia page, primarily because one may want
@@ -913,21 +914,22 @@ Configuration:
 
 Summary of optional features:
 
-  real (floating pt)	${my_real_type}
-  programs		${i_do_have_programs}
-  native scripting	${i_do_have_native_scripting}
-  python scripting	${i_do_have_python_scripting}
-  python extension	${i_do_have_python_extension}
-  freetype debugger	${i_do_have_freetype_debugger}
-  raw points mode	${i_do_have_debug_raw_points}
-  tile path		${i_do_have_tile_path}
-  gb12345 encoding	${i_do_have_gb12345}
-  fontforge-extras	${fontforge_extras}
+			HaveIt?	UseIt?
+  real (floating pt)		${my_real_type}
+  programs		yes	${i_do_have_programs}
+  native scripting	yes	${i_do_have_native_scripting}
+  python scripting	${enable_python_scripting}	${i_do_have_python_scripting}
+  python extension		${i_do_have_python_extension}
+  freetype debugger		${i_do_have_freetype_debugger}
+  raw points mode		${i_do_have_debug_raw_points}
+  tile path			${i_do_have_tile_path}
+  gb12345 encoding		${i_do_have_gb12345}
+  fontforge-extras	yes	${fontforge_extras}
   potrace or autotrace	${i_do_find_auto_po_trace}
 
 Summary of optional dependencies:
 
-Optional Library	UseIt?	HaveIt?	WebsiteURL
+Optional Library	HaveIt?	UseIt?	WebsiteURL
   cairo			${with_cairo}	${i_do_have_cairo}	${cairo_url}
   giflib		${with_giflib}	${i_do_have_giflib}	${giflib_url}
   libjpeg		${with_libjpeg}	${i_do_have_libjpeg}	${libjpeg_url}
@@ -936,6 +938,7 @@ Optional Library	UseIt?	HaveIt?	WebsiteURL
   libspiro		${with_libspiro}	${i_do_have_libspiro}	${libspiro_url}
   libtiff		${with_libtiff}	${i_do_have_libtiff}	${libtiff_url}
   libuninameslist	${with_libuninameslist}	${i_do_have_libuninameslist}	${libuninameslist_url}
+  python-dev		${enable_python_scripting}	${i_do_have_python_scripting}	${python_url}
   zeromq (libzmq)		${i_do_have_libzmq}	${libzmq_url}
   X Window System		${i_do_have_x}	${libxorg_url}
   GDK backend		${fontforge_can_use_gdk}	${fontforge_gdk_version}	${gdk_url}

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -33,56 +33,112 @@ dnl First check if python and developer files are available, if yes, then
 dnl continue, however, if user indicates yes, then we must verify that we
 dnl do have python and developer files available, otherwise halt and let
 dnl user know that they must add python and python developer files too.
+dnl This is setup to try v3.3+ first, then v2.7+ if user requests nothing
+dnl or yes or A. If user request 2 or 3, then we check for 2.7+ or 3.3+
 AC_DEFUN([FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING_AND_EXTENSION],
 [
-i_want_python_dev=2.7
+i_want_python_ver="A"
 AC_ARG_ENABLE([python-scripting],
         [AS_HELP_STRING([--disable-python-scripting],[disable Python scripting. If you
         REQUIRE Python, then use --enable-python-scripting to force a yes for install.
-        If you want python>=3.3, then use --enable-python-scripting=3])],
+        If you want python>=3.3, then use --enable-python-scripting=3, use 2 if you
+        want python>=2.7. yes will use 3.3+ or 2.7+ (whichever is available).])],
         [i_do_have_python_scripting="${enableval}"; enable_python_scripting="${enableval}"],
         [i_do_have_python_scripting=yes; enable_python_scripting=check])
-AC_MSG_CHECKING([python script is $i_do_have_python_scripting and want is $want_python])
-AC_MSG_RESULT([ version])
-# default is to load python 2.7 or higher, but user requests 3.3 or higher
-if test i_do_have_python_scripting > 2; then
-   if test i_do_have_python_scripting > 3; then
-      i_want_python_dev=3.3
-   else
-      i_want_python_dev=2.7
-   fi
-   i_do_have_python_scripting=yes
-   enable_python_scripting=yes
-fi
-AC_MSG_CHECKING([python script is $i_do_have_python_scripting and want is $want_python])
-AC_MSG_RESULT([ version])
 AC_ARG_ENABLE([python-extension],
          [AS_HELP_STRING([--disable-python-extension],
                          [do not build the Python extension modules "psMat" and "fontforge",
                           even if they were included in this source distribution])],
          [i_do_have_python_extension="${enableval}"; enable_python_extension="${enableval}"],
          [i_do_have_python_extension=yes; enable_python_extension=check])
+# default is to load python 3.3+ or 2.7+, but user forces a request for 2.7+ or 3.3+
+if test x${i_do_have_python_scripting} = x2; then
+   i_want_python_ver="2"
+   i_do_have_python_scripting=yes
+   enable_python_scripting=yes
+else
+   if test x${i_do_have_python_scripting} = x3; then
+      i_want_python_ver="3"
+      i_do_have_python_scripting=yes
+      enable_python_scripting=yes
+   else
+      if test ${i_do_have_python_scripting}x = Ax; then
+         i_want_python_ver="A"
+         i_do_have_python_scripting=yes
+         enable_python_scripting=yes
+      else
+         if test ${i_do_have_python_scripting}x = ax; then
+            i_want_python_ver="A"
+            i_do_have_python_scripting=yes
+            enable_python_scripting=yes
+         fi
+      fi
+   fi
+fi
 # force yes for python_scripting if user says yes for python_extension
 if test x"${enable_python_extension}" = xyes; then
    i_do_have_python_scripting=yes
-   enable_python_scripting=yes
-fi
-# test for python and python-dev
-if test x"${i_do_have_python_scripting}" = xyes; then
-   AM_PATH_PYTHON([i_want_python_dev],,[:])
-   PKG_CHECK_MODULES([PYTHON],[python-"${PYTHON_VERSION}"],
-      [PKG_CHECK_MODULES([PYTHONDEV],[python-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=no; force_off_python_extension=yes])],
-      [i_do_have_python_scripting=no; force_off_python_extension=yes])
-   if ( PYTHON_VERSION >= 2.7; then
-      if ( PYTHON_VERSION >= 3.3; then
-         i_want_python_dev=3.3
-      else
-         i_want_python_dev=2.7
-      fi
-   else
-      i_want_python_dev=""
+   if test x"${enable_python_scripting}" = xno; then
+      enable_python_scripting=yes
    fi
 fi
+# first, test for python (we want defaults returned, avoid adding anything in yes section)
+if test x"${i_do_have_python_scripting}" = xyes; then
+   if test x${i_want_python_ver} = x3; then
+      AM_PATH_PYTHON([3.3],,[i_do_have_python_scripting=no])
+   else
+      if test x${i_want_python_ver} = x2; then
+         AM_PATH_PYTHON([2.7],,[i_do_have_python_scripting=no])
+dnl TODO: verify this is actually 2.7+ and not 3.3+
+dnl      if test x"${i_do_have_python_scripting}" = xyes; then
+dnl         if PY_MAJOR_VERSION >= 3; then
+dnl            i_do_have_python_scripting=no
+dnl         fi
+dnl      fi
+      else
+dnl      # default is try for 3.3+, otherwise try for 2.7+
+dnl      AM_PATH_PYTHON([3.3],,[i_do_have_python_scripting=no])
+dnl      if test x"${i_do_have_python_scripting}" != xyes; then
+dnl         i_do_have_python_scripting=yes
+            AM_PATH_PYTHON([2.7],,[i_do_have_python_scripting=no])
+dnl         if test x"${i_do_have_python_scripting}" = xyes; then
+dnl            i_want_python_ver="2" dnl only 2.7+ available
+dnl         else
+               i_want_python_ver=
+dnl         fi
+dnl      else
+dnl         i_want_python_ver="3" might be 3 and 2 available
+dnl      fi
+      fi
+   fi
+fi
+# second, test for python-dev
+if test x"${i_do_have_python_scripting}" != xyes; then
+   i_want_python_ver=
+else
+   PKG_CHECK_MODULES([PYTHON],[python-"${PYTHON_VERSION}"], dnl   [PKG_CHECK_MODULES([PYTHONDEV],[python-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=maybe])],
+      [PKG_CHECK_MODULES([PYTHONDEV],[python-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=no])],
+      [i_do_have_python_scripting=no])
+dnl dnl TODO: have python3 AND python2, but only have python2 dev, but no python3 dev
+dnl if test x"${i_do_have_python_scripting}" = xmaybe; then
+dnl   if test x${i_want_python_ver} = xA; then
+dnl      i_want_python_ver="2"
+dnl      i_do_have_python_scripting=yes
+dnl      AM_PATH_PYTHON([2.7],,[i_do_have_python_scripting=no])
+dnl      if test x"${i_do_have_python_scripting}" = xyes; then
+dnl         PKG_CHECK_MODULES([PYTHONDEV],[python-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=no])
+dnl      fi
+dnl   else
+dnl      i_do_have_python_scripting=no
+dnl   fi
+dnl   i_want_python_ver=
+dnl fi
+   if test x"${i_do_have_python_scripting}" = xno; then
+      force_off_python_extension=yes
+   fi
+
+fi
+# third, check for header file in case older distro package info not enough
 if test x"${i_do_have_python_scripting}" = xyes -a x"${PYTHON_CFLAGS}" = x; then
    AC_CHECK_HEADER([python.h],[],[i_do_have_python_scripting=no])
 fi
@@ -91,6 +147,7 @@ AC_MSG_CHECKING([Build with Python support?])
 if test x"${enable_python_scripting}" = xyes; then
    if test x"${i_do_have_python_scripting}" = xyes; then
       AC_MSG_RESULT([yes])
+      i_want_python_ver="${PYTHON_VERSION}"
    else
       AC_MSG_FAILURE([ERROR: Please install the PYTHON Developer Package],[1])
    fi
@@ -99,22 +156,22 @@ else
       AC_MSG_RESULT([no])
       i_do_have_python_scripting=no
       i_do_have_python_extension=no
+      i_want_python_ver=
       AC_DEFINE([_NO_PYTHON],1,[Define if not using Python.])
       PYTHON_CFLAGS=""
       PYTHON_LIBS=""
    else
       AC_MSG_RESULT([yes])
+      i_want_python_ver="${PYTHON_VERSION}"
+
    fi
 fi
 AC_MSG_CHECKING([Build with Python extension modules "psMat" and "fontforge"?])
-if test x"${enable_python_extension}" = xyes; then
+if test x"${i_do_have_python_extension}" = xyes; then
    AC_MSG_RESULT([yes])
 else
    AC_MSG_RESULT([no])
 fi
-AC_MSG_CHECKING([python version is $PYTHON_VERSION])
-AC_MSG_RESULT([version])
-
 AC_SUBST([PYTHON_CFLAGS])
 AC_SUBST([PYTHON_LIBS])
 AM_CONDITIONAL([PYTHON_SCRIPTING],[test x"${i_do_have_python_scripting}" = xyes])

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -35,10 +35,27 @@ dnl do have python and developer files available, otherwise halt and let
 dnl user know that they must add python and python developer files too.
 AC_DEFUN([FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING_AND_EXTENSION],
 [
+i_want_python_dev=2.7
 AC_ARG_ENABLE([python-scripting],
-        [AS_HELP_STRING([--disable-python-scripting],[disable Python scripting])],
+        [AS_HELP_STRING([--disable-python-scripting],[disable Python scripting. If you
+        REQUIRE Python, then use --enable-python-scripting to force a yes for install.
+        If you want python>=3.3, then use --enable-python-scripting=3])],
         [i_do_have_python_scripting="${enableval}"; enable_python_scripting="${enableval}"],
         [i_do_have_python_scripting=yes; enable_python_scripting=check])
+AC_MSG_CHECKING([python script is $i_do_have_python_scripting and want is $want_python])
+AC_MSG_RESULT([ version])
+# default is to load python 2.7 or higher, but user requests 3.3 or higher
+if test i_do_have_python_scripting > 2; then
+   if test i_do_have_python_scripting > 3; then
+      i_want_python_dev=3.3
+   else
+      i_want_python_dev=2.7
+   fi
+   i_do_have_python_scripting=yes
+   enable_python_scripting=yes
+fi
+AC_MSG_CHECKING([python script is $i_do_have_python_scripting and want is $want_python])
+AC_MSG_RESULT([ version])
 AC_ARG_ENABLE([python-extension],
          [AS_HELP_STRING([--disable-python-extension],
                          [do not build the Python extension modules "psMat" and "fontforge",
@@ -52,10 +69,19 @@ if test x"${enable_python_extension}" = xyes; then
 fi
 # test for python and python-dev
 if test x"${i_do_have_python_scripting}" = xyes; then
-   AM_PATH_PYTHON([2.7],,[:])
+   AM_PATH_PYTHON([i_want_python_dev],,[:])
    PKG_CHECK_MODULES([PYTHON],[python-"${PYTHON_VERSION}"],
       [PKG_CHECK_MODULES([PYTHONDEV],[python-"${PYTHON_VERSION}"],,[i_do_have_python_scripting=no; force_off_python_extension=yes])],
       [i_do_have_python_scripting=no; force_off_python_extension=yes])
+   if ( PYTHON_VERSION >= 2.7; then
+      if ( PYTHON_VERSION >= 3.3; then
+         i_want_python_dev=3.3
+      else
+         i_want_python_dev=2.7
+      fi
+   else
+      i_want_python_dev=""
+   fi
 fi
 if test x"${i_do_have_python_scripting}" = xyes -a x"${PYTHON_CFLAGS}" = x; then
    AC_CHECK_HEADER([python.h],[],[i_do_have_python_scripting=no])
@@ -86,6 +112,9 @@ if test x"${enable_python_extension}" = xyes; then
 else
    AC_MSG_RESULT([no])
 fi
+AC_MSG_CHECKING([python version is $PYTHON_VERSION])
+AC_MSG_RESULT([version])
+
 AC_SUBST([PYTHON_CFLAGS])
 AC_SUBST([PYTHON_LIBS])
 AM_CONDITIONAL([PYTHON_SCRIPTING],[test x"${i_do_have_python_scripting}" = xyes])

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -25,14 +25,32 @@ fi
 ])
 
 
-dnl FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING
-dnl --------------------------------------
-AC_DEFUN([FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING],
+dnl FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING_AND_EXTENSION
+dnl ----------------------------------------------------
+dnl Add Python scripting by default and also add python extensions too.
+dnl If user says nothing, then assume yes unless python is not available.
+dnl First check if python and developer files are available, if yes, then
+dnl continue, however, if user indicates yes, then we must verify that we
+dnl do have python and developer files available, otherwise halt and let
+dnl user know that they must add python and python developer files too.
+AC_DEFUN([FONTFORGE_ARG_DISABLE_PYTHON_SCRIPTING_AND_EXTENSION],
 [
 AC_ARG_ENABLE([python-scripting],
         [AS_HELP_STRING([--disable-python-scripting],[disable Python scripting])],
         [i_do_have_python_scripting="${enableval}"; enable_python_scripting="${enableval}"],
         [i_do_have_python_scripting=yes; enable_python_scripting=check])
+AC_ARG_ENABLE([python-extension],
+         [AS_HELP_STRING([--disable-python-extension],
+                         [do not build the Python extension modules "psMat" and "fontforge",
+                          even if they were included in this source distribution])],
+         [i_do_have_python_extension="${enableval}"; enable_python_extension="${enableval}"],
+         [i_do_have_python_extension=yes; enable_python_extension=check])
+# force yes for python_scripting if user says yes for python_extension
+if test x"${enable_python_extension}" = xyes; then
+   i_do_have_python_scripting=yes
+   enable_python_scripting=yes
+fi
+# test for python and python-dev
 if test x"${i_do_have_python_scripting}" = xyes; then
    AM_PATH_PYTHON([2.7],,[:])
    PKG_CHECK_MODULES([PYTHON],[python-"${PYTHON_VERSION}"],
@@ -54,6 +72,7 @@ else
    if test x"${i_do_have_python_scripting}" = xno || test x"${enable_python_scripting}" = xno; then
       AC_MSG_RESULT([no])
       i_do_have_python_scripting=no
+      i_do_have_python_extension=no
       AC_DEFINE([_NO_PYTHON],1,[Define if not using Python.])
       PYTHON_CFLAGS=""
       PYTHON_LIBS=""
@@ -61,26 +80,15 @@ else
       AC_MSG_RESULT([yes])
    fi
 fi
+AC_MSG_CHECKING([Build with Python extension modules "psMat" and "fontforge"?])
+if test x"${enable_python_extension}" = xyes; then
+   AC_MSG_RESULT([yes])
+else
+   AC_MSG_RESULT([no])
+fi
 AC_SUBST([PYTHON_CFLAGS])
 AC_SUBST([PYTHON_LIBS])
 AM_CONDITIONAL([PYTHON_SCRIPTING],[test x"${i_do_have_python_scripting}" = xyes])
-])
-
-
-dnl FONTFORGE_ARG_DISABLE_PYTHON_EXTENSION
-dnl --------------------------------------
-AC_DEFUN([FONTFORGE_ARG_DISABLE_PYTHON_EXTENSION],
-[
-AC_ARG_ENABLE([python-extension],
-         [AS_HELP_STRING([--disable-python-extension],
-                         [do not build the Python extension modules "psMat" and "fontforge",
-                          even if they were included in this source distribution])],
-         [i_do_have_python_extension="${enableval}"],
-         [i_do_have_python_extension=yes])
-dnl don't try to make the module unless we have python
-if test x"${force_off_python_extension}" = xyes; then
-         i_do_have_python_extension=no
-fi
 AM_CONDITIONAL([PYTHON_EXTENSION],[test x"${i_do_have_python_extension}" = xyes])
 ])
 


### PR DESCRIPTION
Fix a long standing bug where configure does not differentiate between python (the interpreter), and python-dev which is required for adding scripting and extensions. This clarifies that configure
will check and quietly continue if no python is requested.
If user requests python scripting during configure, but there is no python dev package, then configure will HALT with an error.