### PR TITLE
Clarify Xwindows OR GDK when choosing to use FontForge with a GUI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
       - deadsnakes
     packages: [autoconf, automake, autotools-dev, bzip2, gcc-7, libtool,
       libjpeg-dev, libtiff4-dev, libpng12-dev, libfreetype6-dev, libgif-dev,
-      libx11-dev, libxml2-dev, libpango1.0-dev, libcairo2-dev, python3.6-dev, lcov]
+      libx11-dev, libxml2-dev, libpango1.0-dev, libpangoxft-1.0-dev, libcairo2-dev, python3.6-dev, lcov]
   coverity_scan:
     project:
       name: "fontforge/fontforge"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
       - deadsnakes
     packages: [autoconf, automake, autotools-dev, bzip2, gcc-7, libtool,
       libjpeg-dev, libtiff4-dev, libpng12-dev, libfreetype6-dev, libgif-dev,
-      libx11-dev, libxml2-dev, libpango1.0-dev, libpangoxft-1.0-dev, libcairo2-dev, python3.6-dev, lcov]
+      libx11-dev, libxml2-dev, libpango1.0-dev, libpangox-1.0-dev, libcairo2-dev, python3.6-dev, lcov]
   coverity_scan:
     project:
       name: "fontforge/fontforge"

--- a/configure.ac
+++ b/configure.ac
@@ -419,7 +419,15 @@ if test x"${have_glib}" != xpkg; then
 fi
 
 if test x"${i_do_have_x}" = xyes; then
-   PKG_CHECK_MODULES([PANGO],[pango >= 1.10 pangoxft])
+   # pango depends on glib2. Required by GUI for {cairo or gtk/gtk2 or Mac CoreText}
+   # pangoxft is submodule of pango (used in gxcdraw) (there are other versions of Xft)
+   PKG_CHECK_MODULES([PANGO],[pango >= 1.10 pangoft2 pangoxft])
+   have_libpango=no
+   AC_CHECK_HEADER([pangoxft.h],
+      AC_CHECK_FUNC([pango_xft_get_font_map],[have_libpango=yes]))
+   if test x"${have_libpango}" != xyes; then
+      AC_MSG_FAILURE([ERROR: Please install Developer version of pango, pangoft2, pangoxft.],[1])
+   fi
 fi
 
 PKG_CHECK_MODULES([FREETYPE],[freetype2 >= 2.3.7])
@@ -936,7 +944,6 @@ Summary of optional features:
 Summary of optional dependencies:
 
 Optional Library	UseIt?	HaveIt?	WebsiteURL
-  cairo			${with_cairo}	${i_do_have_cairo}	${cairo_url}
   giflib		${with_giflib}	${i_do_have_giflib}	${giflib_url}
   libjpeg		${with_libjpeg}	${i_do_have_libjpeg}	${libjpeg_url}
   libpng		${with_libpng}	${i_do_have_libpng}	${libpng_url}
@@ -945,10 +952,13 @@ Optional Library	UseIt?	HaveIt?	WebsiteURL
   libtiff		${with_libtiff}	${i_do_have_libtiff}	${libtiff_url}
   libuninameslist	${with_libuninameslist}	${i_do_have_libuninameslist}	${libuninameslist_url}
   python-dev		${enable_python_scripting}	${i_do_have_python_scripting}	${python_url}
-  zeromq (libzmq)		${i_do_have_libzmq}	${libzmq_url}
   woff2			${fontforge_can_use_woff2}	${fontforge_has_woff2}	${woff2_url}
+
+Graphical UI Choices	UseIt?	HaveIt?	WebsiteURL
   X Window System		${i_do_have_x}	${libxorg_url}
+    cairo		${with_cairo}	${i_do_have_cairo}	${cairo_url}
   GDK backend		${fontforge_can_use_gdk}	${fontforge_gdk_version}	${gdk_url}
+  zeromq (libzmq)		${i_do_have_libzmq}	${libzmq_url}
 ])
 
 #--------------------------------------------------------------------------

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -198,8 +198,13 @@ fi
 
 dnl FONTFORGE_ARG_ENABLE_GDK
 dnl ------------------------
+dnl The default action  is to check for Xwindows and use it if available,
+dnl but this can be overridden by using --enable-gdk to use gdk2 or gdk3.
+dnl If no option {gdk2/gdk3} is specified, then the default is to try use
+dnl gdk3. If no gdk development module is found then come to a hard stop.
 AC_DEFUN([FONTFORGE_ARG_ENABLE_GDK],
 [
+fontforge_gdk_version=no
 AC_ARG_ENABLE([gdk],
         [AS_HELP_STRING([--enable-gdk=TYPE],
                 [Enable the GDK GUI backend. TYPE is either gdk2 or gdk3.])],
@@ -214,7 +219,7 @@ if test x$use_gdk = xyes ; then
             AC_MSG_NOTICE([building the GUI with the GDK2 backend...])
         ],
         [
-            AC_MSG_ERROR([Cannot build GDK backend without GDK installed.])
+            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GDK2 Developer Package.])
         ])
     else
         PKG_CHECK_MODULES([GDK],[gdk-3.0 >= 3.10],
@@ -225,7 +230,7 @@ if test x$use_gdk = xyes ; then
             AC_MSG_NOTICE([building the GUI with the GDK3 backend...])
         ],
         [
-            AC_MSG_ERROR([Cannot build GDK backend without GDK installed.])
+            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GDK3 Developer Package.])
         ])
     fi
 else


### PR DESCRIPTION
GDK graphical backend was recently added, and we need to organize the
options as a list to show users two GUI choices.

GDK brings its' own copies of pango and cairo, but X has the choice of
including cairo, so we show cairo as a subset of X (Pango required).
Add some more info for pango (see issues #2734, #2968, where's xft?),
and do extra header and function checks for distros that forget to go
look into /usr/local.
GDK is of better interest on the Mac, so issue #3077 not as important.

Put collab in the GUI section of the list since it is not used in the
command line version of FontForge.