### PR TITLE
better handle parens in fontname

### DIFF
--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -960,7 +960,7 @@ SplineFont *_ReadSplineFont(FILE *file, const char *filename, enum openflags ope
 
     // For non-URLs:
     // treat /whatever/foo.ufo/ as simply /whatever/foo.ufo
-    if (!strstr(fname,"://") && fnamelen && fname[filenamelen-1] == '/')
+    if (!strstr(fname,"://") && fnamelen && fname[fnamelen-1] == '/')
         fname[fnamelen-1] = '\0';
 
     strippedname = fname;


### PR DESCRIPTION
partial fix for #3133

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [X] Describe your changes in detail.

When loading a font, you can specify the name of the specific font you want in the filename (`filename(fontname)`). However, this didn't work if the font name had parentheses in it. This commit fixes one instance of fontnames being parsed.

I also made a change to the code that handles non-URL filenames ending with a slash. Both that code and my code need the length of the filename, so I changed it to get that at the top and use it in both places.

### Final checklist
- [X] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.