### PR TITLE
Fix erroneous "rb" in strcmp

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -10105,7 +10105,7 @@ static void term(Context *c,Val *val) {
 			    free(val->u.sval);
 			    val->u.sval = ret;
 			}
-		    } else if ( strcmp(c->tok_text,"rb")==0 ) {
+		    } else if ( strcmp(c->tok_text,"r")==0 ) {
 			pt = strrchr(val->u.sval,'/');
 			if ( pt==NULL ) pt=val->u.sval;
 			ept = strrchr(pt,'.');


### PR DESCRIPTION
Introduced from 12f7ca9240affc892bc3e136df01f20a11de1733
