### PR TITLE
Add user decompositions

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -2151,6 +2151,10 @@ must be created through the font.
 	references replaced after the save finishes)</TD>
     </TR>
     <TR>
+      <TD><CODE>user_decomp</CODE></TD>
+      <TD colspan=2>Your preferred decomposition for this glyph; used by <TT>build</TT>.</TD>
+    </TR>
+    <TR>
       <TD><CODE>userdata</CODE></TD>
       <TD colspan=2>Deprecated name for <A HREF="#glyph-temporary">temporary field
 	above</A></TD>

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -1436,7 +1436,7 @@ void FVBuildAccent(FontViewBase *fv,int onlyaccents) {
 	if ( SFIsSomethingBuildable(fv->sf,sc,fv->active_layer,onlyaccents) ) {
 	    sc = SFMakeChar(fv->sf,fv->map,i);
 	    sc->ticked = true;
-	    SCBuildComposit(fv->sf,sc,fv->active_layer,fv->active_bitmap,onlycopydisplayed);
+	    SCBuildComposit(fv->sf,sc,fv->active_layer,fv->active_bitmap,onlycopydisplayed,onlyaccents);
 	}
 	if ( !ff_progress_next())
     break;

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -1119,11 +1119,14 @@ const unichar_t *SFGetAlternate(SplineFont *sf, int base,SplineChar *sc,int noch
     const unichar_t *upt, *pt; unichar_t *gpt;
     char *dot = NULL;
 
-    if ( sc!=NULL && (dot = strchr(sc->name,'.'))!=NULL ) {
-	/* agrave.sc should be built from a.sc and grave or grave.sc */
-	char *temp = copyn(sc->name,dot-sc->name);
-	base = UniFromName(temp,sf->uni_interp,NULL);
-	free(temp);
+    if ( sc!=NULL ) {
+        if ( sc->user_decomp != NULL ) return sc->user_decomp;
+        if ((dot = strchr(sc->name,'.'))!=NULL ) {
+            /* agrave.sc should be built from a.sc and grave or grave.sc */
+            char *temp = copyn(sc->name,dot-sc->name);
+            base = UniFromName(temp,sf->uni_interp,NULL);
+            free(temp);
+        }
     }
 
     if ( base>=0xac00 && base<=0xd7a3 ) { /* Hangul syllables */

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -1347,6 +1347,8 @@ return( false );
 int SFIsSomethingBuildable(SplineFont *sf,SplineChar *sc, int layer, int onlyaccents) {
     int unicodeenc = sc->unicodeenc;
 
+    if (sc->user_decomp) return true;
+
     if ( onlyaccents &&		/* Don't build greek accents out of latin ones */
 	    (unicodeenc==0x1fbd || unicodeenc==0x1fbe || unicodeenc==0x1fbf ||
 	     unicodeenc==0x1fef || unicodeenc==0x1ffd || unicodeenc==0x1ffe))
@@ -2794,7 +2796,13 @@ return;
     SCSynchronizeWidth(sc,sc->width + xoff,sc->width,NULL);
 }
 
-void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *bdf, int disp_only ) {
+int SCUserDecompAccent(SplineChar *sc, unichar_t accent, int accent_hint) {
+    return (sc->user_decomp != NULL && 
+            accent != '\0' && 
+            accent_hint);
+}
+
+void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *bdf, int disp_only, int accent_hint) {
     const unichar_t *pt, *apt; unichar_t ch;
     real ia;
     char *dot;
@@ -2868,8 +2876,8 @@ return;
 	    /* a reference to space */;
 	else if ( sc->width == base->sc->width )
 	    base->use_my_metrics = true;
-	while ( iscombining(*pt) || (ch=='L' && *pt==0xb7) ||	/* b7, centered dot is used as a combining accent for Ldot but as a lig for ldot */
-		*pt==0x384 || *pt==0x385 || (*pt>=0x1fbd && *pt<=0x1fff ))	/* Special greek accents */
+	while ( iscombining(*pt) || SCUserDecompAccent(sc, *pt, accent_hint) || (ch=='L' && *pt==0xb7) ||	/* b7, centered dot is used as a combining accent for Ldot but as a lig for ldot */
+		*pt==0x384 || *pt==0x385 || (*pt>=0x1fbd && *pt<=0x1fff) )	/* Special greek accents */
 	    SCCenterAccent(sc,base!=NULL?base->sc:NULL,sf,layer,*pt++,bdf,disp_only,ia,ch,dot);
 	while ( *pt ) {
 	    if ( base!=NULL ) base->use_my_metrics = false;

--- a/fontforge/fvcomposite.h
+++ b/fontforge/fvcomposite.h
@@ -15,6 +15,6 @@ extern int SFIsCompositBuildable(SplineFont *sf, int unicodeenc, SplineChar *sc,
 extern int SFIsRotatable(SplineFont *sf, SplineChar *sc);
 extern int SFIsSomethingBuildable(SplineFont *sf, SplineChar *sc, int layer, int onlyaccents);
 extern void _SCAddRef(SplineChar *sc, SplineChar *rsc, int layer, real transform[6]);
-extern void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *bdf, int disp_only);
+extern void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *bdf, int disp_only, int accent_hint);
 
 #endif /* FONTFORGE_FVCOMPOSITE_H */

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -7276,6 +7276,11 @@ static int PyFF_Glyph_set_user_decomp(PyFF_Glyph *self,PyObject *value, void *UN
         return -1;
     }
 
+    if (strlen(newv) > 5) {
+        PyErr_WarnEx(PyExc_ValueError, "It doesn't make sense for the decomposition to be this long; truncated to five characters", 1);
+        newv[5] = '\0';
+    }
+
     free(self->sc->user_decomp);
     self->sc->user_decomp = utf82u_copy(newv);
 

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -7271,21 +7271,20 @@ static int PyFF_Glyph_set_user_decomp(PyFF_Glyph *self,PyObject *value, void *UN
         /* Need to force utf8 encoding rather than accepting the "default" */
         /*  which would happen if we treated unicode as a string */
         temp = PyUnicode_AsUTF8String(value);
-        newv = copy( PyBytes_AsString(temp));
+        udbuf = utf82u_copy(PyBytes_AsString(temp));
         Py_DECREF(temp);
     } else {
-        newv = copy( PyBytes_AsString(value));
+        udbuf = utf82u_copy(PyBytes_AsString(value));
     }
     
-    if ( newv==NULL ) return -1;
+    if ( udbuf==NULL ) return -1;
 
-    if (newv[0] == '\0') {
+    if (udbuf[0] == '\0') {
         if (self->sc->user_decomp != NULL) { free(self->sc->user_decomp); }
         self->sc->user_decomp = NULL;
         return 0;
     }
 
-    udbuf = utf82u_copy(newv);
 
     if (u_strlen(udbuf) > 5) {
          PyErr_WarnEx(PyExc_ValueError, "It doesn't make sense for the decomposition to be this long; truncated to five characters", 1);
@@ -7950,7 +7949,7 @@ static PyObject *PyFFGlyph_Build(PyObject *self, PyObject *args) {
     SplineChar *sc = ((PyFF_Glyph *) self)->sc;
     int layer = ((PyFF_Glyph *) self)->layer;
     int accent_hint = false;
-    PyObject *accent_hint_pyo;
+    PyObject *accent_hint_pyo = NULL;
 
     if ( PyArg_ParseTuple(args, "|O", &accent_hint_pyo) ) {
         if (accent_hint_pyo == Py_True) {

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -7242,6 +7242,45 @@ static int PyFF_Glyph_set_vhints(PyFF_Glyph *self,PyObject *value, void *UNUSED(
 return( PyFF_Glyph_set_hints(self,true,value));
 }
 
+static PyObject *PyFF_Glyph_get_user_decomp(PyFF_Glyph *self, void *UNUSED(closure)) {
+    if ( self->sc->user_decomp==NULL ) {
+        return( Py_BuildValue("s", "" ));
+    }
+    else {
+        char* out = u2utf8_copy(self->sc->user_decomp);
+        return( PyUnicode_DecodeUTF8(out, strlen(out), NULL) );
+    }
+}
+
+static int PyFF_Glyph_set_user_decomp(PyFF_Glyph *self,PyObject *value, void *UNUSED(closure)) {
+    char *newv;
+    PyObject *temp;
+
+    if (value == Py_None) {
+        self->sc->user_decomp = NULL;
+        return 0;
+    }
+
+    if ( PyUnicode_Check(value)) {
+	/* Need to force utf8 encoding rather than accepting the "default" */
+	/*  which would happen if we treated unicode as a string */
+	temp = PyUnicode_AsUTF8String(value);
+	newv = copy( PyBytes_AsString(temp));
+	Py_DECREF(temp);
+    } else {
+        return -1;
+    }
+
+    if ( newv==NULL ) {
+        return -1;
+    }
+
+    free(self->sc->user_decomp);
+    self->sc->user_decomp = utf82u_copy(newv);
+
+    return 0;
+}
+
 static PyObject *PyFF_Glyph_get_comment(PyFF_Glyph *self, void *UNUSED(closure)) {
     if ( self->sc->comment==NULL )
 return( Py_BuildValue("s", "" ));
@@ -7793,6 +7832,9 @@ static PyGetSetDef PyFF_Glyph_getset[] = {
     {(char *)"comment",
      (getter)PyFF_Glyph_get_comment, (setter)PyFF_Glyph_set_comment,
      (char *)"Glyph comment", NULL},
+    {(char *)"user_decomp",
+     (getter)PyFF_Glyph_get_user_decomp, (setter)PyFF_Glyph_set_user_decomp,
+     (char *)"Glyph user decompositon", NULL},
     {(char *)"glyphclass",
      (getter)PyFF_Glyph_get_glyphclass, (setter)PyFF_Glyph_set_glyphclass,
      (char *)"glyph class", NULL},

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -7257,7 +7257,6 @@ static PyObject *PyFF_Glyph_get_user_decomp(PyFF_Glyph *self, void *UNUSED(closu
 }
 
 static int PyFF_Glyph_set_user_decomp(PyFF_Glyph *self,PyObject *value, void *UNUSED(closure)) {
-    char *newv;
     PyObject *temp;
     unichar_t *udbuf;
 
@@ -7283,12 +7282,6 @@ static int PyFF_Glyph_set_user_decomp(PyFF_Glyph *self,PyObject *value, void *UN
         if (self->sc->user_decomp != NULL) { free(self->sc->user_decomp); }
         self->sc->user_decomp = NULL;
         return 0;
-    }
-
-
-    if (u_strlen(udbuf) > 5) {
-         PyErr_WarnEx(PyExc_ValueError, "It doesn't make sense for the decomposition to be this long; truncated to five characters", 1);
-         udbuf[5] = '\0';
     }
 
     if (self->sc->user_decomp != NULL) { free(self->sc->user_decomp); }

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -2745,7 +2745,7 @@ return;
 		if ( achar==NULL )
 		    achar = sc_sc;
 		if ( SFGetAlternate(sf,sc->unicodeenc,sc,false)!=NULL )
-		    SCBuildComposit(sf,sc_sc,fv->active_layer,NULL,true);
+		    SCBuildComposit(sf,sc_sc,fv->active_layer,NULL,true,false);
 		if ( sc_sc->layers[fv->active_layer].refs==NULL ) {
 		    RefChar *rlast = NULL;
 		    for ( ref=sc->layers[fv->active_layer].refs; ref!=NULL; ref=ref->next ) {
@@ -2977,7 +2977,7 @@ return;
 	    /*  than I'm going to do here... */
 	    if ( sc->layers[fv->active_layer].splines==NULL &&
 		    SFGetAlternate(sf,sc->unicodeenc,sc,false)!=NULL )
-		SCBuildComposit(sf,sc_sc,fv->active_layer,NULL,true);
+		SCBuildComposit(sf,sc_sc,fv->active_layer,NULL,true,false);
 	    if ( sc_sc->layers[fv->active_layer].refs==NULL ) {
 		RefChar *rlast = NULL;
 		for ( ref=sc->layers[fv->active_layer].refs; ref!=NULL; ref=ref->next ) {
@@ -6910,7 +6910,7 @@ static void SCChangeXHeight(SplineChar *sc,int layer,struct xheightinfo *xi) {
     if ( sc->layers[layer].refs!=NULL &&
 			((alts = SFGetAlternate(sc->parent,sc->unicodeenc,sc,true))!=NULL &&
 			 alts[1]!=0 ))
-	SCBuildComposit(sc->parent,sc,layer,NULL,true);
+	SCBuildComposit(sc->parent,sc,layer,NULL,true,false);
     else {
 	SCPreserveLayer(sc,layer,true);
 	_SCChangeXHeight(sc,layer,xi);

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -1707,6 +1707,11 @@ static void SFDDumpChar(FILE *sfd,SplineChar *sc,EncMap *map,int *newgids,int to
 	SFDDumpUTF7Str(sfd,sc->comment);
 	putc('\n',sfd);
     }
+    if ( sc->user_decomp != NULL ) {
+	fprintf( sfd, "Decomposition: " );
+	SFDDumpUTF7Str(sfd,u2utf8_copy(sc->user_decomp));
+	putc('\n',sfd);
+    }
     if ( sc->color!=COLOR_DEFAULT )
 	fprintf( sfd, "Colour: %x\n", (int) sc->color );
     if ( sc->parent->multilayer ) {
@@ -5834,6 +5839,8 @@ exit(1);
 	    sc->color = temp;
 	} else if ( strmatch(tok,"Comment:")==0 ) {
 	    sc->comment = SFDReadUTF7Str(sfd);
+	} else if ( strmatch(tok,"Decomposition:")==0 ) {
+	    sc->user_decomp = utf82u_copy(SFDReadUTF7Str(sfd));
 	} else if ( strmatch(tok,"TileMargin:")==0 ) {
 	    getreal(sfd,&sc->tile_margin);
 	} else if ( strmatch(tok,"TileBounds:")==0 ) {

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -1709,7 +1709,9 @@ static void SFDDumpChar(FILE *sfd,SplineChar *sc,EncMap *map,int *newgids,int to
     }
     if ( sc->user_decomp != NULL ) {
 	fprintf( sfd, "Decomposition: " );
-	SFDDumpUTF7Str(sfd,u2utf8_copy(sc->user_decomp));
+	char* temp_ud = u2utf8_copy(sc->user_decomp);
+	SFDDumpUTF7Str(sfd, temp_ud);
+	free(temp_ud);
 	putc('\n',sfd);
     }
     if ( sc->color!=COLOR_DEFAULT )
@@ -5840,7 +5842,9 @@ exit(1);
 	} else if ( strmatch(tok,"Comment:")==0 ) {
 	    sc->comment = SFDReadUTF7Str(sfd);
 	} else if ( strmatch(tok,"Decomposition:")==0 ) {
-	    sc->user_decomp = utf82u_copy(SFDReadUTF7Str(sfd));
+	    char* decomp = SFDReadUTF7Str(sfd);
+	    sc->user_decomp = utf82u_copy(decomp);
+	    free(decomp);
 	} else if ( strmatch(tok,"TileMargin:")==0 ) {
 	    getreal(sfd,&sc->tile_margin);
 	} else if ( strmatch(tok,"TileBounds:")==0 ) {

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -1542,6 +1542,7 @@ typedef struct splinechar {
     real tile_margin;			/* If the glyph is used as a tile */
     DBounds tile_bounds;
     char * glif_name; // This stores the base name of the glyph when saved to U. F. O..
+    unichar_t* user_decomp; // User decomposition for building this character
 } SplineChar;
 
 #define TEX_UNDEF 0x7fff

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -5935,6 +5935,7 @@ void SplineCharFreeContents(SplineChar *sc) {
 return;
     if (sc->name != NULL) free(sc->name);
     if (sc->comment != NULL) free(sc->comment);
+    if (sc->user_decomp != NULL) free(sc->user_decomp);
     for ( i=0; i<sc->layer_cnt; ++i ) {
 #if defined(_NO_PYTHON)
         if (sc->layers[i].python_persistent != NULL) free( sc->layers[i].python_persistent );	/* It's a string of pickled data which we leave as a string */

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -74,25 +74,29 @@ typedef struct charinfo {
 #define CID_Cancel	1005
 #define CID_ComponentMsg	1006
 #define CID_Components	1007
-#define CID_Comment	1008
-#define CID_Color	1009
-#define CID_GClass	1010
-#define CID_Tabs	1011
+#define CID_ComponentTextField  1008
+#define CID_ComponentChangeMsg  1009
+#define CID_ComponentDefaultCB  1010
+#define CID_ComponentInterpMsg  1011
+#define CID_Comment	1012
+#define CID_Color	1013
+#define CID_GClass	1014
+#define CID_Tabs	1015
 
-#define CID_TeX_Height	1012
-#define CID_TeX_Depth	1013
-#define CID_TeX_Italic	1014
-#define CID_HorAccent	1015
+#define CID_TeX_Height	1016
+#define CID_TeX_Depth	1017
+#define CID_TeX_Italic	1018
+#define CID_HorAccent	1019
 /* Room for one more here, if we need it */
-#define CID_TeX_HeightD	1017
-#define CID_TeX_DepthD	1018
-#define CID_TeX_ItalicD	1019
-#define CID_HorAccentD	1020
+#define CID_TeX_HeightD	1020
+#define CID_TeX_DepthD	1021
+#define CID_TeX_ItalicD	1022
+#define CID_HorAccentD	1023
 
-#define CID_ItalicDevTab	1022
-#define CID_AccentDevTab	1023
+#define CID_ItalicDevTab	1024
+#define CID_AccentDevTab	1025
 
-#define CID_IsExtended	1024
+#define CID_IsExtended	1026
 #define CID_DefLCCount	1040
 #define CID_LCCount	1041
 #define CID_LCCountLab	1042
@@ -1225,6 +1229,7 @@ static SplineChar *CI_SCDuplicate(SplineChar *sc) {
     newsc->unicodeenc = sc->unicodeenc;
     newsc->orig_pos = sc->orig_pos;
     newsc->comment = copy(sc->comment);
+    newsc->user_decomp = sc->user_decomp;
     newsc->unlink_rm_ovrlp_save_undo = sc->unlink_rm_ovrlp_save_undo;
     newsc->glyph_class = sc->glyph_class;
     newsc->color = sc->color;
@@ -1436,6 +1441,7 @@ return( false );
 	ci->cachedsc = chunkalloc(sizeof(SplineChar));
 	ci->cachedsc->orig_pos = ci->sc->orig_pos;
 	ci->cachedsc->parent = ci->sc->parent;
+    ci->cachedsc->user_decomp = ci->sc->user_decomp;
 	scl = chunkalloc(sizeof(struct splinecharlist));
 	scl->sc = ci->cachedsc;
 	scl->next = ci->changes;
@@ -3653,6 +3659,69 @@ static int CI_DefLCChange(GGadget *g, GEvent *e) {
 return( true );
 }
 
+// Turn the user's entered decomposition into the format returned by SFGetAlternate
+unichar_t* CI_ParseUserDecomposition(char* inp) {
+    unsigned long len = strlen(inp);
+    char* end;
+    unichar_t* out = malloc(len*sizeof(unichar_t));
+
+    int j = 0;
+    for (unsigned long i = strtoul(inp, &end, 16); inp != end; i = strtoul(inp, &end, 16)) {
+        inp = end;
+        out[j] = i;
+        j++;
+    }
+
+    out[j] = '\0';
+
+    return out;
+}
+
+char* CI_CreateInterpretedAsLabel(unichar_t* inp) {
+    char* lblprefix = "Interpreted as: ";
+    char* lblerror = "Error: wrong format";
+    // 2 makes it large enough to hold the error string
+    int factor = inp == NULL ? 2 : u_strlen(inp);
+    char* lblbuf = malloc(strlen(lblprefix)+(factor*4));
+
+    // If I don't validate it, the string will become "(null)"
+    bool valid = true;
+    unichar_t* inp_ptr = inp;
+    if (inp != NULL)
+    while (*inp_ptr != '\0') {
+        if (*inp_ptr > 0x10FFFF) valid = false;
+        inp_ptr++;
+    }
+
+    if (inp != NULL && inp[0] != 0 && valid) {
+        sprintf(lblbuf, "%s%s", lblprefix, u2utf8_copy(inp));
+    } else {
+        strcpy(lblbuf, lblerror);
+    }
+
+    return lblbuf;
+}
+
+static int CI_CmpUseNonDefault(GGadget *g, GEvent *e) {
+    int show = !GGadgetIsChecked(g);
+    CharInfo *ci = GDrawGetUserData(GGadgetGetWindow(g));
+    GGadget* cotf = GWidgetGetControl(ci->gw,CID_ComponentTextField);
+    GGadget* coim = GWidgetGetControl(ci->gw,CID_ComponentInterpMsg);
+    GGadgetSetEnabled(cotf, show);
+    if (!show) {
+        ci->sc->user_decomp = NULL;
+        GGadgetSetTitle8(coim, "");
+    } else {
+        unichar_t* ud = CI_ParseUserDecomposition(GGadgetGetTitle8(cotf));
+        ci->sc->user_decomp = ud;
+        char* lbl = CI_CreateInterpretedAsLabel(ud);
+        GGadgetSetTitle8(coim, lbl);
+        free(lbl);
+    }
+
+    return true;
+}
+
 void GV_ToMD(GGadget *g, struct glyphvariants *gv) {
     int cols = GMatrixEditGetColCnt(g), j;
     struct matrix_data *mds;
@@ -3807,6 +3876,7 @@ static void CIFillup(CharInfo *ci) {
     char buffer[400];
     char buf[200];
     const unichar_t *bits;
+    int *d_ptr = sc->user_decomp;
     int i,j,gid, isv;
     struct matrix_data *mds[pst_max];
     int cnts[pst_max];
@@ -3909,7 +3979,12 @@ static void CIFillup(CharInfo *ci) {
     CI_DoHideUnusedPair(ci);
     CI_DoHideUnusedSingle(ci);
 
-    bits = SFGetAlternate(sc->parent,sc->unicodeenc,sc,true);
+	GGadget *cotf = GWidgetGetControl(ci->gw,CID_ComponentTextField);
+	GGadget *codcb = GWidgetGetControl(ci->gw,CID_ComponentDefaultCB);
+	GGadget *coim = GWidgetGetControl(ci->gw,CID_ComponentInterpMsg);
+	GGadget *cola = GWidgetGetControl(ci->gw,CID_ComponentChangeMsg);
+
+    bits = SFGetAlternate(sc->parent,sc->unicodeenc,NULL,true);
     GGadgetSetTitle8(GWidgetGetControl(ci->gw,CID_ComponentMsg),
 	bits==NULL ? _("No components") :
 	hascomposing(sc->parent,sc->unicodeenc,sc) ? _("Accented glyph composed of:") :
@@ -3917,18 +3992,69 @@ static void CIFillup(CharInfo *ci) {
     if ( bits==NULL ) {
 	ubuf[0] = '\0';
 	GGadgetSetTitle(GWidgetGetControl(ci->gw,CID_Components),ubuf);
+    GGadgetSetTitle(cotf,ubuf);
+    GGadgetSetTitle8(coim,"");
+    GGadgetSetEnabled(cotf, false);
+    GGadgetSetEnabled(cola, false);
+    GGadgetSetEnabled(codcb, false);
+    GGadgetSetChecked(codcb, true);
     } else {
-	unichar_t *temp = malloc(11*u_strlen(bits)*sizeof(unichar_t));
+	unichar_t *temp = malloc(18*u_strlen(bits)*sizeof(unichar_t));
 	unichar_t *upt=temp;
+    // i.e. five six hex digit long codepoints with spaces after them
+    char* codepoints_as_hex = malloc((6 * 5) + 5);
+    codepoints_as_hex[0] = '\0';
 	while ( *bits!='\0' ) {
-	    sprintf(buffer, "U+%04x ", *bits );
+	    sprintf(buffer, "U+%04x (", *bits );
 	    uc_strcpy(upt,buffer);
 	    upt += u_strlen(upt);
+	    if (iscombining(*bits)) {
+	        upt += 1;
+	        upt[-1] = 0x25CC; // DOTTED CIRCLE “◌”
+	    }
+	    upt += 1;
+	    upt[-1] = *bits;
+	    sprintf(buffer, ") ");
+	    uc_strcpy(upt,buffer);
+	    upt += u_strlen(upt);
+
+        if (sc->user_decomp == NULL) {
+            sprintf(buffer, "%04x ", *bits);
+            codepoints_as_hex = strcat(codepoints_as_hex, buffer);
+        }
 	    ++bits;
 	}
 	upt[-1] = '\0';
 	GGadgetSetTitle(GWidgetGetControl(ci->gw,CID_Components),temp);
 	free(temp);
+
+    if (sc->user_decomp != NULL) {
+        while ( *d_ptr!='\0' ) {
+            sprintf(buffer, "%04x ", *d_ptr);
+            codepoints_as_hex = strcat(codepoints_as_hex, buffer);
+            ++d_ptr;
+        }
+    }
+
+    d_ptr = sc->user_decomp;
+
+    GGadgetSetTitle8(GWidgetGetControl(ci->gw,CID_ComponentTextField),codepoints_as_hex);
+
+    if (!GGadgetIsEnabled(codcb)) GGadgetSetEnabled(codcb, true);
+    char* lbl = CI_CreateInterpretedAsLabel(sc->user_decomp);
+    if (sc->user_decomp != NULL) {
+        GGadgetSetChecked(codcb, false);
+        GGadgetSetEnabled(cotf, true);
+        GGadgetSetEnabled(cola, true);
+        GGadgetSetTitle8(coim,lbl);
+    } else {
+        GGadgetSetChecked(codcb, true);
+        GGadgetSetEnabled(cotf, false);
+        GGadgetSetEnabled(cola, false);
+        GGadgetSetTitle8(coim,"");
+    }
+    free(lbl);
+
     }
 
     GGadgetSelectOneListItem(GWidgetGetControl(ci->gw,CID_Color),0);
@@ -4122,15 +4248,15 @@ void SCCharInfo(SplineChar *sc,int deflayer, EncMap *map,int enc) {
     CharInfo *ci;
     GRect pos;
     GWindowAttrs wattrs;
-    GGadgetCreateData ugcd[14], cgcd[6], psgcd[7][7], cogcd[3], mgcd[9], tgcd[16];
+    GGadgetCreateData ugcd[14], cgcd[6], psgcd[7][7], cogcd[6], mgcd[9], tgcd[16];
     GGadgetCreateData lcgcd[4], vargcd[2][7];
-    GTextInfo ulabel[14], clabel[6], pslabel[7][6], colabel[3], mlabel[9], tlabel[16];
+    GTextInfo ulabel[14], clabel[6], pslabel[7][6], colabel[4], mlabel[9], tlabel[16];
     GTextInfo lclabel[4], varlabel[2][6];
     GGadgetCreateData mbox[4], *mvarray[7], *mharray1[7], *mharray2[8];
     GGadgetCreateData ubox[3], *uhvarray[29], *uharray[6];
     GGadgetCreateData cbox[3], *cvarray[5], *charray[4];
     GGadgetCreateData pstbox[7][4], *pstvarray[7][5], *pstharray1[7][8];
-    GGadgetCreateData cobox[2], *covarray[4];
+    GGadgetCreateData cobox[2], *covarray[8];
     GGadgetCreateData tbox[3], *thvarray[36], *tbarray[4];
     GGadgetCreateData lcbox[2], *lchvarray[4][4];
     GGadgetCreateData varbox[2][2], *varhvarray[2][5][4];
@@ -4466,22 +4592,44 @@ return;
 	colabel[0].text = (unichar_t *) _("Accented glyph composed of:");
 	colabel[0].text_is_1byte = true;
 	cogcd[0].gd.label = &colabel[0];
-	cogcd[0].gd.pos.x = 5; cogcd[0].gd.pos.y = 5; 
 	cogcd[0].gd.flags = gg_enabled|gg_visible|gg_utf8_popup;
 	cogcd[0].gd.cid = CID_ComponentMsg;
 	cogcd[0].creator = GLabelCreate;
 
-	cogcd[1].gd.pos.x = 5; cogcd[1].gd.pos.y = cogcd[0].gd.pos.y+12;
 	cogcd[1].gd.flags = gg_enabled|gg_visible|gg_utf8_popup;
 	cogcd[1].gd.cid = CID_Components;
 	cogcd[1].creator = GLabelCreate;
 
-	covarray[0] = &cogcd[0]; covarray[1] = &cogcd[1]; covarray[2] = GCD_Glue; covarray[3] = NULL;
+	colabel[1].text = (unichar_t *) _("\n\nIf the default decomposition is inappropriate for this font, you may choose your own.");
+	colabel[1].text_is_1byte = true;
+	cogcd[2].gd.label = &colabel[1];
+	cogcd[2].gd.flags = gg_enabled|gg_visible|gg_utf8_popup;
+	cogcd[2].gd.cid = CID_ComponentChangeMsg;
+	cogcd[2].creator = GLabelCreate;
+
+	colabel[2].text = (unichar_t *) _("Use default?");
+	colabel[2].text_is_1byte = true;
+	cogcd[3].gd.flags = gg_enabled | gg_visible | gg_cb_on;
+	cogcd[3].gd.cid = CID_ComponentDefaultCB;
+	cogcd[3].gd.handle_controlevent = CI_CmpUseNonDefault;
+	cogcd[3].gd.label = &colabel[2];
+	cogcd[3].creator = GCheckBoxCreate;
+
+	cogcd[4].gd.flags = gg_visible|gg_utf8_popup;
+	cogcd[4].gd.popup_msg = (unichar_t *) _("For example, to build this character from U+0061 (lowercase a) as the base and U+030C (combining caron), write:\n0061 030C");
+	cogcd[4].gd.cid = CID_ComponentTextField;
+	cogcd[4].gd.handle_controlevent = CI_CmpUseNonDefault;
+	cogcd[4].gd.pos.x = 500; cogcd[4].gd.pos.y = 20;
+	cogcd[4].creator = GTextFieldCreate;
+
+	cogcd[5].gd.flags = gg_enabled|gg_visible|gg_utf8_popup;
+	cogcd[5].gd.cid = CID_ComponentInterpMsg;
+	cogcd[5].creator = GLabelCreate;
+
+	covarray[0] = &cogcd[0]; covarray[1] = &cogcd[1]; covarray[2] = &cogcd[2]; covarray[3] = &cogcd[3]; covarray[4] = &cogcd[4]; covarray[5] = &cogcd[5]; covarray[6] = GCD_Glue; covarray[7] = NULL;
 	cobox[0].gd.flags = gg_enabled|gg_visible;
 	cobox[0].gd.u.boxelements = covarray;
 	cobox[0].creator = GVBoxCreate;
-	
-
 
 	memset(&tgcd,0,sizeof(tgcd));
 	memset(&tbox,0,sizeof(tbox));
@@ -4897,16 +5045,15 @@ return;
 	aspects[i].text_is_1byte = true;
 	aspects[i++].gcd = psgcd[5];
 
-	aspects[i].text = (unichar_t *) _("Components");
-	aspects[i].text_is_1byte = true;
-	aspects[i].nesting = 1;
-	aspects[i++].gcd = cobox;
-
 	ci->lc_aspect = i;
 	aspects[i].text = (unichar_t *) _("Lig. Carets");
 	aspects[i].text_is_1byte = true;
 	aspects[i].nesting = 1;
 	aspects[i++].gcd = lcbox;
+
+	aspects[i].text = (unichar_t *) _("Components");
+	aspects[i].text_is_1byte = true;
+	aspects[i++].gcd = cobox;
 
 	aspects[i].text = (unichar_t *) _("Counters");
 	aspects[i].text_is_1byte = true;

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -4031,14 +4031,10 @@ static void CIFillup(CharInfo *ci) {
 	GGadgetSetTitle(GWidgetGetControl(ci->gw,CID_Components),temp);
 	free(temp);
     }
+
     if (d_ptr == NULL) d_ptr = bits2;
 
     int d_length = d_ptr ? u_strlen(d_ptr) : 0;
-    if (sc->user_decomp != NULL) {
-        d_length = u_strlen(sc->user_decomp);
-    } else {
-        d_length = u_strlen(bits2);
-    }
 
     const int MAX_UNICHAR_T_BYTES = 4;
     char* codepoints_as_hex = malloc(((2 * MAX_UNICHAR_T_BYTES) * d_length) + d_length + 1);

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -3872,7 +3872,7 @@ static int CI_PickColor(GGadget *g, GEvent *e) {
 return( true );
 }
 
-int BytesNeeded(unichar_t in) {
+static int BytesNeeded(unichar_t in) {
     if (in <= 0xff) {
         return 1;
     } else if (in <= 0xffff) {
@@ -4031,12 +4031,9 @@ static void CIFillup(CharInfo *ci) {
 	GGadgetSetTitle(GWidgetGetControl(ci->gw,CID_Components),temp);
 	free(temp);
     }
-    if (bits2 == NULL) {
-        bits2 = (unichar_t*) L"\0";
-    } 
+    if (d_ptr == NULL) d_ptr = bits2;
 
-    // i.e. five six hex digit long codepoints with spaces after them, + '\0'
-    int d_length;
+    int d_length = d_ptr ? u_strlen(d_ptr) : 0;
     if (sc->user_decomp != NULL) {
         d_length = u_strlen(sc->user_decomp);
     } else {
@@ -4065,6 +4062,7 @@ static void CIFillup(CharInfo *ci) {
     }
 
     GGadgetSetTitle8(GWidgetGetControl(ci->gw,CID_ComponentTextField),codepoints_as_hex);
+    free(codepoints_as_hex);
 
     if (!GGadgetIsEnabled(codcb)) GGadgetSetEnabled(codcb, true);
     char* lbl = CI_CreateInterpretedAsLabel(sc->user_decomp);

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -3663,7 +3663,7 @@ return( true );
 unichar_t* CI_ParseUserDecomposition(char* inp) {
     unsigned long len = strlen(inp);
     char* end;
-    unichar_t* out = malloc(len*sizeof(unichar_t)+1);
+    unichar_t* out = malloc((len+1)*sizeof(unichar_t));
 
     int j = 0;
     for (unsigned long i = strtoul(inp, &end, 16); inp != end; i = strtoul(inp, &end, 16)) {
@@ -3678,11 +3678,10 @@ unichar_t* CI_ParseUserDecomposition(char* inp) {
 }
 
 char* CI_CreateInterpretedAsLabel(unichar_t* inp) {
-    char* lblprefix = "Interpreted as: ";
-    char* lblerror = "Error: wrong format";
+    char* lblprefix = _("Interpreted as: ");
+    char* lblerror = _("Error: wrong format");
     // 2 makes it large enough to hold the error string
-    int factor = inp == NULL ? 2 : u_strlen(inp);
-    char* lblbuf = malloc(strlen(lblprefix)+(factor*4));
+    char* lblbuf;
 
     // If I don't validate it, the string will become "(null)"
     bool valid = true;
@@ -3696,9 +3695,11 @@ char* CI_CreateInterpretedAsLabel(unichar_t* inp) {
 
     if (inp != NULL && inp[0] != 0 && valid) {
         char* inp_l = u2utf8_copy(inp);
+        lblbuf = malloc(strlen(lblprefix)+strlen(inp_l)+1);
         sprintf(lblbuf, "%s%s", lblprefix, inp_l);
         free(inp_l);
     } else {
+        lblbuf = malloc(strlen(lblerror)+1);
         strcpy(lblbuf, lblerror);
     }
 

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -10651,7 +10651,7 @@ static void CVMenuBuildAccent(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *
 	/* It's ok */;
     else if ( !SFIsSomethingBuildable(cv->b.fv->sf,cv->b.sc,layer,true) )
 return;
-    SCBuildComposit(cv->b.fv->sf,cv->b.sc,layer,NULL,onlycopydisplayed);
+    SCBuildComposit(cv->b.fv->sf,cv->b.sc,layer,NULL,onlycopydisplayed,true);
 }
 
 static void CVMenuBuildComposite(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
@@ -10663,7 +10663,7 @@ static void CVMenuBuildComposite(GWindow gw, struct gmenuitem *UNUSED(mi), GEven
 	/* It's ok */;
     else if ( !SFIsCompositBuildable(cv->b.fv->sf,cv->b.sc->unicodeenc,cv->b.sc,layer) )
 return;
-    SCBuildComposit(cv->b.fv->sf,cv->b.sc,layer,NULL,onlycopydisplayed);
+    SCBuildComposit(cv->b.fv->sf,cv->b.sc,layer,NULL,onlycopydisplayed,false);
 }
 
 static void CVMenuReverseDir(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -2921,7 +2921,7 @@ static void _MVMenuBuildAccent(MetricsView *mv,int onlyaccents) {
     if ( i!=-1 ) {
 	SplineChar *sc = mv->glyphs[i].sc;
 	if ( SFIsSomethingBuildable(mv->sf,sc,mv->layer,onlyaccents) )
-	    SCBuildComposit(mv->sf,sc,mv->layer,NULL,onlycopydisplayed);
+	    SCBuildComposit(mv->sf,sc,mv->layer,NULL,onlycopydisplayed,onlyaccents);
     }
 }
 


### PR DESCRIPTION
This closes fontforge/fontforge#3615.

This supersedes fontforge/fontforge#3617.

This allows users to set their own decomposition for each buildable
glyph.

A new line is added for each char in the SFD, `Decomposition`. It has
the same format as the `Comment` line.

Through the Python interface, users can set the decompositon using the
`glyph.user_decomp` attribute. This has been added to `python.html`.

`SFGetAlternate` now respects user decompositions if a `SplineChar` is
passed, as happens when characters are built.

Besides all the changes to "Glyph Info &rarr; Components", I unindented
"Components", so it is no longer under "Ligatures" in the menu, since
with this patch that no longer makes sense.

The "Components" section now looks like this:

![glyph info](https://user-images.githubusercontent.com/838783/55939927-9c02cd80-5c71-11e9-9885-59dfaee60b94.png)


- [x] New feature (non-breaking change which adds functionality)
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.