### PR TITLE
Minor pycontrib fixes, graphicore option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -729,7 +729,12 @@ if test x"${i_do_have_python_scripting}" = xyes; then
    fi
 fi
 
-AM_CONDITIONAL([HAVE_IPYTHON],[test x"${have_ipython}" = xyes])
+AC_ARG_ENABLE([python-graphicore],
+        [AS_HELP_STRING([--enable-python-graphicore],
+                [enable a menu entry for IPython interactive shell])],
+        [have_python_graphicore=yes])
+
+AM_CONDITIONAL([HAVE_IPYTHON],[test x"${have_ipython}" = xyes && test x"${have_python_graphicore}" = xyes])
 
 #--------------------------------------------------------------------------
 #--------------------------------------------------------------------------

--- a/pycontrib/collab/web-test-collab.py
+++ b/pycontrib/collab/web-test-collab.py
@@ -68,7 +68,7 @@ def OnCollabUpdate(f):
             "end": "null" # this is simply so we dont have to manage keeping the last item with no terminating ,
             }, 
             sort_keys=True, indent=4, separators=(',', ': '))
-    print js
+    print(js)
     fi = open(fontJsonOnDisk, 'w')
     fi.write(js)
 

--- a/pycontrib/simple/expand-a.py
+++ b/pycontrib/simple/expand-a.py
@@ -25,7 +25,6 @@ for x in range(0, len(c)):
     fontforge.logWarning( "old x:" + str(p.x) + " y:" + str(p.y) )
     p.x = p.x * mag
     p.y = p.y * mag
-    c[x] = p
 
 for x in range(0, len(c)):
     p = c[x]


### PR DESCRIPTION
This is a minimal change (and effort) repair for pycontrib in a Python 3 environment. The `graphicore` IPython shell now has its own configuration flag, which with any luck won't be used. `simple/expand-a.py` has a fix that shouldn't be necessary but is, and the script works fine without the line. `webcontrib.py` has a Python-3 edit. 

I haven't otherwise touched `collab`. It's not great to ship with things that won't work but at least it doesn't output any warnings when not used. `gdraw` also remains as a probably-unused module. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [ ] Describe your changes in detail.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
