### PR TITLE
Fix compilation when compiled without python support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
     if [ ! -z "$LINUX_FULL" ] ; then
       export FFCONFIG="$FFCONFIG --enable-code-coverage --enable-debug"
     elif [ ! -z "$LINUX_NOX" ]; then
-      export FFCONFIG="$FFCONFIG --without-x"
+      export FFCONFIG="$FFCONFIG --without-x --disable-python-extension --disable-python-scripting"
     fi
 
     # For some inane reason Travis defines this to '-g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,16 +127,15 @@ script:
   - make check
   - if [ ! -z "$LINUX_FULL" ]; then make distcheck; fi
   - fontforge -version
-  - $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version()); fontforge.font();"
+  - if [ -z "$LINUX_NOX" ]; then $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version()); fontforge.font();"; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
 
 after_success:
   - if [ ! -z "$LINUX_FULL" ]; then coveralls --gcov-options '\-bulp' --gcov $(which $GCOV) || true; fi
 
 after_failure:
-  - cat config.log
-  - cat Makefile
   - which python
+  - env
 
 deploy:
   provider: bintray

--- a/fontforgeexe/cvexportdlg.c
+++ b/fontforgeexe/cvexportdlg.c
@@ -638,8 +638,8 @@ static int _Export(SplineChar *sc,BDFChar *bc,int layer) {
 #ifndef _NO_PYTHON
     if ( _format>=fv_pythonbase )
 	ext = py_ie[_format-fv_pythonbase].extension;
-#endif
     else
+#endif
 	ext = _format==0?"eps":_format==1?"fig":_format==2?"svg":
 		_format==3?"glif":
 		_format==4?"pdf":_format==5?"plate":

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,6 +48,10 @@ noinst_FILES = * fonts/* results/* results
 TESTSUITE = $(srcdir)/testsuite
 EXTRA_DIST = testsuite.at $(srcdir)/package.m4 $(TESTSUITE) atlocal.in
 
+if !PYTHON_SCRIPTING
+TESTSUITEFLAGS = FONTFORGE_NO_PYTHON=1
+endif !PYTHON_SCRIPTING
+
 FONTFORGE = $(top_builddir)/fontforgeexe/fontforge
 
 check-local: $(builddir)/fonts atconfig atlocal $(TESTSUITE) $(FONTFORGE) $(GENERATED_INPUTS) $(FETCHED_INPUTS)
@@ -117,11 +121,11 @@ prefetch-nonfree-fonts: $(FETCHED_INPUTS_NONFREE)
 # Inputs we can generate from files in git
 fonts/Ambrosia.pt3: fonts/Ambrosia.sfd
 	$(MKDIR_P) $(builddir)/fonts
-	$(FONTFORGE) -c 'open(argv[1]).generate(argv[2])' $< $@
+	$(FONTFORGE) -lang=ff -c 'Open($$1); Generate($$2)' $< $@
 
 fonts/Ambrosia.woff2: fonts/Ambrosia.sfd
 	$(MKDIR_P) $(builddir)/fonts
-	$(FONTFORGE) -c 'open(argv[1]).generate(argv[2])' $< $@
+	$(FONTFORGE) -lang=ff -c 'Open($$1); Generate($$2)' $< $@
 
 fonts/MunhwaGothic-Bold:
 	$(MKDIR_P) $(builddir)/fonts

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -53,6 +53,7 @@ m4_defun([run_python],[(${abs_top_builddir}/fontforgeexe/fontforge -lang py -scr
 m4_defun([check_python],[
 AT_SETUP([$1])
 AT_SKIP_IF([test ! -r "${abs_srcdir}/$2"])
+AT_SKIP_IF([test ! -z "$FONTFORGE_NO_PYTHON"])
 check_file([test_input], [$3])
 AT_CHECK([run_python([$2],[$test_input])],[0],[ignore],[ignore])
 AT_CLEANUP


### PR DESCRIPTION
Update travis NOX target to also compile without python support

Regression from ca2f4bb97794bf983bbc0b25145248c21c9030d1