### PR TITLE
Fix Mac bundle creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,7 @@ script:
   - if [ ! -z "$LINUX_FULL" ]; then make distcheck; fi
   - fontforge -version
   - if [ -z "$LINUX_NOX" ]; then $PYTHON travis-scripts/pyhook_smoketest.py; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && ([ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "travis" ]); then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffosxbuild.sh $PREFIX $TRAVIS_COMMIT; fi
   - if [ ! -z "$LINUX_RELEASE" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis-scripts/ffappimagebuild.sh; fi
 
 after_success:
@@ -168,4 +168,4 @@ deploy:
     condition: '"$BINTRAY_DEPLOY" = "true"'
     branch:
       - master
-      - travis
+      #- travis

--- a/travis-scripts/ffosxbuild.sh
+++ b/travis-scripts/ffosxbuild.sh
@@ -51,8 +51,10 @@ echo "Bundling Python libraries..."
 otool -L $workdir/bin/fontforge
 
 pylib=$(otool -L $workdir/bin/fontforge | grep -i python | sed -e 's/ \(.*\)//')
-pycruft=$(dirname $pylib)/../../..
-cp -a $pycruft/Python.framework $outdir/Contents/Frameworks
+pycruft=$(realpath $(dirname $pylib)/../../..)
+echo "pycruft: $pycruft"
+mkdir -p $outdir/Contents/Frameworks
+cp -av $pycruft/Python.framework $outdir/Contents/Frameworks
 pushd $outdir/Contents/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
 rm site-packages || rm -rf site-packages
 ln -s ../../../../../../Resources/opt/local/lib/python2.7/site-packages


### PR DESCRIPTION
This is a follow-up to #3562. With breakpad gone, the `Frameworks` folder didn't exist, so instead of copying `Python.framework` into `Frameworks`, it copied `Python.framework`, renaming it to `Frameworks`. So this ensures that the framework directory is created before copying in that folder.