### PR TITLE
Fix View -> Combinations -> Anchor Glyph at Point

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -7434,9 +7434,7 @@ static void CVMenuAPAttachSC(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)
     AnchorPoint *ap;
     AnchorClass *ac;
 
-    ap = mi->ti.userdata;
-    if ( ap==NULL )
-	for ( ap = cv->b.sc->anchor; ap!=NULL && !ap->selected; ap=ap->next );
+    for ( ap = cv->b.sc->anchor; ap!=NULL && !ap->selected; ap=ap->next );
     if ( ap==NULL )
 	ap = cv->b.sc->anchor;
     if ( ap==NULL )


### PR DESCRIPTION
It has been broken since 2007! (since commit b5ee0b3c1).

`mi->ti.userdata` is the `SplineChar` of the anchor point, not the anchor point itself. Seems to be a copypasta!

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
