### PR TITLE
SFDDumpGuidelines: Fix format specifier

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -1220,7 +1220,7 @@ static void SFDDumpGuidelines(FILE *sfd, GuidelineSet *gl) {
 	putc(' ',sfd);
 	SFDDumpUTF7Str(sfd,gl->identifier);
 	putc(' ',sfd);
-	fprintf( sfd, "%g %g %g %lu %d",
+	fprintf( sfd, "%g %g %g %u %d",
 		(double) gl->point.x, (double) gl->point.y,
 		(double) gl->angle, gl->color, gl->flags);
 	putc('\n',sfd);


### PR DESCRIPTION
Fixes

```
sfd.c: In function ‘SFDDumpGuidelines’:
sfd.c:1223:28: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 6 has type ‘uint32 {aka unsigned int}’ [-Wformat=]
  fprintf( sfd, "%g %g %g %lu %d",
                          ~~^
                          %u
sfd.c:1225:23:
   (double) gl->angle, gl->color, gl->flags);
```

Introduced from #3388
