### PR TITLE
Fix for #3133 Can't open subfont with name containing parentheses

### DIFF
--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -2080,8 +2080,8 @@ static SplineFont *SearchTtfResources(FILE *f,long rlistpos,int subcnt,long rdat
     SplineFont *sf;
     int which = 0;
     char **names;
-    char *pt,*lparen, *rparen;
-    char *chosenname=NULL;
+    char *pt,*lparen;
+    char *find=NULL,*chosenname=NULL;
 
     fseek(f,rlistpos,SEEK_SET);
     if ( subcnt>1 || (flags&ttf_onlynames) ) {
@@ -2106,15 +2106,9 @@ static SplineFont *SearchTtfResources(FILE *f,long rlistpos,int subcnt,long rdat
 return( (SplineFont *) names );
 	}
 	if ((pt = strrchr(filename,'/'))==NULL ) pt = filename;
-	/* Someone gave me a font "Nafees Nastaleeq(Updated).ttf" and complained */
-	/*  that ff wouldn't open it */
-	/* Now someone will complain about "Nafees(Updated).ttc(fo(ob)ar)" */
-	if ( (lparen = strrchr(pt,'('))!=NULL &&
-		(rparen = strrchr(lparen,')'))!=NULL &&
-		rparen[1]=='\0' ) {
-	    char *find = copy(lparen+1);
-	    pt = strchr(find,')');
-	    if ( pt!=NULL ) *pt='\0';
+	if ( lparen = SFSubfontnameStart(pt) ) {
+	    find = copy(lparen+1);
+	    find[strlen(find)-1] = '\0';
 	    for ( which=subcnt-1; which>=0; --which )
 		if ( strcmp(names[which],find)==0 )
 	    break;
@@ -2180,7 +2174,7 @@ return( (SplineFont *) names );
 	    len += temp;
 	}
 	rewind(ttf);
-	sf = _SFReadTTF(ttf,flags,openflags,NULL,NULL);
+	sf = _SFReadTTF(ttf,flags,openflags,NULL,NULL,NULL);
 	fclose(ttf);
 	if ( sf!=NULL ) {
 	    free(buffer);
@@ -2577,10 +2571,10 @@ static FOND *PickFOND(FOND *fondlist,char *filename,char **name, int *style) {
     char *find = NULL;
 
     if ((pt = strrchr(filename,'/'))!=NULL ) pt = filename;
-    if ( (lparen = strchr(filename,'('))!=NULL && strchr(lparen,')')!=NULL ) {
+    if ( lparen = SFSubfontnameStart(pt) ) {
 	find = copy(lparen+1);
-	pt = strchr(find,')');
-	if ( pt!=NULL ) *pt='\0';
+	find[strlen(find)-1] = '\0';
+	find = copy(lparen+1);
 	for ( test=fondlist; test!=NULL; test=test->next ) {
 	    for ( i=0; i<48; ++i )
 		if ( test->psnames[i]!=NULL && strcmp(find,test->psnames[i])==0 ) {
@@ -2810,7 +2804,7 @@ return( (SplineFont *) ret );
 	dlen -= len;
     }
     rewind(temp);
-    sf = _SFReadTTF(temp,flags,openflags,NULL,NULL);
+    sf = _SFReadTTF(temp,flags,openflags,NULL,NULL,NULL);
     fclose(temp);
     free(buffer);
 return( sf );

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -2574,7 +2574,6 @@ static FOND *PickFOND(FOND *fondlist,char *filename,char **name, int *style) {
     if ( lparen = SFSubfontnameStart(pt) ) {
 	find = copy(lparen+1);
 	find[strlen(find)-1] = '\0';
-	find = copy(lparen+1);
 	for ( test=fondlist; test!=NULL; test=test->next ) {
 	    for ( i=0; i<48; ++i )
 		if ( test->psnames[i]!=NULL && strcmp(find,test->psnames[i])==0 ) {

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1978,7 +1978,7 @@ return( NULL );
 	sf = SplineFontFromPSFont(fd);
 	PSFontFree(fd);
     } else if ( type==2 ) {
-	sf = _SFReadTTF(file,0,pc->openflags,pc->fontnames[font_num],NULL);
+	sf = _SFReadTTF(file,0,pc->openflags,pc->fontnames[font_num],NULL,NULL);
     } else {
 	int len;
 	fseek(file,0,SEEK_END);

--- a/fontforge/parsepfa.c
+++ b/fontforge/parsepfa.c
@@ -2617,7 +2617,7 @@ return;
 		parseline(fp,buffer,in);
 	}
     } else if (( fp->fd->fonttype==42 || fp->fd->cidfonttype==2 ) && fp->sfnts!=NULL ) {
-	fp->fd->sf = _SFReadTTF(fp->sfnts,0,0,"<Temp File>",fp->fd);
+	fp->fd->sf = _SFReadTTF(fp->sfnts,0,0,"<Temp File>",NULL,fp->fd);
 	fclose(fp->sfnts);
     }
 }

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -574,8 +574,8 @@ char *TTFGetFontName(FILE *ttf,int32 offset,int32 off2) {
 /*                                                                           */
 /* There are five ways that one enclosed font is selected:                   */
 /*   1)  there is only one font enclosed, so we force defaulting to that one.*/
-/*   2a) the filename has a font index appended, we choose that N'th font.   */
-/*   2b) the filename has a font name appended, we try to match that name    */
+/*   2a) info->chosenname is a number, we choose that N'th font.             */
+/*   2b) info->chosenname is a non-number, we try to match that string       */
 /*           in list of discovered font names and select that named font.    */
 /*   3)  the user is prompted with a list of all discovered font names, and  */
 /*           asked to select one, and then that N'th font is chosen.         */
@@ -584,9 +584,9 @@ char *TTFGetFontName(FILE *ttf,int32 offset,int32 off2) {
 /* On failure and no font is chosen, returns false.                          */
 /*                                                                           */
 /* On success, true is returned.  The chosen font name (allocated) pointer   */
-/*   is returned via 'chosenname'. Additionally, the file position is set    */
-/*   pointing to the chosen TTF font offset table, ready for reading the     */
-/*   TTF header.                                                             */
+/*   is returned via 'info->chosenname'. Additionally, the file position     */
+/*   is set pointing to the chosen TTF font offset table, ready for          */
+/*   reading the TTF header.                                                 */
 /*                                                                           */
 /* Example filename strings with appended font selector:                     */
 /*     ./tests/fonts/mingliu.windows.ttc(PMingLiU)                           */
@@ -600,10 +600,9 @@ char *TTFGetFontName(FILE *ttf,int32 offset,int32 off2) {
 /*    call fseek() to position to the chosen TTF header offset table. Then   */
 /*    the chosen font name is copied into 'chosenname'.                      */
 
-static int PickTTFFont(FILE *ttf,char *filename,char **chosenname) {
+static int PickTTFFont(FILE *ttf, struct ttfinfo *info) {
     int32 *offsets, cnt, i, choice;
     char **names;
-    char *pt, *lparen, *rparen;
 
     /* TTCF version = */ getlong(ttf);
     cnt = getlong(ttf);
@@ -623,38 +622,25 @@ static int PickTTFFont(FILE *ttf,char *filename,char **chosenname) {
         if ( names[i]==NULL ) 
             asprintf(&names[i], "<Unknown font name %d>", i+1);
     }
-    pt = strrchr(filename,'/');
-    if ( pt==NULL ) pt = filename;
-    /* Someone gave me a font "Nafees Nastaleeq(Updated).ttf" and complained */
-    /*  that ff wouldn't open it */
-    /* Now someone will complain about "Nafees(Updated).ttc(fo(ob)ar)" */
-    if ( (lparen = strrchr(pt,'('))!=NULL &&
-	    (rparen = strrchr(lparen,')'))!=NULL &&
-	    rparen[1]=='\0' ) {
-        char *find = copyn(lparen+1, rparen-lparen-1);
+    if ( info->chosenname!=NULL ) {
 	for ( choice=cnt-1; choice>=0; --choice )
             if ( names[choice]!=NULL )
-	        if ( strcmp(names[choice],find)==0 )
+	        if ( strcmp(names[choice],info->chosenname)==0 )
 	            break;
 	if ( choice==-1 ) {
 	    char *end;
-	    choice = strtol(find,&end,10);
+	    choice = strtol(info->chosenname,&end,10);
 	    if ( *end!='\0' )
 		choice = -1;
             else if ( choice < 0 || choice >= cnt )
 		choice = -1;
 	}
 	if ( choice==-1 ) {
-	    char *fn = copy(filename);
-	    fn[lparen-filename] = '\0';
 	    ff_post_error(_("Not in Collection"),
 /* GT: The user is trying to open a font file which contains multiple fonts and */
 /* GT: has asked for a font which is not in that file. */
-/* GT: The string will look like: <fontname> is not in <filename> */
-		    _("%1$s is not in %2$.100s"),find,fn);
-	    free(fn);
+		    _("%1$s is not in font file"),info->chosenname);
 	}
-	free(find);
     } else if ( no_windowing_ui )
 	choice = 0;
     else
@@ -664,7 +650,9 @@ static int PickTTFFont(FILE *ttf,char *filename,char **chosenname) {
     if ( choice!=-1 ) {
         /* position file to start of the chosen TTF font header */
 	fseek(ttf,offsets[choice],SEEK_SET);
-	*chosenname = names[choice];
+	if (info->chosenname != NULL)
+	    free(info->chosenname);
+	info->chosenname = names[choice];
 	names[choice] = NULL;
     }
     for ( i=0; i<cnt; ++i )
@@ -995,8 +983,7 @@ static struct tablenames { uint32 tag; const char *name; } stdtables[] = {
     { 0, NULL }
 };
 
-static int readttfheader(FILE *ttf, struct ttfinfo *info,char *filename,
-	char **choosenname) {
+static int readttfheader(FILE *ttf, struct ttfinfo *info) {
     int i, j, k, offset, length, version;
     uint32 tag;
     int first = true;
@@ -1005,7 +992,7 @@ static int readttfheader(FILE *ttf, struct ttfinfo *info,char *filename,
     if ( version==CHR('t','t','c','f')) {
 	/* TrueType font collection */
 	info->is_ttc = true;
-	if ( !PickTTFFont(ttf,filename,choosenname))
+	if ( !PickTTFFont(ttf,info) )
 return( 0 );
 	/* If they picked a font, then we should be left pointing at the */
 	/*  start of the Table Directory for that font */
@@ -5509,7 +5496,7 @@ static int readttf(FILE *ttf, struct ttfinfo *info, char *filename) {
     fseek(ttf,0,SEEK_SET);
 
     ff_progress_change_stages(3);
-    if ( !readttfheader(ttf,info,filename,&info->chosenname)) {
+    if ( !readttfheader(ttf,info) ) {
 return( 0 );
     }
     /* TrueType doesn't need this but opentype dictionaries do */
@@ -6283,7 +6270,7 @@ static SplineFont *SFFillFromTTF(struct ttfinfo *info) {
 return( sf );
 }
 
-SplineFont *_SFReadTTF(FILE *ttf, int flags,enum openflags openflags, char *filename,struct fontdict *fd) {
+SplineFont *_SFReadTTF(FILE *ttf, int flags,enum openflags openflags, char *filename,char *chosenname,struct fontdict *fd) {
     struct ttfinfo info;
     int ret;
 
@@ -6294,6 +6281,8 @@ SplineFont *_SFReadTTF(FILE *ttf, int flags,enum openflags openflags, char *file
     info.weight_width_slope_only = false;
     info.openflags = openflags;
     info.fd = fd;
+    if ( chosenname!=NULL) 
+	info.chosenname = copy(chosenname);
     ret = readttf(ttf,&info,filename);
     if ( !ret )
 return( NULL );
@@ -6303,23 +6292,23 @@ return( SFFillFromTTF(&info));
 SplineFont *SFReadTTF(char *filename, int flags, enum openflags openflags) {
     FILE *ttf;
     SplineFont *sf;
-    char *temp=filename, *pt, *lparen, *rparen;
+    char *strippedname=filename, *chosenname=NULL, *pt, *lparen;
 
     pt = strrchr(filename,'/');
     if ( pt==NULL ) pt = filename;
-    if ( (lparen = strrchr(pt,'('))!=NULL &&
-	    (rparen = strrchr(lparen,')'))!=NULL &&
-	    rparen[1]=='\0' ) {
-	temp = copy(filename);
-	pt = temp + (lparen-filename);
-	*pt = '\0';
+    if ( lparen = SFSubfontnameStart(pt) ) {
+        strippedname = copy(filename);
+        strippedname[lparen-filename] = '\0';
+        chosenname = copy(lparen+1);
+        chosenname[strlen(chosenname)-1] = '\0';
     }
-    ttf = fopen(temp,"rb");
-    if ( temp!=filename ) free(temp);
+    ttf = fopen(strippedname,"rb");
     if ( ttf==NULL )
 return( NULL );
 
-    sf = _SFReadTTF(ttf,flags,openflags,filename,NULL);
+    sf = _SFReadTTF(ttf,flags,openflags,strippedname,chosenname,NULL);
+    if ( strippedname!=filename ) free(strippedname);
+    if ( chosenname!=NULL ) free(chosenname);
     fclose(ttf);
 return( sf );
 }

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -581,6 +581,8 @@ char *TTFGetFontName(FILE *ttf,int32 offset,int32 off2) {
 /*           asked to select one, and then that N'th font is chosen.         */
 /*   4)  when there is no UI, then font index zero is used.                  */
 /*                                                                           */
+/* When used, info->chosenname must be a string that can be free()d          */
+/*                                                                           */
 /* On failure and no font is chosen, returns false.                          */
 /*                                                                           */
 /* On success, true is returned.  The chosen font name (allocated) pointer   */
@@ -6281,6 +6283,8 @@ SplineFont *_SFReadTTF(FILE *ttf, int flags,enum openflags openflags, char *file
     info.weight_width_slope_only = false;
     info.openflags = openflags;
     info.fd = fd;
+    /* Pass the subfont name (if present) via info->chosenname. This may
+     * be free()d and replaced so make a copy */
     if ( chosenname!=NULL) 
 	info.chosenname = copy(chosenname);
     ret = readttf(ttf,&info,filename);
@@ -6296,6 +6300,7 @@ SplineFont *SFReadTTF(char *filename, int flags, enum openflags openflags) {
 
     pt = strrchr(filename,'/');
     if ( pt==NULL ) pt = filename;
+    /* Extract the subfont name if present */
     if ( lparen = SFSubfontnameStart(pt) ) {
         strippedname = copy(filename);
         strippedname[lparen-filename] = '\0';

--- a/fontforge/parsettf.h
+++ b/fontforge/parsettf.h
@@ -16,7 +16,7 @@ extern int ttfFixupRef(SplineChar **chars, int i);
 extern SplineFont *CFFParse(char *filename);
 extern SplineFont *_CFFParse(FILE *temp, int len, char *fontsetname);
 extern SplineFont *SFReadTTF(char *filename, int flags, enum openflags openflags);
-extern SplineFont *_SFReadTTF(FILE *ttf, int flags, enum openflags openflags, char *filename, struct fontdict *fd);
+extern SplineFont *_SFReadTTF(FILE *ttf, int flags, enum openflags openflags, char *filename, char *chosenname, struct fontdict *fd);
 extern struct otfname *FindAllLangEntries(FILE *ttf, struct ttfinfo *info, int id);
 extern void AltUniFigure(SplineFont *sf, EncMap *map, int check_dups);
 extern void TTF_PSDupsDefault(SplineFont *sf);

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -931,6 +931,28 @@ return(copy(tmpfilename));			/* The filename does not exist */
     }
 }
 
+/* The following won't work if the fontname has unbalanced
+ * parentheses, but short of requiring those to be escaped
+ * somehow that case is tricky. (One could guess the cutoff
+ * by looking for a file extension.)
+ * */
+char *SFSubfontnameStart(char *fname) {
+    char *rparen, *paren;
+    int cnt = 1;
+    if ( fname==NULL || (rparen = strrchr(fname,')'))==NULL || rparen[1]!='\0' )
+	return NULL;
+    paren = rparen;
+    while ( --paren>=fname ) {
+	if ( *paren == '(' )
+	    --cnt;
+	else if ( *paren == ')' ) 
+	    ++cnt;
+	if ( cnt==0 )
+	    return paren;
+    }
+    return NULL;
+}
+
 /* This does not check currently existing fontviews, and should only be used */
 /*  by LoadSplineFont (which does) and by RevertFile (which knows what it's doing) */
 SplineFont *_ReadSplineFont(FILE *file, const char *filename, enum openflags openflags) {
@@ -938,7 +960,8 @@ SplineFont *_ReadSplineFont(FILE *file, const char *filename, enum openflags ope
     char ubuf[251], *temp;
     int fromsfd = false;
     int i;
-    char *pt, *ext2, *strippedname = 0, *oldstrippedname = 0, *tmpfile=NULL, *paren=NULL, *fullname, *rparen;
+    char *pt, *ext2, *strippedname = NULL, *chosenname = NULL, *oldstrippedname = NULL;
+    char *tmpfile=NULL, *paren=NULL, *fullname;
     char *archivedir=NULL;
     int len;
     int checked;
@@ -970,14 +993,12 @@ SplineFont *_ReadSplineFont(FILE *file, const char *filename, enum openflags ope
     strippedname = fname;
     pt = strrchr(fname,'/');
     if ( pt==NULL ) pt = fname;
-    /* Someone gave me a font "Nafees Nastaleeq(Updated).ttf" and complained */
-    /*  that ff wouldn't open it */
-    /* Now someone will complain about "Nafees(Updated).ttc(fo(ob)ar)" */
-    if ( (paren = strrchr(pt,'('))!=NULL &&
-	    (rparen = strrchr(paren,')'))!=NULL &&
-	    rparen[1]=='\0' ) {
-	    strippedname = copy(fname);
-	    strippedname[paren-fname] = '\0';
+
+    if ( paren = SFSubfontnameStart(pt) ) {
+	strippedname = copy(fname);
+	strippedname[paren-fname] = '\0';
+	chosenname = copy(paren+1);
+	chosenname[strlen(chosenname)-1] = '\0';
     }
 
     if ( strstr(strippedname,"://")!=NULL ) {
@@ -1116,14 +1137,14 @@ SplineFont *_ReadSplineFont(FILE *file, const char *filename, enum openflags ope
 		(ch1=='O' && ch2=='T' && ch3=='T' && ch4=='O') ||
 		(ch1=='t' && ch2=='r' && ch3=='u' && ch4=='e') ||
 		(ch1=='t' && ch2=='t' && ch3=='c' && ch4=='f') ) {
-	    sf = _SFReadTTF(file,0,openflags,fullname,NULL);
+	    sf = _SFReadTTF(file,0,openflags,strippedname,chosenname,NULL);
 	    checked = 't';
 	} else if ( ch1=='w' && ch2=='O' && ch3=='F' && ch4=='F' ) {
-	    sf = _SFReadWOFF(file,0,openflags,fullname,NULL);
+	    sf = _SFReadWOFF(file,0,openflags,strippedname,chosenname,NULL);
 	    checked = 'w';
 	} else if ( ch1=='w' && ch2=='O' && ch3=='F' && ch4=='2' ) {
 #ifdef FONTFORGE_CAN_USE_WOFF2
-	    sf = _SFReadWOFF2(file,0,openflags,fullname,NULL);
+	    sf = _SFReadWOFF2(file,0,openflags,strippedname,chosenname,NULL);
 	    checked = 'w';
 #endif
 	} else if (( ch1=='%' && ch2=='!' ) ||
@@ -1273,6 +1294,8 @@ SplineFont *_ReadSplineFont(FILE *file, const char *filename, enum openflags ope
 	    free(oldstrippedname);
     if ( fullname!=fname && fullname!=strippedname )
 	    free(fullname);
+    if ( chosenname!=NULL )
+	    free(chosenname);
     if ( tmpfile!=NULL ) {
 	    unlink(tmpfile);
 	    free(tmpfile);

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -931,7 +931,18 @@ return(copy(tmpfilename));			/* The filename does not exist */
     }
 }
 
-/* The following won't work if the fontname has unbalanced
+/* Returns a pointer to the start of the parenthesized 
+ * subfont name (optionally) used when opening TTC or Macbinary
+ * files, or NULL if no subfont is specified.
+ *
+ * The subfont specification must extend to the end of the string
+ * so that font filenames containing parentheses will not be
+ * misinterpreted. 
+ *
+ * Because the name *must* be in parentheses, a non-NULL pointer
+ * will be to a string of at least two characters.
+ * 
+ * The following won't work if the fontname has unbalanced
  * parentheses, but short of requiring those to be escaped
  * somehow that case is tricky. (One could guess the cutoff
  * by looking for a file extension.)

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2290,6 +2290,7 @@ extern char *Unarchive(char *name, char **_archivedir);
 extern char *Decompress(char *name, int compression);
 extern uint16 MacStyleCode( SplineFont *sf, uint16 *psstyle );
 extern char **NamesReadUFO(char *filename);
+extern char *SFSubfontnameStart(char *fname);
 
 
 extern const char *UnicodeRange(int unienc);

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -187,7 +187,7 @@ return( strm.total_out );
     }
 }
 
-SplineFont *_SFReadWOFF(FILE *woff,int flags,enum openflags openflags, char *filename,struct fontdict *fd) {
+SplineFont *_SFReadWOFF(FILE *woff,int flags,enum openflags openflags, char *filename,char *chosenname,struct fontdict *fd) {
     int flavour;
     int iscff;
     int len, len_stated;
@@ -315,7 +315,7 @@ return( NULL );
 	putlong(sfnt,checksum);
     }
     rewind(sfnt);
-    sf = _SFReadTTF(sfnt,flags,openflags,filename,fd);
+    sf = _SFReadTTF(sfnt,flags,openflags,filename,chosenname,fd);
     fclose(sfnt);
 
     if ( sf!=NULL ) {
@@ -671,7 +671,7 @@ int _WriteWOFF2Font(FILE *fp, SplineFont *sf, enum fontformat format, int32_t *b
     return ret;
 }
 
-SplineFont *_SFReadWOFF2(FILE *fp, int flags, enum openflags openflags, char *filename, struct fontdict *fd)
+SplineFont *_SFReadWOFF2(FILE *fp, int flags, enum openflags openflags, char *filename,char *chosenname,struct fontdict *fd)
 {
     size_t raw_input_length = 0;
     uint8_t *raw_input = ReadFileToBuffer(fp, &raw_input_length);
@@ -701,7 +701,7 @@ SplineFont *_SFReadWOFF2(FILE *fp, int flags, enum openflags openflags, char *fi
         return NULL;
     }
 
-    SplineFont *ret = _SFReadTTF(tmp, flags, openflags, filename, fd);
+    SplineFont *ret = _SFReadTTF(tmp, flags, openflags, filename, chosenname, fd);
     fclose(tmp);
     return ret;
 }

--- a/fontforge/woff.h
+++ b/fontforge/woff.h
@@ -8,7 +8,7 @@
 
 extern int WriteWOFFFont(char *fontname, SplineFont *sf, enum fontformat format, int32 *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer);
 extern int _WriteWOFFFont(FILE *woff, SplineFont *sf, enum fontformat format, int32 *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer);
-extern SplineFont *_SFReadWOFF(FILE *woff, int flags, enum openflags openflags, char *filename, struct fontdict *fd);
+extern SplineFont *_SFReadWOFF(FILE *woff, int flags, enum openflags openflags, char *filename, char *chosenname, struct fontdict *fd);
 
 #ifdef FONTFORGE_CAN_USE_WOFF2
 #define WOFF2_DEFAULT_MAX_SIZE (30 * 1024 * 1024) /* = woff2::kDefaultMaxSize */
@@ -19,7 +19,7 @@ extern int woff2_convert_woff2_to_ttf(const uint8_t *data, size_t length, uint8_
 
 extern int WriteWOFF2Font(char *fontname, SplineFont *sf, enum fontformat format, int32 *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer);
 extern int _WriteWOFF2Font(FILE *woff, SplineFont *sf, enum fontformat format, int32 *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer);
-extern SplineFont *_SFReadWOFF2(FILE *woff, int flags, enum openflags openflags, char *filename, struct fontdict *fd);
+extern SplineFont *_SFReadWOFF2(FILE *woff, int flags, enum openflags openflags, char *filename, char *chosenname, struct fontdict *fd);
 #endif
 
 #endif /* FONTFORGE_WOFF_H */

--- a/tests/test929.py
+++ b/tests/test929.py
@@ -1,0 +1,11 @@
+#Needs: fonts/NotoSans-Regular.ttc
+
+import fontforge
+import sys
+
+for i, s in enumerate(('Noto Sans', 'Noto Sans UI')):
+    for k in (str(i), s):
+        f = fontforge.open(sys.argv[1] + '(' + k + ')')
+        if f.fullname != s:
+            raise ValueError('Expected fontname "' + s + '" instead of "' + f.fontname + '" for key "' + k + '"')
+        f.close()

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -129,5 +129,6 @@ check_python([libnameslist checks],[test1010.py])
 #check_python([find overlap bug],[findoverlapbugs.py])
 check_python([Validate WOFF output],[test926.py],[DejaVuSerif.sfd])
 check_python([WOFF2 round tripping],[test927.py],[Ambrosia.woff2])
+check_python([Open Subfonts],[test929.py],[NotoSans-Regular.ttc])
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
I replumbed the TTF path a bit so that the suffix convention isn't so intrusive. Unfortunately that was just too convoluted for `macbinary.c` so I replaced the "parsing" code where it was. 

There is a `.ttc` in [NotoSans.zip](https://github.com/fontforge/fontforge/files/2790233/NotoSans.zip) that can be tested with this:

```
#!/usr/bin/env python

import sys
import fontforge

for i, s in enumerate(('Noto (Sans)', 'Noto (Sans) UI')):
    for k in (str(i), s):
        f = fontforge.open(sys.argv[1] + '(' + k + ')')
        print(f.fullname)
        if f.fullname != s:
            raise ValueError('Expected fontname "' + s + '" instead of "' + f.fontname + '" for key "' + k + '"')
        f.close()
```
None of this will work if the embedded parentheses are not balanced, but it won't (or shouldn't) crash. 

I added the test because although the code path is tested in the internal scripting language that test

1. Doesn't try opening by offset and
2. Doesn't verify that the right subfont was opened. 

Closes #3133

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
