### PR TITLE
Clarify Xwindows OR GDK when choosing to use FontForge with a GUI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,8 @@ AC_PREREQ([2.68])
 #--------------------------------------------------------------------------
 # PackageTimestamp version
 m4_define([fontforge_package_stamp], [20170731])
+# reminder: When updating FontForge, also take note of desktop/* dates and
+# startnoui.c, startui.c
 #--------------------------------------------------------------------------
 # Making point releases:
 #   fontforge_major_version += 0;
@@ -936,7 +938,6 @@ Summary of optional features:
 Summary of optional dependencies:
 
 Optional Library	UseIt?	HaveIt?	WebsiteURL
-  cairo			${with_cairo}	${i_do_have_cairo}	${cairo_url}
   giflib		${with_giflib}	${i_do_have_giflib}	${giflib_url}
   libjpeg		${with_libjpeg}	${i_do_have_libjpeg}	${libjpeg_url}
   libpng		${with_libpng}	${i_do_have_libpng}	${libpng_url}
@@ -945,10 +946,13 @@ Optional Library	UseIt?	HaveIt?	WebsiteURL
   libtiff		${with_libtiff}	${i_do_have_libtiff}	${libtiff_url}
   libuninameslist	${with_libuninameslist}	${i_do_have_libuninameslist}	${libuninameslist_url}
   python-dev		${enable_python_scripting}	${i_do_have_python_scripting}	${python_url}
-  zeromq (libzmq)		${i_do_have_libzmq}	${libzmq_url}
   woff2			${fontforge_can_use_woff2}	${fontforge_has_woff2}	${woff2_url}
+
+Graphical UI Choices	UseIt?	HaveIt?	WebsiteURL
   X Window System		${i_do_have_x}	${libxorg_url}
+    cairo		${with_cairo}	${i_do_have_cairo}	${cairo_url}
   GDK backend		${fontforge_can_use_gdk}	${fontforge_gdk_version}	${gdk_url}
+  zeromq (libzmq)		${i_do_have_libzmq}	${libzmq_url}
 ])
 
 #--------------------------------------------------------------------------

--- a/fontforgeexe/startnoui.c
+++ b/fontforgeexe/startnoui.c
@@ -83,7 +83,7 @@ int fontforge_main( int argc, char **argv ) {
     extern const char *source_version_str;
     extern const char *source_modtime_str;
 
-    fprintf( stderr, "Copyright (c) 2000-2014 by George Williams. See AUTHORS for Contributors.\n" );
+    fprintf( stderr, "Copyright (c) 2000-2018 by George Williams. See AUTHORS for Contributors.\n" );
     fprintf( stderr, " License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n" );
     fprintf( stderr, " with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.\n" );
     fprintf( stderr, " Based on sources from %s"

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -909,7 +909,7 @@ int fontforge_main( int argc, char **argv ) {
     }
 
     if (!quiet) {
-        fprintf( stderr, "Copyright (c) 2000-2014 by George Williams. See AUTHORS for Contributors.\n" );
+        fprintf( stderr, "Copyright (c) 2000-2018 by George Williams. See AUTHORS for Contributors.\n" );
         fprintf( stderr, " License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n" );
         fprintf( stderr, " with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.\n" );
         fprintf( stderr, " Based on sources from %s"

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -219,7 +219,7 @@ if test x$use_gdk = xyes ; then
             AC_MSG_NOTICE([building the GUI with the GDK2 backend...])
         ],
         [
-            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GDK Developer Package.])
+            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GTK+ Developer Package.])
         ])
     else
         PKG_CHECK_MODULES([GDK],[gdk-3.0 >= 3.10],
@@ -230,7 +230,7 @@ if test x$use_gdk = xyes ; then
             AC_MSG_NOTICE([building the GUI with the GDK3 backend...])
         ],
         [
-            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GDK Developer Package.])
+            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GTK+ Developer Package.])
         ])
     fi
 else

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -198,8 +198,13 @@ fi
 
 dnl FONTFORGE_ARG_ENABLE_GDK
 dnl ------------------------
+dnl The default action  is to check for Xwindows and use it if available,
+dnl but this can be overridden by using --enable-gdk to use gdk2 or gdk3.
+dnl If no option {gdk2/gdk3} is specified, then the default is to try use
+dnl gdk3. If no gdk development module is found then come to a hard stop.
 AC_DEFUN([FONTFORGE_ARG_ENABLE_GDK],
 [
+fontforge_gdk_version=no
 AC_ARG_ENABLE([gdk],
         [AS_HELP_STRING([--enable-gdk=TYPE],
                 [Enable the GDK GUI backend. TYPE is either gdk2 or gdk3.])],
@@ -214,7 +219,7 @@ if test x$use_gdk = xyes ; then
             AC_MSG_NOTICE([building the GUI with the GDK2 backend...])
         ],
         [
-            AC_MSG_ERROR([Cannot build GDK backend without GDK installed.])
+            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GDK Developer Package.])
         ])
     else
         PKG_CHECK_MODULES([GDK],[gdk-3.0 >= 3.10],
@@ -225,7 +230,7 @@ if test x$use_gdk = xyes ; then
             AC_MSG_NOTICE([building the GUI with the GDK3 backend...])
         ],
         [
-            AC_MSG_ERROR([Cannot build GDK backend without GDK installed.])
+            AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GDK Developer Package.])
         ])
     fi
 else


### PR DESCRIPTION
GDK graphical backend was recently added, and we need to organize options as a list to show users two GUI choices to avoid confusion of thinking you need to include everything to build with a GUI.

This sort of closes #3353 by helping the user identify differences in ./configure
...will have to leave the pango.xft checks of #3353 for resolving later.

This also updates a few values to 2018 (closes #3220), and adds a reminder in configure.ac for when we build next release to check files and update dates accordingly.