### PR TITLE
Initial prototype of fix for #3422 bad woff2 generation

### DIFF
--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -1876,6 +1876,8 @@ return( vs_maskttf );
 return( vs_maskps );
     else if ( format==ff_svg )
 return( vs_maskttf );
+    else if ( format==ff_woff2 )
+return( vs_maskttf );
     else
 return( sf->subfontcnt!=0 || sf->cidmaster!=NULL ? vs_maskcid :
 	sf->layers[layer].order2 ? vs_maskttf : vs_maskps );

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2076,11 +2076,18 @@ struct enc;
 extern char *strconcat(const char *str, const char *str2);
 
 extern void SFApplyFeatureFile(SplineFont *sf,FILE *file,char *filename);
+/* Any additions to this enum should be accounted for in 
+ * splinechar.c:VSMaskFromFormat() . There are also tables 
+ * indexed by values of this enum scattered throughout the
+ * code
+ */
 enum fontformat { ff_pfa, ff_pfb, ff_pfbmacbin, ff_multiple, ff_mma, ff_mmb,
 	ff_ptype3, ff_ptype0, ff_cid, ff_cff, ff_cffcid,
 	ff_type42, ff_type42cid,
 	ff_ttf, ff_ttfsym, ff_ttfmacbin, ff_ttc, ff_ttfdfont, ff_otf, ff_otfdfont,
 	ff_otfcid, ff_otfciddfont, ff_svg, ff_ufo, ff_ufo2, ff_ufo3, ff_woff, ff_woff2, ff_none };
+#define isttf_ff(ff) ((ff)>=ff_ttf && (ff)<=ff_ttfdfont)
+#define isttflike_ff(ff) (((ff)>=ff_ttf && (ff)<=ff_otfdfont) || (ff)==ff_woff2)
 extern struct pschars *SplineFont2ChrsSubrs(SplineFont *sf, int iscjk,
 	struct pschars *subrs,int flags,enum fontformat format,int layer);
 struct cidbytes;

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -2844,7 +2844,7 @@ static void sethead(struct head *head,SplineFont *sf,struct alltabs *at,
     head->checksumAdj = 0;
     head->magicNum = 0x5f0f3cf5;
     head->flags = 8|2|1;		/* baseline at 0, lsbline at 0, round ppem */
-    if ( format>=ff_ttf && format<=ff_ttfdfont ) {
+    if ( isttf_ff(format) ) {
 	if ( AnyInstructions(sf) )
 	    head->flags = 0x10|8|4|2|1;	/* baseline at 0, lsbline at 0, round ppem, instructions may depend on point size, instructions change metrics */
 	else if ( AnyMisleadingBitmapAdvances(sf,bsizes))
@@ -3366,7 +3366,7 @@ static void setos2(struct os2 *os2,struct alltabs *at, SplineFont *sf,
 	os2->version = 4;
     if ( sf->os2_version > os2->version )
 	os2->version = sf->os2_version;
-    if (( format>=ff_ttf && format<=ff_otfdfont) && (at->gi.flags&ttf_flag_symbol))
+    if ( isttflike_ff(format) && (at->gi.flags&ttf_flag_symbol))
 	modformat = ff_ttfsym;
 
     os2->weightClass = sf->pfminfo.weight;
@@ -3445,8 +3445,8 @@ docs are wrong.
 	    /*  BMP then last is 0xffff */
 	    /* sc->ttf_glyph>2 is to skip the first few truetype glyphs but */
 	    /*  that doesn't work for cff files which only have .notdef to ignore */
-	    if ( ( format>=ff_ttf && format<=ff_otfdfont && sc->ttf_glyph>2) ||
-		    ( format>=ff_ttf && format<=ff_otfdfont && sc->ttf_glyph>0) ) {
+	    if ( ( isttflike_ff(format) && sc->ttf_glyph>2 ) ||
+		    ( isttflike_ff(format) && sc->ttf_glyph>0 ) ) {
 		if ( sc->unicodeenc<=0xffff ) {
 		    if ( sc->unicodeenc<first ) first = sc->unicodeenc;
 		    if ( sc->unicodeenc>last ) last = sc->unicodeenc;
@@ -4052,7 +4052,7 @@ static void dumpnames(struct alltabs *at, SplineFont *sf,enum fontformat format)
     nt.format	     = format;
     nt.applemode     = at->applemode;
     nt.strings	     = tmpfile();
-    if (( format>=ff_ttf && format<=ff_otfdfont) && (at->gi.flags&ttf_flag_symbol))
+    if (isttflike_ff(format) && (at->gi.flags&ttf_flag_symbol))
 	nt.format    = ff_ttfsym;
 
     memset(&dummy,0,sizeof(dummy));
@@ -4830,7 +4830,7 @@ static void dumpcmap(struct alltabs *at, SplineFont *sf,enum fontformat format) 
     int mspos, ucs4pos, cjkpos, applecjkpos, vspos, start_of_macroman;
     int modformat = format;
 
-    if (( format>=ff_ttf && format<=ff_otfdfont) && (at->gi.flags&ttf_flag_symbol))
+    if (isttflike_ff(format) && (at->gi.flags&ttf_flag_symbol))
 	modformat = ff_ttfsym;
 
     at->cmap = tmpfile();


### PR DESCRIPTION
This is a *prototype* for a fix for #3422 and a context to discuss the issues raised by that bug. 

At the point of opening what this fix does is move the inequality-based checks for tff and ttf-like formats into macros defined after `enum fontformat` in `splinefont.h`. It also adds `ff_woff2` to that check.

I have verified that a WOFF2 file generated from the OTF attached to issue #3422 doesn't have the nonsensical First and Last Char Index values. But I'm really not the right person to systematically test woff2 generation. 
 
If and when verified:
Closes #3422

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

