### PR TITLE
Update version again to 20190317

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_PREREQ([2.68])
 
 #--------------------------------------------------------------------------
 # PackageTimestamp version
-m4_define([fontforge_package_stamp], [20190316])
+m4_define([fontforge_package_stamp], [20190317])
 # reminder: When updating FontForge, also take note of desktop/* dates and
 # startnoui.c, startui.c
 #--------------------------------------------------------------------------


### PR DESCRIPTION
We still haven't released, and it's the next day (or the next day UTC, which matters because that's what the builds will all be marked with)

