### PR TITLE
Make it clear which GUI backend is in use

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -281,6 +281,15 @@ static void SplashLayout() {
 #ifdef FONTFORGE_CONFIG_USE_DOUBLE
     uc_strcat(pt,"-D");
 #endif
+#ifdef BUILT_WITH_GDK2
+    uc_strcat(pt,"-GDK2");
+#endif
+#ifdef BUILT_WITH_GDK3
+    uc_strcat(pt,"-GDK3");
+#endif
+#ifdef BUILT_WITH_XORG
+    uc_strcat(pt,"-Xorg");
+#endif
     uc_strcat(pt,")");
     pt += u_strlen(pt);
     lines[linecnt++] = pt;
@@ -925,6 +934,15 @@ int fontforge_main( int argc, char **argv ) {
 #endif
 #ifdef FONTFORGE_CONFIG_USE_DOUBLE
 	        "-D"
+#endif
+#ifdef BUILT_WITH_GDK2
+            "-GDK2"
+#endif
+#ifdef BUILT_WITH_GDK3
+            "-GDK3"
+#endif
+#ifdef BUILT_WITH_XORG
+            "-Xorg"
 #endif
 	        ".\n",
 	        FONTFORGE_MODTIME_STR );

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -216,6 +216,7 @@ if test x$use_gdk = xyes ; then
             fontforge_can_use_gdk=yes
             fontforge_gdk_version=GDK2
             AC_DEFINE(FONTFORGE_CAN_USE_GDK,[],[FontForge will build the GUI with the GDK2 backend])
+            AC_DEFINE(BUILT_WITH_GDK2,[],[Built with GDK2])
             AC_MSG_NOTICE([building the GUI with the GDK2 backend...])
         ],
         [
@@ -227,6 +228,7 @@ if test x$use_gdk = xyes ; then
             fontforge_can_use_gdk=yes
             fontforge_gdk_version=GDK3
             AC_DEFINE(FONTFORGE_CAN_USE_GDK,[],[FontForge will build the GUI with the GDK3 backend])
+            AC_DEFINE(BUILT_WITH_GDK3,[],[Built with GDK3])
             AC_MSG_NOTICE([building the GUI with the GDK3 backend...])
         ],
         [

--- a/m4/fontforge_config_x_libraries.m4
+++ b/m4/fontforge_config_x_libraries.m4
@@ -20,6 +20,7 @@ if test x"${i_do_have_x}" = xyes; then
                   [XKB_LIBS="${found_lib}"],
                   [AC_DEFINE(_NO_XKB,1,[Define if not using xkb.])],
                   [$X_LIBS $X_PRE_LIBS $X_EXTRA_LIBS])
+   AC_DEFINE([BUILT_WITH_XORG],[],[Define if using X.org])
 fi
 AC_SUBST([XINPUT_LIBS])
 AC_SUBST([XKB_LIBS])


### PR DESCRIPTION
This will help prevent confusion among users about which backend they
are using. This will make conversations like the one in #3570 less
likely to recur.

Just so everyone knows, I indeed tested this PR with `--with-x`, `--without-x`, `--enable-gdk=gdk3` and `--enable-gdk=gdk2` and saw the expected results.

![gdk3](https://user-images.githubusercontent.com/838783/54863588-880c3000-4d85-11e9-9bc3-7ff0c0db0467.png)
