### PR TITLE
Point types and point type conversion for python interface

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -915,10 +915,15 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD><CODE>fontforge.point</CODE></TD>
-      <TD><CODE>([x,y,on-curve,selected])</CODE></TD>
+      <TD><CODE>([x,y,on-curve,type,selected])</CODE></TD>
       <TD>Creates a new point. Optionally specifying its x,y
          location, on-curve status and selected status. x and y
-         must be supplied together</TD>
+         must be supplied together.
+	<P>A "point initializer tuple" is any tuple
+	<CODE>(x,y[,True|False[,0|1|2|3[,True|False]]])</CODE>, where
+	<CODE>x</CODE> and <CODE>y</CODE> are numbers, the third value
+	corresponds to <CODE>on-curve</CODE>, the fourth to <CODE>type</CODE>,
+	and the fifth to <CODE>selected</CODE>.</TD>
     </TR>
     <TR>
       <TH colspan=3>Members</TH>
@@ -948,6 +953,21 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	on setting a layer.  FontForge usually retains the selection status of
 	any point between and that of an on-curve point when saving, whether or
 	not a UI is present.
+      </TD>
+    </TR>
+    <TR>
+      <TD><CODE>type</CODE></TD>
+      <TD colspan=2>For an on-curve point, its FontForge point type.
+	<P>
+	There are four types: <CODE>fontforge.splineCorner</CODE>==0,
+	<CODE>fontforge.splineCurve</CODE>==1,
+	<CODE>fontforge.splineHVCurve</CODE>==2, and
+	<CODE>fontforge.splineTangent</CODE>==3. A new point will have
+	type <CODE>splineCorner</CODE>. When assigning a layer to
+	<CODE>glyph.layers</CODE>, <CODE>glyph.background</CODE> or
+	<CODE>glyph.foreground</CODE> the type value is ignored. To
+	influence the type FontForge will associate with an on-curve point
+	use <CODE><A HREF="python.html#g-setLayer">glyph.setLayer</A></CODE>
       </TD>
     </TR>
     <TR>
@@ -1145,7 +1165,7 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     <TR>
       <TD colspan=2><CODE>c[i:j] = d</CODE></TD>
       <TD>The points between i and j are replaced by those in d; i must be &gt;= j.
-        d can be a contour or a sequence of point initializers, as in [(1,1,False),(2,1)].
+        d can be a contour or a sequence of point initializer tuples, as in [(1,1,False),(2,1)].
         If c[j:i:-1] is used instead the points of d are assigned in reverse order.</TD>
     </TR>
     <TR>
@@ -1227,8 +1247,8 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
       <TD><CODE>(point[,pos])</CODE></TD>
       <TD>Adds point to the contour. If the optional third argument is give, the
 	line will be added after the pos'th point, otherwise it will be at the end
-	of the contour. The point may be either a point or a tuple with three members
-	(x,y,on_curve)</TD>
+	of the contour. The point may be either a point or a point initializer tuple.
+	</TD>
     </TR>
     <TR>
       <TD><CODE>makeFirst</CODE></TD>
@@ -2703,6 +2723,64 @@ pen = None;				# Finalize the pen. This tells FontForge
       <TD><CODE>()</CODE></TD>
       <TD>Returns whether any of the contours in this glyph intersects any other
 	contour in the glyph (including itself).</TD>
+    </TR>
+    <TR>
+      <TD><CODE><A name="g-setLayer">setLayer</A></CODE></TD>
+      <TD><CODE>(layer,layer-index[,flags])</CODE></TD>
+      <TD>An alternative to assigning to <CODE>layers</CODE>, <CODE>background</CODE>,
+	or <CODE>foreground</CODE>, and equivalent to those when not using the optional
+	<CODE>flags</CODE> argument. When present <CODE>flags</CODE> can be used to
+	influence the types FontForge will assign to on-curve points. It
+	should be a tuple of up to three of the following strings. (In the following
+	descriptions "<em>selected</em>" refers to points picked out by the
+	chosen "select_" flag, which is unrelated to the <CODE>point.selected</CODE>
+	field. At most one "select_" flag and one mode flag should be included.)
+	<DL>
+	  <DT>select_none
+	  <DD>Each (on-curve) point will be assigned a type corresponding to its
+	  <CODE>point.type</CODE> value.
+	  <DT>select_all
+	  <DD>(default) Each point will have a type assigned according to the
+	  chosen mode.
+	  <DT>select_smooth
+	  <DD>Each point with the type <CODE>splineCorner</CODE> will retain
+	  that type, others will be assigned a type according to the chosen 
+	  mode. This makes the <CODE>point.type</CODE> field function like
+	  the <CODE>smooth</CODE> tag in the UFO glif format and some other
+	  spline storage formats. 
+	  <DT>select_incompat
+	  <DD>Each point with a type compatible with its current geometry will
+	  retain that type, others will be assigned a type according to the chosen
+	  mode.
+	  <DT>by_geom
+	  <DD>(default) In this mode, each <EM>selected</EM> point will be assigned
+	  a type based on only its geometry. (However, see "hvcurve" below.)
+	  <DT>downgrade
+	  <DD>In this mode, each <EM>selected</EM> point will be assigned the 
+	  most specific type compatible with its geometry and its <CODE>point.type</CODE>.
+	  A point marked <CODE>splineHVCurve</CODE> can keep that type or be 
+	  downgraded to <CODE>splineCurve</CODE> or <CODE>splineCorner</CODE>, while
+	  a <CODE>splineCurve</CODE> or <CODE>splineTangent</CODE> can keep that 
+	  (respective) type or be downgraded to <CODE>splineCorner</CODE>. 
+	  (<CODE>splineCorner</CODE> is compatible with any geometry.)
+	  <DT>check
+	  <DD>In this mode, the type of each <EM>selected</EM> point is verified to be 
+	  compatible with its geometry. If it is not compatible the function
+	  raises an exception. (At present this exception is
+	  not very informative. However, to identify the specific problem
+	  one can duplicate the layer, use <CODE>setLayer</CODE> with 'downgrade', 
+	  and then retrieve the layer and compare it with the original.)
+	  <DT>force
+	  <DD>In this mode, the geometry of each <EM>selected</EM> point is 
+	  altered to match its <CODE>point.type</CODE>, similar to changing a 
+	  point's type using the UI. Note that FontForge's point conversion
+	  algorithm is not sophisticated and may not have the desired result.
+	  <DT>hvcurve
+	  <DD>This extra flag can be used to include <CODE>splineHVCurve</CODE>
+	  among the types that can be assigned "by geometry". Normally FontForge
+	  assigns <CODE>splineCurve</CODE> to on-curve points with strictly 
+	  horizontal or vertical off-curve points. 
+	</DL></TD>
     </TR>
     <TR>
       <TD><CODE>simplify</CODE></TD>

--- a/fontforge/ffpython.h
+++ b/fontforge/ffpython.h
@@ -112,6 +112,7 @@ typedef struct ff_point {
     double x,y;
     uint8 on_curve;
     uint8 selected;
+    uint8 type;
     uint8 interpolated;
     char *name;
 } PyFF_Point;

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -291,8 +291,10 @@ static void PyFF_PickleTypesInit(void);
 
 static int SSSelectOnCurve(SplineSet *ss,int pos);
 static SplineSet *SSFromContour(PyFF_Contour *, int *start);
+static SplineSet *_SSFromContour(PyFF_Contour *, int *start, int flags);
 static PyFF_Contour *ContourFromSS(SplineSet *,PyFF_Contour *);
 static SplineSet *SSFromLayer(PyFF_Layer *);
+static SplineSet *_SSFromLayer(PyFF_Layer *, int flags);
 static PyFF_Layer *LayerFromSS(SplineSet *,PyFF_Layer *);
 static PyFF_Layer *LayerFromLayer(Layer *,PyFF_Layer *);
 
@@ -1751,7 +1753,20 @@ return( reto );
 /* Points */
 /* ************************************************************************** */
 
