### PR TITLE
Cross-application modal input restriction

### DIFF
--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -791,25 +791,25 @@ static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
     GPtrArray *stack = gw->display->transient_stack;
 
     if ( gww && gw->display->restrict_count == 0 )
-	return false;
+        return false;
 
     while (gww != NULL) {
-		GGDKWindow last_modal = NULL;
+        GGDKWindow last_modal = NULL;
 
-		for (int i = ((int)stack->len)-1; i >= 0; --i) {
-			GGDKWindow ow = (GGDKWindow)stack->pdata[i];
-			if (ow == gww || ow->restrict_input_to_me) { // fudged
-				last_modal = ow;
-				break;
-			}
-		}
+        for (int i = ((int)stack->len)-1; i >= 0; --i) {
+            GGDKWindow ow = (GGDKWindow)stack->pdata[i];
+            if (ow == gww || ow->restrict_input_to_me) { // fudged
+                last_modal = ow;
+                break;
+            }
+        }
 
-		if (last_modal == NULL || last_modal == gww) {
-			return false;
-		}
+        if (last_modal == NULL || last_modal == gww) {
+            return false;
+        }
 
-		gww = gww->parent;
-	}
+        gww = gww->parent;
+    }
 
     if (event->type != GDK_MOTION_NOTIFY && event->type != GDK_BUTTON_RELEASE) {
         gdk_window_beep(gw->w);
@@ -998,7 +998,7 @@ static void _GGDKDraw_DispatchEvent(GdkEvent *event, gpointer data) {
                         gw == gdisp->bs.release_w &&
                         gevent.u.mouse.button == gdisp->bs.release_button &&
                         (int32_t)(gevent.u.mouse.time - gdisp->bs.last_press_time) < gdisp->bs.double_time &&
-                        gevent.u.mouse.time >= gdisp->bs.last_press_time) {	// Time can wrap
+                        gevent.u.mouse.time >= gdisp->bs.last_press_time) {  // Time can wrap
 
                     gdisp->bs.cur_click++;
                 } else {
@@ -1576,19 +1576,19 @@ static void GGDKDrawSetTransientFor(GWindow transient, GWindow owner) {
         gdk_window_set_transient_for(gw->w, ow->w);
         gdk_window_set_modal_hint(gw->w, true);
         gw->istransient = true;
-	g_ptr_array_add(gdisp->transient_stack, gw);
-	if (gw->restrict_input_to_me)
-	    _GGDKDraw_ChangeRestrictCount(gdisp, 1);
+        g_ptr_array_add(gdisp->transient_stack, gw);
+        if (gw->restrict_input_to_me)
+            _GGDKDraw_ChangeRestrictCount(gdisp, 1);
     } else {
         gdk_window_set_modal_hint(gw->w, false);
         gdk_window_set_transient_for(gw->w, gw->display->groot->w);
         gw->istransient = false;
 
-	// Be extra careful and ensure the window was on the list, in
-	// case there are spurious remove calls.
+        // Be extra careful and ensure the window was on the list, in
+        // case there are spurious remove calls.
         // TODO: optimise; search from the back; it is meant to be a stack...
         if ( g_ptr_array_remove(gdisp->transient_stack, gw) && gw->restrict_input_to_me )
-	    _GGDKDraw_ChangeRestrictCount(gdisp, -1);
+            _GGDKDraw_ChangeRestrictCount(gdisp, -1);
     }
 
     gw->transient_owner = ow;

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -205,7 +205,7 @@ static gboolean _GGDKDraw_OnWindowDestroyed(gpointer data) {
                     tw->istransient = false;
                     if (tw->restrict_input_to_me)
                         _GGDKDraw_ChangeRestrictCount(gw->display, -1);
-                    }
+                }
             }
             if (!gdk_window_is_destroyed(gw->w)) {
                 gdk_window_destroy(gw->w);

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -197,7 +197,6 @@ static gboolean _GGDKDraw_OnWindowDestroyed(gpointer data) {
                     GGDKWindow tw = (GGDKWindow)gw->display->transient_stack->pdata[i];
                     if (tw->transient_owner == gw) {
                         GGDKDrawSetTransientFor((GWindow)tw, NULL);
-                        break;
                     }
                 }
             }

--- a/gdraw/ggdkdrawP.h
+++ b/gdraw/ggdkdrawP.h
@@ -218,6 +218,8 @@ typedef struct ggdkdisplay { /* :GDisplay */
     GGDKKeyState ks;
     GGDKWindow default_icon;
     GGDKWindow last_nontransient_window;
+    GPtrArray *transient_stack; // When can a transient window have a transient child?
+    int restrict_count;
 
     GMainLoop  *main_loop;
     GdkDisplay *display;
@@ -263,7 +265,6 @@ struct ggdkwindow { /* :GWindow */
     unsigned int has_had_faked_configure: 1;
 
     int reference_count; // Knowing when to destroy is tricky...
-    GPtrArray *transient_childs; // Handling transients is tricky...
     guint resize_timeout; // Resizing is tricky...
 
     GWindow redirect_from;		/* only redirect input from this window and its children */

--- a/gdraw/ggdkdrawP.h
+++ b/gdraw/ggdkdrawP.h
@@ -218,7 +218,7 @@ typedef struct ggdkdisplay { /* :GDisplay */
     GGDKKeyState ks;
     GGDKWindow default_icon;
     GGDKWindow last_nontransient_window;
-    GPtrArray *transient_stack; // When can a transient window have a transient child?
+    GPtrArray *transient_stack;
     int restrict_count;
 
     GMainLoop  *main_loop;


### PR DESCRIPTION
This is my variant of @jtanx's https://github.com/fontforge/fontforge/tree/gdk-transients/gdraw branch. It maintains a count of the restricted windows, partly to speed up `_GGDKDraw_FilterByModal` but mostly to make it easy to a) check whether there is currently an input restriction and b) trigger a change on a 0->1 or 1->0 transition. (Hence the currently one-line `GGDK_ChangeRestrictCount`.) 

I've been using this for the past few days and it seems to work fine, but on the inspection level there's a potential problem:
```
static void GGDKDrawSetVisible(GWindow w, int show) {
    Log(LOGDEBUG, "0x%p %d", w, show);
    GGDKWindow gw = (GGDKWindow)w;
    _GGDKDraw_CleanupAutoPaint(gw->display);
    if (show) {
        if (gdk_window_is_visible(gw->w)) {
            Log(LOGDEBUG, "0x%p %d DISCARDED", w, show);
            return;
        }
#ifdef GDK_WINDOWING_QUARTZ
        // Quartz backend fails to send a configure event after showing a window
        // But FF expects one.
        _GGDKDraw_OnFakedConfigure(gw);
#endif
        gdk_window_show(gw->w);
    } else {
        GGDKDrawSetTransientFor((GWindow)gw, NULL);
        gdk_window_hide(gw->w);
    }
}
```
This works fine for new windows because they've already had Transients set when relevant. And it works fine on a visible->invisible transition because of the `GGDKDrawSetTransientFor()` call. But on its face it's not likely to work when making a window that has been hidden visible again. 

Do we know that either:
1. We never make hidden transient windows visible again, or
2. the code that does so already calls `GDrawSetTransientFor()` to handle the case?  

Closes #3498

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
