### PR TITLE
Fix "Close Tab" behaviour

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -6691,9 +6691,12 @@ static void CVMenuCloseTab(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNU
 return;
     pos = GTabSetGetSel(cv->tabs);
     free(cv->former_names[pos]);
-    for ( i=pos+1; i<cv->former_cnt; ++i )
+    for ( i=pos+1; i<cv->former_cnt; ++i ) {
 	cv->former_names[i-1] = cv->former_names[i];
+    cv->cvtabs[i-1] = cv->cvtabs[i];
+    }
     --cv->former_cnt;
+    CVChangeSC_fetchTab(cv, pos);
     GTabSetRemoveTabByPos(cv->tabs,pos);	/* This should send an event that the selection has changed */
     GTabSetRemetric(cv->tabs);
 }


### PR DESCRIPTION
### Bug description
I have an outline window open with several glyphs in multiple tabs. If I click File -> Close Tab, correct behaviour occurs only if the last tab is selected. Otherwise, the following tab is seemingly closed instead of the currently selected one. After clicking on the remaining tabs that follow the currently selected tab, they suddenly change to different characters. This way, the tabs return to a state as if only the last tab was closed.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
In `CVMenuCloseTab()`, there is a loop that updates `CharView->former_names[]` so that the closed tab is removed. Later in `GTabSetRemoveTabByPos()`, the same is done for `CharView->tabs->tabs[]`. Then `GTabSetChanged()` is called, which creates an event and passes it to an event handler, which I tracked down to be `CVChangeToFormer()`. This finds the glyph and passes it to `CVChangeSC()`.

The problem is that this function calls `CVChangeSC_storeTab()` with `CharView->oldtabnum` (old selected tab index) and `CVChangeSC_fetchTab()` with the currently selected tab index. I think this code is meant to handle tab switching and not cases when the tabs are deleted and therefore reindexed. The function `CVChangeSC()` gets called whenever a tab is switched and the store/fetch functions update `CharView->charselector`. The problem is that, when a tab is closed, the tab index does not change and there is another tab array `CharView->cvtabs` that is not updated anywhere. So those functions just push the closed tab in the `charselector`, so nothing gets really closed and since the tab length is reduced, one tab is removed at the end.

The tabs are being tracked in multiple arrays like `former_names`, `tabs` and `cvtabs`, so I am guessing that if only the first two get updated and the last one does not, it results in a conflict when clicking on some tabs and they get updated to match `cvtabs`, which was never updated. When tracing all the names and labels in these variables, you can notice prevailing discrepancies as you continue closing and opening tabs.

I added the the `cvtabs` cleanup into `CVMenuCloseTab()` that gets called first. As `cvtabs` is statically allocated, nothing needs to be freed and simple reassignment is fine. Also, the title of `CharView->charselector` (apparently) needs to be updated before the function `CVChangeSC()` handles tab switching, otherwise it will revert to the old tab again. I did it by a `CVChangeSC_fetchTab()` call.

:arrow_right: The changes are minimal, the bug should be easily reproducible and the fix works. Nevertheless, I would like someone to review this who actually knows what all these structs and functions are meant for :-)

### Final checklist
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.