### PR TITLE
Fix -Wstrncat-size warning

### DIFF
--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -1622,7 +1622,7 @@ return( SplineFontRasterize(_sf,layer,pixelsize,true));
     strcpy(aa,_("Generating anti-alias font"));
     if ( sf->fontname!=NULL ) {
 	strcat(aa,": ");
-	strncat(aa,sf->fontname,sizeof(aa)-strlen(aa));
+	strncat(aa,sf->fontname,sizeof(aa)-strlen(aa)-1);
 	aa[sizeof(aa)-1] = '\0';
     }
     ff_progress_start_indicator(10,_("Rasterizing..."),


### PR DESCRIPTION
Clang 10.0 complains that "the value of the size argument in 'strncat' is too large, might lead to a buffer overflow" with the suggested fix of "change the argument to be the free space in the destination buffer minus the terminating null byte".

This should prevent a buffer overflow.