### PR TITLE
Fix for #3258 Crash on Remove Overlap

### DIFF
--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -537,7 +537,7 @@ static void MonotonicElide(struct mlist ** base, struct monotonic * input1) {
 static void CleanMonotonics(struct monotonic ** base_pointer) {
   // It is necessary to use double pointers so that we can set the previous reference.
   struct monotonic ** current_pointer = base_pointer;
-  struct monotonic * tmp_pointer;
+  struct monotonic * tmp_pointer, * last_pointer = NULL;
   while (*current_pointer) {
     if (((*current_pointer)->next == NULL) || ((*current_pointer)->prev == NULL)) {
       if (((*current_pointer)->next != NULL) || ((*current_pointer)->prev != NULL)) {
@@ -546,9 +546,13 @@ static void CleanMonotonics(struct monotonic ** base_pointer) {
         tmp_pointer = (*current_pointer)->linked;
         chunkfree(*current_pointer, sizeof(struct monotonic));
         (*current_pointer) = tmp_pointer;
+	if (last_pointer!=NULL)
+          last_pointer->linked = tmp_pointer;
       }
+    } else {
+      last_pointer = *current_pointer;
+      current_pointer = &((*current_pointer)->linked);
     }
-    current_pointer = &((*current_pointer)->linked);
   }
   return;
 }


### PR DESCRIPTION
Closes #3258 .

@frank-trampe Did you intend something more like the following in `CleanMonotonics()`? It seems to test well with the sample included in the referenced bug. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [ ] Describe your changes in detail.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

