### PR TITLE
Support shorthand contextual multiple substitutions

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -4819,26 +4819,24 @@ static void fea_ParseSubstitute(struct parseState *tok) {
 		    LogError(_("No substitution specified on line %d of %s"), tok->line[tok->inc_depth], tok->filename[tok->inc_depth] );
 		    ++tok->err_count;
 		} else {
-		    for ( i=0, rp=rpl; g!=NULL && rp!=NULL; ++i, rp=rp->next ) {
-		        if ( rp->lookupname!=NULL ) {
-			    head = chunkalloc(sizeof(struct feat_item));
-			    head->type = ft_lookup_ref;
-			    head->u1.lookup_name = copy(rp->lookupname);
-		        } else if ( g->next==NULL || g->next->mark_count!=g->mark_count ) {
-			    head = fea_process_sub_single(tok,g,rp,NULL);
-		        } else if ( g->next!=NULL && g->mark_count==g->next->mark_count ) {
-			    head = fea_process_sub_ligature(tok,g,rpl,NULL);
-		        } else {
-			    head = NULL;
-			    LogError(_("Unparseable contextual sequence on line %d of %s"), tok->line[tok->inc_depth], tok->filename[tok->inc_depth] );
-			    ++tok->err_count;
-		        }
-		        r->lookups[i].lookup = (OTLookup *) head;
-		        cnt = g->mark_count;
-		        while ( g!=NULL && g->mark_count == cnt )	/* skip everything involved here */
-			    g=g->next;
-		        for ( ; g!=NULL && g->mark_count!=0; g=g->next ); /* skip any uninvolved glyphs */
+		    if ( rpl->lookupname!=NULL ) {
+			head = chunkalloc(sizeof(struct feat_item));
+			head->type = ft_lookup_ref;
+			head->u1.lookup_name = copy(rpl->lookupname);
+		    } else if ( g->next==NULL || g->next->mark_count!=g->mark_count ) {
+			head = fea_process_sub_single(tok,g,rpl,NULL);
+		    } else if ( g->next!=NULL && g->mark_count==g->next->mark_count ) {
+			head = fea_process_sub_ligature(tok,g,rpl,NULL);
+		    } else {
+			head = NULL;
+			LogError(_("Unparseable contextual sequence on line %d of %s"), tok->line[tok->inc_depth], tok->filename[tok->inc_depth] );
+			++tok->err_count;
 		    }
+		    r->lookups[0].lookup = (OTLookup *) head;
+		    cnt = g->mark_count;
+		    while ( g!=NULL && g->mark_count == cnt )	/* skip everything involved here */
+			g=g->next;
+		    for ( ; g!=NULL && g->mark_count!=0; g=g->next ); /* skip any uninvolved glyphs */
 		}
 	    }
 	    fea_markedglyphsFree(rpl);

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -4733,6 +4733,7 @@ static void fea_ParseSubstitute(struct parseState *tok) {
     /* name from <class> => alternate subs */
     /* <glyph sequence> by name => ligature */
     /* <marked glyph sequence> by <name> => context chaining */
+    /* <marked glyph sequence> by <glyph sequence> => context chaining */
     /* <marked glyph sequence> by <lookup name>* => context chaining */
     /* [ignore sub] <marked glyph sequence> (, <marked g sequence>)* */
     /* reversesub <marked glyph sequence> by <name> => reverse context chaining */
@@ -4835,7 +4836,10 @@ static void fea_ParseSubstitute(struct parseState *tok) {
 			head->type = ft_lookup_ref;
 			head->u1.lookup_name = copy(rpl->lookupname);
 		    } else if ( g->next==NULL || g->next->mark_count!=g->mark_count ) {
-			head = fea_process_sub_single(tok,g,rpl,NULL);
+			if (rpl->next)
+			    head = fea_process_sub_multiple(tok,g,rpl,NULL);
+			else
+			    head = fea_process_sub_single(tok,g,rpl,NULL);
 		    } else if ( g->next!=NULL && g->mark_count==g->next->mark_count ) {
 			head = fea_process_sub_ligature(tok,g,rpl,NULL);
 		    } else {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -162,7 +162,8 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 	test118.pe test119.pe test120.pe test121.pe		\
 	test122.pe test123.pe test124.pe test125.pe		\
 	test126.pe test127.pe test128.pe test129.pe		\
-	test130.pe test131.pe test132.pe test133.pe
+	test130.pe test131.pe test132.pe test133.pe		\
+	test134.pe
 
 # python test scripts
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
@@ -188,6 +189,7 @@ GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/MinionPro-Regular.otf				\
 	fonts/LucidaGrande.ttc					\
 	fonts/nuvo-medium-woff-demo.woff		\
+	fonts/test134.fea					\
 	$(FETCHED_INPUTS)						\
 	$(FETCHED_INPUTS_NONFREE)
 

--- a/tests/fonts/test134.fea
+++ b/tests/fonts/test134.fea
@@ -1,0 +1,3 @@
+lookup test {
+  sub A' B by C D;
+} test;

--- a/tests/test134.pe
+++ b/tests/test134.pe
@@ -1,0 +1,46 @@
+New()
+
+Select("A")
+SetGlyphName("A")
+SetWidth(100)
+
+Select("B")
+SetGlyphName("B")
+SetWidth(100)
+
+Select("C")
+SetGlyphName("C")
+SetWidth(100)
+
+Select("D")
+SetGlyphName("D")
+SetWidth(100)
+
+MergeFeature($1)
+
+lookups = GetLookups("GSUB")
+if (SizeOf(lookups) != 2)
+  Error("There should be two lookups")
+endif
+
+i = 0
+while (i < SizeOf(lookups))
+  subtables = GetLookupSubtables(lookups[i])
+  if (SizeOf(subtables) != 1)
+    Print("Lookup: ", lookups[i])
+    Error("There should be one subtable")
+  endif
+  if (i == 1)
+    Select("A")
+    sub = GetPosSub(subtables[0])
+    if (SizeOf(sub) != 1)
+      Error("Incorrect number of substitutions")
+    endif
+    if (SizeOf(sub[0]) != 4 || sub[0][1] != "MultSubs" || sub[0][2] != "C" || sub[0][3] != "D")
+      Error("Incorrect substitution")
+    endif
+  endif
+  i++
+endloop
+
+Close()

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -109,6 +109,7 @@ check_pedit([TTC loading],[test130.pe],[NotoSans-Regular.ttc])
 check_pedit([libnameslist checks],[test131.pe])
 check_pedit([WOFF2 round tripping],[test132.pe],[Ambrosia.woff2])
 check_pedit([Allowed characters in glyph class names],[test133.pe],[test133.fea])
+check_pedit([Short-hand contextual multiple substitution],[test134.pe],[test134.fea])
 
 AT_BANNER([FontForge Python Scripting Tests])
 


### PR DESCRIPTION
Similar to https://github.com/adobe-type-tools/afdko/pull/729. Also fix and invalid write that would happens when such substitutions are encountered.

Valgrind log:
```
    ==26093== Invalid write of size 8
    ==26093==    at 0x4FCE0D8: fea_ParseSubstitute (featurefile.c:4837)
    ==26093==    by 0x4FCE0D8: fea_LookupSwitch (featurefile.c:5006)
    ==26093==    by 0x4FCE5AB: fea_ParseLookupDef (featurefile.c:5071)
    ==26093==    by 0x4FCE5AB: fea_ParseLookupDef (featurefile.c:5023)
    ==26093==    by 0x4FD0B81: fea_ParseFeatureFile (featurefile.c:6151)
    ==26093==    by 0x4FD0B81: SFApplyFeatureFile (featurefile.c:7385)
    ==26093==    by 0x4FD361E: SFApplyFeatureFilename (featurefile.c:7426)
    ==26093==    by 0x51441CF: LoadKerningDataFromMetricsFile (splinesaveafm.c:3533)
    ==26093==    by 0x50C1648: bMergeKern (scripting.c:2563)
    ==26093==    by 0x50CE92B: docall (scripting.c:9687)
    ==26093==    by 0x50CEF95: handlename (scripting.c:9798)
    ==26093==    by 0x50D02B4: term (scripting.c:10042)
    ==26093==    by 0x50D05A7: mul (scripting.c:10187)
    ==26093==    by 0x50D07AD: add (scripting.c:10232)
    ==26093==    by 0x50D0B18: comp (scripting.c:10307)
    ==26093==  Address 0xc803788 is 8 bytes after a block of size 16 alloc'd
    ==26093==    at 0x4839B65: calloc (vg_replace_malloc.c:752)
    ==26093==    by 0x4FC451B: fea_markedglyphs_to_fpst (featurefile.c:4560)
    ==26093==    by 0x4FCD8B1: fea_ParseSubstitute (featurefile.c:4795)
    ==26093==    by 0x4FCD8B1: fea_LookupSwitch (featurefile.c:5006)
    ==26093==    by 0x4FCE5AB: fea_ParseLookupDef (featurefile.c:5071)
    ==26093==    by 0x4FCE5AB: fea_ParseLookupDef (featurefile.c:5023)
    ==26093==    by 0x4FD0B81: fea_ParseFeatureFile (featurefile.c:6151)
    ==26093==    by 0x4FD0B81: SFApplyFeatureFile (featurefile.c:7385)
    ==26093==    by 0x4FD361E: SFApplyFeatureFilename (featurefile.c:7426)
    ==26093==    by 0x51441CF: LoadKerningDataFromMetricsFile (splinesaveafm.c:3533)
    ==26093==    by 0x50C1648: bMergeKern (scripting.c:2563)
    ==26093==    by 0x50CE92B: docall (scripting.c:9687)
    ==26093==    by 0x50CEF95: handlename (scripting.c:9798)
    ==26093==    by 0x50D02B4: term (scripting.c:10042)
    ==26093==    by 0x50D05A7: mul (scripting.c:10187)
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)