### PR TITLE
Fix stroke outlining

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -868,8 +868,8 @@ enum outlinesfm_flags {
     sfm_stroke=0x1,
     sfm_fill=0x2,
     sfm_nothing=0x4,
-    sfm_stroke_trans = (0x1|0x8),
-    sfm_clip_preserve = 0x16
+    sfm_stroke_trans = 0x8,
+    sfm_outline = 0x16
 };
 extern void CVDrawSplineSetSpecialized( CharView *cv, GWindow pixmap, SplinePointList *set,
 					Color fg, int dopoints, DRect *clip,

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -869,7 +869,7 @@ enum outlinesfm_flags {
     sfm_fill=0x2,
     sfm_nothing=0x4,
     sfm_stroke_trans = 0x8,
-    sfm_outline = 0x16
+    sfm_clip = 0x16
 };
 extern void CVDrawSplineSetSpecialized( CharView *cv, GWindow pixmap, SplinePointList *set,
 					Color fg, int dopoints, DRect *clip,

--- a/gdraw/ggdkcdraw.c
+++ b/gdraw/ggdkcdraw.c
@@ -769,7 +769,9 @@ void GGDKDrawPushClip(GWindow w, GRect *rct, GRect *old) {
 void GGDKDrawPopClip(GWindow w, GRect *old) {
     //Log(LOGDEBUG, " ");
     GGDKWindow gw = (GGDKWindow)w;
-    gw->ggc->clip = *old;
+    if (old) {
+        gw->ggc->clip = *old;
+    }
     // cc can be NULL if the autopaint cleanup had to run because
     // a raise/lower/move/resize function was called.
     if (gw->cc != NULL) {

--- a/gdraw/gxdraw.c
+++ b/gdraw/gxdraw.c
@@ -1820,7 +1820,9 @@ static void GXDrawPushClip(GWindow w, GRect *rct, GRect *old) {
 }
 
 static void GXDrawPopClip(GWindow w, GRect *old) {
-    w->ggc->clip = *old;
+    if (old) {
+        w->ggc->clip = *old;
+    }
 #ifndef _NO_LIBCAIRO
     if ( ((GXWindow) w)->usecairo )
 	_GXCDraw_PopClip((GXWindow) w);


### PR DESCRIPTION
Fixes #3510, supercedes #3522. To achieve the same effect as #3522, set the outline thickness preference to 1 (or 0).

- Iterate the SPL once; clip and stroke in one operation
- Don't call pop clip with no old clip to pass in (so allow NULL for the old clip)


~~tbh even this is not quite ideal (but no different to the old outlining code) - ideally you'd create the full path first then clip and stroke, instead of clipping and stroking each subpath, as otherwise it doesn't pick up the winding properly, which affects which side it outlines. But it also allows each subpath to potentially have a different outline colour.~~