### PR TITLE
Fix for #3287 Crash when deleting glyphs

### DIFF
--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -261,7 +261,7 @@ static int _SCRefNumberPoints2(SplineSet **_rss,SplineChar *sc,int pnum,int laye
 		rsp->nextcpindex = 0xffff;
 	    else
 		rsp->nextcpindex = pnum++;
-	    if ( sp->next==NULL )
+	    if ( sp->next==NULL || rsp->next==NULL )
 	break;
 	    sp = sp->next->to;
 	    rsp = rsp->next->to;


### PR DESCRIPTION
This is a one line list traversal fix. A reviewer with better understanding of the code will have to confirm that there is not something more systemic that needs repair, but this addresses the crash in the referenced bug. 

To reproduce I followed the instructions with this file loaded: [dvs.zip](https://github.com/fontforge/fontforge/files/2744775/dvs.zip)

Closes #3287 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x]  My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
