### PR TITLE
Fix merging with a font with subfonts (e.g. #3491)

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -1532,14 +1532,18 @@ return(NULL);
 return( new );
 }
 
-void SFFlatten(SplineFont *cidmaster) {
+void SFFlatten(SplineFont **cidmasterpp) {
     SplineChar **glyphs;
+    SplineFont *cidmaster = *cidmasterpp;
     int i,j,max;
 
     if ( cidmaster==NULL )
-return;
-    if ( cidmaster->cidmaster!=NULL )
+	return;
+
+    if ( cidmaster->cidmaster!=NULL ) {
 	cidmaster = cidmaster->cidmaster;
+	cidmasterpp = &cidmaster;
+    }
     /* This doesn't change the ordering, so no need for special tricks to */
     /*  preserve scrolling location. */
     for ( i=max=0; i<cidmaster->subfontcnt; ++i ) {
@@ -1556,18 +1560,21 @@ return;
 	    }
 	}
     }
-    CIDFlatten(cidmaster,glyphs,max);
+    *cidmasterpp = CIDFlatten(cidmaster,glyphs,max);
 }
 
-int SFFlattenByCMap(SplineFont *sf,char *cmapname) {
+int SFFlattenByCMap(SplineFont **sfpp,char *cmapname) {
     struct cmap *cmap;
     int i,j,k,l,m, extras, max, curmax, warned;
     int found[4];
     SplineChar **glyphs = NULL, *sc;
+    SplineFont *sf = *sfpp;
     FontViewBase *fvs;
 
-    if ( sf->cidmaster!=NULL )
+    if ( sf->cidmaster!=NULL ) {
 	sf = sf->cidmaster;
+	sfpp = &sf;
+    }
     if ( sf->subfontcnt==0 ) {
 	ff_post_error(_("Not a CID-keyed font"),_("Not a CID-keyed font"));
 return( false );
@@ -1604,7 +1611,7 @@ return( false );
 	break;
 	    }
     }
-    sf = CIDFlatten(sf,glyphs,curmax);
+    *sfpp = sf = CIDFlatten(sf,glyphs,curmax);
 
     warned = false;
     for ( fvs=sf->fv; fvs!=NULL; fvs=fvs->nextsame ) {

--- a/fontforge/encoding.h
+++ b/fontforge/encoding.h
@@ -61,7 +61,7 @@ extern int CIDFromName(char *name, SplineFont *cidmaster);
 extern int CountOfEncoding(Encoding *encoding_name);
 extern int MaxCID(struct cidmap *map);
 extern int NameUni2CID(struct cidmap *map, int uni, const char *name);
-extern int SFFlattenByCMap(SplineFont *sf, char *cmapname);
+extern int SFFlattenByCMap(SplineFont **sf, char *cmapname);
 extern int SFForceEncoding(SplineFont *sf, EncMap *old, Encoding *new_enc);
 extern int SFReencode(SplineFont *sf, const char *encname, int force);
 extern SplineFont *CIDFlatten(SplineFont *cidmaster, SplineChar **glyphs, int charcnt);

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -1255,7 +1255,7 @@ return;
 	CIDMergeFont(fv->sf->cidmaster,other,preserveCrossFontKerning);
     else {
 	if (other->subfonts!=NULL)
-	    SFFlatten(other); /* Harmless because other is freed in _MergeFont() */
+	    SFFlatten(&other); /* Non-corrupting because other is freed in _MergeFont() */
 	__MergeFont(fv->sf,other,preserveCrossFontKerning);
     }
 }

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -13931,7 +13931,7 @@ return (NULL);
 return( NULL );
     }
 
-    SFFlatten(sf->cidmaster);
+    SFFlatten(&(sf->cidmaster));
 Py_RETURN( self );
 }
 
@@ -13950,7 +13950,7 @@ return( NULL );
     if ( !PyArg_ParseTuple(args,"s", &locfilename ))
 return( NULL );
 
-    if ( !SFFlattenByCMap(sf,locfilename)) {
+    if ( !SFFlattenByCMap(&sf,locfilename)) {
 	PyErr_Format(PyExc_EnvironmentError,"Can't find (or can't parse) cmap file: %s", locfilename);
 return( NULL );
     }

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -6638,7 +6638,7 @@ static void bCIDFlatten(Context *c) {
     if ( sf->cidmaster==NULL )
 	ScriptErrorString( c, "Not a cid-keyed font", sf->fontname );
 
-    SFFlatten(sf->cidmaster);
+    SFFlatten(&(sf->cidmaster));
 }
 
 static void bCIDFlattenByCMap(Context *c) {
@@ -6650,7 +6650,7 @@ static void bCIDFlattenByCMap(Context *c) {
 
     t = script2utf8_copy(c->a.vals[1].u.sval);
     locfilename = utf82def_copy(t);
-    if ( !SFFlattenByCMap(sf,locfilename))
+    if ( !SFFlattenByCMap(&sf,locfilename))
 	ScriptErrorString( c, "Can't find (or can't parse) cmap file",c->a.vals[1].u.sval);
     free(t); free(locfilename);
 }

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2339,7 +2339,7 @@ extern void SFLayerSetBackground(SplineFont *sf,int layer,int is_back);
 extern void SplineSetsRound2Int(SplineSet *spl,real factor,int inspiro,int onlysel);
 extern void SCRound2Int(SplineChar *sc,int layer, real factor);
 
-extern void SFFlatten(SplineFont *cidmaster);
+extern void SFFlatten(SplineFont **cidmaster);
 
 extern void SCCopyLayerToLayer(SplineChar *sc, int from, int to,int doclear);
 

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -3705,7 +3705,7 @@ static void FVMenuFlatten(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUS
 
     if ( cidmaster==NULL )
 return;
-    SFFlatten(cidmaster);
+    SFFlatten(&cidmaster);
 }
 
 static void FVMenuFlattenByCMap(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
@@ -3719,7 +3719,7 @@ return;
     if ( cmapname==NULL )
 return;
     SFFindNearTop(fv->b.sf);
-    SFFlattenByCMap(cidmaster,cmapname);
+    SFFlattenByCMap(&cidmaster,cmapname);
     SFRestoreNearTop(fv->b.sf);
     free(cmapname);
 }

--- a/gtkui/fontview.c
+++ b/gtkui/fontview.c
@@ -2501,7 +2501,7 @@ void FontViewMenu_Flatten(GtkMenuItem *menuitem, gpointer user_data) {
 
     if ( cidmaster==NULL )
 return;
-    SFFlatten(cidmaster);
+    SFFlatten(&cidmaster);
 }
 
 void FontViewMenu_FlattenByCMap(GtkMenuItem *menuitem, gpointer user_data) {
@@ -2515,7 +2515,7 @@ return;
     if ( cmapname==NULL )
 return;
     SFFindNearTop(fv->b.sf);
-    SFFlattenByCMap(cidmaster,cmapname);
+    SFFlattenByCMap(&cidmaster,cmapname);
     SFRestoreNearTop(fv->b.sf);
     free(cmapname);
 }


### PR DESCRIPTION
Another shot at fixing the merge of a font with a font that has subfonts. 

Closes #3491 (see that bug for commentary) 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
