### PR TITLE
Add "UnicodeStrict" option

### DIFF
--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -44,6 +44,7 @@
 
 int accent_offset = 6;
 int GraveAcuteCenterBottom = 1;
+int UnicodeStrict = false;
 int PreferSpacingAccents = true;
 int CharCenterHighest = 1;
 
@@ -1155,6 +1156,10 @@ return( adobes_pua_alts[base-0xf600]);
     if ( base==-1 || base>=65536 || unicode_alternates[base>>8]==NULL ||
 	    (upt = unicode_alternates[base>>8][base&0xff])==NULL )
 return( SFAlternateFromLigature(sf,base,sc));
+
+    if (UnicodeStrict) {
+        return upt;
+    }
 
 	    /* The definitions of some of the greek letters may make some */
 	    /*  linguistic sense, but I can't use it to place the accents */

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -72,6 +72,7 @@ extern Encoding *default_encoding;
 extern int autohint_before_generate;
 extern int use_freetype_to_rasterize_fv;
 extern int use_freetype_with_aa_fill_cv;
+extern int UnicodeStrict;
 extern int OpenCharsInNewWindow;
 extern int ItalicConstrained;
 extern int accent_offset;
@@ -313,6 +314,7 @@ static struct prefs_list {
 	{ N_("AutoSaveFrequency"), pr_int, &AutoSaveFrequency, NULL, NULL, '\0', NULL, 0, N_( "The number of seconds between autosaves. If you set this to 0 there will be no autosaves.") },
 	{ N_("RevisionsToRetain"), pr_int, &prefRevisionsToRetain, NULL, NULL, '\0', NULL, 0, N_( "When Saving, keep this number of previous versions of the file. file.sfd-01 will be the last saved file, file.sfd-02 will be the file saved before that, and so on. If you set this to 0 then no revisions will be retained.") },
 	{ N_("UndoRedoLimitToSave"), pr_int, &UndoRedoLimitToSave, NULL, NULL, '\0', NULL, 0, N_( "The number of undo and redo operations which will be saved in sfd files.\nIf you set this to 0 undo/redo information is not saved to sfd files.\nIf set to -1 then all available undo/redo information is saved without limit.") },
+	{ N_("UnicodeStrict"), pr_bool, &UnicodeStrict, NULL, NULL, '\0', NULL, 0, N_( "Whether or not the Unicode Standard should be strictly adhered to even in cases its contents may be dubious, controversial, or even wrong.\nThis currently only changes certain build procedures when using “Make Accented Glyph”, but can likely be extended to other parts of FontForge.") },
 	PREFS_LIST_EMPTY
 },
   new_list[] = {


### PR DESCRIPTION
In many places in the code, George has put his own opinions on the
appearance of Unicode characters above the Unicode standard itself. He
may have done so rightly in some cases, but the problem is that he was
wrong in others (at least under the current version of the Unicode
Standard).

This PR adds a new option, "UnicodeSupremacy", which users to use the
standard above George's opinions when building characters via "Build
Accented Glyph"—there are likely more places it could be added, but this
is a start.

Close fontforge/fontforge#3615

Video showing what this does: [USO.zip](https://github.com/fontforge/fontforge/files/3032714/USO.zip)