### PR TITLE
Always enable glif hashing and switch from uthash to glib

### DIFF
--- a/INSTALL-git.md
+++ b/INSTALL-git.md
@@ -23,7 +23,7 @@ sudo apt-get install autotools-dev libjpeg-dev libtiff5-dev libpng-dev libgif-de
 To download all dependencies on Ubuntu, run:
 
 ```sh
-sudo apt-get install packaging-dev pkg-config python-dev libpango1.0-dev libglib2.0-dev libxml2-dev giflib-dbg libjpeg-dev libtiff-dev uthash-dev libspiro-dev build-essential automake flex bison;
+sudo apt-get install packaging-dev pkg-config python-dev libpango1.0-dev libglib2.0-dev libxml2-dev giflib-dbg libjpeg-dev libtiff-dev libspiro-dev build-essential automake flex bison;
 ```
 
 Install the *unifont* package to get a full display of the reference glyphs.

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,6 @@ GITIGNOREFILES = \
 	m4/ltsugar.m4 \
 	m4/ltversion.m4 \
 	m4/lt~obsolete.m4 \
-	uthash/ \
 	'**/*.gcno' \
 	'**/*.gcda'
 
@@ -50,7 +49,7 @@ GITIGNOREFILES = \
 AM_CPPFLAGS =
 AM_LDFLAGS =
 
-BUILT_SOURCES = uthash/src
+BUILT_SOURCES =
 EXTRA_DIST =
 CLEANFILES =
 MOSTLYCLEANFILES =
@@ -111,7 +110,6 @@ EXTRA_DIST += \
 	Packaging/FontForge.spec \
 	Packaging/FontForge.static.spec \
 	README \
-	uthash/src \
 	$(NULL)
 
 #--------------------------------------------------------------------------
@@ -125,15 +123,6 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-theme-2012 --enable-debug
 #	--without-libuninameslist --without-libunicodenames	\
 #	--without-libreadline
 
-
-#--------------------------------------------------------------------------
-uthash/src:
-	if [ ! -e uthash/src ]; then \
-	if [ -e uthash ] ; then rm -r uthash ; fi ; \
-	git clone https://github.com/troydhanson/uthash ; \
-	fi ;
-
-# We import a selection of targets from Frank's standard packaging Makefile.
 
 # automake can't parse certain parts of Makefile syntax,
 # and there isn't an easy way to make it copy things that it doesn't

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -122,8 +122,6 @@ AM_CFLAGS = $(WARN_CFLAGS)
 AM_CPPFLAGS = "-I$(top_builddir)/inc" "-I$(top_srcdir)/inc"		\
 	"-I$(top_builddir)/lib" "-I$(top_srcdir)/lib"			\
 	"-DSHAREDIR=\"${MY_SHAREDIR}\"" "-DDOCDIR=\"${MY_DOCDIR}\""	\
-	"-I$(top_builddir)/uthash/src" "-I$(top_srcdir)/uthash/src"	\
-	"-DFF_UTHASH_GLIF_NAMES=1"					\
 	$(MY_CFLAGS)
 
 #--------------------------------------------------------------------------

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -56,6 +56,8 @@
 
 #include <ffglib.h>
 
+#include "glif_name_hash.h"
+
 /* Adobe's opentype feature file */
 /* Which suffers incompatible changes according to Adobe's whim */
 /* Currently trying to support the version of december 2008, Version 1.8. */
@@ -2117,18 +2119,12 @@ static char *fea_canonicalClassOrder(char *class) {
 return( class );
 }
 
-#ifdef FF_UTHASH_GLIF_NAMES
-#include "glif_name_hash.h"
-#endif
 
 static int fea_classesIntersect(char *class1, char *class2) {
     char *pt1, *start1, *pt2, *start2;
     int ch1, ch2;
 
-#ifdef FF_UTHASH_GLIF_NAMES
-    struct glif_name_index _glif_name_hash;
-    struct glif_name_index * glif_name_hash = &_glif_name_hash; // Open the hash table.
-    memset(glif_name_hash, 0, sizeof(struct glif_name_index));
+    struct glif_name_index * glif_name_hash = glif_name_index_new(); // Open the hash table.
     long int index = 0;
     long int break_point = 0;
     int output = 0;
@@ -2158,31 +2154,9 @@ static int fea_classesIntersect(char *class1, char *class2) {
         }
         *pt2 = ch2; // Restore the byte.
     }
