### PR TITLE
Last minute MacOS build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,9 @@ install:
       sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb"
       brew unlink python || true
       brew install ./travis-scripts/fontforge.rb --only-dependencies || true
+      export HOMEBREW_NO_AUTO_UPDATE=1
+      # Pin pango to this version, because of issues, see #3343
+      brew unlink pango && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/ad91e4df4a843764901811a965a17f650f34e2c1/Formula/pango.rb && brew link pango || true
       # 10 billion years later...
     fi
 
@@ -142,7 +145,7 @@ script:
   - if [ ! -z "$LINUX_FULL" ]; then make distcheck; fi
   - fontforge -version
   - if [ -z "$LINUX_NOX" ]; then $PYTHON travis-scripts/pyhook_smoketest.py; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ([ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "travis" ]); then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
   - if [ ! -z "$LINUX_RELEASE" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffappimagebuild.sh; fi
 
 after_success:

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1226,7 +1226,11 @@ int fontforge_main( int argc, char **argv ) {
     wattrs.utf8_window_title = "FontForge";
     wattrs.border_width = 2;
     wattrs.background_color = 0xffffff;
+#ifdef FONTFORGE_CAN_USE_GDK
+    wattrs.is_dlg = true;
+#else
     wattrs.is_dlg = !listen_to_apple_events;
+#endif
     pos.x = pos.y = 200;
     pos.width = splashimage.u.image->width;
     pos.height = splashimage.u.image->height-56;		/* 54 */
@@ -1381,8 +1385,11 @@ exit( 0 );
 	// WARNING: See declaration of RunApplicationEventLoop() above as to
 	// why you might not want to call that function anymore.
 	// RunApplicationEventLoop();
-	
+#ifndef FONTFORGE_CAN_USE_GDK
     } else
+#else
+    }
+#endif
 #endif
     if ( doopen || !any )
 	_FVMenuOpen(NULL);

--- a/travis-scripts/_FontForge
+++ b/travis-scripts/_FontForge
@@ -132,7 +132,7 @@ export PATH="$PATH:$bundle_bin"
 echo $WRAPPER $bundle_bin/fontforge > /tmp/oo
 
 if [ $# -eq 0 ] ; then
-    ( exec $WRAPPER $bundle_bin/fontforge -new & )
+    ( exec $WRAPPER $bundle_bin/fontforge -new  )
 else
-    ( exec $WRAPPER $bundle_bin/fontforge "$@" & )
+    ( exec $WRAPPER $bundle_bin/fontforge "$@"  )
 fi

--- a/travis-scripts/ffosxbuild.sh
+++ b/travis-scripts/ffosxbuild.sh
@@ -15,7 +15,8 @@ if [ -z $workdir ]; then
 fi
 
 builddate=`date +%Y-%m-%d`
-outdir=FontForge-$builddate-${hash:0:7}.app
+#outdir=FontForge-$builddate-${hash:0:7}.app
+outdir=FontForge.app
 
 if [ ! -f $BASE/lddx ]; then
     echo "Fetching lddx..."
@@ -107,11 +108,13 @@ sed -i -e "s/CFBundleVersionChangeMe/$FONTFORGE_VERSIONDATE_RAW/g" $outdir/Conte
 rm /tmp/fontforge-config-sorted
 
 # Package it up
+dmgname=FontForge-$builddate-${hash:0:7}.app.dmg
+
 hdiutil create -size 800m   \
    -volname   FontForge     \
    -srcfolder $outdir       \
    -ov        -format UDBZ  \
-   $outdir.dmg
+   $dmgname
 
 # Update the bintray descriptor... sigh. If this fails, then oh well, no bintray
 echo "Updating the bintray descriptor..."


### PR DESCRIPTION
If all goes well, I'll be using the travis mac build output for the release. The main things are:

* Disable listening to mac events, this is broken, and causes weird interaction with FontForge (e.g. doesn't show any windows on start, and only shows something when you click on the dock, it also doesn't quit when all the windows are closed). 
* Pin Pango to 1.42.2, to work around #3343 