### PR TITLE
Allow passing a font object to mergeFonts()

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -4832,8 +4832,8 @@ pen = None;				# Finalize the pen. This tells FontForge
     </TR>
     <TR>
       <TD><CODE>mergeFonts</CODE></TD>
-      <TD><CODE>(filename[,<BR>
-	preserveCrossFontKerning])</CODE></TD>
+      <TD><CODE>(filename[,preserveCrossFontKerning])<BR>
+                (font[,preserveCrossFontKerning])</CODE></TD>
       <TD>Merges the font in the file into the current font.</TD>
     </TR>
     <TR>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -16100,15 +16100,22 @@ static PyObject *PyFFFont_MergeFonts(PyFF_Font *self, PyObject *args) {
 return (NULL);
     fv = self->fv;
     if ( !PyArg_ParseTuple(args,"es|ii","UTF-8",&filename,
-	    &preserveCrossFontKerning, &openflags) )
+	    &preserveCrossFontKerning, &openflags) ) {
+	PyFF_Font *other;
+	PyErr_Clear();
+	if ( !PyArg_ParseTuple(args,"O!|i",&PyFF_FontType,&other,
+		&preserveCrossFontKerning) || CheckIfFontClosed(other) )
 return( NULL );
-    locfilename = utf82def_copy(filename);
-    PyMem_Free(filename);
-    sf = LoadSplineFont(locfilename,openflags);
-    if ( sf==NULL ) {
-	PyErr_Format(PyExc_EnvironmentError, "No font found in file \"%s\"", locfilename);
-	free(locfilename);
+	sf = other->fv->sf;
+    } else {
+	locfilename = utf82def_copy(filename);
+	PyMem_Free(filename);
+	sf = LoadSplineFont(locfilename,openflags);
+	if ( sf==NULL ) {
+	    PyErr_Format(PyExc_EnvironmentError, "No font found in file \"%s\"", locfilename);
+	    free(locfilename);
 return( NULL );
+	}
     }
     free(locfilename);
     if ( sf->fv==NULL )


### PR DESCRIPTION
Allow passing a font object to `mergeFonts()`, so that one can merge an already opened font instead of having to save it to the disk first.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)