### PR TITLE
Expose interpolated quadratic points in python contours

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -942,8 +942,15 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD><CODE>selected</CODE></TD>
-      <TD colspan=2>Whether this point is selected in the UI. If an off-curve point
-	is selected in means the preceding (interpolated) on-curve point is selected.</TD>
+      <TD colspan=2>Whether this point is selected in the UI. In the case of
+        an off-curve point of a quadratic spline, selected is true when the
+	preceding (interpolated) on-curve point is selected. Otherwise (as with
+	a cubic curve) selected for an off-curve point also corresponds to 
+	UI selection.
+	<P>The value can also be set to change the selected status in the UI.
+        When not running with a UI FontForge will retain point selection status
+        between most calls and will usually mark the status in saved files as
+        it would when a UI is present.</TD>
     </TR>
     <TR>
       <TD><CODE>name</CODE></TD>

--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -942,15 +942,31 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD><CODE>selected</CODE></TD>
-      <TD colspan=2>Whether this point is selected in the UI. In the case of
-        an off-curve point of a quadratic spline, selected is true when the
-	preceding (interpolated) on-curve point is selected. Otherwise (as with
-	a cubic curve) selected for an off-curve point also corresponds to 
-	UI selection.
-	<P>The value can also be set to change the selected status in the UI.
-        When not running with a UI FontForge will retain point selection status
-        between most calls and will usually mark the status in saved files as
-        it would when a UI is present.</TD>
+      <TD colspan=2>Whether this point is selected in the UI.</TD>
+	<P>
+	The value of this member also determines the selected status in the UI
+	on setting a layer.  FontForge usually retains the selection status of
+	any point between and that of an on-curve point when saving, whether or
+	not a UI is present.
+      </TD>
+    </TR>
+    <TR>
+      <TD><CODE>interpolated</CODE></TD>
+      <TD colspan=2>True if FontForge treats this (quadratic, on-curve) point as
+        interpolated. All interpolated points should be mid-way between their off-curve
+        points, but some such points are not treated as interpolated. This flag is
+        ignored when setting a layer.
+        <P>
+        Older versions of FontForge omitted interpolated points. This
+	was equivalent to executing the following on a contour:
+	<P>
+	<TT>c[:] = [ p for p in c if not p.interpolated ]</TT> </TD>
+	<P>
+	This member will be false for a point marked "Never interpolate" in FontForge
+	but there is currently no way of setting or preserving that mark when a
+	layer is replaced using the Python interfaces. A "round trip" through a Python
+	contour therefore clears that mark on any points that have it, and FontForge
+	treats mid-placed and omitted on_curve points as equivalent.
     </TR>
     <TR>
       <TD><CODE>name</CODE></TD>
@@ -1122,8 +1138,8 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD colspan=2><CODE>c[i:j]</CODE></TD>
-      <TD>The contour containing points between i and j; i must be &gt;= j. 
-	Alternatively, c[j:i:-1] returns those points in reverse order 
+      <TD>The contour containing points between i and j; i must be &gt;= j.
+	Alternatively, c[j:i:-1] returns those points in reverse order
 	(larger strides are not supported).</TD>
     </TR>
     <TR>
@@ -1143,7 +1159,7 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD colspan=2><CODE>p in c</CODE></TD>
-      <TD>When p i sa point returns whether some point (p.x,p.y) is in the contour c. 
+      <TD>When p i sa point returns whether some point (p.x,p.y) is in the contour c.
         p can also be a tuple of two numbers</TD>
     </TR>
     <TR>
@@ -1441,7 +1457,7 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     </TR>
     <TR>
       <TD colspan=2><CODE>l[i]</CODE></TD>
-      <TD>The <EM>i</EM>th contour in the layer. You may assign a contour 
+      <TD>The <EM>i</EM>th contour in the layer. You may assign a contour
 	 to this (keeping the number of contours constant) or use "del l[i]"
 	 to remove the entry (reducing the number by one)</TD>
     </TR>

