### PR TITLE
Fix loading of internal python module when used from pyhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ script:
   - make check
   - if [ ! -z "$LINUX_FULL" ]; then make distcheck; fi
   - fontforge -version
-  - if [ -z "$LINUX_NOX" ]; then $PYTHON -c "import fontforge; import psMat; print(fontforge.__version__, fontforge.version()); fontforge.font();"; fi
+  - if [ -z "$LINUX_NOX" ]; then $PYTHON travis-scripts/pyhook_smoketest.py; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
   - if [ ! -z "$LINUX_RELEASE" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffappimagebuild.sh; fi
 

--- a/travis-scripts/pyhook_smoketest.py
+++ b/travis-scripts/pyhook_smoketest.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import fontforge
+import psMat
+import pickle
+
+print(fontforge.__version__, fontforge.version())
+
+fontforge.font()
+
+print(pickle.loads(pickle.dumps(fontforge.point())))


### PR DESCRIPTION
Fixes #3518

This is equivalent to doing something like

```py
import sys
sys.modules['__FontForge_Internals___'] = the_module
```
