### PR TITLE
cvpalettes.c: Recreate cvtools/bvtools each time it needs to be associated with a new window

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -900,7 +900,7 @@ extern int CVPaletteIsVisible(CharView *cv,int which);
 extern void CVPaletteSetVisible(CharView *cv,int which,int visible);
 extern void CVPalettesRaise(CharView *cv);
 extern void CVLayersSet(CharView *cv);
-extern void _CVPaletteActivate(CharView *cv,int force);
+extern void _CVPaletteActivate(CharView *cv,int force,int docking_changed);
 extern void CVPaletteActivate(CharView *cv);
 extern void CV_LayerPaletteCheck(SplineFont *sf);
 extern void CVPalettesHideIfMine(CharView *cv);

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -6442,6 +6442,12 @@ return( GGadgetDispatchEvent(cv->vsb,event));
 	    ActiveCharView = cv;
 	    if ( cv->gic!=NULL )
 		GDrawSetGIC(gw,cv->gic,0,20);
+
+	    // X11 on Windows is broken, non-active windows
+	    // receive this event on mouseover
+#if !defined(_WIN32) || !defined(FONTFORGE_CAN_USE_GDK)
+	    CVPaletteActivate(cv);
+#endif
 	}
       break;
     }

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -3689,7 +3689,7 @@ void CVChangeSC( CharView *cv, SplineChar *sc )
     GDrawSetWindowTitles8(cv->gw,buf,title);
     CVInfoDraw(cv,cv->gw);
     free(title);
-    _CVPaletteActivate(cv,true);
+    _CVPaletteActivate(cv,true,false);
 
     if ( cv->tabs!=NULL ) {
 	for ( i=0; i<cv->former_cnt; ++i )
@@ -4701,7 +4701,7 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
     GDrawSetWindowTitles8(cv->gw,buf,title);
     CVInfoDraw(cv,cv->gw);
     free(title);
-    _CVPaletteActivate(cv,true);
+    _CVPaletteActivate(cv,true,false);
     
     TRACE("CVSwitchActiveSC() idx:%d\n", idx );
 
@@ -6445,7 +6445,7 @@ return( GGadgetDispatchEvent(cv->vsb,event));
 
 	    // X11 on Windows is broken, non-active windows
 	    // receive this event on mouseover
-#if !defined(_WIN32) || !defined(FONTFORGE_CAN_USE_GDK)
+#if !defined(_WIN32) || defined(FONTFORGE_CAN_USE_GDK)
 	    CVPaletteActivate(cv);
 #endif
 	}

--- a/gtkui/viewsgtk.h
+++ b/gtkui/viewsgtk.h
@@ -628,7 +628,7 @@ extern int CVPaletteIsVisible(CharView *cv,int which);
 extern void CVPaletteSetVisible(CharView *cv,int which,int visible);
 extern void CVPalettesRaise(CharView *cv);
 extern void CVLayersSet(CharView *cv);
-extern void _CVPaletteActivate(CharView *cv,int force);
+extern void _CVPaletteActivate(CharView *cv,int force,int docking_changed);
 extern void CVPaletteActivate(CharView *cv);
 extern void CVPalettesHideIfMine(CharView *cv);
 extern int BVPaletteIsVisible(BitmapView *bv,int which);


### PR DESCRIPTION
Broken since the reparenting stuff was removed. Having a single set of
palette tools seems like a bad idea...

Fixes #3397