### PR TITLE
Fix leaks in CoreFoundation code.

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -714,19 +714,22 @@ static int get_mac_x11_prop(char *keystr) {
     CFStringRef key, appID;
     int val;
 
-    appID = CFStringCreateWithBytes(NULL,(uint8 *) "com.apple.x11",strlen("com.apple.x11"), kCFStringEncodingISOLatin1, 0);
+    appID = CFSTR("com.apple.x11");
     key   = CFStringCreateWithBytes(NULL,(uint8 *) keystr,strlen(keystr), kCFStringEncodingISOLatin1, 0);
     ret = CFPreferencesCopyAppValue(key,appID);
     if ( ret==NULL ) {
 	/* Sigh. Apple uses a different preference file under 10.5.6 I really */
 	/*  wish they'd stop making stupid, unnecessary changes */
-	appID = CFStringCreateWithBytes(NULL,(uint8 *) "org.x.X11",strlen("org.x.X11"), kCFStringEncodingISOLatin1, 0);
+	appID = CFSTR("org.x.X11");
 	ret = CFPreferencesCopyAppValue(key,appID);
     }
+    CFRelease(key);
     if ( ret==NULL )
 return( -1 );
-    if ( CFGetTypeID(ret)!=CFBooleanGetTypeID())
+    if ( CFGetTypeID(ret)!=CFBooleanGetTypeID()) {
+    CFRelease(ret);
 return( -2 );
+    }
     val = CFBooleanGetValue(ret);
     CFRelease(ret);
 return( val );


### PR DESCRIPTION
These leaks were found by using the command-line version of the Clang Static Analyzer.

### Motivation and Context
- [X] Why is this change required? What problem does it solve?
This fixes memory leaks in the `get_mac_x11_prop` function in startui.c.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)

### Description
- [X] Describe your changes in detail.
Details on how to build/get the analyzer can be found [here](https://clang-analyzer.llvm.org).

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [X] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

As it stands, the Clang Static Analyzer complains about 2137 bugs it found (on macOS). Also, the logs it generates can take up 1 GB or more of disk space (but are usually around 200 MB compressed).