### PR TITLE
Re-enable tooltips (aka "popup windows") in GXdraw

### DIFF
--- a/gdraw/ggadgets.c
+++ b/gdraw/ggadgets.c
@@ -554,7 +554,7 @@ return( false );
     popup_timer = NULL;
 
     /* Is the cursor still in the original window? */
-    if (GDrawGetPointerWindow(root) != popup_info.gw)
+    if (GDrawGetPointerWindow(popup_info.gw) != popup_info.gw)
         return true;
 
     lines = 0; width = 1;


### PR DESCRIPTION
I mentioned in #3397 that I wasn't seeing any tooltips in the more recent builds. So I figured I should look into that too. 

The function responsible for displaying a tooltip after the timer goes off is `GGadgetPopupTest()`, which starts like this:
```
static int GGadgetPopupTest(GEvent *e) {
    unichar_t *msg;
    int lines, temp, width;
    GWindow root = GDrawGetRoot(GDrawGetDisplayOfWindow(popup));
    GRect pos, size;
    unichar_t *pt, *ept;
    int as, ds, ld, img_height=0;
    GEvent where;

    if ( e->type!=et_timer || e->u.timer.timer!=popup_timer || popup==NULL )
return( false );
    popup_timer = NULL;

    /* Is the cursor still in the original window? */
    if (GDrawGetPointerWindow(root) != popup_info.gw)
        return true;
```
The last two lines are a recent change/addition. 

`GDrawGetPointerWindow()` and its innards are:
```
static Window _GXDrawGetPointerWindow(GWindow w) {
    GXWindow gw = (GXWindow) w;
    Display *display = gw->display->display;
    int junk;
    Window parent, child, wjunk;
    int x, y; unsigned int state;

    parent = gw->display->groot->w;
    for (;;) {
        child = None;
        if ( !XQueryPointer(display,parent,&wjunk,&child,&junk,&junk,&x,&y,&state))
    break;
        if ( child==None )
    break;
        parent = child;
    }
return( parent );
}

static GWindow GXDrawGetPointerWindow(GWindow w) {
    GXWindow gw = (GXWindow) w;
    Display *display = gw->display->display;
    void *ret;
    Window parent;

    parent = _GXDrawGetPointerWindow(w);
    if ( (gw->w&0xfff00000) == (parent&0xfff00000)) {
        /* It is one of our windows, so it is safe to look for it */
        if ( XFindContext(display,parent,gw->display->mycontext,(void *) &ret)==0 )
return( (GWindow) ret );
    }
return( NULL );
}
```
Note that `_GXDrawGetPointerWindow()` pulls the display and then the root window from the
argument, and `GXDrawGetPointerWindow()` has that bitmask-based test for whether the window ID maps to the same application. Basically `GXDrawGetPointerWindow()` is designed to be called with some application window rather than the root window. 

This change calls it with `popup_info.gw` (which given that the code pulls the root window from the argument is as good as anythng), which reenables tooltips. 

Provide a general summary of your changes in the **Title** above.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