-static PyFF_Point *PyFFPoint_CNew(double x, double y, int on_curve, int sel, char *name) {
+static const char *py_point_types[] = { "splineCorner", "splineCurve", "splineHVCurve",
+				     "splineTangent", NULL };
+// point types: see 'enum pointtype' in splinefont.h
+static const int typemap_from_python[] = { 1, 0, 3, 2 };
+static const int typemap_to_python[] = { 1, 0, 3, 2 };
+#define MAX_POINTTYPE_VAL 3
+
+static void AddPointConstants( PyObject *module ) {
+    int i;
+    for ( i=0; py_point_types[i]!=NULL; ++i )
+        PyModule_AddObject(module, py_point_types[i], Py_BuildValue("i",i));
+}
+
+static PyFF_Point *PyFFPoint_CNew(double x, double y, int on_curve, int sel, int type, char *name) {
     /* Convenience routine for creating a new point from C */
     PyFF_Point *self = (PyFF_Point *)PyFF_PointType.tp_alloc(&PyFF_PointType, 0);
     if ( self==NULL )
@@ -1760,13 +1775,14 @@ static PyFF_Point *PyFFPoint_CNew(double x, double y, int on_curve, int sel, cha
     self->y = y;
     self->on_curve = on_curve;
     self->selected = sel;
+    self->type = type;
     self->name = copy(name);
     return( self );
 }
 
 static PyObject *PyFFPoint_dup(PyFF_Point *self) {
     PyFF_Point *ret = PyFFPoint_CNew(self->x, self->y, self->on_curve,
-                                     self->selected, self->name);
+                                     self->selected, self->type, self->name);
     ret->interpolated = self->interpolated;
     return( (PyObject *) ret );
 }
@@ -1774,7 +1790,7 @@ static PyObject *PyFFPoint_dup(PyFF_Point *self) {
 static PyFF_Point *PyFFPoint_Parse(PyObject *args, bool dup, bool always) {
     double x,y;
     PyFF_Point *p=NULL;
-    int i, on, sel, interp;
+    int i, on, sel, type, interp;
 
     if ( args==NULL && !always )
 	return NULL;
@@ -1783,26 +1799,28 @@ static PyFF_Point *PyFFPoint_Parse(PyObject *args, bool dup, bool always) {
     on = true;
     sel = false;
     interp = false;
-    if ( !PyArg_ParseTuple( args, "(ddii)", &x, &y, &on, &sel )) {
+    type = typemap_to_python[pt_corner];
+    if ( !PyArg_ParseTuple( args, "(ddi)|ii", &x, &y, &on, &type, &sel )) {
 	PyErr_Clear();
-	if ( !PyArg_ParseTuple( args, "(ddi)|i", &x, &y, &on, &sel )) {
+	if ( !PyArg_ParseTuple( args, "(dd)|iii", &x, &y, &on, &type, &sel )) {
 	    PyErr_Clear();
-	    if ( !PyArg_ParseTuple( args, "(dd)|ii", &x, &y, &on, &sel )) {
+	    if ( !PyArg_ParseTuple( args, "dd|iiii", &x, &y, &on, &type, &sel, &interp )) {
 		PyErr_Clear();
-		if ( !PyArg_ParseTuple( args, "dd|iii", &x, &y, &on, &sel, &interp )) {
-		    PyErr_Clear();
-		    if ( PyType_IsSubtype(&PyFF_PointType, Py_TYPE(args)) ) { 
-			p = (PyFF_Point *) args;
-		    } else if ( !always ) {
-			return( NULL );
-		    }
+		if ( PyType_IsSubtype(&PyFF_PointType, Py_TYPE(args)) ) { 
+		    p = (PyFF_Point *) args;
+		} else if ( !always ) {
+		    return( NULL );
 		}
 	    }
 	}
     }
 
+    if ( type < 0 || type > MAX_POINTTYPE_VAL ) {
+	PyErr_Format(PyExc_TypeError, "Unrecognized point type");
+	return NULL;
+    }
     if ( p==NULL ) {
-	p = PyFFPoint_CNew(x,y,on,sel,NULL);
+	p = PyFFPoint_CNew(x,y,on,sel,type,NULL);
 	if ( p==NULL )
 	    return( NULL );
 	if ( interp )
@@ -1842,13 +1860,14 @@ static PyObject *PyFFPoint_pickleReducer(PyFF_Point *self, PyObject *UNUSED(args
     reductionTuple = PyTuple_New(2);
     Py_INCREF(_new_point);
     PyTuple_SetItem(reductionTuple,0,_new_point);
-    argTuple = PyTuple_New(5);
+    argTuple = PyTuple_New(6);
     PyTuple_SetItem(reductionTuple,1,argTuple);
     PyTuple_SetItem(argTuple,0,Py_BuildValue("d", (double)self->x));
     PyTuple_SetItem(argTuple,1,Py_BuildValue("d", (double)self->y));
     PyTuple_SetItem(argTuple,2,Py_BuildValue("i", self->on_curve));
-    PyTuple_SetItem(argTuple,3,Py_BuildValue("i", self->selected));
-    PyTuple_SetItem(argTuple,4,Py_BuildValue("i", self->interpolated));
+    PyTuple_SetItem(argTuple,3,Py_BuildValue("i", self->type));
+    PyTuple_SetItem(argTuple,4,Py_BuildValue("i", self->selected));
+    PyTuple_SetItem(argTuple,5,Py_BuildValue("i", self->interpolated));
 return( reductionTuple );
 }
 
@@ -1927,6 +1946,8 @@ static PyMemberDef FFPoint_members[] = {
      (char *)"whether this point lies on the curve or is a control point"},
     {(char *)"selected", T_UBYTE, offsetof(PyFF_Point, selected), 0,
      (char *)"whether this point is selected"},
+    {(char *)"type", T_UBYTE, offsetof(PyFF_Point, type), 0,
+     (char *)"the FontForge spline point type"},
     {(char *)"interpolated", T_UBYTE, offsetof(PyFF_Point, interpolated), 0,
      (char *)"whether this (quadratic) point is interpolated"},
     {NULL, 0, 0, 0, NULL}  /* Sentinel */
@@ -2274,7 +2295,7 @@ return( 0 );
     if ( !val ) {
 	self->closed = false;
 	if ( self->pt_cnt>1 && self->points[0]->on_curve )
-	    self->points[self->pt_cnt++] = PyFFPoint_CNew(self->points[0]->x,self->points[0]->y,true,false,NULL);
+	    self->points[self->pt_cnt++] = PyFFPoint_CNew(self->points[0]->x,self->points[0]->y,true,false,0,NULL);
     } else {
 	self->closed = true;
 	if ( self->pt_cnt>1 && self->points[0]->on_curve &&
@@ -2806,7 +2827,7 @@ return( NULL );
         /* Messes with self->points */
         PyMem_Resize(self->points,PyFF_Point *,self->pt_max += 10);
     }
-    self->points[0] = PyFFPoint_CNew(x,y,true,false,NULL);
+    self->points[0] = PyFFPoint_CNew(x,y,true,false,0,NULL);
     self->pt_cnt = 1;
     PyFFContour_ClearSpiros((PyFF_Contour *) self);
 
@@ -2840,7 +2861,7 @@ return( NULL );
     }
     for ( i=self->pt_cnt-1; i>pos; --i )
 	self->points[i+1] = self->points[i];
-    self->points[pos+1] = PyFFPoint_CNew(x,y,true,false,NULL);
+    self->points[pos+1] = PyFFPoint_CNew(x,y,true,false,0,NULL);
     PyFFContour_ClearSpiros((PyFF_Contour *) self);
     ++self->pt_cnt;
 
@@ -2861,9 +2882,9 @@ return( NULL );
 	if ( !PyArg_ParseTuple( args, "dddddd|i", &x[0], &y[0], &x[1], &y[1], &x[2], &y[2], &pos ))
 return( NULL );
     }
-    np = PyFFPoint_CNew(x[0],y[0],false,false,NULL);
-    pp = PyFFPoint_CNew(x[1],y[1],false,false,NULL);
-    p = PyFFPoint_CNew(x[2],y[2],true,false,NULL);
+    np = PyFFPoint_CNew(x[0],y[0],false,false,0,NULL);
+    pp = PyFFPoint_CNew(x[1],y[1],false,false,0,NULL);
+    p = PyFFPoint_CNew(x[2],y[2],true,false,0,NULL);
     if ( p==NULL ) {
 	Py_XDECREF(pp);
 	Py_XDECREF(np);
@@ -2907,8 +2928,8 @@ return( NULL );
 	if ( !PyArg_ParseTuple( args, "dddd|i", &x[0], &y[0], &x[1], &y[1], &pos ))
 return( NULL );
     }
-    cp = PyFFPoint_CNew(x[0],y[0],false,false,NULL);
-    p = PyFFPoint_CNew(x[1],y[1],true,false,NULL);
+    cp = PyFFPoint_CNew(x[0],y[0],false,false,0,NULL);
+    p = PyFFPoint_CNew(x[1],y[1],true,false,0,NULL);
     if ( p==NULL ) {
 	Py_XDECREF(cp);
 return( NULL );
@@ -2938,13 +2959,16 @@ Py_RETURN( self );
 static PyObject *PyFFContour_InsertPoint(PyFF_Contour *self, PyObject *args) {
     double x,y;
     PyFF_Point *p=NULL;
-    int i, on, pos, sel;
+    int i, on, pos, sel, type;
 
     x = y = 0.0;
     pos = -1;
     on = true;
     sel = false;
-    if ( !PyArg_ParseTuple( args, "(ddii)|i", &x, &y, &on, &sel, &pos )) {
+    type = typemap_to_python[pt_corner];
+    if ( !PyArg_ParseTuple( args, "(ddiii)|i", &x, &y, &on, &type, &sel, &pos )) {
+	PyErr_Clear();
+    if ( !PyArg_ParseTuple( args, "(ddii)|i", &x, &y, &on, &type, &pos )) {
 	PyErr_Clear();
 	if ( !PyArg_ParseTuple( args, "(ddi)|i", &x, &y, &on, &pos )) {
 	    PyErr_Clear();
@@ -2957,9 +2981,10 @@ static PyObject *PyFFContour_InsertPoint(PyFF_Contour *self, PyObject *args) {
 	    }
 	}
     }
+    }
 
     if ( p==NULL ) {
-	p = PyFFPoint_CNew(x,y,on,false,NULL);
+	p = PyFFPoint_CNew(x,y,on,sel,type,NULL);
 	if ( p==NULL )
 	    return( NULL );
     } else {
@@ -4835,9 +4860,48 @@ return( true );
 return( 0 );
 }
 
-static SplineSet *SSFromContour(PyFF_Contour *c,int *tt_start) {
+/* Point convertion flags: see 'enum pconvert_flags' in splinefont.h */
+struct flaglist pconvertflags[] = {
+    { "select_none", pconvert_flag_none },
+    { "select_all", pconvert_flag_all },
+    { "select_smooth", pconvert_flag_smooth },
+    { "select_incompat", pconvert_flag_incompat },
+    { "by_geom", pconvert_flag_by_geom },
+    { "force", pconvert_flag_force_type },
+    { "downgrade", pconvert_flag_downgrade },
+    { "check", pconvert_flag_check_compat },
+    { "hvcurve", pconvert_flag_hvcurve },
+    FLAGLIST_EMPTY /* Sentinel */
+};
+
+static int CheckPConvertFlags(int flags, int defaults) {
+	const int sels = pconvert_flag_none|pconvert_flag_all|pconvert_flag_smooth;
+	const int modes = pconvert_flag_by_geom|pconvert_flag_force_type
+	                  |pconvert_flag_downgrade|pconvert_flag_check_compat;
+	int defsel = defaults&sels, defmode = defaults&modes, sel, mode;
+
+	sel = flags&sels;
+	if ( sel==0 )
+		flags |= defsel;
+	else if ( ( sel & (sel-1) ) != 0 ) {
+		PyErr_Format(PyExc_ValueError, "At most one point selection flag is allowed.");
+		return -1;
+	}
+
+	mode = flags&modes;
+	if ( mode==0 )
+		flags |= defmode; // Harmless if sel == pconvert_flag_none
+	else if ( ( mode & (mode-1) ) != 0 ) {
+		PyErr_Format(PyExc_ValueError, "At most one point conversion mode flag is allowed.");
+		return -1;
+	}
+	// Don't worry about extraneous bits for now.
+	return flags;
+}
+
+static SplineSet *_SSFromContour(PyFF_Contour *c,int *tt_start, int flags) {
     int start = 0, next;
-    int i, skipped=0, index;
+    int i, skipped=0, index, ok;
     int nexti, previ;
     SplineSet *ss;
     SplinePoint *sp;
@@ -4868,9 +4932,15 @@ return( NULL );
 		ss->first = ss->last = SplinePointCreate(c->points[0]->x,c->points[0]->y);
 		ss->start_offset = 0;
 		ss->first->selected = c->points[0]->selected;
+		ss->first->pointtype = typemap_from_python[c->points[0]->type];
 		ss->first->name = copy(c->points[0]->name);
-		SPLCategorizePoints(ss);
-return( ss );
+		ok = _SPLCategorizePoints(ss, flags);
+		if ( !ok ) {
+		    // assert ( flags&pconvert_flag_check );
+		    PyErr_Format(PyExc_TypeError, "At least one point has a geometry incompatible with its type");
+		    return( NULL );
+		}
+		return( ss );
 	    }
 	    ++i;
 	    ++next;
@@ -4879,6 +4949,7 @@ return( ss );
 	while ( i<c->pt_cnt ) {
 	    if ( c->points[i]->on_curve ) {
 		sp = SplinePointCreate(c->points[i]->x,c->points[i]->y);
+		sp->pointtype = typemap_from_python[c->points[i]->type];
 		sp->selected = c->points[i]->selected;
 		sp->name = copy(c->points[i]->name);
 		sp->ttfindex = next++;
@@ -4902,6 +4973,7 @@ return( ss );
 	    } else {
 		if ( !c->points[i-1]->on_curve ) {
 		    sp = SplinePointCreate((c->points[i]->x+c->points[i-1]->x)/2,(c->points[i]->y+c->points[i-1]->y)/2);
+		    sp->pointtype = typemap_from_python[c->points[i]->type];
 		    sp->ttfindex = -1;
 		    sp->prevcp.x = c->points[i-1]->x;
 		    sp->prevcp.y = c->points[i-1]->y;
@@ -4954,6 +5026,7 @@ return( ss );
 	    if ( !c->points[i]->on_curve )
 	continue;
 	    sp = SplinePointCreate(c->points[i]->x,c->points[i]->y);
+	    sp->pointtype = typemap_from_python[c->points[i]->type];
 	    sp->selected = c->points[i]->selected;
 	    sp->name = copy(c->points[i]->name);
 	    sp->ttfindex = next++;
@@ -5023,8 +5096,17 @@ return( NULL );
     }
     if ( tt_start!=NULL )
 	*tt_start = next;
-    SPLCategorizePoints(ss);
-return( ss );
+    ok = _SPLCategorizePoints(ss, flags);
+    if ( !ok ) {
+	// assert ( flags&pconvert_flag_check );
+	PyErr_Format(PyExc_TypeError, "At least one point has a geometry incompatible with its type");
+	return( NULL );
+    }
+    return( ss );
+}
+
+static SplineSet *SSFromContour(PyFF_Contour *c,int *tt_start) {
+	return _SSFromContour(c, tt_start, pconvert_flag_none);
 }
 
 static PyFF_Contour *ContourFromSS(SplineSet *ss,PyFF_Contour *ret) {
@@ -5044,20 +5126,24 @@ static PyFF_Contour *ContourFromSS(SplineSet *ss,PyFF_Contour *ret) {
     for ( k=0; k<2; ++k ) {
 	if ( ss->first->next == NULL ) {
 	    if ( k )
-		ret->points[0] = PyFFPoint_CNew(ss->first->me.x,ss->first->me.y,true,ss->first->selected,ss->first->name);
+		ret->points[0] = PyFFPoint_CNew(ss->first->me.x,ss->first->me.y,true,
+		                                ss->first->selected,typemap_to_python[ss->first->pointtype],
+						ss->first->name);
 	    cnt = 1;
 	} else if ( ss->first->next->order2 ) {
 	    ret->is_quadratic = true;
 	    cnt = 0;
 	    for ( sp=ss->first; ; ) {
 		if ( k ) {
-		    ret->points[cnt] = PyFFPoint_CNew(sp->me.x,sp->me.y,true,sp->selected, sp->name);
+		    ret->points[cnt] = PyFFPoint_CNew(sp->me.x,sp->me.y,true,sp->selected,
+		                                      typemap_to_python[sp->pointtype], sp->name);
 		    ret->points[cnt]->interpolated = SPInterpolate(sp);
 		}
 		++cnt;
 		if ( !sp->nonextcp ) {
 		    if ( k )
-			ret->points[cnt] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,sp->nextcpselected,sp->name);
+			ret->points[cnt] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,
+			                                  sp->nextcpselected,0,sp->name);
 		    ++cnt;
 		}
 		if ( sp->next==NULL )
@@ -5072,14 +5158,14 @@ static PyFF_Contour *ContourFromSS(SplineSet *ss,PyFF_Contour *ret) {
 	    ret->is_quadratic = false;
 	    for ( sp=ss->first, cnt=0; ; ) {
 		if ( k )
-		    ret->points[cnt] = PyFFPoint_CNew(sp->me.x,sp->me.y,true, sp->selected, sp->name);
+		    ret->points[cnt] = PyFFPoint_CNew(sp->me.x,sp->me.y,true, sp->selected,typemap_to_python[sp->pointtype], sp->name);
 		++cnt;			/* Sp itself */
 		if ( sp->next==NULL )
 	    break;
 		if ( !sp->nonextcp || !sp->next->to->noprevcp ) {
 		    if ( k ) {
-			ret->points[cnt  ] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,sp->nextcpselected,NULL);
-			ret->points[cnt+1] = PyFFPoint_CNew(sp->next->to->prevcp.x,sp->next->to->prevcp.y,false,sp->next->to->prevcpselected,NULL);
+			ret->points[cnt  ] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,sp->nextcpselected,0,NULL);
+			ret->points[cnt+1] = PyFFPoint_CNew(sp->next->to->prevcp.x,sp->next->to->prevcp.y,false,sp->next->to->prevcpselected,0,NULL);
 		    }
 		    cnt += 2;		/* not a line => 2 control points */
 		}
@@ -5099,13 +5185,13 @@ static PyFF_Contour *ContourFromSS(SplineSet *ss,PyFF_Contour *ret) {
 return( ret );
 }
 
-static SplineSet *SSFromLayer(PyFF_Layer *layer) {
+static SplineSet *_SSFromLayer(PyFF_Layer *layer, int flags) {
     int start = 0;
     SplineSet *head=NULL, *tail, *cur;
     int i;
 
     for ( i=0; i<layer->cntr_cnt; ++i ) {
-	cur = SSFromContour( layer->contours[i],&start );
+	cur = _SSFromContour( layer->contours[i], &start, flags );
 	if ( cur!=NULL ) {
 	    if ( head==NULL )
 		head = cur;
@@ -5115,6 +5201,10 @@ static SplineSet *SSFromLayer(PyFF_Layer *layer) {
 	}
     }
 return( head );
+}
+
+static SplineSet *SSFromLayer(PyFF_Layer *layer) {
+	return _SSFromLayer(layer, pconvert_flag_none);
 }
 
 static PyFF_Layer *LayerFromSS(SplineSet *ss,PyFF_Layer *layer) {
@@ -5565,10 +5655,11 @@ return( -1 );
 return( 0 );
 }
 
-static PyObject *PyFF_Glyph_get_a_layer(PyFF_Glyph *self,int layeri) {
+static PyObject *PyFF_Glyph_get_a_layer(PyFF_Glyph *self,void *vli) {
     SplineChar *sc = self->sc;
     Layer *layer;
     PyFF_Layer *ly;
+    int layeri = (int)(size_t)vli;
 
     if ( layeri<ly_grid || layeri>=sc->layer_cnt ) {
 	PyErr_Format(PyExc_ValueError, "Layer is out of range" );
@@ -5621,10 +5712,7 @@ void set_pyFF_sendRedoIfInSession_Func( pyFF_sendRedoIfInSession_Func_t f )
     pyFF_sendRedoIfInSession_Func = f;
 }
 
-
-
-
-static int PyFF_Glyph_set_a_layer(PyFF_Glyph *self,PyObject *value, void *UNUSED(closure), int layeri) {
+static int PyFF_Glyph_CSetLayer(PyFF_Glyph *self, PyObject *value, int layeri, int flags) {
     SplineChar *sc = self->sc;
     Layer *layer;
     SplineSet *ss, *newss;
@@ -5639,10 +5727,10 @@ return( -1 );
 	layer = &sc->layers[layeri];
     if ( PyType_IsSubtype(&PyFF_LayerType, Py_TYPE(value)) ) {
 	isquad = ((PyFF_Layer *) value)->is_quadratic;
-	ss = SSFromLayer( (PyFF_Layer *) value);
+	ss = _SSFromLayer( (PyFF_Layer *) value, flags);
     } else if ( PyType_IsSubtype(&PyFF_ContourType, Py_TYPE(value)) ) {
 	isquad = ((PyFF_Contour *) value)->is_quadratic;
-	ss = SSFromContour( (PyFF_Contour *) value,NULL);
+	ss = _SSFromContour( (PyFF_Contour *) value, NULL, flags);
     } else {
 	PyErr_Format(PyExc_TypeError, "Argument must be a layer or a contour" );
 return( -1 );
@@ -5663,6 +5751,10 @@ return( -1 );
     SCCharChangedUpdate(sc,self->layer);
     get_pyFF_sendRedoIfInSession_Func()( cv );
 return( 0 );
+}
+
+static int PyFF_Glyph_set_a_layer(PyFF_Glyph *self,PyObject *value, void *vli) {
+	return PyFF_Glyph_CSetLayer(self, value, (int)(size_t)vli, pconvert_flag_all|pconvert_flag_by_geom);
 }
 
 static int SFFindLayerIndexByName(SplineFont *sf,char *name) {
@@ -5832,7 +5924,7 @@ return( NULL );
 	PyErr_Format(PyExc_TypeError, "Index must be a layer name or index" );
 return( NULL );
     }
-return( PyFF_Glyph_get_a_layer((PyFF_Glyph *) PySC_From_SC(sc),layer));
+return( PyFF_Glyph_get_a_layer((PyFF_Glyph *) PySC_From_SC(sc),(void *)(size_t)layer));
 }
 
 static int PyFF_LayerArrayIndexAssign( PyObject *self, PyObject *index, PyObject *value ) {
@@ -5852,7 +5944,7 @@ return( -1 );
 	PyErr_Format(PyExc_TypeError, "Index must be a layer name or index" );
 return( -1 );
     }
-return( PyFF_Glyph_set_a_layer((PyFF_Glyph *) PySC_From_SC(sc),value,NULL,layer));
+return( PyFF_Glyph_CSetLayer((PyFF_Glyph *) PySC_From_SC(sc),value,layer,pconvert_flag_all|pconvert_flag_by_geom));
 }
 
 static PyGetSetDef PyFF_LayerArray_getset[] = {
@@ -6893,22 +6985,6 @@ static int PyFF_Glyph_set_glyphclass(PyFF_Glyph *self,PyObject *value, void *UNU
     return( 0 );
 }
 
-static PyObject *PyFF_Glyph_get_foreground(PyFF_Glyph *self, void *UNUSED(closure)) {
-return( PyFF_Glyph_get_a_layer(self,ly_fore));
-}
-
-static int PyFF_Glyph_set_foreground(PyFF_Glyph *self,PyObject *value, void *closure) {
-return( PyFF_Glyph_set_a_layer(self,value,closure,ly_fore));
-}
-
-static PyObject *PyFF_Glyph_get_background(PyFF_Glyph *self, void *UNUSED(closure)) {
-return( PyFF_Glyph_get_a_layer(self,ly_back));
-}
-
-static int PyFF_Glyph_set_background(PyFF_Glyph *self,PyObject *value, void *closure) {
-return( PyFF_Glyph_set_a_layer(self,value,closure,ly_back));
-}
-
 static PyObject *PyFF_Glyph_get_layers(PyFF_Glyph *self, void *UNUSED(closure)) {
     PyFF_LayerArray *layers;
 
@@ -7609,11 +7685,11 @@ static PyGetSetDef PyFF_Glyph_getset[] = {
      (getter)PyFF_Glyph_get_encoding, NULL,
      (char *)"Returns the glyph's encoding in the current font (readonly)", NULL},
     {(char *)"foreground",
-     (getter)PyFF_Glyph_get_foreground, (setter)PyFF_Glyph_set_foreground,
-     (char *)"Returns the foreground layer of the glyph", NULL},
+     (getter)PyFF_Glyph_get_a_layer, (setter)PyFF_Glyph_set_a_layer,
+     (char *)"Returns the foreground layer of the glyph", (void *)ly_fore},
     {(char *)"background",
-     (getter)PyFF_Glyph_get_background, (setter)PyFF_Glyph_set_background,
-     (char *)"Returns the background layer of the glyph", NULL},
+     (getter)PyFF_Glyph_get_a_layer, (setter)PyFF_Glyph_set_a_layer,
+     (char *)"Returns the background layer of the glyph", (void *)ly_back},
     {(char *)"layers",
      (getter)PyFF_Glyph_get_layers, NULL,
      (char *)"Returns an array of layers", NULL},
@@ -8012,7 +8088,7 @@ static PyObject *PyFFGlyph_draw(PyObject *self, PyObject *args) {
     if ( !PyArg_ParseTuple(args,"O", &pen ) )
 return( NULL );
 
-    layer = PyFF_Glyph_get_a_layer((PyFF_Glyph *) self,((PyFF_Glyph *) self)->layer);
+    layer = PyFF_Glyph_get_a_layer((PyFF_Glyph *) self,(void *)(size_t)((PyFF_Glyph *) self)->layer);
     result = PyFFLayer_draw( (PyFF_Layer *) layer,args);
     Py_XDECREF(layer);
 
@@ -9068,6 +9144,52 @@ static PyObject *PyFFGlyph_isWorthOutputting(PyFF_Glyph *self, PyObject *UNUSED(
 return( ret );
 }
 
+static PyObject *PyFFGlyph_setLayer(PyFF_Glyph *self, PyObject *args) {
+	int arglen = PySequence_Size(args);
+	PyObject *layer, *index;
+	int layeri, flags = 0;
+
+	if (arglen < 2 || arglen > 3) {
+		PyErr_Format(PyExc_ValueError, "Must be called with a layer, a layer identifier, and an optional flags tuple" );
+		return NULL;
+	}
+
+	layer = PySequence_GetItem(args,0);
+	if ( !PyType_IsSubtype(&PyFF_LayerType, Py_TYPE(layer)) ) {
+		PyErr_Format(PyExc_ValueError, "First argument must be a layer" );
+		return NULL;
+	}
+
+	index = PySequence_GetItem(args,1);
+	if ( STRING_CHECK(index)) {
+		char *name;
+		PYGETSTR(index, name, NULL);
+		layeri = SFFindLayerIndexByName(self->sc->parent,name);
+		if ( layeri<0 ) {
+			PyErr_Format(PyExc_ValueError, "Layer '%s' not found", name);
+			ENDPYGETSTR();
+			return NULL;
+		}
+		ENDPYGETSTR();
+	} else if ( PyInt_Check(index)) {
+		layeri = PyInt_AsLong(index);
+	} else {
+		PyErr_Format(PyExc_TypeError, "Index must be a layer name or index" );
+		return NULL;
+	}
+	if ( arglen>2 ) {
+		flags = FlagsFromTuple( PySequence_GetItem(args,2),pconvertflags,"Point Conversion flags");
+	}
+	flags = CheckPConvertFlags(flags, pconvert_flag_all|pconvert_flag_by_geom);
+	if ( flags < 0 ) 
+		return NULL;
+
+	if ( PyFF_Glyph_CSetLayer(self,layer,layeri,flags) == 0 ) 
+		Py_RETURN (self);
+
+	return NULL;
+}
+
 static PyMethodDef PyFF_Glyph_methods[] = {
     { "glyphPen", (PyCFunction) PyFFGlyph_GlyphPen, METH_VARARGS | METH_KEYWORDS, "Create a pen object which can draw into this glyph"},
     { "draw", (PyCFunction) PyFFGlyph_draw, METH_VARARGS , "Draw the glyph's outline to the pen argument"},
@@ -9099,6 +9221,7 @@ static PyMethodDef PyFF_Glyph_methods[] = {
     { "removePosSub", PyFFGlyph_removePosSub, METH_VARARGS, "Removes position/substitution data from the glyph"},
     { "round", (PyCFunction)PyFFGlyph_Round, METH_VARARGS, "Rounds point coordinates (and reference translations) to integers"},
     { "selfIntersects", (PyCFunction)PyFFGlyph_selfIntersects, METH_NOARGS, "Returns whether this glyph intersects itself" },
+    { "setLayer", (PyCFunction)PyFFGlyph_setLayer, METH_VARARGS, "Replaces the content of the specified layer" },
     { "validate", (PyCFunction)PyFFGlyph_validate, METH_VARARGS, "Returns whether this glyph is valid for output (if not check validation_state" },
     { "simplify", (PyCFunction)PyFFGlyph_Simplify, METH_VARARGS, "Simplifies a glyph" },
     { "stroke", (PyCFunction)PyFFGlyph_Stroke, METH_VARARGS, "Strokes the contours in a glyph"},
@@ -18332,6 +18455,7 @@ static void AddHookDictionary( PyObject *module );
 static void AddSpiroConstants( PyObject *module );
 static void FinalizeFontforgeModule( PyObject* module ) {
     AddHookDictionary( module );
+    AddPointConstants( module );
     AddSpiroConstants( module );
     PyModule_AddObject( module, "unspecifiedMathValue",
                         Py_BuildValue("i", TEX_UNDEF) );

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1764,6 +1764,7 @@ static enum pointtype PyFF_ConvertToPointType(int val) {
 	case 2: return pt_hvcurve;
 	case 3: return pt_tangent;
     }
+    return pt_corner;
 }
 
 static int PyFF_ConvertFromPointType(enum pointtype pt) {
@@ -1773,6 +1774,7 @@ static int PyFF_ConvertFromPointType(enum pointtype pt) {
 	case pt_tangent: return 3;
 	case pt_hvcurve: return 2;
     }
+    return 0;
 }
 
 static void AddPointConstants( PyObject *module ) {

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2160,6 +2160,21 @@ extern void SCAddRef(SplineChar *sc,SplineChar *rsc,int layer, real xoff, real y
 extern void SplineCharFree(SplineChar *sc);
 extern void ScriptLangListFree(struct scriptlanglist *sl);
 
+enum pconvert_flags {
+	// Point selection (mutually exclusive)
+	pconvert_flag_none = 0x01,
+	pconvert_flag_all = 0x02,
+	pconvert_flag_smooth = 0x04,
+	pconvert_flag_incompat = 0x08,
+	// Conversion modes (mutually exclusive)
+	pconvert_flag_by_geom = 0x100,
+	pconvert_flag_force_type = 0x200,
+	pconvert_flag_downgrade = 0x400,
+	pconvert_flag_check_compat = 0x0800,
+	// Additional
+	pconvert_flag_hvcurve = 0x4000
+};
+
 #if 1
 // These relate to experimental support for U. F. O. groups.
 #define GROUP_NAME_KERNING_UFO 1
@@ -2171,6 +2186,7 @@ extern void MMSetFree(MMSet *mm);
 extern void SFRemoveUndoes(SplineFont *sf,uint8 *selected,EncMap *map);
 extern void SplineRefigure(Spline *spline);
 extern void SPLCategorizePoints(SplinePointList *spl);
+extern int _SPLCategorizePoints(SplinePointList *spl, int flags);
 extern SplinePointList *SplinePointListCopy(const SplinePointList *base);
 /* The order of the enum elements below doesn't make much sense, but it's done*/
 /*  this way to preserve binary compatibility */

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1066,19 +1066,19 @@ void SplineFontQuickConservativeBounds(SplineFont *sf,DBounds *b) {
     if ( b->maxy<-65536 ) b->maxy = 0;
 }
 
-void SplinePointCategorize(SplinePoint *sp) {
-    int oldpointtype = sp->pointtype;
+int SplinePointCategory(SplinePoint *sp) {
+    enum pointtype pt;
 
-    sp->pointtype = pt_corner;
+    pt = pt_corner;
     if ( sp->next==NULL && sp->prev==NULL )
 	;
     else if ( (sp->next!=NULL && sp->next->to->me.x==sp->me.x && sp->next->to->me.y==sp->me.y) ||
 	    (sp->prev!=NULL && sp->prev->from->me.x==sp->me.x && sp->prev->from->me.y==sp->me.y ))
 	;
     else if ( sp->next==NULL ) {
-	sp->pointtype = sp->noprevcp ? pt_corner : pt_curve;
+	pt = sp->noprevcp ? pt_corner : pt_curve;
     } else if ( sp->prev==NULL ) {
-	sp->pointtype = sp->nonextcp ? pt_corner : pt_curve;
+	pt = sp->nonextcp ? pt_corner : pt_curve;
     } else if ( sp->nonextcp && sp->noprevcp ) {
 	;
     } else {
@@ -1110,7 +1110,7 @@ void SplinePointCategorize(SplinePoint *sp) {
 	/*  result is less than 1 em-unit then we've got colinear control points */
 	/*  (within the resolution of the integer grid) */
 	/* Not quite... they could point in the same direction */
-        if ( oldpointtype==pt_curve )
+        if ( sp->pointtype==pt_curve )
             bounds = 4.0;
         else
             bounds = 1.0;
@@ -1118,73 +1118,110 @@ void SplinePointCategorize(SplinePoint *sp) {
 		((nclen>=pclen && (cross = pcdir.x*ncunit.y - pcdir.y*ncunit.x)<bounds && cross>-bounds ) ||
 		 (pclen>nclen && (cross = ncdir.x*pcunit.y - ncdir.y*pcunit.x)<bounds && cross>-bounds )) &&
 		 ncdir.x*pcdir.x + ncdir.y*pcdir.y < 0 )
-	    sp->pointtype = pt_curve;
+	    pt = pt_curve;
 	/* Cross product of control point with unit vector normal to line in */
 	/*  opposite direction should be less than an em-unit for a tangent */
 	else if (( nclen==0 && pclen!=0 && (cross = pcdir.x*ndir.y-pcdir.y*ndir.x)<bounds && cross>-bounds ) ||
 		( pclen==0 && nclen!=0 && (cross = ncdir.x*pdir.y-ncdir.y*pdir.x)<bounds && cross>-bounds ))
-	    sp->pointtype = pt_tangent;
+	    pt = pt_tangent;
 
-	/* If a point started out hv, and could still be hv, them make it so */
-	/*  but don't make hv points de novo, Alexey doesn't like change */
-	/*  (this only works because hv isn't a default setting, so if it's */
-	/*   there it was done intentionally) */
-	if ( sp->pointtype == pt_curve && oldpointtype == pt_hvcurve &&
+	if (pt == pt_curve &&
 		((sp->nextcp.x==sp->me.x && sp->prevcp.x==sp->me.x && sp->nextcp.y!=sp->me.y) ||
 		 (sp->nextcp.y==sp->me.y && sp->prevcp.y==sp->me.y && sp->nextcp.x!=sp->me.x)))
-	    sp->pointtype = pt_hvcurve;
+	    pt = pt_hvcurve;
     }
+    return pt;
 }
 
 int SplinePointIsACorner(SplinePoint *sp) {
-    enum pointtype old = sp->pointtype, new;
+	return SplinePointCategory(sp) == pt_corner;
+}
 
-    SplinePointCategorize(sp);
-    new = sp->pointtype;
-    sp->pointtype = old;
-return( new==pt_corner );
+enum pointtype SplinePointDowngrade(int current, int geom) {
+	enum pointtype np = current;
+
+	if ( current==pt_curve && geom!=pt_curve ) {
+		if ( geom==pt_hvcurve )
+			np = pt_curve;
+		else 
+			np = pt_corner;
+	} else if ( current==pt_hvcurve && geom!=pt_hvcurve ) {
+		if ( geom==pt_curve )
+			np = pt_curve;
+		else
+			np = pt_corner;
+	} else if ( current==pt_tangent && geom!=pt_tangent ) {
+		np = pt_corner;
+	}
+
+	return np;
+}
+
+// Assumes flag combinations are already verified. Only returns false
+// when called with check_compat
+int _SplinePointCategorize(SplinePoint *sp, int flags) {
+	enum pointtype geom, dg, cur;
+
+	if ( flags & pconvert_flag_none )
+		// No points selected for conversion -- keep type as is
+		return true;
+	if ( flags & pconvert_flag_smooth && sp->pointtype == pt_corner )
+		// Convert only "smooth" points, not corners
+		return true;
+
+	geom = SplinePointCategory(sp);
+	dg = SplinePointDowngrade(sp->pointtype, geom);
+
+	if ( flags & pconvert_flag_incompat && sp->pointtype == dg )
+		// Only convert points incompatible with current type
+		return true;
+
+	if ( flags & pconvert_flag_by_geom ) {
+		if ( ! ( flags & pconvert_flag_hvcurve ) && geom == pt_hvcurve )
+			sp->pointtype = pt_curve;
+		else
+			sp->pointtype = geom;
+	} else if ( flags & pconvert_flag_downgrade ) {
+		sp->pointtype = dg;
+	} else if ( flags & pconvert_flag_force_type ) {
+		if ( sp->pointtype != dg ) {
+			cur = sp->pointtype;
+			sp->pointtype = dg;
+			SPChangePointType(sp,cur);
+		}
+	} else if ( flags & pconvert_flag_check_compat ) {
+		if ( sp->pointtype != dg )
+			return false;
+	}
+	return true;
+}
+
+void SplinePointCategorize(SplinePoint *sp) {
+	_SplinePointCategorize(sp, pconvert_flag_all|pconvert_flag_by_geom);
+}
+
+// _SplinePointCategorize only returns false when called with check_compat flag,
+// in which case no point values are altered and the "early" return will not leave
+// splines partially adjusted.
+int _SPLCategorizePoints(SplinePointList *spl, int flags) {
+    Spline *spline, *first, *last=NULL;
+    int ok = true;
+
+    for ( ; spl!=NULL; spl = spl->next ) {
+	first = NULL;
+	for ( spline = spl->first->next; spline!=NULL && spline!=first && ok; spline=spline->to->next ) {
+	    ok = _SplinePointCategorize(spline->from, flags);
+	    last = spline;
+	    if ( first==NULL ) first = spline;
+	}
+	if ( spline==NULL && last!=NULL && ok )
+	    _SplinePointCategorize(last->to, flags);
+    }
+    return ok;
 }
 
 void SPLCategorizePoints(SplinePointList *spl) {
-    Spline *spline, *first, *last=NULL;
-
-    for ( ; spl!=NULL; spl = spl->next ) {
-	first = NULL;
-	for ( spline = spl->first->next; spline!=NULL && spline!=first; spline=spline->to->next ) {
-	    SplinePointCategorize(spline->from);
-	    last = spline;
-	    if ( first==NULL ) first = spline;
-	}
-	if ( spline==NULL && last!=NULL )
-	    SplinePointCategorize(last->to);
-    }
-}
-
-void SPLCategorizePointsKeepCorners(SplinePointList *spl) {
-    // It's important when round-tripping U. F. O. data that we keep corners as corners and non-corners as non-corners.
-    Spline *spline, *first, *last=NULL;
-    int old_type;
-
-    for ( ; spl!=NULL; spl = spl->next ) {
-	first = NULL;
-	for ( spline = spl->first->next; spline!=NULL && spline!=first; spline=spline->to->next ) {
-	    // If it is a corner, we leave it as a corner.
-	    if ((old_type = spline->from->pointtype) != pt_corner) {
-	      SplinePointCategorize(spline->from);
-	      // If it was not a corner, we do not let it change to a corner.
-	      if (spline->from->pointtype == pt_corner) spline->from->pointtype = old_type;
-	    }
-	    last = spline;
-	    if ( first==NULL ) first = spline;
-	}
-	if ( spline==NULL && last!=NULL )
-	    // If it is a corner, we leave it as a corner.
-	    if ((old_type = last->to->pointtype) != pt_corner) {
-	      SplinePointCategorize(last->to);
-	      // If it was not a corner, we do not let it change to a corner.
-	      if (last->to->pointtype == pt_corner) last->to->pointtype = old_type;
-	    }
-    }
+	_SPLCategorizePoints(spl, pconvert_flag_all|pconvert_flag_by_geom);
 }
 
 void SCCategorizePoints(SplineChar *sc) {

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1066,7 +1066,7 @@ void SplineFontQuickConservativeBounds(SplineFont *sf,DBounds *b) {
     if ( b->maxy<-65536 ) b->maxy = 0;
 }
 
-int SplinePointCategory(SplinePoint *sp) {
+static int SplinePointCategory(SplinePoint *sp) {
     enum pointtype pt;
 
     pt = pt_corner;
@@ -1137,7 +1137,7 @@ int SplinePointIsACorner(SplinePoint *sp) {
 	return SplinePointCategory(sp) == pt_corner;
 }
 
-enum pointtype SplinePointDowngrade(int current, int geom) {
+static enum pointtype SplinePointDowngrade(int current, int geom) {
 	enum pointtype np = current;
 
 	if ( current==pt_curve && geom!=pt_curve ) {

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -173,7 +173,6 @@ extern void SFInstanciateRefs(SplineFont *sf);
 extern void SFReinstanciateRefs(SplineFont *sf);
 extern void SFRemoveAnchorClass(SplineFont *sf, AnchorClass *an);
 extern void SFRemoveSavedTable(SplineFont *sf, uint32 tag);
-extern void SPLCategorizePointsKeepCorners(SplinePointList *spl);
 extern void SplineCharFindBounds(SplineChar *sc, DBounds *bounds);
 extern void SplineCharFreeContents(SplineChar *sc);
 extern void SplineCharLayerFindBounds(SplineChar *sc, int layer, DBounds *bounds);

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -3225,7 +3225,7 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 	}
     }
     xmlFreeDoc(doc);
-    SPLCategorizePointsKeepCorners(sc->layers[layerdest].splines);
+    _SPLCategorizePoints(sc->layers[layerdest].splines, pconvert_flag_smooth|pconvert_flag_by_geom);
 return( sc );
 }
 

--- a/tests/test930.py
+++ b/tests/test930.py
@@ -5,6 +5,8 @@ import fontforge as f
 
 # point
 
+co = f.splineCorner
+
 # Embedded tuple
 p = f.point((2.3,2.4))
 if p.x != 2.3 or p.y != 2.4 or not p.on_curve or p.selected:
@@ -14,7 +16,7 @@ p = f.point((2.3,2.4,False))
 if p.x != 2.3 or p.y != 2.4 or p.on_curve or p.selected:
     raise ValueError("Bad point values" )
 
-p = f.point((2.3,2.4,False,True))
+p = f.point((2.3,2.4),False,co,True)
 if p.x != 2.3 or p.y != 2.4 or p.on_curve or not p.selected:
     raise ValueError("Bad point values" )
 
@@ -27,7 +29,7 @@ p = f.point([2.3,2.4,False])
 if p.x != 2.3 or p.y != 2.4 or p.on_curve or p.selected:
     raise ValueError("Bad point values" )
 
-p = f.point([2.3,2.4,False,True])
+p = f.point([2.3,2.4],False,co,True)
 if p.x != 2.3 or p.y != 2.4 or p.on_curve or not p.selected:
     raise ValueError("Bad point values" )
 
@@ -40,7 +42,7 @@ p = f.point(2.3,2.4,False)
 if p.x != 2.3 or p.y != 2.4 or p.on_curve or p.selected:
     raise ValueError("Bad point values" )
 
-p = f.point(2.3,2.4,False,True)
+p = f.point(2.3,2.4,False,co,True)
 if p.x != 2.3 or p.y != 2.4 or p.on_curve or not p.selected:
     raise ValueError("Bad point values" )
 

--- a/tests/test931.py
+++ b/tests/test931.py
@@ -1,0 +1,99 @@
+# Point type conversion tests
+
+import fontforge
+
+co = fontforge.splineCorner
+cu = fontforge.splineCurve
+tn = fontforge.splineTangent
+hv = fontforge.splineHVCurve
+
+ff = fontforge.font()
+
+g = ff.createMappedChar('a')
+
+c = fontforge.contour()
+c[:] = [(0,0,True,hv),(0,0,False),(5,-1,False),(5,0,True,hv),(5,1,False),(5,3,False),(4,4,True,hv),(3,5,False),(0,3,False),(0,2,True,hv)]
+c.closed = True
+
+l = fontforge.layer()
+l += c
+
+g.setLayer(l,1,('select_none','hvcurve'))
+cc = g.layers[1][0]
+for (i,t) in [(0,hv),(3,hv),(6,hv),(9,hv)]:
+    if cc[i].type != t:
+        raise ValueError("Type of point " + str(i) + " should be " + str(t) + " rather than " + str(cc[i].type))
+
+g.setLayer(l,1,('select_all','hvcurve','force'))
+cc = g.layers[1][0]
+for (i,t) in [(1,False),(2,True),(4,True),(5,False),(7,False),(8,False)]:
+    if (cc[i] == c[i]) != t:
+        print(cc[i],c[i])
+        raise ValueError("Coordinates of point " + str(i) + " should have " + ("stayed the same" if t else "changed"))
+
+c[9].type = tn
+g.setLayer(l,1,('select_all','hvcurve','downgrade'))
+cc = g.layers[1][0]
+for (i,t) in [(0,co),(3,hv),(6,cu),(9,tn)]:
+    if cc[i].type != t:
+        raise ValueError("Type of point " + str(i) + " should be " + str(t) + " rather than " + str(cc[i].type))
+
+c[9].type = cu
+c[3].type = tn
+c[6].type = co
+g.setLayer(l,1,('select_incompat','hvcurve','by_geom'))
+cc = g.layers[1][0]
+for (i,t) in [(0,co),(3,hv),(6,co),(9,tn)]:
+    if cc[i].type != t:
+        raise ValueError("Type of point " + str(i) + " should be " + str(t) + " rather than " + str(cc[i].type))
+
+c[3].type = cu
+c[9].type = cu
+g.setLayer(l,1,('select_smooth','hvcurve','by_geom'))
+cc = g.layers[1][0]
+for (i,t) in [(0,co),(3,hv),(6,co),(9,tn)]:
+    if cc[i].type != t:
+        raise ValueError("Type of point " + str(i) + " should be " + str(t) + " rather than " + str(cc[i].type))
+
+c[3].type = cu
+c[9].type = cu
+g.setLayer(l,1,('select_smooth','by_geom'))
+cc = g.layers[1][0]
+for (i,t) in [(0,co),(3,cu),(6,co),(9,tn)]:
+    if cc[i].type != t:
+        raise ValueError("Type of point " + str(i) + " should be " + str(t) + " rather than " + str(cc[i].type))
+
+c[0].type = c[3].type = c[6].type = c[9].type = co
+g.setLayer(l,1,('select_all','by_geom'))
+cc = g.layers[1][0]
+for (i,t) in [(0,co),(3,cu),(6,cu),(9,tn)]:
+    if cc[i].type != t:
+        raise ValueError("Type of point " + str(i) + " should be " + str(t) + " rather than " + str(cc[i].type))
+
+c[3].type = hv
+try:
+    g.setLayer(l,1,('select_all','check'))
+except:
+    raise ValueError("setLayer with 'check' failed when all types compatible with geometry")
+
+c[3].type = tn
+try:
+    g.setLayer(l,1,('select_all','check'))
+except:
+    pass
+else:
+    raise ValueError("setLayer with 'check' did not raise error for incompatible type")
+
+try:
+    g.setLayer(l,1,('select_all','select_none','by_geom'))
+except:
+    pass
+else:
+    raise ValueError("setLayer did not raise error for incompatible select flags")
+
+try:
+    g.setLayer(l,1,('select_all','check','by_geom'))
+except:
+    pass
+else:
+    raise ValueError("setLayer did not raise error for incompatible conversion mode flags")

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -137,6 +137,7 @@ check_python([WOFF2 round tripping],[test927.py],[Ambrosia.woff2])
 check_python([String Conversion],[test928.py],[DejaVuSerif.sfd])
 check_python([Open Subfonts],[test929.py],[NotoSans-Regular.ttc])
 check_python([Point, contour, and Layer fidelity],[test930.py])
+check_python([Point type conversion tests],[test931.py])
 check_python([Round-trip point selection tests],[test932.py])
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
(Staging note: I was not expecting that this code would be ready before the next release. #3458 is mostly about things that are objectively broken in relation to the documented interface, and should probably go in. #3467 could be argued either way, but is sorely needed for interactive spline editing. This change is also sorely needed, but I take no position on whether to "hold up" a release for its review and testing.)

Many open FontForge issues include a suggestion to implement a missing feature using python. That the python interface is low-level is fine -- it's far preferable to build it up on the python side than using the c-api, whether or not someone has come along yet to do so. 

What isn't fine is that the interface is incomplete, in that it lacks control over the type that FontForge assigns to an on-curve point. I could argue the need for that control in various ways, but here is the simplest: Just as a UFO -> FontForge -> UFO "round-trip" should produce the same data, so should a UI -> python -> UI "round-trip". Or at least such a round-trip should be *possible* if that's what an implementer prefers. 

The code of this request provides the missing control. I believe it is entirely upwardly compatible with the existing interface. The new `fontforge.point` `type` field will not affect code unaware of it, and the field is ignored when "storing" a layer in the pre-existing ways (those being the `foreground` and `background` properties and the `layers` dictionary). The changes slightly modify the UFO import path, but the new code will (or should ...) produce the same result as the old. 

I have not yet modified the documentation because the modifications are more substantial and no one has yet answered my question about the website. Before then I'm including a documentation fragment below. I believe it includes enough explanation to evaluate the code changes. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

# The `type` field

Each `point` also has a one-byte integer `type` field. The valid values for this field are:

* fontforge.splineCorner (0)
* fontforge.splineCurve (1)
* fontforge.splineHVCurve (2)
* fontforge.splineTangent (3)

which correspond to the point types supported by FontForge. A point has this field whether it is marked on- or off-curve, but it is not set or interpreted by FontForge for off-curve points. Functions that return a `fontforge.layer` object set the value of `type` for each embedded contour point. The value corresponds to the type of the point currently recorded in FontForge. That type will typically match the geometry of the point but -- just as in the UI -- it is not guaranteed to do so. 

Many `fontforge.layer` and `fontforge.contour` methods, including `simplify`, convert the object to FontForge's internal representation and back. These methods will retain the `type` value for on-curve points but not off-curve points. 

## Point type conversion

For compatibility reasons, `type` values are ignored when a layer is set using the `glyph.background` or `glyph.foreground` properties or the `glyph.layers` dictionary. The `glyph.setLayer()` method, in contrast, supports a number of flags that allow the type value to influence the type FontForge records for that point, and therefore the behavior of that point in the UI. All flags are described below, but the following simple guidelines produce a good result in almost all cases:

1. When a layer is constructed from scratch with python code, all type values can be left as `splineCorner`. When the layer is set by calling `setLayer()` with no flags, or using `foreground`, `background`, or `layers`, FontForge will set the type of each point based on its geometry. 

2. When an existing layer is copied from a `fontforge.glyph` and modified,  it is usually better to save the modifications by calling `setLayer()` with the `select_incompat` and `by_geom` flags. That way each type will be retained unless it is incompatible with that point's geometry, in which case it will be reset to an appropriate value. To further improve that result, the type of any new or modified point can be set to `splineTangent`. (That type is only compatible with tangent geometry, and will therefore either be compatible and saved or incompatible and cause FontForge to set the type based on geometry).

There are three types of flag.

### Selection flags 

The selection flags control which type values FontForge will *consider* converting. The types of any points not "selected" will not be altered. At most one of these flags should be specified:

* `select_all`: Every point is selected for possible type conversion. This the default.

* `select_none`: No point is selected. All on-curve points will retain their assigned types.

* `select_incompat`: A point is selected only if its type is incompatible with its geometry. `splineCorner` is compatible with all geometries and `splineCurve` is compatible with `splineHVCurve` geometries. `splineCurve` and `splineTangent` are treated as mutually-incompatible. 

* `select_smooth`: A point is selected if its current type is `splineCurve`, `splineHVCurve` or `splineTangent`, but not if its type is `splineCorner`. This option is a good choice for importing spline data that includes a `smooth` boolean, or storing data produced by a "smooth-aware" library. In either case, the type field can be treated as a boolean using 0 for not-smooth and 1 for smooth. "smooth" points will therefore be selected for potential conversion while non-smooth points will remain as corners. This flag corresponds to how UFO glyf data is imported into FontForge. (Similarly, the `type` field can be treated as a boolean when translating data from FontForge into a format with a `smooth` boolean.) 

### Conversion flags

The conversion flags control when and how FontForge converts the type of the selected points.  At most one of these flags should be specified:

* `by_geom`: The type of each selected point is assigned based on the geometry of the point without reference to its current type (although the current type may have contributed to its having been selected).

* `downgrade`: The type of each selected point is retained unless it is compatible with the point's geometry, in which case it is set to the most specific "compatible" type. (`splineHVcurve` can be downgraded to `splineCurve` or `splineCorner`, both `splineCurve` and `splineTangent` can only be downgraded to `splineCorner`. `splineCorner` is compatible with all geometries.) 

* `check`: The type of each selected point is verified to be compatible with its geometry. If there is at least one incompatible point `setLayer()` will not replace the specified layer and will throw an exception.

* `force`: If the type of a selected point is compatible with its geometry, that type and geometry are retained. Otherwise, the point is converted to one of that type, altering its geometry as if the same operation were performed in the UI. Because the FontForge point conversion code rarely produces a good initial result, this option is mostly present for completeness. 

### Other flags

At present there is one additional flag that affects the conversion process:

* `hvcurve`: By default FontForge does not convert a point to the `splineHVCurve` type even when its geometry is compatible. This is true both of the `fontforge.layer` interface and when importing font data from other formats. Given that the geometry of  `splineCurve` points can be constrained to HV geometry with modifier keys, FontForge assumes that most users will be happy using that type. This flag adds `splineHVCurve` to the types that the `by_geom` will convert to. 