### PR TITLE
Fix for #3425 SVG causes NaN value in spline creation

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1264,16 +1264,15 @@ static void SVGTraceArc(SplineSet *cur,BasePoint *current,
 	   lambda = sqrt(lambda);
 	   rx *= lambda;
 	   ry *= lambda;
-	}
-	factor = rx*rx*ry*ry - rx*rx*y1p*y1p - ry*ry*x1p*x1p;
-	if ( RealNear(factor,0))
-	    factor = 0;		/* Avoid rounding errors that lead to small negative values */
-	else
+	   cxp = cyp = 0;
+	} else {
+	    factor = rx*rx*ry*ry - rx*rx*y1p*y1p - ry*ry*x1p*x1p;
 	    factor = sqrt(factor/(rx*rx*y1p*y1p+ry*ry*x1p*x1p));
-	if ( large_arc==sweep )
-	    factor = -factor;
-	cxp = factor*(rx*y1p)/ry;
-	cyp =-factor*(ry*x1p)/rx;
+	    if ( large_arc==sweep )
+		factor = -factor;
+	    cxp = factor*(rx*y1p)/ry;
+	    cyp =-factor*(ry*x1p)/rx;
+	}
 	cx = cosr*cxp - sinr*cyp + (current->x+x)/2;
 	cy = sinr*cxp + cosr*cyp + (current->y+y)/2;
 


### PR DESCRIPTION
In the comments for #3425 I note that the guts of `SVGTraceArc()` are based on section [F.6.5](https://www.w3.org/TR/SVG11/implnote.html#ArcConversionEndpointToCenter) of the SVG 1.1 spec, which corresponds to section [B.2.4](https://www.w3.org/TR/SVG2/implnote.html#ArcConversionEndpointToCenter) of the SVG 2 spec. There are no substantial differences between the two. 

The current master has this code:
```
    if ( rx!=0 && ry!=0 ) {
        /* Page 647 in the SVG 1.1 spec describes how to do this */
        /* This is Appendix F (Implementation notes) section 6.5 */
        cosr = cos(axisrot); sinr = sin(axisrot);
        x1p = cosr*(current->x-x)/2 + sinr*(current->y-y)/2;
        y1p =-sinr*(current->x-x)/2 + cosr*(current->y-y)/2;
        /* Correct for bad radii */
        lambda = x1p*x1p/(rx*rx) + y1p*y1p/(ry*ry);
        if ( lambda>1 ) {
           lambda = sqrt(lambda);
           rx *= lambda;
           ry *= lambda;
        }
        factor = rx*rx*ry*ry - rx*rx*y1p*y1p - ry*ry*x1p*x1p;
        if ( RealNear(factor,0))
            factor = 0;         /* Avoid rounding errors that lead to small negative values */
        else
            factor = sqrt(factor/(rx*rx*y1p*y1p+ry*ry*x1p*x1p));
        if ( large_arc==sweep )
            factor = -factor;
        cxp = factor*(rx*y1p)/ry;
        cyp =-factor*(ry*x1p)/rx;
        cx = cosr*cxp - sinr*cyp + (current->x+x)/2;
        cy = sinr*cxp + cosr*cyp + (current->y+y)/2;
```
The `RealNear()` check seems to be Williams' addition, and due to not fully interpreting F.6.6/B.2.5 step 4:
> Proceed with the remaining elliptical arc computations, such as those in the Conversion from endpoint to center parameterization algorithm. Note: As a consequence of the radii corrections in this section, the equation (5.2) for the center of the ellipse always has at least one solution (i.e. the radicand is never negative). In the case that the radii are scaled up using equation (eq. 6.3), the radicand of (eq. 5.2) is zero and there is exactly one solution for the center of the ellipse.

In other words, `lambda>1` is the intended test for whether it is necessary to calculate `factor`. 

I have successfully given myself the bird with the file from #3425 and tested with some other SVGs I have lying around, and things seem fine on that basis. @ctrlcctrlv : you reported in another bug that SVG round-trips are a key part of your workflow. If you have some time, could you give this change some exercise and report back? 

Closes #3425

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
