### PR TITLE
Fix viewBox in exported SVG glyph

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1049,9 +1049,11 @@ return( 0 );
 return( ret );
 }
 
+#define SVGMINLRPAD 10
+
 int _ExportSVG(FILE *svg,SplineChar *sc,int layer) {
     char *end;
-    int em_size;
+    int em_size, xstart, xend;
     DBounds b;
 
     SplineCharLayerFindBounds(sc,layer,&b);
@@ -1064,8 +1066,19 @@ int _ExportSVG(FILE *svg,SplineChar *sc,int layer) {
     switch_to_c_locale(&tmplocale, &oldlocale); // Switch to the C locale temporarily and cache the old locale.
     fprintf(svg, "<?xml version=\"1.0\" standalone=\"no\"?>\n" );
     fprintf(svg, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" >\n" );
-    fprintf(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"0 0 %d %d\">\n",
-	    (int) ceil(sc->width), (int) ceil(em_size));
+    // Adjust horizontal ViewBox to display entire glyph 
+    xstart = floor(b.minx);
+    if (xstart > SVGMINLRPAD)
+	xstart = 0; // Start from origin when sufficiently past it
+    else
+	xstart -= SVGMINLRPAD; // Give glyphs starting near or before the origin some extra space
+    xend = ceil(b.maxx);
+    if (xend < ceil(sc->width) - SVGMINLRPAD)
+	xend = ceil(sc->width); // End at the advance width when sufficiently short of it
+    else
+	xend += SVGMINLRPAD; // Give glyphs ending near or past the advance width some extra space
+    fprintf(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"%d 0 %d %d\">\n",
+	    xstart, xend - xstart, (int) ceil(em_size));
     fprintf(svg, "  <g transform=\"matrix(1 0 0 -1 0 %d)\">\n",
 	    sc->parent->ascent );
     if ( sc->parent->multilayer || sc->parent->strokedfont || !svg_sc_any(sc,layer)) {


### PR DESCRIPTION
This push request started out as a fix for the vertical alignment of the ViewBox in exported glyph SVGs, and the earlier comments relate to that issue. Request #3428 now fills that role and has a copy of the original description that appeared here. 

This request can now serve as a place to work out what the exported format *should* be, and perhaps could be given sufficient warning. Some desirable features are:

1. All of every glyph, or all of almost every glyph, is visible when opening the SVG in a standard tool. 
2. The left and right side bearings:
    1. are maintained by an export/import cycle through SVG
    2. can be extracted by a script without too much difficulty.
    3. will or could be displayed in sister tools
3. The italic slant and perhaps other metrics are also "available" in the SVG.

@ctrlcctrlv has suggested adding sodipodi:guides as a solution and that does seem like a possibility. This would involve:

1. Adjusting ViewBox parameters 1 and 3 to display the entire glyph
2. Placing guides with reference points at (FontForge space) zero-Y and X points at zero X (corresponding to the start) and `sc->width` (corresponding to the right side bearing). The second X value could then be converted the RSB coordinate with minimal difficulty. 
3. Angle both guides at the italic angle of the font. 
4. On import use the value from 2 to set the RSB (and continue to use the SVG zero-relative placement to determine the LSB). 

The main thing standing in the way of a prototype of this proposal is that sodipodi:guide appears to be a sub-part of sodipodi:namedview, and the latter has a lot of aspects we might not want to specify. (It doesn't help that the DTD is no longer at its documented location and I haven't tracked it down yet -- it may never have existed.)  My initial impression is that these guides may not be very "separable", making them a less attractive solution. 

Vertical display is a separate and more limited problem. I've run into at least one font with accented capital characters that exceed font's vertical height. Personally I think it would be OK, and possibly beneficial, to continue to cut the tops off of such glyphs with the ViewBox as an indication that an important limit has been exceeded. 