### PR TITLE
Allow hyphen in glyph class names

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -2600,7 +2600,7 @@ return;
 	    ch = getc(in);
 	    check_keywords = false;
 	}
-	while ( isalnum(ch) || ch=='_' || ch=='.' ) {
+	while ( isalnum(ch) || ch=='_' || ch=='.' || (ch=='-' && tok->type==tk_class) ) {
 	    if ( pt<tok->tokbuf+MAXT )
 		*pt++ = ch;
 	    ch = getc(in);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -162,7 +162,7 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 	test118.pe test119.pe test120.pe test121.pe		\
 	test122.pe test123.pe test124.pe test125.pe		\
 	test126.pe test127.pe test128.pe test129.pe		\
-	test130.pe test131.pe test132.pe
+	test130.pe test131.pe test132.pe test133.pe
 
 # python test scripts
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\

--- a/tests/fonts/test133.fea
+++ b/tests/fonts/test133.fea
@@ -1,0 +1,5 @@
+@ABC_def-123.test = [A B];
+
+lookup test {
+  sub @ABC_def-123.test by @ABC_def-123.test;
+} test;

--- a/tests/test133.pe
+++ b/tests/test133.pe
@@ -1,0 +1,10 @@
+New()
+Select("A")
+SetGlyphName("A")
+Select("B")
+SetGlyphName("B")
+MergeFeature($1)
+if ( SizeOf(GetLookupSubtables("test"))<=0 )
+  Error("No lookup subtables")
+endif
+Close()

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -108,6 +108,7 @@ check_pedit([Ligatures and Fractions Table Lookups],[test129.pe])
 check_pedit([TTC loading],[test130.pe],[NotoSans-Regular.ttc])
 check_pedit([libnameslist checks],[test131.pe])
 check_pedit([WOFF2 round tripping],[test132.pe],[Ambrosia.woff2])
+check_pedit([Allowed characters in glyph class names],[test133.pe],[test133.fea])
 
 AT_BANNER([FontForge Python Scripting Tests])
 


### PR DESCRIPTION
AFDKO’s makeotf allows them.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)