### PR TITLE
Upgrade libunicode functions to avoid segfaults or other errors.

### DIFF
--- a/Unicode/memory.c
+++ b/Unicode/memory.c
@@ -47,11 +47,10 @@ char *copyn(const char *str,long n) {
      *      https://github.com/fontforge/fontforge/issues/1239
      */
     char *ret;
-    if ( str==NULL )
-    	return( NULL );
-
-    ret = (char *) malloc(n+1);
-    memcpy(ret,str,n);
-    ret[n]='\0';
-    return( ret );
+    if ( str!=NULL && ++n>0 && (ret=(char *)(malloc(n)))!=NULL ) {
+	if ( (--n) ) memcpy(ret,str,n);
+	ret[n]='\0';
+	return( ret );
+    }
+    return( NULL );
 }

--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -845,7 +845,7 @@ long utf8_strlen(const char *utf8_str) {
     long len = 0;
 
     while ( utf8_ildb(&utf8_str)>0 && ++len>0 );
-    return( len );
+    return( len < 0 ? -1 : len );
 }
 
 long utf82u_strlen(const char *utf8_str) {
@@ -856,7 +856,7 @@ long utf82u_strlen(const char *utf8_str) {
     while ( (ch = utf8_ildb(&utf8_str))>0 && ++len>0 )
 	if ( ch>=0x10000 )
 	    ++len;
-    return( len );
+    return( len < 0 ? -1 : len );
 }
 
 void utf8_strncpy(register char *to, const char *from, int len) {

--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -323,7 +323,7 @@ unichar_t *u_copynallocm(const unichar_t *pt, long n, long m) {
     if ( pt && ++n>0 && ++m>0 && m>=n ) {
 #ifdef MEMORY_MASK
 	if ( n>MEMORY_MASK/sizeof(unichar_t) )
-	    n = MEMORY_MASK/sizeof(unichar_t)-1;
+	    n = MEMORY_MASK/sizeof(unichar_t);
 #endif
 	if ( (res=(unichar_t *)(calloc(m,sizeof(unichar_t)))) ) {
 	    if ( (--n) ) memcpy(res,pt,n*sizeof(unichar_t));
@@ -355,38 +355,40 @@ return( u_copy( s1 ));
 return( pt );
 }
 
-unichar_t *uc_copyn(const char *pt,int len) {
-    unichar_t *res, *rpt;
+unichar_t *uc_copyn(const char *pt, int n) {
+/* Copy n unsigned chars{0..255} to a unichar_t type */
+/* string. If not printable, return an empty string. */
+    unichar_t *res, *rpt, t;
 
-    if(!pt)
-return((unichar_t *)0);
-
+    if ( pt && ++n>0 ) {
 #ifdef MEMORY_MASK
-    if ( (len+1)*sizeof(unichar_t)>=MEMORY_MASK )
-	len = MEMORY_MASK/sizeof(unichar_t)-1;
+	if ( n>MEMORY_MASK/sizeof(unichar_t) )
+	    n = MEMORY_MASK/sizeof(unichar_t);
 #endif
-    res = (unichar_t *) malloc((len+1)*sizeof(unichar_t));
-    for ( rpt=res; --len>=0 ; *rpt++ = *(unsigned char *) pt++ );
-    *rpt = '\0';
-return(res);
+	if ( (res=rpt=(unichar_t *)(malloc(n*sizeof(unichar_t)))) ) {
+	    if ( (--n) ) {
+		while ( --n>=0 ) {
+		    t = (unichar_t)(*(unsigned char *) pt++);
+		    *rpt++ = t & 0xff;
+		}
+	    }
+	    *rpt = 0;
+	    return( res );
+	}
+    }
+    return( calloc(1,sizeof(unichar_t)) );
 }
 
 unichar_t *uc_copy(const char *pt) {
+/* Copy unsigned char{0..255} string to unichar type */
+/* string. If not printable, return an empty string. */
     unichar_t *res, *rpt;
     int n;
 
-    if(!pt)
-return((unichar_t *)0);
+    if ( pt && (n=strlen(pt))>0 )
+	return( uc_copyn(pt,n) );
 
-    n = strlen(pt);
-#ifdef MEMORY_MASK
-    if ( (n+1)*sizeof(unichar_t)>=MEMORY_MASK )
-	n = MEMORY_MASK/sizeof(unichar_t)-1;
-#endif
-    res = (unichar_t *) malloc((n+1)*sizeof(unichar_t));
-    for ( rpt=res; --n>=0 ; *rpt++ = *(unsigned char *) pt++ );
-    *rpt = '\0';
-return(res);
+    return( calloc(1,sizeof(unichar_t)) );
 }
 
 char *cu_copyn(const unichar_t *pt,int len) {

--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -301,26 +301,36 @@ return( NULL );
 
 unichar_t *u_copyn(const unichar_t *pt, long n) {
     unichar_t *res;
+
+    if ( pt && ++n>0 ) {
 #ifdef MEMORY_MASK
-    if ( n*sizeof(unichar_t)>=MEMORY_MASK )
-	n = MEMORY_MASK/sizeof(unichar_t)-1;
+	if ( n>MEMORY_MASK/sizeof(unichar_t) )
+	    n = MEMORY_MASK/sizeof(unichar_t);
 #endif
-    res = (unichar_t *) malloc((n+1)*sizeof(unichar_t));
-    memcpy(res,pt,n*sizeof(unichar_t));
-    res[n]='\0';
-return(res);
+	if ( (res=(unichar_t *)(malloc(n*sizeof(unichar_t)))) ) {
+	    if ( (--n) ) memcpy(res,pt,n*sizeof(unichar_t));
+	    res[n] = 0;
+	    return( res );
+	}
+    }
+    return( NULL );
 }
 
 unichar_t *u_copynallocm(const unichar_t *pt, long n, long m) {
+/* Alloc space for m unichar chars and copy n unichar chars */
     unichar_t *res;
+
+    if ( pt && ++n>0 && ++m>0 && m>=n ) {
 #ifdef MEMORY_MASK
-    if ( n*sizeof(unichar_t)>=MEMORY_MASK )
-	n = MEMORY_MASK/sizeof(unichar_t)-1;
+	if ( n>MEMORY_MASK/sizeof(unichar_t) )
+	    n = MEMORY_MASK/sizeof(unichar_t)-1;
 #endif
-    res = malloc((m+1)*sizeof(unichar_t));
-    memcpy(res,pt,n*sizeof(unichar_t));
-    res[n]='\0';
-return(res);
+	if ( (res=(unichar_t *)(calloc(m,sizeof(unichar_t)))) ) {
+	    if ( (--n) ) memcpy(res,pt,n*sizeof(unichar_t));
+	    return( res );
+	}
+    }
+    return( NULL );
 }
 
 unichar_t *u_copy(const unichar_t *pt) {

--- a/inc/ustring.h
+++ b/inc/ustring.h
@@ -40,7 +40,7 @@ extern unichar_t *u_copynallocm(const unichar_t *pt, long n, long m);
 extern unichar_t *uc_copyn(const char *, int);
 extern unichar_t *uc_copy(const char*);
 extern unichar_t *u_concat(const unichar_t*,const unichar_t*);
-extern char      *cu_copyn(const unichar_t *pt,int len);
+extern char      *cu_copyn(const unichar_t *pt,int n);
 extern char      *cu_copy(const unichar_t*);
 
 extern long uc_strcmp(const unichar_t *,const char *);


### PR DESCRIPTION
Check values coming into copyn functions before processing data to avoid segfaults and/or other errors.