-    glif_name_hash_destroy(glif_name_hash); // Close the hash table.
+    glif_name_index_destroy(glif_name_hash); // Close the hash table.
     if (output == 1) return 1;
     return 0;
-#else
-    for ( pt1=class1 ; ; ) {
-        while ( *pt1==' ' ) ++pt1;
-        if ( *pt1=='\0' )
-            return( 0 );
-        for ( start1 = pt1; *pt1!=' ' && *pt1!='\0'; ++pt1 );
-        ch1 = *pt1; *pt1 = '\0';
-        for ( pt2=class2 ; ; ) {
-            while ( *pt2==' ' ) ++pt2;
-            if ( *pt2=='\0' )
-                break;
-            for ( start2 = pt2; *pt2!=' ' && *pt2!='\0'; ++pt2 );
-            ch2 = *pt2; *pt2 = '\0';
-            if ( strcmp(start1,start2)==0 ) {
-                *pt2 = ch2; *pt1 = ch1;
-                return( 1 );
-            }
-            *pt2 = ch2;
-        }
-        *pt1 = ch1;
-    }
-#endif
 }
 
 

--- a/fontforge/glif_name_hash.c
+++ b/fontforge/glif_name_hash.c
@@ -1,55 +1,33 @@
 #include "glif_name_hash.h"
 
-#include <stdlib.h>
-#include <string.h>
-#include <ustring.h>
-#include <uthash.h>
+#include <ffglib.h>
 
