### PR TITLE
Expose selection of off-curve cubic points in python interface

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -942,8 +942,15 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD><CODE>selected</CODE></TD>
-      <TD colspan=2>Whether this point is selected in the UI. If an off-curve point
-	is selected in means the preceding (interpolated) on-curve point is selected.</TD>
+      <TD colspan=2>Whether this point is selected in the UI. In the case of
+        an off-curve point of a quadratic spline, selected is true when the
+	preceding (interpolated) on-curve point is selected. Otherwise (as with
+	a cubic curve) selected for an off-curve point also corresponds to 
+	UI selection.
+	<P>The value can also be set to change the selected status in the UI.
+        When not running with a UI FontForge will retain point selection status
+        between most calls and will usually mark the status in saved files as
+        it would when a UI is present.</TD>
     </TR>
     <TR>
       <TD><CODE>name</CODE></TD>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -4954,6 +4954,7 @@ return( ss );
 	    if ( !c->points[previ]->on_curve ) {
 		sp->prevcp.x = c->points[previ]->x;
 		sp->prevcp.y = c->points[previ]->y;
+		sp->prevcpselected = c->points[previ]->selected;
 		// if ( sp->prevcp.x!=sp->me.x || sp->prevcp.y!=sp->me.y ) // This is unnecessary since the other converter only makes a control point if there is supposed to be one.
 		    sp->noprevcp = false;
 	    }
@@ -4964,6 +4965,7 @@ return( ss );
 	    if ( !c->points[nexti]->on_curve ) {
 		sp->nextcp.x = c->points[nexti]->x;
 		sp->nextcp.y = c->points[nexti]->y;
+		sp->nextcpselected = c->points[nexti]->selected;
 		next += 2;
 		// if ( sp->nextcp.x!=sp->me.x || sp->nextcp.y!=sp->me.y ) // This is unnecessary since the other converter only makes a control point if there is supposed to be one.
 		    sp->nonextcp = false;
@@ -5064,8 +5066,8 @@ static PyFF_Contour *ContourFromSS(SplineSet *ss,PyFF_Contour *ret) {
 	    break;
 		if ( !sp->nonextcp || !sp->next->to->noprevcp ) {
 		    if ( k ) {
-			ret->points[cnt  ] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,false,NULL);
-			ret->points[cnt+1] = PyFFPoint_CNew(sp->next->to->prevcp.x,sp->next->to->prevcp.y,false,false,NULL);
+			ret->points[cnt  ] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,sp->nextcpselected,NULL);
+			ret->points[cnt+1] = PyFFPoint_CNew(sp->next->to->prevcp.x,sp->next->to->prevcp.y,false,sp->next->to->prevcpselected,NULL);
 		    }
 		    cnt += 2;		/* not a line => 2 control points */
 		}


### PR DESCRIPTION
When writing python scripts to "interactively" modify splines it can be useful to know which off-curve points are selected -- a status FontForge already tracks separately from that of on-curve points. At present the python interface just sets `selected` to false for all off-curve points. 

This change bidirectional `selected` status tracking for *cubic* off-curve points. (The status was already bidirectional for on-curve points.) 

Should this change also be made for quadratic off-curve points? One would think so! Unfortunately the original implementer applied an alternate interpretation to the field:

> If an off-curve point is selected in means the preceding (interpolated) on-curve point is selected.

So it's unclear what to do about that. 

This change is borderline-incompatible in that a script that assumes only on-curve points will be selected will no longer work as intended. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
