### PR TITLE
Simplify GDK/X11 identification

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -281,14 +281,14 @@ static void SplashLayout() {
 #ifdef FONTFORGE_CONFIG_USE_DOUBLE
     uc_strcat(pt,"-D");
 #endif
-#ifdef BUILT_WITH_GDK2
-    uc_strcat(pt,"-GDK2");
-#endif
-#ifdef BUILT_WITH_GDK3
+#ifdef FONTFORGE_CAN_USE_GDK
+#  if GDK_MAJOR_VERSION >= 3
     uc_strcat(pt,"-GDK3");
-#endif
-#ifdef BUILT_WITH_XORG
-    uc_strcat(pt,"-Xorg");
+#  else
+    uc_strcat(pt,"-GDK2");
+#  endif
+#else
+    uc_strcat(pt,"-X11");
 #endif
     uc_strcat(pt,")");
     pt += u_strlen(pt);

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -216,7 +216,6 @@ if test "x$enable_gdk" = "xgdk2"; then
     [
         fontforge_gdk_version=GDK2
         AC_DEFINE(FONTFORGE_CAN_USE_GDK,[],[FontForge will build the GUI with the GDK2 backend])
-        AC_DEFINE(BUILT_WITH_GDK2,[],[Built with GDK2])
         AC_MSG_NOTICE([building the GUI with the GDK2 backend...])
     ],
     [
@@ -228,7 +227,6 @@ elif ! test "x$enable_gdk" = "xno"; then
         fontforge_can_use_gdk=yes
         fontforge_gdk_version=GDK3
         AC_DEFINE(FONTFORGE_CAN_USE_GDK,[],[FontForge will build the GUI with the GDK3 backend])
-        AC_DEFINE(BUILT_WITH_GDK3,[],[Built with GDK3])
         AC_MSG_NOTICE([building the GUI with the GDK3 backend...])
     ],
     [

--- a/m4/fontforge_config_x_libraries.m4
+++ b/m4/fontforge_config_x_libraries.m4
@@ -20,7 +20,6 @@ if test x"${i_do_have_x}" = xyes; then
                   [XKB_LIBS="${found_lib}"],
                   [AC_DEFINE(_NO_XKB,1,[Define if not using xkb.])],
                   [$X_LIBS $X_PRE_LIBS $X_EXTRA_LIBS])
-   AC_DEFINE([BUILT_WITH_XORG],[],[Define if using X.org])
 fi
 AC_SUBST([XINPUT_LIBS])
 AC_SUBST([XKB_LIBS])


### PR DESCRIPTION
Uses pre-existing defines, instead of creating new ones.

Follow-up to #3572
