### PR TITLE
Add `WriteModificationTime` option

### DIFF
--- a/doc/html/sfdformat.html
+++ b/doc/html/sfdformat.html
@@ -247,7 +247,8 @@ CIDVersion: 1.2
       ModificationTime
     <DD>
       These two dates are expressed as seconds since 00:00:00, 1 January, 1970
-      -- standard unix dates.
+      -- standard unix dates. Writing ModificationTime can be disabled, and is
+      optional; FontForge understands fonts without it.
     <DT>
       GaspTable
     <DD>

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -75,6 +75,7 @@
 
 int UndoRedoLimitToSave = 0;
 int UndoRedoLimitToLoad = 0;
+int WriteModificationTime = true;
 
 static const char *joins[] = { "miter", "round", "bevel", "inher", NULL };
 static const char *caps[] = { "butt", "round", "square", "inher", NULL };
@@ -2318,7 +2319,9 @@ int SFD_DumpSplineFontMetadata( FILE *sfd, SplineFont *sf )
     fprintf(sfd, "OS2_WeightWidthSlopeOnly: %d\n", sf->weight_width_slope_only );
     fprintf(sfd, "OS2_UseTypoMetrics: %d\n", sf->use_typo_metrics );
     fprintf(sfd, "CreationTime: %lld\n", sf->creationtime );
+    if (WriteModificationTime) {
     fprintf(sfd, "ModificationTime: %lld\n", sf->modificationtime );
+    }
     if ( sf->pfminfo.pfmset ) {
 	fprintf(sfd, "PfmFamily: %d\n", sf->pfminfo.pfmfamily );
 	fprintf(sfd, "TTFWeight: %d\n", sf->pfminfo.weight );

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -188,6 +188,7 @@ extern int AutoSaveFrequency;			/* autosave.c */
 extern int UndoRedoLimitToSave;  /* sfd.c */
 extern int UndoRedoLimitToLoad;  /* sfd.c */
 extern int prefRevisionsToRetain; /* sfd.c */
+extern int WriteModificationTime; /* sfd.c */
 extern int prefs_cv_show_control_points_always_initially; /* from charview.c */
 extern int prefs_create_dragging_comparison_outline;      /* from charview.c */
 extern int prefs_cv_outline_thickness; /* from charview.c */
@@ -399,6 +400,7 @@ static struct prefs_list {
 	{ N_("RecognizePUANames"), pr_bool, &recognizePUA, NULL, NULL, 'U', NULL, 0, N_("Once upon a time, Adobe assigned PUA (public use area) encodings\nfor many stylistic variants of characters (small caps, old style\nnumerals, etc.). Adobe no longer believes this to be a good idea,\nand recommends that these encodings be ignored.\n\n The assignments were originally made because most applications\ncould not handle OpenType features for accessing variants. Adobe\nnow believes that all apps that matter can now do so. Applications\nlike Word and OpenOffice still can't handle these features, so\n fontforge's default behavior is to ignore Adobe's current\nrecommendations.\n\nNote: This does not affect figuring out unicode from the font's encoding,\nit just controls determining unicode from a name.") },
 	{ N_("UnicodeGlyphNames"), pr_bool, &allow_utf8_glyphnames, NULL, NULL, 'O', NULL, 0, N_("Allow the full unicode character set in glyph names.\nThis does not conform to adobe's glyph name standard.\nSuch names should be for internal use only and\nshould NOT end up in production fonts." ) },
 	{ N_("AddCharToNameList"), pr_bool, &add_char_to_name_list, NULL, NULL, 'O', NULL, 0, N_( "When displaying a list of glyph names\n(or sometimes just a single glyph name)\nFontForge will add the unicode character\nthe name refers to in parenthesis after\nthe name. It does this because some names\nare obscure.\nSome people would prefer not to see this,\nso this preference item lets you turn off\n this behavior" ) },
+	{ N_("WriteModificationTime"), pr_bool, &WriteModificationTime, NULL, NULL, 'U', NULL, 0, N_("Whether or not to write the modification time into the SFD file.\nDisabling this might make working with version control systems such as Git easier.") },
 	PREFS_LIST_EMPTY
 },
  generate_list[] = {


### PR DESCRIPTION
By default, FontForge writes a `ModificationTime` into every SFD file.
This can disturb merging when using a version control system to manage
your font versions. Merge conflicts are inevitable with this line and
very annoying.

This PR adds an option to remove the line. I tested it, and FontForge
opens SFD files without the line without complaint or line in the
Warnings dialog.

If this PR is merged, the default will be to write the line, as is the
current action.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Final checklist
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.