### PR TITLE
Fix input restriction status on a few windows

### DIFF
--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -5568,7 +5568,7 @@ static int kern_format_dlg( SplineFont *sf, int def_layer,
 
     wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_undercursor|wam_isdlg|wam_restrict;
     wattrs.event_masks = ~(1<<et_charup);
-    wattrs.restrict_input_to_me = false;
+    wattrs.restrict_input_to_me = true;
     wattrs.undercursor = 1;
     wattrs.cursor = ct_pointer;
     wattrs.utf8_window_title = _("Kerning format") ;
@@ -6181,11 +6181,11 @@ void AddRmLang(SplineFont *sf, struct lkdata *lk,int add_lang) {
 
     wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_undercursor|wam_isdlg|wam_restrict;
     wattrs.event_masks = ~(1<<et_charup);
-    wattrs.restrict_input_to_me = false;
+    wattrs.restrict_input_to_me = true;
     wattrs.undercursor = 1;
     wattrs.cursor = ct_pointer;
     wattrs.utf8_window_title = add_lang ? _("Add Language(s) to Script") : _("Remove Language(s) from Script");
-    wattrs.is_dlg = false;
+    wattrs.is_dlg = true;
     pos.x = pos.y = 0;
     pos.width = 100;
     pos.height = 100;
@@ -6501,11 +6501,11 @@ void FVMassGlyphRename(FontView *fv) {
 
     wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_undercursor|wam_isdlg|wam_restrict;
     wattrs.event_masks = ~(1<<et_charup);
-    wattrs.restrict_input_to_me = false;
+    wattrs.restrict_input_to_me = true;
     wattrs.undercursor = 1;
     wattrs.cursor = ct_pointer;
     wattrs.utf8_window_title = _("Mass Glyph Rename");
-    wattrs.is_dlg = false;
+    wattrs.is_dlg = true;
     pos.x = pos.y = 0;
     pos.width = 100;
     pos.height = 100;


### PR DESCRIPTION
There is still one remaining case which causes a crash, https://github.com/fontforge/fontforge/issues/3595#issuecomment-477916062 , but @jtanx seems to have a handle on that per https://github.com/fontforge/fontforge/issues/3589#issuecomment-477947581 , it seems a separate bug.

@skef greatly helped with this :smile::+1: