### PR TITLE
Fix for #3482 infinite "Anchor Class Name" windows with return char

### DIFF
--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1313,6 +1313,9 @@ static int gmenu_key(struct gmenu *m, GEvent *event) {
     GMenu *top;
     unichar_t keysym = event->u.chr.keysym;
 
+    if ( m->dying )
+	return( false );
+
     if ( islower(keysym)) keysym = toupper(keysym);
     if ( event->u.chr.state&ksm_meta && !(event->u.chr.state&(menumask&~(ksm_meta|ksm_shift)))) {
 	/* Only look for mneumonics in the child */


### PR DESCRIPTION
I'm making this into a push request instead of just a diff in the issue because

1. I'm afraid it will get lost otherwise and
2. even if it's not perfect it's probably better than the current code. 

Here is the problem in summary: 

`GMenuPopupCheckKey()` is responsible for calling `gmenu_key()` on the current popup menu (if there is one) to convert relevant key events into popup menu operations. A return key event is "relevant" in that it gets passed to `GMenuSpecialKeys()`. This code seems to exist to support keyboard selection of popup-menu items, but I haven't found any way of getting that to work by actually using the keyboard. 

Anyway, what winds up happening is that even though the old popup menu from which "Anchor Point" was selected is no longer visible, it hasn't been cleaned out of (static) `most_recent_popup_menu`. "Return" maps, roughly speaking, to activating the currently selected item which is "Anchor Point" -- because that's what was selected to activate the dialog in the first place. Hence the new dialog. 

With this change `GMenuPopupCheckKey()` is called only if the current window is the "`popupowner`". There is a similar clause shortly below. I *think* this is fine, and anyway `GMenuPopupCheckKey()` may serve no constructive purpose now. But I'm not certain.  

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
