### PR TITLE
Fix segfault when trying to open some UFO font files

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -3495,6 +3495,8 @@ int SFLFindOrder(SplineFont *sf, int layerdest) {
     int i, ret;
 
     for ( i=0; i<sf->glyphcnt; ++i ) if ( sf->glyphs[i]!=NULL ) {
+            if (layerdest >= sf->glyphs[i]->layer_cnt)
+                continue;
 	ret = SPLFindOrder(sf->glyphs[i]->layers[layerdest].splines);
 	if ( ret!=-1 )
 return( ret );


### PR DESCRIPTION
This is a patch received on Debian bug#912062¹. It would be good to get a review from upstream on the same.

¹ https://bugs.debian.org/912062

