### PR TITLE
PyFFPoint_set_name: Set the name properly

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1884,7 +1884,9 @@ static int PyFFPoint_set_name(PyFF_Point *self,PyObject *value, void *UNUSED(clo
 	self->name = NULL;
     }
     if ( value!=Py_None ) {
-	PYGETSTR(value, self->name, -1);
+	char *name;
+	PYGETSTR(value, name, -1);
+	self->name = copy(name);
 	ENDPYGETSTR();
     }
 return( 0 );


### PR DESCRIPTION
PYGETSTR returns a non-transferrable reference to the string, which
is cleaned up when ENDPYGETSTR is called.

Found this out when testing it with `PYTHONMALLOC=malloc_debug`.
