### PR TITLE
Fix for #3229 NULL pointer dereference in readcffglyphs

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3974,18 +3974,20 @@ return( 0 );
     else {
 	fseek(ttf,info->cff_start+dicts[which]->fdarrayoff,SEEK_SET);
 	subdicts = readcfftopdicts(ttf,NULL,info->cff_start,info,dicts[which]);
-	fseek(ttf,info->cff_start+dicts[which]->fdselectoff,SEEK_SET);
-	fdselect = readfdselect(ttf,dicts[which]->glyphs.cnt,info);
-	for ( j=0; subdicts[j]!=NULL; ++j ) {
-	    if ( subdicts[j]->private_offset!=-1 )
-		readcffprivate(ttf,subdicts[j],info);
-	    if ( subdicts[j]->charsetoff!=-1 )
-		readcffset(ttf,subdicts[j],info);
+	if ( subdicts!=NULL ) {
+	    fseek(ttf,info->cff_start+dicts[which]->fdselectoff,SEEK_SET);
+	    fdselect = readfdselect(ttf,dicts[which]->glyphs.cnt,info);
+	    for ( j=0; subdicts[j]!=NULL; ++j ) {
+		if ( subdicts[j]->private_offset!=-1 )
+		    readcffprivate(ttf,subdicts[j],info);
+		if ( subdicts[j]->charsetoff!=-1 )
+		    readcffset(ttf,subdicts[j],info);
+	    }
+	    cidfigure(info,dicts[which],strings,scnt,&gsubs,subdicts,fdselect);
+	    for ( j=0; subdicts[j]!=NULL; ++j )
+		TopDictFree(subdicts[j]);
+	    free(subdicts); free(fdselect);
 	}
-	cidfigure(info,dicts[which],strings,scnt,&gsubs,subdicts,fdselect);
-	for ( j=0; subdicts[j]!=NULL; ++j )
-	    TopDictFree(subdicts[j]);
-	free(subdicts); free(fdselect);
     }
     if ( dicts[which]->encodingoff!=-1 )
 	readcffenc(ttf,dicts[which],info,strings,scnt);
@@ -4016,7 +4018,11 @@ return( 0 );
 	free(gsubs.values[i]);
     free(gsubs.values); free(gsubs.lens);
 
-return( 1 );
+    if (info->chars==NULL) {
+	return( 0 );
+    }
+
+    return( 1 );
 }
 
 static int readtyp1glyphs(FILE *ttf,struct ttfinfo *info) {


### PR DESCRIPTION
The font provided in the bug is corrupt; `ttfdump` prints "Unexpected EOF". 

This change protects against dereferencing a NULL `subtables` pointer. It then determines that there are no glyphs found and returns 0 from `readcffglyphs`, ending the attempt to open the file.

Closes #3229 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