-struct glif_name_private {
-  long int gid;
-  char * glif_name;
-  UT_hash_handle gid_hash;
-  UT_hash_handle glif_name_hash;
-};
-
-struct glif_name_index {
-  struct glif_name_private * gid_hash;
-  struct glif_name_private * glif_name_hash;
-};
-
-static void glif_name_hash_add(struct glif_name_index * hash, struct glif_name_private * item) {
-  HASH_ADD(gid_hash, hash->gid_hash, gid, sizeof(item->gid), item);
-  HASH_ADD_KEYPTR(glif_name_hash, hash->glif_name_hash, item->glif_name, strlen(item->glif_name), item);
-}
-
-static void glif_name_hash_remove(struct glif_name_index * hash, struct glif_name_private * item) {
-  HASH_DELETE(gid_hash, hash->gid_hash, item);
-  HASH_DELETE(glif_name_hash, hash->glif_name_hash, item);
+static void glif_name_destroy(gpointer data) {
+  struct glif_name * entry = (struct glif_name *)data;
+  g_free(entry->glif_name);
+  free(entry);
 }
 
 struct glif_name_index * glif_name_index_new() {
-  return calloc(1, sizeof(struct glif_name_index));
+  return (struct glif_name_index *)g_hash_table_new_full(g_str_hash, g_str_equal, NULL, glif_name_destroy);
 }
 
 struct glif_name * glif_name_search_glif_name(struct glif_name_index * hash, const char * glif_name) {
-  struct glif_name_private * output = NULL;
-  HASH_FIND(glif_name_hash, hash->glif_name_hash, glif_name, strlen(glif_name), output);
-  return (struct glif_name *)output;
+  g_return_val_if_fail(hash != NULL && glif_name != NULL, NULL);
+
+  return (struct glif_name *) g_hash_table_lookup((GHashTable *)hash, glif_name);
 }
 
 void glif_name_track_new(struct glif_name_index * hash, long int gid, const char * glif_name) {
-  struct glif_name_private * new_node = calloc(1, sizeof(struct glif_name_private));
+  g_return_if_fail(hash != NULL && glif_name != NULL);
+
+  struct glif_name * new_node = calloc(1, sizeof(struct glif_name));
   new_node->gid = gid;
-  new_node->glif_name = copy(glif_name);
-  glif_name_hash_add(hash, new_node);
+  new_node->glif_name = g_strdup(glif_name);
+
+  g_hash_table_replace((GHashTable *)hash, new_node->glif_name, new_node);
 }
 
 void glif_name_index_destroy(struct glif_name_index * hash) {
-  struct glif_name_private *current, *tmp;
-  HASH_ITER(gid_hash, hash->gid_hash, current, tmp) {
-    glif_name_hash_remove(hash, current);
-    if (current->glif_name != NULL) { free(current->glif_name); current->glif_name = NULL; }
-    free(current); current = NULL;
-  }
-  free(hash);
+  g_hash_table_destroy((GHashTable *)hash);
 }

--- a/fontforge/glif_name_hash.c
+++ b/fontforge/glif_name_hash.c
@@ -1,6 +1,7 @@
 #include "glif_name_hash.h"
 
 #include <ffglib.h>
+#include <stdlib.h>
 
 static void glif_name_destroy(gpointer data) {
   struct glif_name * entry = (struct glif_name *)data;

--- a/fontforge/glif_name_hash.c
+++ b/fontforge/glif_name_hash.c
@@ -1,55 +1,55 @@
 #include "glif_name_hash.h"
-#ifdef FF_UTHASH_GLIF_NAMES
-struct glif_name * glif_name_new() {
-  struct glif_name * output = malloc(sizeof(struct glif_name));
-  if (output == NULL) return NULL;
-  memset(output, 0, sizeof(struct glif_name));
-  return output;
-}
-struct glif_name_index * glif_name_index_new() {
-  struct glif_name_index * output = malloc(sizeof(struct glif_name_index));
-  if (output == NULL) return NULL;
-  memset(output, 0, sizeof(struct glif_name_index));
-  return output;
-}
-void glif_name_hash_add(struct glif_name_index * hash, struct glif_name * item) {
+
+#include <stdlib.h>
+#include <string.h>
+#include <ustring.h>
+#include <uthash.h>
+
+struct glif_name_private {
+  long int gid;
+  char * glif_name;
+  UT_hash_handle gid_hash;
+  UT_hash_handle glif_name_hash;
+};
+
+struct glif_name_index {
+  struct glif_name_private * gid_hash;
+  struct glif_name_private * glif_name_hash;
+};
+
+static void glif_name_hash_add(struct glif_name_index * hash, struct glif_name_private * item) {
   HASH_ADD(gid_hash, hash->gid_hash, gid, sizeof(item->gid), item);
   HASH_ADD_KEYPTR(glif_name_hash, hash->glif_name_hash, item->glif_name, strlen(item->glif_name), item);
 }
-struct glif_name * glif_name_search_gid(struct glif_name_index * hash, long int gid) {
-  struct glif_name * output = NULL;
-  HASH_FIND(gid_hash, hash->gid_hash, &gid, sizeof(gid), output);
-  return output;
-}
-struct glif_name * glif_name_search_glif_name(struct glif_name_index * hash, const char * glif_name) {
-  struct glif_name * output = NULL;
-  HASH_FIND(glif_name_hash, hash->glif_name_hash, glif_name, strlen(glif_name), output);
-  return output;
-}
-int glif_name_track_collide(struct glif_name_index * hash, long int gid, const char * glif_name) {
-  if ((glif_name_search_gid(hash, gid) != NULL) ||
-      (glif_name_search_glif_name(hash, glif_name) != NULL))
-    return 1;
-  return 0;
-}
-void glif_name_track_new(struct glif_name_index * hash, long int gid, const char * glif_name) {
-  struct glif_name * new_node = glif_name_new();
-  new_node->gid = gid;
-  new_node->glif_name = malloc(strlen(glif_name)+1);
-  strcpy(new_node->glif_name, glif_name);
-  glif_name_hash_add(hash, new_node);
-}
-void glif_name_hash_remove(struct glif_name_index * hash, struct glif_name * item) {
+
+static void glif_name_hash_remove(struct glif_name_index * hash, struct glif_name_private * item) {
   HASH_DELETE(gid_hash, hash->gid_hash, item);
   HASH_DELETE(glif_name_hash, hash->glif_name_hash, item);
 }
-void glif_name_hash_destroy(struct glif_name_index * hash) {
-  struct glif_name *current, *tmp;
+
+struct glif_name_index * glif_name_index_new() {
+  return calloc(1, sizeof(struct glif_name_index));
+}
+
+struct glif_name * glif_name_search_glif_name(struct glif_name_index * hash, const char * glif_name) {
+  struct glif_name_private * output = NULL;
+  HASH_FIND(glif_name_hash, hash->glif_name_hash, glif_name, strlen(glif_name), output);
+  return (struct glif_name *)output;
+}
+
+void glif_name_track_new(struct glif_name_index * hash, long int gid, const char * glif_name) {
+  struct glif_name_private * new_node = calloc(1, sizeof(struct glif_name_private));
+  new_node->gid = gid;
+  new_node->glif_name = copy(glif_name);
+  glif_name_hash_add(hash, new_node);
+}
+
+void glif_name_index_destroy(struct glif_name_index * hash) {
+  struct glif_name_private *current, *tmp;
   HASH_ITER(gid_hash, hash->gid_hash, current, tmp) {
     glif_name_hash_remove(hash, current);
     if (current->glif_name != NULL) { free(current->glif_name); current->glif_name = NULL; }
     free(current); current = NULL;
   }
+  free(hash);
 }
-#endif
-

--- a/fontforge/glif_name_hash.h
+++ b/fontforge/glif_name_hash.h
@@ -1,30 +1,19 @@
 #ifndef _GLIF_NAME_HASH_H
 #define _GLIF_NAME_HASH_H
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
 
-#ifdef FF_UTHASH_GLIF_NAMES
-#include "uthash.h"
+#include <fontforge-config.h>
+
+struct glif_name_index;
 
 struct glif_name {
   long int gid;
   char * glif_name;
-  UT_hash_handle gid_hash;
-  UT_hash_handle glif_name_hash;
 };
-struct glif_name_index {
-  struct glif_name * gid_hash;
-  struct glif_name * glif_name_hash;
-};
-struct glif_name * glif_name_new();
+
 struct glif_name_index * glif_name_index_new();
-void glif_name_hash_add(struct glif_name_index * hash, struct glif_name * item);
-struct glif_name * glif_name_search_gid(struct glif_name_index * hash, long int gid);
-struct glif_name * glif_name_search_glif_name(struct glif_name_index * hash, const char * glif_name);
-int glif_name_track_collide(struct glif_name_index * hash, long int gid, const char * glif_name);
+void glif_name_index_destroy(struct glif_name_index * hash);
+
 void glif_name_track_new(struct glif_name_index * hash, long int gid, const char * glif_name);
-void glif_name_hash_remove(struct glif_name_index * hash, struct glif_name * item);
-void glif_name_hash_destroy(struct glif_name_index * hash);
-#endif
+struct glif_name * glif_name_search_glif_name(struct glif_name_index * hash, const char * glif_name);
+
 #endif

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -55,9 +55,7 @@
 #include <locale.h>
 #include "sfd1.h" // This has the extended SplineFont type SplineFont1 for old file versions.
 #include <ffglib.h>
-#ifdef FF_UTHASH_GLIF_NAMES
-# include "glif_name_hash.h"
-#endif
+#include "glif_name_hash.h"
 
 /*#define DEBUG 1*/
 
@@ -6799,7 +6797,6 @@ char * delimit_null(const char * input, char delimiter) {
   return output;
 }
 
-#ifdef FF_UTHASH_GLIF_NAMES
 int HashKerningClassNamesFlex(SplineFont *sf, struct glif_name_index * class_name_hash, int capitalize) {
     struct kernclass *current_kernclass;
     int isv;
@@ -6832,7 +6829,6 @@ int HashKerningClassNames(SplineFont *sf, struct glif_name_index * class_name_ha
 int HashKerningClassNamesCaps(SplineFont *sf, struct glif_name_index * class_name_hash) {
   return HashKerningClassNamesFlex(sf, class_name_hash, 1);
 }
-#endif
 
 int KerningClassSeekByAbsoluteIndex(const struct splinefont *sf, int seek_index, struct kernclass **okc, int *oisv, int *oisr, int *ooffset) {
     int current = 0;

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -1,6 +1,7 @@
 #ifndef FONTFORGE_SPLINEUTIL_H
 #define FONTFORGE_SPLINEUTIL_H
 
+#include "glif_name_hash.h"
 #include "psfont.h"
 #include "splinefont.h"
 #include "ttfinstrs.h"
@@ -206,12 +207,9 @@ extern void TTFLangNamesFree(struct ttflangname *l);
 extern void TtfTablesFree(struct ttf_table *tab);
 extern void ValDevFree(ValDevTab *adjust);
 
-#ifdef FF_UTHASH_GLIF_NAMES
-struct glif_name_index;
 extern int KerningClassSeekByAbsoluteIndex(const struct splinefont *sf, int seek_index, struct kernclass **okc, int *oisv, int *oisr, int *ooffset);
 extern int HashKerningClassNames(SplineFont *sf, struct glif_name_index * class_name_hash);
 extern int HashKerningClassNamesCaps(SplineFont *sf, struct glif_name_index * class_name_hash);
 extern int HashKerningClassNamesFlex(SplineFont *sf, struct glif_name_index * class_name_hash, int capitalize);
-#endif /* FF_UTHASH_GLIF_NAMES */
 
 #endif /* FONTFORGE_SPLINEUTIL_H */

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -3298,7 +3298,6 @@ static uint32 script_from_glyph_list(SplineFont *sf, const char *glyph_names) {
 #define GROUP_NAME_RIGHT 8 // Otherwise left (or above).
 
 static void MakeKerningClasses(SplineFont *sf, struct ff_glyphclasses *group_base) {
-  // This silently ignores already extant groups for now but avoids duplicates unless group_base has internal duplication.
   int left_count = 0, right_count = 0, above_count = 0, below_count = 0;
   int left_start = 0, right_start = 0, above_start = 0, below_start = 0;
 

--- a/git.mk
+++ b/git.mk
@@ -189,7 +189,6 @@ $(srcdir)/.gitignore: Makefile.am $(top_srcdir)/git.mk
 			"*.tab.c" \
 			$(MAINTAINERCLEANFILES) \
 			$(BUILT_SOURCES) \
-			"/uthash/" \
 			$(DEPDIR) \
 			Makefile \
 			Makefile.in \

--- a/pkg.mk
+++ b/pkg.mk
@@ -52,13 +52,11 @@ deb-src-control:
 endif
 
 deb-src: deb-src-control
-	$(MAKE) uthash/src;
 	cd tests ; $(MAKE) prefetch-fonts ;
 	for cfile in config/* m4/* ; do if [ -e "$cfile" ] ; then rm -f "$cfile" ; fi ; done ;
 	cd .. ; if [ "$(F_FAKE_PRODUCT_NAME)" != "$(F_PACKAGE_NAME)" ] ; then cp -pRP $(F_FAKE_PRODUCT_NAME) $(F_PACKAGE_NAME) ; fi ; cd $(F_PACKAGE_NAME) ; yes | debuild -S -sa ;
 
 deb: deb-src-control
-	$(MAKE) uthash/src;
 	cd tests ; $(MAKE) prefetch-fonts ;
 	for cfile in config/* ; do if [ -e "$cfile" ] ; then rm -f "$cfile" ; fi ; done ;
 	cd .. ; if [ "$(F_FAKE_PRODUCT_NAME)" != "$(F_PACKAGE_NAME)" ] ; then cp -pRP $(F_FAKE_PRODUCT_NAME) $(F_PACKAGE_NAME) ; fi ; cd $(F_PACKAGE_NAME) ; yes | debuild ;
@@ -68,7 +66,6 @@ rpm-src-control:
 	for file in Packaging/redhat/m4/* ; do m4 -D "PACKAGE_NAME=$(F_PACKAGE_NAME)" -D "PACKAGE_VERSION=$(RPM_PACKAGE_VERSION)" -D "BINARY=0" -D "PREFIX=/usr" -D "SOURCE_TARBALL_NAME=$(F_PACKAGE_NAME)-$(RPM_PACKAGE_VERSION).tar.gz" < "$$file" > redhat/"`basename "$$file"`" ; done ;
 
 rpm-src: rpm-src-control
-	$(MAKE) uthash/src;
 	cd tests ; $(MAKE) prefetch-fonts ;
 	for cfile in config/* m4/* ; do if [ -e "$cfile" ] ; then rm -f "$cfile" ; fi ; done ;
 	cd .. ; cp -pRP $(F_FAKE_PRODUCT_NAME)/redhat/rpm.spec ./$(F_PACKAGE_NAME)-$(RPM_PACKAGE_VERSION).spec ; if [ "$(F_FAKE_PRODUCT_NAME)" != "$(F_PACKAGE_NAME)-$(F_PACKAGE_VERSION)" ] ; then cp -pRP $(F_FAKE_PRODUCT_NAME) $(F_PACKAGE_NAME)-$(RPM_PACKAGE_VERSION) ; fi ; tar -czf $(F_PACKAGE_NAME)-$(RPM_PACKAGE_VERSION).tar.gz $(F_PACKAGE_NAME)-$(RPM_PACKAGE_VERSION) ;


### PR DESCRIPTION
As I was working on trying out cmake/meson, it became apparent that it doesn't actually build without uthash present (i.e. without FF_UTHASH_GLIF_NAMES defined, things break).

So the intent of this PR is twofold:
* Always enable glif name hashing, since it's basically a hard requirement (and likely has been for years). At the same time, make the implementation of the glif name hash opaque, so that it's easy to switch out the implementation
* Switch to using glib over uthash. glib is already a hard dependency in FontForge, and using it means that we don't have to continue bundling uthash with the source distribution. It's also just one less dependency to manage.

Tested manually and also with the following:

```c
#include "glif_name_hash.h"
#include <stdio.h>
#include <string.h>

int main() {
    for (int k = 0; k < 100; k++) {
        struct glif_name_index *idx = glif_name_index_new();
        
        for (int i = 0; i < 100; i++) {
            char buf[100];
            sprintf(buf, "ENTRY %d", i);
            glif_name_track_new(idx, i, buf);
        }
        
        for (int i = 0; i < 100; i++) {
            char buf[100];
            sprintf(buf, "ENTRY %d", i);

            struct glif_name *entry =  glif_name_search_glif_name(idx, buf);
            if (entry == NULL) {
                printf("ERROR: Not found: %d (%s)\n", i, buf);
                return 1;
            }
            
            if (entry->gid != i) {
                printf("ERROR: gid mismatch: %ld vs %d (%s vs %s)\n", entry->gid, i, entry->glif_name, buf);
                return 2;
            }
            
            if (strcmp(entry->glif_name, buf)) {
                printf("ERROR: name mismatch: %s vs %s (%d)\n", entry->glif_name, buf, i);
                return 3;
            }
        }

        for (int i = 100; i < 200; i++) {
            char buf[100];
            sprintf(buf, "ENTRY %d", i);
            
            struct glif_name *entry =  glif_name_search_glif_name(idx, buf);
            if (entry != NULL) {
                printf("ERROR: Unexpected: %d (%s) - got: (%ld, %s)\n", i, buf, entry->gid, entry->glif_name);
                return 1;
            }
        }
        
        glif_name_index_destroy(idx);
    }

    return 0;
}
```

Compiled with `gcc -g -std=c99 -Ifontforge -I/usr/local/include  -I/usr/local/include/fontforge test.c  -L/usr/local/lib -lfontforge -otest -Wall`