### PR TITLE
Revert "Apply a patch from Adrien for handling underline position better sans spurious whitespace changes."

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -5175,21 +5175,9 @@ static void readttfpostnames(FILE *ttf,struct ttfinfo *info) {
 	fseek(ttf,info->postscript_start,SEEK_SET);
 	format = getlong(ttf);
 	info->italicAngle = getfixed(ttf);
-    /*
-     * Due to the legacy of two formats, there are two underlinePosition
-     * attributes in an OpenType CFF font, one being stored in the CFF table.
-     * FontForge due to its pfa heritage will only keep the PostScript/CFF
-     * underlinePosition in the SplineFont so we'll calculate that here if we
-     * are indeed working on a TTF.
-     * If we have a CFF font, cffinfofillup() has already read the appropriate
-     * data and so we don't rewind it (if info->uwidth is odd we are possibly
-     * introducing a rounding error).
-     */
-	if (info->cff_start==0) {
 	info->upos = (short) getushort(ttf);
 	info->uwidth = (short) getushort(ttf);
-	info->upos -= info->uwidth/2;		/* 'post' defn of this field is different from FontInfo defn and I didn't notice */
-	}
+	info->upos += info->uwidth/2;		/* 'post' defn of this field is different from FontInfo defn and I didn't notice */
 	info->isFixedPitch = getlong(ttf);
 	/* mem1 = */ getlong(ttf);
 	/* mem2 = */ getlong(ttf);


### PR DESCRIPTION
This reverts commit 5aa59fb77c642ee80b4ed16f9136182a3220576b.

The commit broke reading the rest of the post table for CFF fonts since
the two fields are not properly skipped when read. Furthermore in
OpenType the values in post table are authoritative over the CFF table,
so the old behaviour before this commit was correct.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)