### PR TITLE
Coverity: several reports

### DIFF
--- a/gdraw/ggadgets.c
+++ b/gdraw/ggadgets.c
@@ -255,6 +255,7 @@ void *GResource_font_cvt(char *val, void *def) {
 
     if ( fi==NULL )
 return( def );
+    free(def);
 return( (void *) fi );
 }
 


### PR DESCRIPTION
Coverity indicates this (eg: cid#1083113)
1530  toolsfont = GDrawInstanciateFont(NULL,&rq);
8. noescape: Resource toolsfont is not freed or pointed-to in GResourceFindFont. [show details]
CID 1083113 (#1 of 1): Resource leak (RESOURCE_LEAK)9. overwrite_var: Overwriting toolsfont in toolsfont = GResourceFindFont("ToolsPalette.Font", toolsfont) leaks the storage that toolsfont points to.
1531  toolsfont = GResourceFindFont("ToolsPalette.Font",toolsfont);

Let's investigate:
GDrawInstanciateFont returns an object "toolfont" (which is the result of an allocation but can be NULL).

Then GResourceFindFont is called and one of its argument is "toolsfonts";
Here's its definitione:
FontInstance *GResourceFindFont(char *resourcename,FontInstance *deffont) {
    char *val = GResourceFindString(resourcename);
    if ( val==NULL )
return( deffont );
return( GResource_font_cvt(val,deffont));
}

so if "ressourcename" is found, val is not null and we call "GResource_font_cvt"
this function  (in ggadgets.c) has this declaration:
void *GResource_font_cvt(char *val, void *def)

if we focus on "def" var, we've got in the definition of this function this:
    if ( def!=NULL )
	GDrawDecomposeFont((FontInstance *)def, &rq);
    if ( fi==NULL )
return( def );
return( (void *) fi );

So if "fi" is not NULL, we don't return "def" (which corresponds to "toolsfont") but "fi"
and "def" is leaked since the return of the function will be assigned to "toolfonts"

Provide a general summary of your changes in the **Title** above.

### Important
Mark with [x] to select. Leave as [ ] to unselect.

### Motivation and Context
- [ ] Why is this change required? What problem does it solve?
- [ ] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [ ] Describe your changes in detail.

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [ ] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. FontForge is a big program, so Travis can easily take over 20 minutes to confirm your changes are buildable. Please be patient. More details about using Travis can be found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#using-travis-ci).  
  
If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. If no error is shown, just re-run the Travis test for your pull-request (that failed) to see a fresh report since the last report may be for someone else that did a later pull request, or for mainline code. If you add new code to fix your issue/problem, then take note that you need to check the next pull request in the Travis system. Travis issue numbers are different from GitHub issue numbers.
