### PR TITLE
Increase buffer size to prevent stack smashing

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -6042,7 +6042,7 @@ static void SFDFixupBitmapRefs( BDFFont *bdf ) {
 
 static int SFDGetBitmapFont(FILE *sfd,SplineFont *sf,int fromdir,char *dirname) {
     BDFFont *bdf, *prev;
-    char tok[200];
+    char tok[2000];
     int pixelsize, ascent, descent, depth=1;
     int ch, enccount;
 


### PR DESCRIPTION
### Motivation and Context
- [x] Why is this change required? What problem does it solve?
This fixes a crash with `*** stack smashing detected ***` when opening an SFD file.
- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.
This prevents a crash when opening an SFD file with embedded BDF properties longer than 200 chars. In my case, for example, it was a very long copyright field.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.