### PR TITLE
Conditional jump depends on uninitialised value

### DIFF
--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -425,7 +425,7 @@ void AnchorClassDecompose(SplineFont *sf,AnchorClass *_ac, int classcnt, int *su
 	    heads[i].glyphs[heads[i].cnt] = NULL;
     }
     for ( i=0; i<classcnt; ++i ) {
-        if ( subcnts[k]!=0 )
+        if ( subcnts[i]!=0 )
             SFOrderedGlyphs(marks[i]);
     }
 


### PR DESCRIPTION
The loop increments “i” but always tries to access “k” value, which seems to be a typo from commit 8c18b53a635816ae6eed9be4ea2b0653d2daf11e.

Valgrind log:
```
==8577== Conditional jump or move depends on uninitialised value(s)
==8577==    at 0x51B3F36: AnchorClassDecompose (tottfgpos.c:428)
==8577==    by 0x51B7380: AnchorsAway (tottfgpos.c:2468)
==8577==    by 0x51B7380: otf_dumpALookup (tottfgpos.c:2598)
==8577==    by 0x51B98BE: G___figureLookups (tottfgpos.c:2667)
==8577==    by 0x51B98BE: dumpg___info (tottfgpos.c:3056)
==8577==    by 0x51BACE9: otf_dumpgpos (tottfgpos.c:3266)
==8577==    by 0x51CD976: initATTables (tottf.c:5303)
==8577==    by 0x51CEF6A: initTables (tottf.c:5784)
==8577==    by 0x51CF2CF: _WriteTTFFont (tottf.c:6135)
==8577==    by 0x51CF916: WriteTTFFont (tottf.c:6168)
==8577==    by 0x50B2186: _DoSave (savefont.c:852)
==8577==    by 0x50B3724: GenerateScript (savefont.c:1274)
==8577==    by 0x50CBDA3: bGenerate (scripting.c:2092)
==8577==    by 0x50CE90B: docall (scripting.c:9687)
==8577==  Uninitialised value was created by a heap allocation
==8577==    at 0x483777F: malloc (vg_replace_malloc.c:299)
==8577==    by 0x51B6D05: AnchorsAway (tottfgpos.c:2447)
==8577==    by 0x51B6D05: otf_dumpALookup (tottfgpos.c:2598)
==8577==    by 0x51B98BE: G___figureLookups (tottfgpos.c:2667)
==8577==    by 0x51B98BE: dumpg___info (tottfgpos.c:3056)
==8577==    by 0x51BACE9: otf_dumpgpos (tottfgpos.c:3266)
==8577==    by 0x51CD976: initATTables (tottf.c:5303)
==8577==    by 0x51CEF6A: initTables (tottf.c:5784)
==8577==    by 0x51CF2CF: _WriteTTFFont (tottf.c:6135)
==8577==    by 0x51CF916: WriteTTFFont (tottf.c:6168)
==8577==    by 0x50B2186: _DoSave (savefont.c:852)
==8577==    by 0x50B3724: GenerateScript (savefont.c:1274)
==8577==    by 0x50CBDA3: bGenerate (scripting.c:2092)
==8577==    by 0x50CE90B: docall (scripting.c:9687)
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)