### PR TITLE
Handle reused mark filtering set in feature files

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -3148,6 +3148,9 @@ static int fea_ParseMarkAttachClass(struct parseState *tok, int is_set) {
 
     for ( i=0; i<tok->gm_cnt[is_set]; ++i ) {
 	if ( strcmp(tok->tokbuf,tok->gdef_mark[is_set][i].name)==0 )
+	    if (is_set)
+return( (tok->gdef_mark[is_set][i].index << 16) | pst_usemarkfilteringset );
+	    else
 return( tok->gdef_mark[is_set][i].index << 8 );
     }
     glyphs = fea_lookup_class_complain(tok,tok->tokbuf);

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -1348,7 +1348,7 @@ static void dump_needednestedlookups(FILE *out, SplineFont *sf, OTLookup *otl) {
 static void dump_lookup(FILE *out, SplineFont *sf, OTLookup *otl) {
     struct lookup_subtable *sub;
     static char *flagnames[] = { "RightToLeft", "IgnoreBaseGlyphs", "IgnoreLigatures", "IgnoreMarks", NULL };
-    int i, k, first;
+    int i, k;
     SplineFont *_sf;
     SplineChar *sc;
     PST *pst;
@@ -1373,19 +1373,12 @@ return;					/* No support for apple "lookups" */
 	fprintf( out, "  lookupflag %d;\n", otl->lookup_flags );
     else {
 	fprintf( out, "  lookupflag" );
-	first = true;
 	for ( i=0; i<4; ++i ) if ( otl->lookup_flags&(1<<i)) {
-	    if ( !first ) {
-		// putc(',',out); // The specification says to do this, but Adobe's software uses spaces.
-	    } else
-		first = false;
 	    fprintf( out, " %s", flagnames[i] );
 	}
 	if ( (otl->lookup_flags&0xff00)!=0 ) {
 	    int index = (otl->lookup_flags>>8)&0xff;
 	    if ( index<sf->mark_class_cnt ) {
-		// if ( !first )
-		//     putc(',',out);
 		fprintf( out, " MarkAttachmentType @" );
 		dump_ascii( out, sf->mark_class_names[index]);
 	    }
@@ -1393,8 +1386,6 @@ return;					/* No support for apple "lookups" */
 	if ( otl->lookup_flags&pst_usemarkfilteringset ) {
 	    int index = (otl->lookup_flags>>16)&0xffff;
 	    if ( index<sf->mark_set_cnt ) {
-		// if ( !first )
-		//     putc(',',out);
 		fprintf( out, " UseMarkFilteringSet @" );
 		dump_ascii( out, sf->mark_set_names[index]);
 	    }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -163,7 +163,7 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 	test122.pe test123.pe test124.pe test125.pe		\
 	test126.pe test127.pe test128.pe test129.pe		\
 	test130.pe test131.pe test132.pe test133.pe		\
-	test134.pe test135.pe
+	test134.pe test135.pe test136.pe
 
 # python test scripts
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
@@ -191,6 +191,7 @@ GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/nuvo-medium-woff-demo.woff		\
 	fonts/test134.fea					\
 	fonts/test135.fea					\
+	fonts/test136.fea					\
 	$(FETCHED_INPUTS)						\
 	$(FETCHED_INPUTS_NONFREE)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -92,6 +92,8 @@ EXTRA_DIST += fonts/AddExtremaTest2.sfd fonts/AddExtremumTest.sfd	\
 	fonts/SimplifyBugs.sfd fonts/SplineOverlapBug1.sfd		\
 	fonts/StrokeTests.sfd fonts/VKern.sfd fonts/MunhwaGothic-Bold \
 	fonts/NotoSans-Regular.ttc fonts/n019003l.pfb fonts/cmbsy10.pfb	\
+	fonts/test133.fea fonts/test134.fea fonts/test135.fea		\
+	fonts/test136.fea						\
 	README
 
 # generated test inputs
@@ -189,9 +191,6 @@ GITIGNOREFILES = $(MAYBE_GENERATED_INPUTS)			\
 	fonts/MinionPro-Regular.otf				\
 	fonts/LucidaGrande.ttc					\
 	fonts/nuvo-medium-woff-demo.woff		\
-	fonts/test134.fea					\
-	fonts/test135.fea					\
-	fonts/test136.fea					\
 	$(FETCHED_INPUTS)						\
 	$(FETCHED_INPUTS_NONFREE)
 

--- a/tests/fonts/test136.fea
+++ b/tests/fonts/test136.fea
@@ -1,0 +1,11 @@
+@test = [B];
+
+lookup test1 {
+  lookupflag UseMarkFilteringSet @test;
+  sub A' B by C;
+} test1;
+
+lookup test2 {
+  lookupflag UseMarkFilteringSet @test;
+  sub B' C by A;
+} test2;

--- a/tests/test136.pe
+++ b/tests/test136.pe
@@ -1,0 +1,52 @@
+New()
+
+Select("A")
+SetGlyphName("A")
+SetWidth(100)
+
+Select("B")
+SetGlyphName("B")
+SetWidth(100)
+
+Select("C")
+SetGlyphName("C")
+SetWidth(100)
+
+MergeFeature($1)
+
+lookups = GetLookups("GSUB")
+if (SizeOf(lookups) != 4)
+  Error("There should be two lookups")
+endif
+
+i = 0
+while (i < SizeOf(lookups))
+  subtables = GetLookupSubtables(lookups[i])
+  if (SizeOf(subtables) != 1)
+    Print("Lookup: ", lookups[i])
+    Error("There should be one subtable")
+  endif
+  if (i == 1)
+    Select("A")
+    sub = GetPosSub(subtables[0])
+    if (SizeOf(sub) != 1)
+      Error("Incorrect number of substitutions")
+    endif
+    if (SizeOf(sub[0]) != 3 || sub[0][1] != "Substitution" || sub[0][2] != "C")
+      Error("Incorrect substitution")
+    endif
+  endif
+  if (i == 3)
+    Select("B")
+    sub = GetPosSub(subtables[0])
+    if (SizeOf(sub) != 1)
+      Error("Incorrect number of substitutions")
+    endif
+    if (SizeOf(sub[0]) != 3 || sub[0][1] != "Substitution" || sub[0][2] != "A")
+      Error("Incorrect substitution")
+    endif
+  endif
+  i++
+endloop
+
+Close()

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -111,6 +111,7 @@ check_pedit([WOFF2 round tripping],[test132.pe],[Ambrosia.woff2])
 check_pedit([Allowed characters in glyph class names],[test133.pe],[test133.fea])
 check_pedit([Short-hand contextual multiple substitution],[test134.pe],[test134.fea])
 check_pedit([GDEF glyph classes],[test135.pe],[test135.fea])
+check_pedit([Re-using mark filtering set],[test136.pe],[test136.fea])
 
 AT_BANNER([FontForge Python Scripting Tests])
 


### PR DESCRIPTION
The subsequent used of a mark filtering set will cause parsing errors due to incorrectly set flag mask.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)