### PR TITLE
Sensibly extend python interface for point selection. 

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -935,13 +935,38 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD><CODE>on_curve</CODE></TD>
-      <TD colspan=2>Whether this is an on curve point or an off curve point (a
-	control point)</TD>
+      <TD colspan=2>True for a point on the curve and false for (in the
+      case of a cubic contour) a control point.</TD>
     </TR>
     <TR>
       <TD><CODE>selected</CODE></TD>
-      <TD colspan=2>Whether this point is selected in the UI. If an off-curve point
-	is selected in means the preceding (interpolated) on-curve point is selected.</TD>
+      <TD colspan=2>For an on-curve point, whether it is selected.
+	For a control point, whether its on-curve point is selected.
+	<P>Most transformations of on-curve points should also include
+	their control points. The <CODE>selected</CODE> flag makes it easier
+	to pick all relevant points using on-curve selection.
+        <P>Setting or clearing the flag will change the selection status of
+	an on-curve point but have no effect for an off-curve point.
+	<P>For quadratic points off-curve points, selected should be true
+	if the preceding <em>interpolated</em> on-curve point is selected. 
+      </TD>
+    </TR>
+    <TR>
+      <TD><CODE>highlighted</CODE></TD>
+      <TD colspan=2>For an on-curve point this will be false. For an off-curve
+	point, whether it is selected.
+	<P>The <CODE>highlighted</CODE> flag can be used when the selection
+	status of a cubic control point is relevant in the python interface.
+	If, for example, a transformation should include all selected on-curve
+	points and their associated off-curve points, and also any additional
+	selected off-curve points, the script can use <CODE>p.selected or
+	p.highlighted</CODE>
+        <P>Setting or clearing the flag will change the selection status of
+	a control point but have no effect for an on-curve point.
+	<P>This interface is only partially implemented for quadratic
+	contours, and some selected off-curve points may not be marked
+	correctly. 
+      </TD>
     </TR>
     <TR>
       <TD><CODE>name</CODE></TD>

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -1528,10 +1528,12 @@ static void note_nested_lookups_used_twice(OTLookup *base) {
 		otl->lookup_type==gpos_context || otl->lookup_type==gpos_contextchain ) {
 	    for ( sub = otl->subtables; sub!=NULL; sub=sub->next ) {
 		FPST *fpst = sub->fpst;
-		for ( r=0; r<fpst->rule_cnt; ++r ) {
-		    for ( s=0; s<fpst->rules[r].lookup_cnt; ++s ) {
-			OTLookup *nested = fpst->rules[r].lookups[s].lookup;
-			++ nested->lookup_length;
+		if (fpst != NULL) {
+		    for ( r=0; r<fpst->rule_cnt; ++r ) {
+			for ( s=0; s<fpst->rules[r].lookup_cnt; ++s ) {
+			    OTLookup *nested = fpst->rules[r].lookups[s].lookup;
+			    ++ nested->lookup_length;
+			}
 		    }
 		}
 	    }

--- a/fontforge/ffpython.h
+++ b/fontforge/ffpython.h
@@ -112,6 +112,7 @@ typedef struct ff_point {
     float x,y;
     uint8 on_curve;
     uint8 selected;
+    uint8 highlighted;
     char *name;
 } PyFF_Point;
 static PyTypeObject PyFF_PointType;

--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -975,13 +975,15 @@ static void RemoveNestedReferences(SplineFont *sf,int isgpos) {
 		otl->lookup_type==gpos_context || otl->lookup_type==gpos_contextchain ) {
 	    for ( sub=otl->subtables; sub!=NULL; sub=sub->next ) {
 		FPST *fpst = sub->fpst;
-		for ( i=0; i<fpst->rule_cnt; ++i ) {
-		    for ( j=0; j<fpst->rules[i].lookup_cnt; ++j ) {
-			if ( fpst->rules[i].lookups[j].lookup == otl ) {
-			    for ( k=j+1; k<fpst->rules[i].lookup_cnt; ++k )
-				fpst->rules[i].lookups[k-1] = fpst->rules[i].lookups[k];
-			    --fpst->rules[i].lookup_cnt;
-			    --j;
+		if (fpst!=NULL) {
+		    for ( i=0; i<fpst->rule_cnt; ++i ) {
+			for ( j=0; j<fpst->rules[i].lookup_cnt; ++j ) {
+			    if ( fpst->rules[i].lookups[j].lookup == otl ) {
+				for ( k=j+1; k<fpst->rules[i].lookup_cnt; ++k )
+				    fpst->rules[i].lookups[k-1] = fpst->rules[i].lookups[k];
+				--fpst->rules[i].lookup_cnt;
+				--j;
+			    }
 			}
 		    }
 		}
@@ -3065,6 +3067,8 @@ static int ContextualMatch(struct lookup_subtable *sub,struct lookup_data *data,
     int lookup_flags = sub->lookup->lookup_flags;
     const char *pt;
 
+    if (fpst==NULL)
+        return 0;
     /* If we should skip the current glyph then don't try for a match here */
     cpos = skipglyphs(lookup_flags,data,pos);
     if ( cpos!=pos )
@@ -4157,10 +4161,12 @@ static void AddOTLToSllk(struct sllk *sllk, OTLookup *otl, struct scriptlanglist
 	struct lookup_subtable *sub;
 	for ( sub=otl->subtables; sub!=NULL; sub=sub->next ) {
 	    FPST *fpst = sub->fpst;
-	    for ( j=0; j<fpst->rule_cnt; ++j ) {
-		struct fpst_rule *r = &fpst->rules[j];
-		for ( k=0; k<r->lookup_cnt; ++k )
-		    AddOTLToSllk(sllk,r->lookups[k].lookup,sl);
+	    if (fpst!=NULL) {
+		for ( j=0; j<fpst->rule_cnt; ++j ) {
+		     struct fpst_rule *r = &fpst->rules[j];
+		     for ( k=0; k<r->lookup_cnt; ++k )
+			AddOTLToSllk(sllk,r->lookups[k].lookup,sl);
+		}
 	    }
 	}
     }


### PR DESCRIPTION

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.

Most of the time you perform a transformation on or otherwise fiddle with a subset of points, you select a set of "base" points and then use all the control points that come with them (I'm taking the "base" terminology from the `Get Info...` point dialog). This is how the `Transform ...` dialog works, for example. 

The existing python "Point" interface says this about the `selected` flag:

> Whether this point is selected in the UI. If an off-curve point is selected it means the preceding (interpolated) on-curve point is selected.

The "interpolated" is a clue that this documentation is quadratic-contour specific. In fact, for cubic
contours only base points are marked selected and control points never are. 

It would be easy to extend the `selected` flag to correspond to whether a control point is selected. But most of the time that's not what you want to know -- you want to know whether the control point's base point is selected. You can get that information but it's a pain -- you have to scan back and forward in the contour's point list, deal with missing control points on straight lines, and so forth. Until the interface is extended more radically so that a control point has a reference to its base point, it's better to just supply the information needed most of the time. 

What I have done in this push is:

1. Extended the meaning of `selected` for control points to be true if the base point is selected and false otherwise.
2. Added a `highlighted` flag that is always false for base points but true for a control point if it is selected.

Selected is also writable for base points and highlighted for control points. Here are some demonstration menu items:

```
import fontforge
import psMat
import math

def regGlyph(fn, ms, sc = None):
    fontforge.registerMenuItem(fn, None, None, "Glyph", sc, ms)

def getSF():
    ss = fontforge.askString("Scale Factor", "Enter one 1-based scale factor or two x y scale factors separated by space")
    sa = ss.split(' ')
    if len(sa) == 1:
        sx = sy = float(sa[0])
    else:
        sx = float(sa[0])
        sy = float(sa[1])
    return (sx, sy)

def scaleSelectedbyContour(junk, glyph):
    l = glyph.layers[1]
    glyph.preserveLayerAsUndo(1)
    sf = getSF()
    for c in l:
        cbb = c.boundingBox()
        tr = psMat.translate(-(cbb[0]+cbb[2]/2), -(cbb[1]+cbb[3])/2)
        tr = psMat.compose(tr, psMat.scale(sf[0], sf[1]))
        tr = psMat.compose(tr, psMat.translate((cbb[0]+cbb[2]/2), (cbb[1]+cbb[3])/2))
        for p in c:
            if p.selected or p.highlighted:
                p.transform(tr)
    glyph.layers[1] = l

def revHighlight(junk, glyph):
    l = glyph.layers[1]
    glyph.preserveLayerAsUndo(1)
    for c in l:
        for p in c:
            if not p.on_curve:
                p.highlighted = not p.highlighted
    glyph.layers[1] = l

def revSelect(junk, glyph):
    l = glyph.layers[1]
    glyph.preserveLayerAsUndo(1)
    for c in l:
        for p in c:
            if p.on_curve:
                p.selected = not p.selected
    glyph.layers[1] = l

regGlyph(scaleSelectedbyContour, "Scale Selected by Contour")
regGlyph(revHighlight, "Reverse selection of control points")
regGlyph(revSelect, "Reverse selection of base points")
```
`scaleSelectedByContour` will prompt for one or two dimensions (1 rather than 100 based, separated by a space if two) that scales selected points in relation to the center of their contour. With base points all control points are included in the transformation. But if additional control points are selected (and their base points carefully de-selected), they will also scale. Note the simple logic for accomplishing this.

The other two functions demonstrate that the selected status can also be updated, which can be used to chain functions or to support "selection macros" for easier hand-manipulation.

I updated the documentation to reflect these changes. 

The Spiro system already has a separate interface, which these changes do not affect. I tried to make the `highlighted` flag consistent for quadratic contours as well, but the since the control points are "shared" it appears that there are subtle rules for which on-curve point stores the selected status that I couldn't decipher (in a short time looking). However, the whole system seems like a mess for quadratic curves anyway, so I'm not sure this really hurts anything.

Given that I did change the meaning of `selected` for cubic curve points, this is a change rather than a mere addition. However, given that spent several hours changing no points at all, before learning by Googling widely that the trick is updating the layer, I'm not sure how many scripts out the world might break with this change. In any case, the value is always false-evaluable in the current implementation for cubics.

* The interface is sort of implicit in the instructions for `preserveLayerAsUndo`, but pretty mysterious otherwise. 

With all my pull requests, but especially this one, I'm happy to try to implement alternative designs as suggested. 

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [ x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.
