### PR TITLE
Revert "Use typo metrics for fitting glyphs in font view"

### DIFF
--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -1747,24 +1747,13 @@ BDFFont *SplineFontPieceMeal(SplineFont *sf,int layer,int ptsize,int dpi,
 	if ( bb.minx<-10*(sf->ascent+sf->descent) ) bb.minx = -2*(sf->ascent+sf->descent);
 	scale = pixelsize/ (real) (bb.maxy-bb.miny);
 	bdf->ascent = rint(bb.maxy*scale);
+	truesize = rint( (sf->ascent+sf->descent)*scale );
+	if ( pixelsize!=0 )
+	    ptsize = rint( ptsize*(double) truesize/pixelsize );
     } else {
-	real ascent = sf->pfminfo.os2_typoascent;
-	real descent = sf->pfminfo.os2_typodescent;
-	ascent += sf->pfminfo.typoascent_add ? sf->ascent : 0;
-	descent -= sf->pfminfo.typodescent_add ? sf->descent: 0;
-	// 1.2 is just an arbitrary value to make the glyph look less tightly fit
-	// in the font view.
-	ascent *= 1.2;
-	descent *= 1.2;
-
-	scale = pixelsize / (real) (ascent - descent);
-	bdf->ascent = rint (ascent * scale);
+	scale = pixelsize / (real) (sf->ascent+sf->descent);
+	bdf->ascent = rint(sf->ascent*scale);
     }
-
-    truesize = rint ((sf->ascent + sf->descent) * scale);
-    if (pixelsize != 0)
-	ptsize = rint (ptsize * (double) truesize / pixelsize);
-
     if ( flags&pf_ft_nohints )
     {
 //	printf("SplineFontPieceMeal() going unhinted...\n");


### PR DESCRIPTION
This reverts commit 4a6155aeb2d8ce381f417844efac5afcf63e4bff because it causes problems in metrics window calculations. See #3470 for analysis. 

Closes #3470 
Closes #3324 

(Both of these are verified as matching the attachment dialog. #3400 may also be fixed but I cannot verify). 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
