### PR TITLE
Fix for #3621 freeze in gtextfield_mouse

### DIFF
--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -1694,28 +1694,26 @@ return( true );
 	i = (event->u.mouse.y-g->inner.y)/gt->fh + gt->loff_top;
 	if ( i<0 ) i = 0;
 	if ( !gt->multi_line ) i = 0;
-	if ( i>=gt->lcnt )
+	if ( i>=gt->lcnt ) {
 	    end = gt->text+curlen;
-	else
+	    i = gt->lcnt - 1;
+	    if (i < 0) i = 0; // Can lcnt ever be 0?
+	} else
 	    end = GTextFieldGetPtFromPos(gt,i,event->u.mouse.x);
     }
 
     if ( event->type == et_mousedown ) {
+	int end8;
 	if ( event->u.mouse.button==3 &&
 		GGadgetWithin(g,event->u.mouse.x,event->u.mouse.y)) {
 	    GTFPopupMenu(gt,event);
 return( true );
 	}
 
-	if ( i>=gt->lcnt )
-	    end1 = end2 = end;
-	else {
-	    int end8;
-	    ll = gt->lines8[i+1]==-1?-1:gt->lines8[i+1]-gt->lines8[i]-1;
-	    GDrawLayoutInit(gt->g.base,gt->utf8_text+gt->lines8[i],ll,NULL);
-	    end8 = GDrawLayoutXYToIndex(gt->g.base,event->u.mouse.x-g->inner.x+gt->xoff_left,0);
-	    end1 = end2 = gt->text + gt->lines[i] + utf82u_index(end8,gt->utf8_text+gt->lines8[i]);
-	}
+	ll = gt->lines8[i+1]==-1?-1:gt->lines8[i+1]-gt->lines8[i]-1;
+	GDrawLayoutInit(gt->g.base,gt->utf8_text+gt->lines8[i],ll,NULL);
+	end8 = GDrawLayoutXYToIndex(gt->g.base,event->u.mouse.x-g->inner.x+gt->xoff_left,0);
+	end1 = end2 = gt->text + gt->lines[i] + utf82u_index(end8,gt->utf8_text+gt->lines8[i]);
 
 	gt->wordsel = gt->linesel = false;
 	if ( event->u.mouse.button==1 && event->u.mouse.clicks>=3 ) {


### PR DESCRIPTION
I don't know what the intention of the old line-selection code was. This replacement selects the semantic rather than the visible line, which matches most other implementations I'm familiar with.

Closes #3621 

I also removed one poor initialization of `sel_end`, but it shouldn't be related to #3620. 

If a newline char value can be the latter half of a wide char then this could have undesired results, but it shouldn't fail -- it might just select less than a semantic line if the wide char in question falls at the end of a visible line. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
