### PR TITLE
Partial fix for viewBox in exported SVG glyph

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1069,8 +1069,7 @@ int _ExportSVG(FILE *svg,SplineChar *sc,int layer) {
     switch_to_c_locale(&tmplocale, &oldlocale); // Switch to the C locale temporarily and cache the old locale.
     fprintf(svg, "<?xml version=\"1.0\" standalone=\"no\"?>\n" );
     fprintf(svg, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" >\n" );
-    fprintf(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"%d %d %d %d\">\n",
-	    (int) floor(b.minx), (int) floor(b.miny),
+    fprintf(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"0 0 %d %d\">\n",
 	    (int) ceil(sc->width), (int) ceil(em_size));
     fprintf(svg, "  <g transform=\"matrix(1 0 0 -1 0 %d)\">\n",
 	    sc->parent->ascent );


### PR DESCRIPTION
This is the more modest version of #3395 without the width adjustments for glyphs that don't fit within their bearings. 

Closes #3271

Below is the description from the other pull request of this change for "the record" because I'm replacing it there. Note that the code for this request pins both the X and the Y value of the ViewBox to zero. Zero is the only X value that rationalizes `sc->width` as the ViewBox width -- making the right side of the box correspond to the edge of the right side bearing. 

---

Export a glyph as an SVG, like `J` from `tests/fonts/CaslonMM.sfd` in the repository, and you get something like J_CaslonMM.svg in this zip: [svgs.zip](https://github.com/fontforge/fontforge/files/2726533/svgs.zip) . Open that in a browser and you see something like this:

![jsvg_browser](https://user-images.githubusercontent.com/6175836/50682460-c0407580-0fc3-11e9-87cd-b26ef654dc17.png)

And the bottom continues to be cut off when you resize the window. So what's going on?

The relevant export code starts this way:

    int _ExportSVG(FILE *svg,SplineChar *sc,int layer) {
        char *end;
        int em_size;
        DBounds b;

        SplineCharLayerFindBounds(sc,layer,&b);
        em_size = sc->parent->ascent+sc->parent->descent;
        if ( b.minx>0 ) b.minx=0;
        if ( b.miny>-sc->parent->descent ) b.miny = -sc->parent->descent;
        if ( b.maxy<em_size ) b.maxy = em_size;

        locale_t tmplocale; locale_t oldlocale; // Declare temporary locale storage.
        switch_to_c_locale(&tmplocale, &oldlocale); // Switch to the C locale temporarily and cache the old locale.
        fprintf(svg, "<?xml version=\"1.0\" standalone=\"no\"?>\n" );
        fprintf(svg, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" >\n" );
        fprintf(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"%d %d %d %d\">\n",
                (int) floor(b.minx), (int) floor(b.miny),
                (int) ceil(sc->width), (int) ceil(em_size));
        fprintf(svg, "  <g transform=\"matrix(1 0 0 -1 0 %d)\">\n",
                sc->parent->ascent );

In the FontForge geometric space descent (in the typography sense) corresponds to *decreasing* `y`, and the origin is typically near the lower left of a glyph. In SVG space descent corresponds to *increasing* `y`, and by convention the origin is usually placed in the upper left of a picture, so that x and y values are generally positive. That's what the transform line does. It has the effect of multiplying all embedded `y` values by negative one and adding the font's `ascent` value, putting the `y` origin at what that line is in FontForge space. This is all good. 

The intent of the `viewBox` code immediately before is also sensible. The height (the fourth value) is set to the calculated em_size and the width (the third) is set to the calculated glyph width. The first value is also set sensibly, given that some glyphs have negative x values and the transform doesn't alter those. However, the second value makes no sense. The transformation has already moved `y`=0 to the proper location so the start of the `viewBox` should just be 0. 

After that change, which is all this pull request is, if you export that character as an SVG you get the other file in the zip, which looks like this in a browser:

![jsvggood_browser](https://user-images.githubusercontent.com/6175836/50683250-3e9e1700-0fc6-11e9-897d-8545003ef7a5.png)

The remaining worry is whether the `viewBox` is being used as some kind of record for importing or some other use. The answer is "no". Try importing either char svg into a font and you get the same effect. And by inspection `viewBox` is parsed twice in `svg.c`, once in `SVGuseTransform` and once in `SVGParseSVG`, but neither the `x` nor the `y` value is used. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [ ] Describe your changes in detail.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

