### PR TITLE
Fix crash opening generate dialog for bitmap fonts

### DIFF
--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -68,9 +68,7 @@ const char *savefont_extensions[] = { ".pfa", ".pfb", ".res", "%s.pfb", ".pfa", 
 	".t42", ".t11",
 	".ttf", ".ttf", ".suit", ".ttc", ".dfont", ".otf", ".otf.dfont", ".otf",
 	".otf.dfont", ".svg", ".ufo", ".ufo2", ".ufo3", ".woff",
-#ifdef FONTFORGE_CAN_USE_WOFF2
 	".woff2",
-#endif
 	NULL };
 const char *bitmapextensions[] = { "-*.bdf", ".ttf", ".dfont", ".ttf", ".otb", ".bmap", ".dfont", ".fon", "-*.fnt", ".pdb", "-*.pt3", ".none", NULL };
 #else
@@ -84,9 +82,7 @@ const char *savefont_extensions[] = { ".pfa", ".pfb", ".bin", "%s.pfb", ".pfa", 
 	".ufo2",
 	".ufo3",
 	".woff",
-#ifdef FONTFORGE_CAN_USE_WOFF2
 	".woff2",
-#endif
 NULL };
 const char *bitmapextensions[] = { "-*.bdf", ".ttf", ".dfont", ".ttf", ".otb", ".bmap.bin", ".fon", "-*.fnt", ".pdb", "-*.pt3", ".none", NULL };
 #endif

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -68,7 +68,11 @@ const char *savefont_extensions[] = { ".pfa", ".pfb", ".res", "%s.pfb", ".pfa", 
 	".t42", ".t11",
 	".ttf", ".ttf", ".suit", ".ttc", ".dfont", ".otf", ".otf.dfont", ".otf",
 	".otf.dfont", ".svg", ".ufo", ".ufo2", ".ufo3", ".woff",
+#ifdef FONTFORGE_CAN_USE_WOFF2
 	".woff2",
+#else
+        NULL,
+#endif
 	NULL };
 const char *bitmapextensions[] = { "-*.bdf", ".ttf", ".dfont", ".ttf", ".otb", ".bmap", ".dfont", ".fon", "-*.fnt", ".pdb", "-*.pt3", ".none", NULL };
 #else
@@ -82,7 +86,11 @@ const char *savefont_extensions[] = { ".pfa", ".pfb", ".bin", "%s.pfb", ".pfa", 
 	".ufo2",
 	".ufo3",
 	".woff",
+#ifdef FONTFORGE_CAN_USE_WOFF2
 	".woff2",
+#else
+        NULL,
+#endif
 NULL };
 const char *bitmapextensions[] = { "-*.bdf", ".ttf", ".dfont", ".ttf", ".otb", ".bmap.bin", ".fon", "-*.fnt", ".pdb", "-*.pt3", ".none", NULL };
 #endif

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -2691,7 +2691,10 @@ return( 0 );
 		master->fontname;
 	unichar_t *temp = malloc(sizeof(unichar_t)*(strlen(fn)+30));
 	uc_strcpy(temp,fn);
-	uc_strcat(temp,savefont_extensions[ofs]!=NULL?savefont_extensions[ofs]:bitmapextensions[old]);
+	if ( ofs==ff_none )
+	    uc_strcat(temp,bitmapextensions[old]);
+	else
+	    uc_strcat(temp,savefont_extensions[ofs]);
 	GGadgetSetTitle(gcd[0].ret,temp);
 	free(temp);
     }


### PR DESCRIPTION
Opening generate font dialog for a bitmap font currently crashes when FontForge is build without WOFF2 support. This is because existing code assumes the last element in `savefont_extensions` array equals `ff_none` and depends on it, but when built without WOFF2 support that array will be one element short and bad things happen.

Fixed by making the calling code more robust, and also removing the `#ifdefs` from the array; it should have the same number of elements regardless of the build options (yay for having more optional features).