### PR TITLE
Support glyph classes in GDEF GlyphClassDef

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -5827,7 +5827,7 @@ static void fea_ParseGDEFTable(struct parseState *tok) {
 		fea_ParseTok(tok);
 		if ( tok->type==tk_char && (( i<3 && tok->tokbuf[0]==',' ) || ( i==3 && tok->tokbuf[0]==';' )) )
 		    ; /* Skip the placeholder for a missing class definition or a final semicolon */
-		else if ( tok->type==tk_class ) {
+		else if ( tok->type==tk_class || ( tok->type==tk_char && tok->tokbuf[0]=='[' ) ) {
 		    item->u1.gdef_classes[i] = fea_ParseGlyphClassGuarded(tok);
 		    fea_ParseTok(tok);
 		    if ( tok->type==tk_char && (( i<3 && tok->tokbuf[0]==',' ) || ( i==3 && tok->tokbuf[0]==';' )) )

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -163,7 +163,7 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 	test122.pe test123.pe test124.pe test125.pe		\
 	test126.pe test127.pe test128.pe test129.pe		\
 	test130.pe test131.pe test132.pe test133.pe		\
-	test134.pe
+	test134.pe test135.pe
 
 # python test scripts
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
@@ -190,6 +190,7 @@ GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/LucidaGrande.ttc					\
 	fonts/nuvo-medium-woff-demo.woff		\
 	fonts/test134.fea					\
+	fonts/test135.fea					\
 	$(FETCHED_INPUTS)						\
 	$(FETCHED_INPUTS_NONFREE)
 

--- a/tests/fonts/test135.fea
+++ b/tests/fonts/test135.fea
@@ -1,0 +1,3 @@
+table GDEF {
+  GlyphClassDef [A], [B], [C], [D];
+} GDEF;

--- a/tests/test135.pe
+++ b/tests/test135.pe
@@ -1,0 +1,41 @@
+New()
+
+Select("A")
+SetGlyphName("A")
+SetWidth(100)
+
+Select("B")
+SetGlyphName("B")
+SetWidth(100)
+
+Select("C")
+SetGlyphName("C")
+SetWidth(100)
+
+Select("D")
+SetGlyphName("D")
+SetWidth(100)
+
+MergeFeature($1)
+
+Select("A")
+if (GlyphInfo("Class") != "base")
+  Error("Incorrect glyph class")
+endif
+
+Select("B")
+if (GlyphInfo("Class") != "ligature")
+  Error("Incorrect glyph class")
+endif
+
+Select("C")
+if (GlyphInfo("Class") != "mark")
+  Error("Incorrect glyph class")
+endif
+
+Select("D")
+if (GlyphInfo("Class") != "component")
+  Error("Incorrect glyph class")
+endif
+
+Close()

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -110,6 +110,7 @@ check_pedit([libnameslist checks],[test131.pe])
 check_pedit([WOFF2 round tripping],[test132.pe],[Ambrosia.woff2])
 check_pedit([Allowed characters in glyph class names],[test133.pe],[test133.fea])
 check_pedit([Short-hand contextual multiple substitution],[test134.pe],[test134.fea])
+check_pedit([GDEF glyph classes],[test135.pe],[test135.fea])
 
 AT_BANNER([FontForge Python Scripting Tests])
 


### PR DESCRIPTION
Only class names were supported, but makeotf supports specifying classes directly as well.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)