### PR TITLE
Be graceful about negative unicode codepoints

### DIFF
--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -184,7 +184,7 @@ const char *StdGlyphName(char *buffer, int uni,enum uni_interp interp,NameList *
     if ( (uni>=0 && uni<' ') ||
 	    (uni>=0x7f && uni<0xa0) )
 	/* standard controls */;
-    else if ( uni!=-1  ) {
+    else if ( uni>0 && uni <= 0x10ffff ) {
 	if ( uni>=0xe000 && uni<=0xf8ff &&
 		(interp==ui_trad_chinese || for_this_font==&ams)) {
 	    const int *pua = interp==ui_trad_chinese ? cns14pua : amspua;
@@ -200,15 +200,23 @@ const char *StdGlyphName(char *buffer, int uni,enum uni_interp interp,NameList *
 			(name = nl->unicode[up][ub][uc])!=NULL )
 	    break;
 	}
+    } else {
+	LogError( _("Warning: StdGlyphName returning name for value %d outside of Unicode range\n"), uni );
     }
     if ( name==NULL ) {
-	if ( uni>=0x10000 )
+	if ( uni>=0x10000 || uni < 0 )
 	    sprintf( buffer, "u%04X", uni);
 	else
 	    sprintf( buffer, "uni%04X", uni);
 	name = buffer;
     }
 return( name );
+}
+
+const char *StdGlyphNameBoundsCheck(char *buffer, int uni,enum uni_interp interp,NameList *for_this_font) {
+    if ( uni<0 || uni > 0x10ffff )
+	return NULL;
+    return StdGlyphName(buffer, uni, interp, for_this_font);
 }
 
 #define RefMax	40

--- a/fontforge/namelist.h
+++ b/fontforge/namelist.h
@@ -8,6 +8,7 @@ extern char **AllNamelistNames(void);
 extern char **SFTemporaryRenameGlyphsToNamelist(SplineFont *sf, NameList *new);
 extern const char *RenameGlyphToNamelist(char *buffer, SplineChar *sc, NameList *old, NameList *new, char **sofar);
 extern const char *StdGlyphName(char *buffer, int uni, enum uni_interp interp, NameList *for_this_font);
+extern const char *StdGlyphNameBoundsCheck(char *buffer, int uni, enum uni_interp interp, NameList *for_this_font);
 extern int UniFromName(const char *name, enum uni_interp interp, Encoding *encname);
 extern NameList *DefaultNameListForNewFonts(void);
 extern NameList *LoadNamelist(char *filename);

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -763,9 +763,10 @@ return( ret );
 
 static PyObject *PyFF_NameFromUnicode(PyObject *UNUSED(self), PyObject *args) {
     char buffer[400], *nlist = NULL;
+    const char *name;
     int uniinterp, uni;
     NameList *for_new_glyphs;
-    PyObject *ret;
+    PyObject *ret = NULL;
 
     if ( !PyArg_ParseTuple(args, "i|s", &uni, &nlist) )
 return( NULL );
@@ -785,8 +786,12 @@ return( NULL );
 	for_new_glyphs = fv_active_in_ui->sf->for_new_glyphs;
     }
 
-    ret = Py_BuildValue("s", StdGlyphName(buffer,uni,uniinterp,for_new_glyphs));
-return( ret );
+    name = StdGlyphNameBoundsCheck(buffer,uni,uniinterp,for_new_glyphs);
+    if ( name!=NULL )
+	ret = Py_BuildValue("s", name);
+    else
+	PyErr_Format(PyExc_ValueError, "Value %d has no Unicode name.", uni);
+    return( ret );
 }
 
 static PyObject *PyFF_UnicodeAnnotationFromLib(PyObject *UNUSED(self), PyObject *args) {


### PR DESCRIPTION
I'm not sure it's necessary to pick a validity cutoff with this function; if it is a reviewer can choose one. This eliminates the reported crash. 

Closes #3555