### PR TITLE
Correct backend for python makeFirst and add bounds/sanity checking

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -2842,13 +2842,21 @@ static PyObject *PyFFContour_MakeFirst(PyFF_Contour *self, PyObject *args) {
     PyFF_Point **temp, **old;
 
     if ( !PyArg_ParseTuple( args, "i", &pos ))
-return( NULL );
+	return( NULL );
+    if ( pos<0 || pos>=self->pt_cnt ) {
+	PyErr_Format(PyExc_TypeError, "Position argument out of bounds");
+	return( NULL );
+    }
+    if ( ! self->points[pos]->on_curve ) {
+	PyErr_Format(PyExc_TypeError, "First point must be on curve");
+	return( NULL );
+    }
 
     temp = PyMem_New(PyFF_Point *,self->pt_max);
     old = self->points;
     for ( i=pos; i<self->pt_cnt; ++i )
 	temp[i-pos] = old[i];
-    off = i;
+    off = i-pos;
     for ( i=0; i<pos; ++i )
 	temp[i+off] = old[i];
     self->points = temp;


### PR DESCRIPTION
Apparently I am the first person to try to use makeFirst from python. Or anyway the first person since it written as it is now. The method was incorrectly calculating the pair copy offset for the second part of the list. This corrects that and adds some bounds checking. It also prevents the user from making an off-curve point the first point, which shouldn't be possible in the GUI and would anyway not make sense.

(I considered adding negative end-indexing or doing something similar to InsertPoint, but InsertPoint does not provide negative end-indexing and just defaulting to making the first point the last doesn't make much sense -- most of the time that will be an off-curve point. So best to know what you're doing with this function and offset from the end yourself when pertinent.)

Here is a little zip file with a short python test and an sfd file to run it on: 

[makefirsttest.zip](https://github.com/fontforge/fontforge/files/2542188/makefirsttest.zip)

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.