--- a/fontforge/ffpython.h
+++ b/fontforge/ffpython.h
@@ -112,6 +112,7 @@ typedef struct ff_point {
     double x,y;
     uint8 on_curve;
     uint8 selected;
+    uint8 interpolated;
     char *name;
 } PyFF_Point;
 static PyTypeObject PyFF_PointType;

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1774,7 +1774,7 @@ static PyObject *PyFFPoint_dup(PyFF_Point *self) {
 static PyFF_Point *PyFFPoint_Parse(PyObject *args, bool dup, bool always) {
     double x,y;
     PyFF_Point *p=NULL;
-    int i, on, sel;
+    int i, on, sel, interp;
 
     if ( args==NULL && !always )
 	return NULL;
@@ -1782,13 +1782,14 @@ static PyFF_Point *PyFFPoint_Parse(PyObject *args, bool dup, bool always) {
     x = y = 0.0;
     on = true;
     sel = false;
+    interp = false;
     if ( !PyArg_ParseTuple( args, "(ddii)", &x, &y, &on, &sel )) {
 	PyErr_Clear();
 	if ( !PyArg_ParseTuple( args, "(ddi)|i", &x, &y, &on, &sel )) {
 	    PyErr_Clear();
 	    if ( !PyArg_ParseTuple( args, "(dd)|ii", &x, &y, &on, &sel )) {
 		PyErr_Clear();
-		if ( !PyArg_ParseTuple( args, "dd|ii", &x, &y, &on, &sel )) {
+		if ( !PyArg_ParseTuple( args, "dd|iii", &x, &y, &on, &sel, &interp )) {
 		    PyErr_Clear();
 		    if ( PyType_IsSubtype(&PyFF_PointType, Py_TYPE(args)) ) { 
 			p = (PyFF_Point *) args;
@@ -1804,6 +1805,8 @@ static PyFF_Point *PyFFPoint_Parse(PyObject *args, bool dup, bool always) {
 	p = PyFFPoint_CNew(x,y,on,sel,NULL);
 	if ( p==NULL )
 	    return( NULL );
+	if ( interp )
+	    p->interpolated = true;
     } else if ( dup ) {
 	p = (PyFF_Point *) PyFFPoint_dup(p);
     } else {

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -5009,7 +5009,7 @@ return( NULL );
     if ( c->closed ) {
 
 	SplineMake(ss->last,ss->first,c->is_quadratic);
-	if ( c->is_quadratic && ss->last->nextcpselected || ss->first->prevcpselected ) {
+	if ( c->is_quadratic && (ss->last->nextcpselected || ss->first->prevcpselected) ) {
             // The convention for tracking selection of quadratic control
 	    // points is to use nextcpselected except at the tail of the
 	    // list, where it's prevcpselected on the first point.

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -4956,6 +4956,7 @@ return( ss );
 	    if ( !c->points[previ]->on_curve ) {
 		sp->prevcp.x = c->points[previ]->x;
 		sp->prevcp.y = c->points[previ]->y;
+		sp->prevcpselected = c->points[previ]->selected;
 		// if ( sp->prevcp.x!=sp->me.x || sp->prevcp.y!=sp->me.y ) // This is unnecessary since the other converter only makes a control point if there is supposed to be one.
 		    sp->noprevcp = false;
 	    }
@@ -4966,6 +4967,7 @@ return( ss );
 	    if ( !c->points[nexti]->on_curve ) {
 		sp->nextcp.x = c->points[nexti]->x;
 		sp->nextcp.y = c->points[nexti]->y;
+		sp->nextcpselected = c->points[nexti]->selected;
 		next += 2;
 		// if ( sp->nextcp.x!=sp->me.x || sp->nextcp.y!=sp->me.y ) // This is unnecessary since the other converter only makes a control point if there is supposed to be one.
 		    sp->nonextcp = false;
@@ -5066,8 +5068,8 @@ static PyFF_Contour *ContourFromSS(SplineSet *ss,PyFF_Contour *ret) {
 	    break;
 		if ( !sp->nonextcp || !sp->next->to->noprevcp ) {
 		    if ( k ) {
-			ret->points[cnt  ] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,false,NULL);
-			ret->points[cnt+1] = PyFFPoint_CNew(sp->next->to->prevcp.x,sp->next->to->prevcp.y,false,false,NULL);
+			ret->points[cnt  ] = PyFFPoint_CNew(sp->nextcp.x,sp->nextcp.y,false,sp->nextcpselected,NULL);
+			ret->points[cnt+1] = PyFFPoint_CNew(sp->next->to->prevcp.x,sp->next->to->prevcp.y,false,sp->next->to->prevcpselected,NULL);
 		    }
 		    cnt += 2;		/* not a line => 2 control points */
 		}

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -1305,6 +1305,13 @@ void SplineRefigure2(Spline *spline) {
 	spline->islinear = false;
 	if ( ysp->b==0 && xsp->b==0 )
 	    spline->islinear = true;	/* This seems extremely unlikely... */
+	if ( from->nextcpselected || to->prevcpselected ) {
+            // The convention for tracking selection of quadratic control
+	    // points is to use nextcpselected except at the tail of the
+	    // list, where it's prevcpselected on the first point.
+	    from->nextcpselected = true;
+	    to->prevcpselected = false;
+	}
     }
     if ( isnan(ysp->b) || isnan(xsp->b) )
 	IError("NaN value in spline creation");

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -4617,6 +4617,9 @@ return( spl );			/* Only one point, reversal is meaningless */
     flag = spline->from->nextcpdef;
     spline->from->nextcpdef = spline->from->prevcpdef;
     spline->from->prevcpdef = flag;
+    flag = spline->from->nextcpselected;
+    spline->from->nextcpselected = spline->from->prevcpselected;
+    spline->from->prevcpselected = flag;
 
     for ( ; spline!=NULL && spline!=first; spline=next ) {
 	next = spline->to->next;
@@ -4631,6 +4634,9 @@ return( spl );			/* Only one point, reversal is meaningless */
 	    flag = spline->to->nextcpdef;
 	    spline->to->nextcpdef = spline->to->prevcpdef;
 	    spline->to->prevcpdef = flag;
+	    flag = spline->to->nextcpselected;
+	    spline->to->nextcpselected = spline->to->prevcpselected;
+	    spline->to->prevcpselected = flag;
 	}
 
 	temp = spline->to;

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -10685,6 +10685,7 @@ static void CVMenuReverseDir(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *U
 	if ( PointListIsSelected(ss)) {
 	    if ( !changed ) {
 		CVPreserveState(&cv->b);
+	        cv->lastselpt = NULL; cv->lastselcp = NULL;
 		changed = true;
 	    }
 	    SplineSetReverse(ss);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -171,8 +171,9 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
 	test1001.py test1001a.py test1001b.py test1001c.py	\
 	test1002.py test1003.py test1004.py test1005.py		\
-	test1006.py test1007.py test1008.py test926.py		\
-	test927.py test1009.py test1010.py
+	test1006.py test1007.py test1008.py test1009.py         \
+	test1010.py test926.py test927.py test928.py test929.py \
+	test930.py test932.py 
 
 EXTRA_DIST += link_test.c randomtest.c build-aux/missing
 

--- a/tests/test932.py
+++ b/tests/test932.py
@@ -2,6 +2,7 @@
 
 import copy
 import fontforge as ff
+import pickle
 
 c0 = [(293.0,48.0,1), (291.0,48.0,1), (271.0,32.0,1), (227.0,-2.0,0), (196.8,-10.0,0), (162.0,-10.0,1), (92.0,-10.0,0), (36.0,16.0,0), (36.0,98.0,1), (36.0,166.0,0), (105.0,219.0,0), (201.0,243.0,1), (287.0,264.0,1), (290.0,265.0,0), (293.0,269.0,0), (293.0,276.0,1), (293.0,389.0,0), (246.0,406.0,0), (212.0,406.0,1), (174.0,406.0,0), (132.0,395.0,0), (132.0,364.0,1), (132.0,353.0,0), (133.0,347.0,0), (134.0,344.0,1), (136.0,340.0,0), (137.0,333.0,0), (137.0,326.0,1), (137.0,313.0,0), (119.0,292.0,0), (90.0,292.0,1), (67.0,292.0,0), (55.0,304.0,0), (55.0,328.0,1), (55.0,385.0,0), (138.0,439.0,0), (220.0,439.0,1), (293.0,439.0,0), (371.0,412.0,0), (371.0,270.0,1), (371.0,123.0,1), (371.0,77.0,0), (372.0,38.0,0), (401.0,38.0,1), (413.7,38.0,0), (430.5,47.8,0), (438.0,54.0,1), (449.3,47.7,0), (453.3,39.3,0), (455.0,27.0,1), (434.3,7.0,0), (398.3,-10.0,0), (360.0,-10.0,1), (309.6,-10.0,0), (299.0,17.0,0)]
 
@@ -89,3 +90,32 @@ lclen = len(l[0])
 for (i,p) in enumerate(l[0]):
     if (i < (lclen-1) and p.selected) or (i == lclen-1 and not p.selected):
         raise ValueError("Round trip of layer changed selection status")
+
+# Point Pickling 
+
+p = ff.point(4.4, 5.5)
+pps = pickle.dumps(p)
+fpp = pickle.loads(pps)
+
+if fpp.x != 4.4 or fpp.y != 5.5 or not fpp.on_curve or fpp.selected or fpp.interpolated:
+    print(fpp, fpp.selected, fpp.interpolated)
+    raise ValueError("Pickling lost a value")
+
+p.on_curve = False
+p.selected = True
+pps = pickle.dumps(p)
+fpp = pickle.loads(pps)
+
+if fpp.x != 4.4 or fpp.y != 5.5 or fpp.on_curve or not fpp.selected or fpp.interpolated:
+    print(fpp, fpp.selected, fpp.interpolated)
+    raise ValueError("Pickling lost a value")
+
+p.selected = False
+p.interpolated = True
+pps = pickle.dumps(p)
+fpp = pickle.loads(pps)
+
+if fpp.x != 4.4 or fpp.y != 5.5 or fpp.on_curve or fpp.selected or not fpp.interpolated:
+    print(fpp, fpp.selected, fpp.interpolated)
+    raise ValueError("Pickling lost a value")
+

--- a/tests/test932.py
+++ b/tests/test932.py
@@ -1,0 +1,91 @@
+# Round-trip point selection tests.
+
+import copy
+import fontforge as ff
+
+c0 = [(293.0,48.0,1), (291.0,48.0,1), (271.0,32.0,1), (227.0,-2.0,0), (196.8,-10.0,0), (162.0,-10.0,1), (92.0,-10.0,0), (36.0,16.0,0), (36.0,98.0,1), (36.0,166.0,0), (105.0,219.0,0), (201.0,243.0,1), (287.0,264.0,1), (290.0,265.0,0), (293.0,269.0,0), (293.0,276.0,1), (293.0,389.0,0), (246.0,406.0,0), (212.0,406.0,1), (174.0,406.0,0), (132.0,395.0,0), (132.0,364.0,1), (132.0,353.0,0), (133.0,347.0,0), (134.0,344.0,1), (136.0,340.0,0), (137.0,333.0,0), (137.0,326.0,1), (137.0,313.0,0), (119.0,292.0,0), (90.0,292.0,1), (67.0,292.0,0), (55.0,304.0,0), (55.0,328.0,1), (55.0,385.0,0), (138.0,439.0,0), (220.0,439.0,1), (293.0,439.0,0), (371.0,412.0,0), (371.0,270.0,1), (371.0,123.0,1), (371.0,77.0,0), (372.0,38.0,0), (401.0,38.0,1), (413.7,38.0,0), (430.5,47.8,0), (438.0,54.0,1), (449.3,47.7,0), (453.3,39.3,0), (455.0,27.0,1), (434.3,7.0,0), (398.3,-10.0,0), (360.0,-10.0,1), (309.6,-10.0,0), (299.0,17.0,0)]
+
+f = ff.font()
+
+g = f.createMappedChar('a')
+
+l = ff.layer()
+c = ff.contour()
+
+# Cubic 
+c[:] = c0
+c.closed = True
+l += c
+
+for (i,p) in enumerate(l[0]):
+    if i % 5 == 0:
+        p.selected = True
+
+g.layers[1] = l
+l = g.layers[1]
+
+for (i,p) in enumerate(l[0]):
+    if (i % 5 == 0 and not p.selected) or (i % 5 != 0 and p.selected):
+        raise ValueError("Round trip of layer changed selection status")
+
+for (i,p) in enumerate(l[0]):
+    p.selected = True
+
+g.layers[1] = l
+l = g.layers[1]
+
+for (i,p) in enumerate(l[0]):
+    if not p.selected:
+        print(i, p)
+        raise ValueError("Round trip of layer changed selection status")
+
+# Quadratic
+
+f.is_quadratic = True
+g.layers[1] = l
+l = g.layers[1]
+
+for (i,p) in enumerate(l[0]):
+    p.selected = True
+
+g.layers[1] = l
+l = g.layers[1]
+
+for (i,p) in enumerate(l[0]):
+    if not p.selected:
+        print(i, p)
+        raise ValueError("Round trip of layer changed selection status")
+
+for (i,p) in enumerate(l[0]):
+    if i % 3 == 0:
+        p.selected = True
+    else:
+        p.selected = False
+
+g.layers[1] = l
+l = g.layers[1]
+
+for (i,p) in enumerate(l[0]):
+    if (i % 3 == 0 and not p.selected) or (i % 3 != 0 and p.selected):
+        raise ValueError("Round trip of layer changed selection status")
+
+# Special attention to the tricky quadratic case
+
+for (i,p) in enumerate(l[0]):
+    p.selected = False
+
+pl = l[0][-1]
+
+if p.on_curve:
+    raise ValueError("Trailing quadratic contour point should be off-curve")
+
+pl.selected = True
+
+g.layers[1] = l
+l = g.layers[1]
+
+lclen = len(l[0])
+
+for (i,p) in enumerate(l[0]):
+    if (i < (lclen-1) and p.selected) or (i == lclen-1 and not p.selected):
+        raise ValueError("Round trip of layer changed selection status")

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -137,5 +137,6 @@ check_python([WOFF2 round tripping],[test927.py],[Ambrosia.woff2])
 check_python([String Conversion],[test928.py],[DejaVuSerif.sfd])
 check_python([Open Subfonts],[test929.py],[NotoSans-Regular.ttc])
 check_python([Point, contour, and Layer fidelity],[test930.py])
+check_python([Round-trip point selection tests],[test932.py])
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
This extends #3467 to property set `selected` on off-curve points in quadratic contours. It includes the commit from that one, so if this is merged that should be closed. 

To do this properly and also expose the selection status of interpolated on-curve points, this also adds an `interpolated` flag and includes those in the python contour. Most code should be fine with interpolated points, especially given that points can be marked as never-interpolated in FontForge. Users who don't want them, perhaps because an old script doesn't expect them, can strip them out with the documented code fragment. 

The `interpolated` flag is ignored when setting a layer. Setting aside `never_interpolated`, FontForge generally treats any point midway between its control points as interpolated. Therefore there has never been much difference between including and omitting an interpolatable point. (Future code could add an error on encountering a non-midway-point marked `interpolated`, but ignoring it is easier and better in almost all cases.) 

Note that the section status of off-curve points is tracked using `nextcpselected` on the previous off-curve point except for the last off-curve point in the list, in which case it is tracked with `prevcpselected` on the first point. I suspect this is a *de facto* standard based on the code in `CheckPoint()`. It might not make sense, but it's hard to judge how much code depends on it so I'm just following it in this new code. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
