### PR TITLE
basic python.html fix-up 

### DIFF
--- a/doc/html/FontForge.css
+++ b/doc/html/FontForge.css
@@ -16,8 +16,8 @@
  BLOCKQUOTE PRE { background: #ffd; color: #000; }
  BLOCKQUOTE#shell PRE { background: #ccf; color: #000; }
  H1 { display: inline }
- TABLE#module { background: #ddf }
- TABLE#type { background: #ffd }
+ TABLE.module { background: #ddf }
+ TABLE.type { background: #ffd }
 
 /* menubar, stolen and modified from the sourceforge stylesheet */
 .menucontainer li

--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -55,10 +55,9 @@
 <BLOCKQUOTE>
 <PRE>fontforge -c 'open(argv[1]).generate(argv[2])'</PRE>
 </BLOCKQUOTE>
-  <TABLE id="module" border=1>
-    <CAPTION>
-      <A NAME="psMat">psMat</A>
-    </CAPTION>
+
+<H2 id="psMat">psMat</H2>
+  <TABLE class="module" border=1>
     <TR>
       <TH span=3>Methods</TH>
     </TR>
@@ -115,11 +114,9 @@
       <TD colspan=3>None</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="module" border=1>
-    <CAPTION>
-      <A NAME="fontforge">fontforge</A>
-    </CAPTION>
+
+<H2 id="fontforge">fontforge</H2>
+  <TABLE class="module" border=1>
     <TR>
       <TH colspan=3>Global Variables</TH>
     </TR>
@@ -347,45 +344,45 @@
     <TR>
       <TD><CODE>UnicodeNames2GetCntFromLib</CODE></TD>
       <TD><CODE>()</CODE></TD>
-	Return the Total Count of all Names that were corrected with a new name.
+      <TD>Return the Total Count of all Names that were corrected with a new name.
 	Errors and corrections happen, therefore names can be corrected in the
 	next Unicode Nameslist version.
-	If there is no libuninameslist ver 0.5 or later available, then return -1
+	If there is no libuninameslist ver 0.5 or later available, then return -1.</TD>
     </TR>
     <TR>
       <TD><CODE>UnicodeNames2GetNxtFromLib</CODE></TD>
       <TD><CODE>(n)</CODE></TD>
-	Errors and corrections happen, therefore names can be corrected in the
+      <TD>Errors and corrections happen, therefore names can be corrected in the
 	next Unicode Nameslist version. With val==unicode value, this function
 	returns -1 if no Names2 exists, or the Nth table location for this
 	unicode value listed in libuninameslist that was corrected to a new name.
-	If there is no libuninameslist ver 0.5 or later, then return -1.
+	If there is no libuninameslist ver 0.5 or later, then return -1.</TD>
     </TR>
     <TR>
       <TD><CODE>UnicodeNames2NxtUniFromLib</CODE></TD>
       <TD><CODE>(n)</CODE></TD>
-	Errors and corrections happen, therefore names can be corrected in the
+      <TD>Errors and corrections happen, therefore names can be corrected in the
 	next Unicode Nameslist version. This function returns the Next Names2
 	listed in libuninameslist internal table that was corrected to a new name.
 	The internal table of Unicode values is of size UnicodeNames2GetCntFromLib().
-	If there is no libuninameslist ver 0.5 or later, then return -1.
+	If there is no libuninameslist ver 0.5 or later, then return -1.</TD>
     </TR>
     <TR>
       <TD><CODE>UnicodeNames2FrmTabFromLib</CODE></TD>
       <TD><CODE>(n)</CODE></TD>
-	Errors and corrections happen, therefore names can be corrected in the
+      <TD>Errors and corrections happen, therefore names can be corrected in the
 	next Unicode Nameslist version. This function returns the Next Names2
 	listed in libuninameslist internal table that was corrected to a new name.
 	The internal table of Unicode values is of size UnicodeNames2GetCntFromLib().
-	If there is no libuninameslist ver 0.5 or later, then return NULL.
+	If there is no libuninameslist ver 0.5 or later, then return NULL.</TD>
     <TR>
     </TR>
       <TD><CODE>UnicodeNames2FromLib</CODE></TD>
       <TD><CODE>(val)</CODE></TD>
-	Errors and corrections happen, therefore names can be corrected in the
+      <TD>Errors and corrections happen, therefore names can be corrected in the
 	next Unicode Nameslist version. This function returns the Names2 or NULL
 	based on the unicode value given.
-	If there is no libuninameslist ver 0.5 or later, then return NULL.
+	If there is no libuninameslist ver 0.5 or later, then return NULL.</TD>
     </TR>
     <TR>
       <TD><CODE>IsFraction</CODE></TD>
@@ -880,36 +877,11 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	<P>
 	Throws an exception if there is no user interface.</TD>
     </TR>
-    <TR>
-      <TH colspan=3>Types</TH>
-    </TR>
-    <TR>
-      <TD colspan=3><A href="#Point">point</A></TD>
-    </TR>
-    <TR>
-      <TD colspan=3><A href="#Contour">contour</A></TD>
-    </TR>
-    <TR>
-      <TD colspan=3><A href="#Layer">layer</A></TD>
-    </TR>
-    <TR>
-      <TD colspan=3><A href="#GlyphPen">glyphPen</A></TD>
-    </TR>
-    <TR>
-      <TD colspan=3><A href="#Glyph">glyph</A></TD>
-    </TR>
-    <TR>
-      <TD colspan=3><A href="#selection">selection</A></TD>
-    </TR>
-    <TR>
-      <TD colspan=3><A href="#Font">font</A></TD>
-    </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A name="Point">point</A>
-    </CAPTION>
+
+<H2 id="Point">point</H2>
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Creation</TH>
     </TR>
@@ -1022,46 +994,41 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	it is useful for anything else.</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A name="Contour">contour</A>
-    </CAPTION>
-    <TR>
-      <TH colspan=3>Description</TH>
-    </TR>
-    <TR>
-      <TD colspan=3>A contour is a collection of points. A contour may be either
-	based on cubic or quadratic splines.
-	<P>
-	If based on cubic splines there should be either 0 or 2 off-curve points
-	between every two on-curve points. If there are no off-curve points then
-	we have a line between those two points. If there are 2 off-curve points
-	we have a cubic bezier curve between the two end points.
-	<P>
-	If based on quadratic splines things are more complex. Again, two adjacent
-	on-curve points yield a line between those points. Two on-curve points with
-	an off-curve point between them yields a quadratic bezier curve. However
-	if there are two adjacent off-curve points then an on-curve point will be
-	interpolated between them. (This should be familiar to anyone who has read
-	the truetype 'glyf' table docs).
-	<P>
-	For examples of what these splines can look like see the
-	<A HREF="bezier.html">section on bezier curves</A>.
-	<P>
-	A contour may be open in which case it is just a long wiggly line, or closed
-	when it is more like a circle with an inside and an outside. Unless you are
-	making stroked fonts all your contours should eventually be closed.
-	<P>
-	Contours may also be expressed in terms of Raph Levien's spiro points. This
-	is an alternate representation for the contour, and is not always available
-	(Only if <CODE><A HREF="python.html#ff-hasSpiro">fontforge.hasSpiro</A>()
-	</CODE>is<CODE> True</CODE>. If available the spiro member will return a
-	tuple of spiro control points, while assigning to this member will change
-	the shape of the contour to match the new spiros.
-	<P>
-	Two contours may be compared to see if they describe similar paths.</TD>
-    </TR>
+
+<H2 id="Contour">contour</H2>
+
+A contour is a collection of points. A contour may be either
+based on cubic or quadratic splines.
+<P>
+If based on cubic splines there should be either 0 or 2 off-curve points
+between every two on-curve points. If there are no off-curve points then
+we have a line between those two points. If there are 2 off-curve points
+we have a cubic bezier curve between the two end points.
+<P>
+If based on quadratic splines things are more complex. Again, two adjacent
+on-curve points yield a line between those points. Two on-curve points with
+an off-curve point between them yields a quadratic bezier curve. However
+if there are two adjacent off-curve points then an on-curve point will be
+interpolated between them. (This should be familiar to anyone who has read
+the truetype 'glyf' table docs).
+<P>
+For examples of what these splines can look like see the
+<A HREF="bezier.html">section on bezier curves</A>.
+<P>
+A contour may be open in which case it is just a long wiggly line, or closed
+when it is more like a circle with an inside and an outside. Unless you are
+making stroked fonts all your contours should eventually be closed.
+<P>
+Contours may also be expressed in terms of Raph Levien's spiro points. This
+is an alternate representation for the contour, and is not always available
+(Only if <CODE><A HREF="python.html#ff-hasSpiro">fontforge.hasSpiro</A>()
+</CODE>is<CODE> True</CODE>. If available the spiro member will return a
+tuple of spiro control points, while assigning to this member will change
+the shape of the contour to match the new spiros.
+<P>
+Two contours may be compared to see if they describe similar paths.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Creation</TH>
     </TR>
@@ -1432,21 +1399,15 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	it is useful for anything else.</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A name="Layer">layer</A>
-    </CAPTION>
-    <TR>
-      <TH colspan=3>Description</TH>
-    </TR>
-    <TR>
-      <TD colspan=3>A layer is a collection of contours. All the contours must
-	be the same order (all quadratic or all cubic). Currently layers do not contain
-	references.
-	<P>
-	Layers may be compared to see if their contours are similar.</TD>
-    </TR>
+
+<H2 id="Layer">layer</H2>
+A layer is a collection of contours. All the contours must
+be the same order (all quadratic or all cubic). Currently layers do not contain
+references.
+<P>
+Layers may be compared to see if their contours are similar.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Creation</TH>
     </TR>
@@ -1767,19 +1728,16 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	it is useful for anything else.</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A name="GlyphPen">glyphPen</A>
-    </CAPTION>
-    <TR>
-      <TD colspan=3>This implements the
-	<A href="http://www.robofab.org/objects/pen.html">Pen Protocol</A> to draw
-	into a FontForge glyph. You create a glyphPen with the
-	<A href="#glyph-glyphPen">glyphPen</A> attribute of a glyph. You then draw
-	into it with the operators below.
-	<BLOCKQUOTE>
-	  <PRE>
+
+<H2 id="GlyphPen">glyphPen</H2>
+
+This implements the <A href="http://www.robofab.org/objects/pen.html">Pen
+Protocol</A> to draw into a FontForge glyph. You create a glyphPen with
+the <A href="#glyph-glyphPen">glyphPen</A> attribute of a glyph. You then draw
+into it with the operators below.
+
+<BLOCKQUOTE>
+<PRE>
 import fontforge;
 font = fontforge.open("Ambrosia.sfd");	#Open a font
 pen = font["B"].glyphPen();		# Create a pen to draw into glyph "B"
@@ -1795,10 +1753,11 @@ pen = None;				# Finalize the pen. This tells FontForge
 					# that the drawing is done and causes
 			                # it to refresh the display (if a UI is active).
 </PRE>
-	</BLOCKQUOTE>
-	<P>
-	This type may not be pickled.</TD>
-    </TR>
+</BLOCKQUOTE>
+<P>
+This type may not be pickled.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Members</TH>
     </TR>
@@ -1878,25 +1837,20 @@ pen = None;				# Finalize the pen. This tells FontForge
 	matrix is a 6 element tuple.</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A name="Glyph">glyph</A>
-    </CAPTION>
-    <TR>
-      <TH colspan=3>Description</TH>
-    </TR>
-    <TR>
-      <TD colspan=3>The glyph type refers to a fontforge Glyph object. It has no
-	independent life of its own, it always lives within a font. It has all the
-	things you expect to be associated with a glyph: a glyph name, a unicode
-	encoding, a drawing layer, GPOS/GSUB features...
-	<P>
-	This type may not be pickled.
-	<P>
-	This type may not be created directly -- all glyphs are bound to a font and
-	must be created through the font.</TD>
-    </TR>
+
+<H2 id="Glyph">glyph</H2>
+
+The glyph type refers to a fontforge Glyph object. It has no
+independent life of its own, it always lives within a font. It has all the
+things you expect to be associated with a glyph: a glyph name, a unicode
+encoding, a drawing layer, GPOS/GSUB features...
+<P>
+This type may not be pickled.
+<P>
+This type may not be created directly -- all glyphs are bound to a font and
+must be created through the font.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Members</TH>
     </TR>
@@ -2947,26 +2901,24 @@ pen = None;				# Finalize the pen. This tells FontForge
 	context of a font. See <A href="#f-createChar">font.createChar</A></TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A name="selection">selection</A>
-    </CAPTION>
-    <TR>
-      <TD colspan=3>This represents a font's selection. You may index it with an
-	encoding value (in the encoding ISO-646-US (ASCII) the character "A" has
-	encoding index 65), or with a glyph's name, or with a string like "uXXXXX"
-	where XXXXX represent the glyph's unicode codepoint in hex, or with a fontforge
-	glyph object. The value of indexing into a selection will be either True
-	or False.
-	<BLOCKQUOTE>
-	  <PRE><FONT COLOR="Gray">&gt;&gt;&gt;</FONT> print fontforge.activeFont().selection[65]
+
+<H2 id="selection">selection</H2>
+
+This represents a font's selection. You may index it with an
+encoding value (in the encoding ISO-646-US (ASCII) the character "A" has
+encoding index 65), or with a glyph's name, or with a string like "uXXXXX"
+where XXXXX represent the glyph's unicode codepoint in hex, or with a fontforge
+glyph object. The value of indexing into a selection will be either True
+or False.
+<BLOCKQUOTE>
+<PRE><FONT COLOR="Gray">&gt;&gt;&gt;</FONT> print fontforge.activeFont().selection[65]
 <FONT COLOR="Gray">True</FONT>
 </PRE>
-	</BLOCKQUOTE>
-	<P>
-	This type may not be pickled.</TD>
-    </TR>
+</BLOCKQUOTE>
+<P>
+This type may not be pickled.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Members</TH>
     </TR>
@@ -3078,18 +3030,15 @@ pen = None;				# Finalize the pen. This tells FontForge
 	selection.</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A NAME="private">private</A>
-    </CAPTION>
-    <TR>
-      <TD colspan=3>This represents a font's postscript private dictionary. You
-	may index it with one of the standard names of things that live in the private
-	dictionary.
-	<P>
-	This type may not be pickled.</TD>
-    </TR>
+
+<H2 id="private">private</H2>
+This represents a font's postscript private dictionary. You
+may index it with one of the standard names of things that live in the private
+dictionary.
+<P>
+This type may not be pickled.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Iterator Protocol</TH>
     </TR>
@@ -3113,18 +3062,15 @@ pen = None;				# Finalize the pen. This tells FontForge
 	can't make a guess it will simply ignore the request.</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A NAME="math">math</A>
-    </CAPTION>
-    <TR>
-      <TD colspan=3>This represents a font's math constant table. Not all fonts
-	have math tables, and checking this field will not create the underlying
-	object, but examining or assigning to its members will create it..
-	<P>
-	This type may not be pickled.</TD>
-    </TR>
+<H2 id="math">math</H2>
+
+This represents a font's math constant table. Not all fonts
+have math tables, and checking this field will not create the underlying
+object, but examining or assigning to its members will create it..
+<P>
+This type may not be pickled.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Members</TH>
     </TR>
@@ -3161,21 +3107,16 @@ pen = None;				# Finalize the pen. This tells FontForge
       <TD>Removes any underlying math table from the font.</TD>
     </TR>
   </TABLE>
-  <P>
-  <TABLE id="type" border=1>
-    <CAPTION>
-      <A name="Font">font</A>
-    </CAPTION>
-    <TR>
-      <TH colspan=3>Description</TH>
-    </TR>
-    <TR>
-      <TD colspan=3>The font type refers to a fontforge Font object. It generally
-	contains a list of glyphs, an encoding to order those glyphs, a fontname,
-	a list of GPOS/GSUB lookups and many other things.
-	<P>
-	This type may not be pickled.</TD>
-    </TR>
+
+<H2 id="Font">font</H2>
+
+The font type refers to a fontforge Font object. It generally
+contains a list of glyphs, an encoding to order those glyphs, a fontname,
+a list of GPOS/GSUB lookups and many other things.
+<P>
+This type may not be pickled.
+
+  <TABLE class="type" border=1>
     <TR>
       <TH colspan=3>Creation</TH>
     </TR>
@@ -5447,7 +5388,7 @@ pen = None;				# Finalize the pen. This tells FontForge
     </TR>
   </TABLE>
   <H3>
-    Stupid example
+    Trivial example
   </H3>
   <TABLE BORDER=1>
     <TR>
@@ -5471,7 +5412,9 @@ n.save("NewFont.sfd")                            #and save it.
     FontForge as a python <A NAME="extension">extension</A>
   </H2>
   <P>
-  When Fontforge is installed, it also installs a Python module, which can be accessed from Python using:
+  In addition to embedding Python, FontForge typically installs a Python module
+  accessible to the system's <code>python</code> executable, which can be
+  accessed using:
   <BLOCKQUOTE id="shell">
     <PRE><FONT COLOR="Gray">&gt;&gt;&gt; </FONT>import fontforge
 </PRE>


### PR DESCRIPTION
Fix UnicodeNames2... table markup
Move top-level names and descriptions outside of tables
Correct faulty use of "id"
Minor changes

Not great, but not wrong and could do for a while. 