### PR TITLE
Greatly improve CharView performance, see #3510

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -1597,14 +1597,12 @@ void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *s
 		GDrawPathClose(pixmap);
 
 	    switch( strokeFillMode ) {
-            case sfm_stroke_trans:
-                GDrawPathStroke( pixmap, fc );
-                break;
             case sfm_stroke:
                 GDrawPathStroke( pixmap, fc | 0xff000000 );
                 break;
             case sfm_clip_preserve:
                 GDrawClipPreserve( pixmap );
+            case sfm_stroke_trans:
             case sfm_fill:
             case sfm_nothing:
                 break;


### PR DESCRIPTION
This probably shouldn't be merged, but for some reason greatly increases
the performance of the character view window. I'm mostly opening this to
try to start a discussion on why it's so slow in the first place.

"Rough" looking glyphs are quite common in fonts, so there's no reason
FontForge shouldn't be able to manipulate them.

See #3510 for how this affects the UI. I'm currently using this patch in 
working on my own fonts. CC: @monkeyiq 