### PR TITLE
Simplified package name 20190316 instead of 3.0.20190316

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ BLANK1=''; AC_SUBST(BLANK1)
 AC_SUBST([BLANK2],[""])
 
 #--------------------------------------------------------------------------
-AC_INIT([fontforge],[fontforge_version],[fontforge-devel@lists.sourceforge.net],
+AC_INIT([fontforge],[fontforge_package_stamp],[fontforge-devel@lists.sourceforge.net],
 	[fontforge_package_name],[https://github.com/fontforge/fontforge])
 AC_CONFIG_SRCDIR([Unicode/ArabicForms.c])
 AC_CONFIG_MACRO_DIR([m4])

--- a/fontforge.pc.in
+++ b/fontforge.pc.in
@@ -9,4 +9,4 @@ localedir=@localedir@
 
 Name: FontForge
 Description: Outline font editor.
-Version: @FONTFORGE_VERSION@
+Version: @FONTFORGE_PACKAGE_STAMP@


### PR DESCRIPTION
squash merge if looks worthwhile, leave-out/close if not.