### PR TITLE
Conform to Adobe feature file spec section 7.b

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -5525,56 +5525,6 @@ return;
     }
     fea_end_statement(tok);
 
-    /* Any of a multiple, alternate, or ligature substitution may have */
-    /* a single destination. In either case it will look just like a single */
-    /* substitution. So if there are both multiple/alternate/ligature and */
-    /* single subs in a lookup translate all the singles into the */
-    /* corresponding type */
-    has_single = has_multiple = has_ligature = has_alternate = false;
-    for ( item=tok->sofar ; item!=NULL && item->type!=ft_feat_start; item=item->next ) {
-	enum otlookup_type cur = fea_LookupTypeFromItem(item);
-	if ( cur==gsub_multiple )
-	    has_multiple = true;
-	else if ( cur==gsub_alternate )
-	    has_alternate = true;
-	else if ( cur==gsub_ligature )
-	    has_ligature = true;
-	else if ( cur==gsub_single )
-	    has_single = true;
-    }
-    if ( has_single ) {
-	enum possub_type psttype = pst_pair;
-	if ( has_multiple && !( has_alternate || has_ligature ) )
-	    psttype = pst_multiple;
-	else if ( has_alternate && !( has_multiple || has_ligature ) )
-	    psttype = pst_alternate;
-	else if ( has_ligature && !( has_multiple || has_alternate ) )
-	    psttype = pst_ligature;
-	if ( psttype!=pst_pair ) {
-	    for ( item=tok->sofar ; item!=NULL && item->type!=ft_feat_start; item=item->next ) {
-		enum otlookup_type cur = fea_LookupTypeFromItem(item);
-		if ( cur==gsub_single )
-		    item->u2.pst->type = psttype;
-	    }
-	}
-    }
-
-    /* Make sure all entries in this lookup of the same lookup type */
-    lookuptype = ot_undef;
-    for ( item=tok->sofar ; item!=NULL && item->type!=ft_feat_start; item=item->next ) {
-	enum otlookup_type cur = fea_LookupTypeFromItem(item);
-	if ( cur==ot_undef )	/* Some entries in the list (lookupflags) have no type */
-	    /* Tum, ty, tum tum */;
-	else if ( lookuptype==ot_undef )
-	    lookuptype = cur;
-	else if ( lookuptype!=cur ) {
-	    LogError(_("All entries in a lookup must have the same type on line %d of %s"),
-		    tok->line[tok->inc_depth], tok->filename[tok->inc_depth] );
-	    ++tok->err_count;
-	    break;
-	}
-    }
-
     item = chunkalloc(sizeof(struct feat_item));
     item->type = ft_feat_end;
     item->u1.tag = feat_tag;
@@ -6208,30 +6158,39 @@ return( type==ft_lookup_end || type == ft_feat_end ||
 	    type == ft_lookup_ref );
 }
 
+/* This function copies entries of a given lookup type into the
+ * lookup_next list of the first argument.  A given lookup is
+ * considered to end on encountering one of the types in
+ * fea_FeatItemEndsLookup or NULL, which is returned.
+ *
+ * When called with type==ot_undef the types are not checked
+ * and assumed to match, a condition verified by some of the
+ * variants of fea_ApplyLookupList.
+ *
+ * When called with another type the function adds elements of
+ * that type to lookup_next until either a list-terminating element
+ * or one of a different type is found.
+ */
 static struct feat_item *fea_SetLookupLink(struct feat_item *nested,
 	enum otlookup_type type) {
     struct feat_item *prev = NULL;
     enum otlookup_type found_type;
 
-    while ( nested!=NULL ) {
-	/* Stop when we find something which forces a new lookup */
-	if ( fea_FeatItemEndsLookup(nested->type) )
-    break;
-	if ( nested->ticked ) {
-	    nested = nested->next;
-    continue;
-	}
-	found_type = fea_LookupTypeFromItem(nested);
-	if ( type==ot_undef || found_type == ot_undef || found_type == type ) {
-	    if ( nested->type!=ft_ap || nested->u2.ap->type!=at_mark )
-		nested->ticked = true;		/* Marks might get used in more than one lookup */
-	    if ( prev!=NULL )
-		prev->lookup_next = nested;
-	    prev = nested;
+    while ( nested!=NULL && !fea_FeatItemEndsLookup(nested->type) ) {
+	if ( !nested->ticked ) {
+	    found_type = fea_LookupTypeFromItem(nested);
+	    if ( type==ot_undef || found_type == ot_undef || found_type == type ) {
+		if ( nested->type!=ft_ap || nested->u2.ap->type!=at_mark )
+		    nested->ticked = true; /* Marks might get used in more than one lookup */
+		if ( prev!=NULL )
+		    prev->lookup_next = nested;
+		prev = nested;
+	    } else if ( type!=ot_undef && found_type!=type )
+		break;
 	}
 	nested = nested->next;
     }
-return( nested );
+    return( nested );
 }
 
 static void fea_ApplyLookupListPST(struct parseState *tok,


### PR DESCRIPTION
A single substitution is arguably a degenerate case of a multiple, ligature, or "alternate" substitution. In #3350 I extended the already-existing treatment of a single as a multiple to include ligature and alternate substitutions, so that lookups of those types could also (conveniently) include single substitution entries. 

The existing code did this in both lookup and feature blocks, but in the later case did not verify that all types of a lookup matched. As it seemed strange to convert singles to multiples without that check, I added it. This turned out [to break at least one feature file](https://github.com/fontforge/fontforge/pull/3350#discussion_r275148092). 

Looking into this, my original thoughts were both right and wrong. It was right that converting the type of singles without checking if all the types matched was strange. It was wrong that any of that should be happening. The specification [says](https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#7b-ordering-of-lookups-and-subtables):

> A lookup in the OpenType font will be created from each named lookup block (§4.e) or each run of rules with the same feature, script, language, lookupflag and lookup type attribute.

Note the term "run of". 

Ignoring the checks I added, the existing implementation doesn't do this. And it's confusing, so bear with me. The relevant code (in `featurefile.c:fea_ApplyFeatureList`) is:

```
          case ft_pst:
          case ft_pstclass:
          case ft_ap:
          case ft_fpst:
            if ( f->type==ft_ap && f->u2.ap->type==at_mark ) {
                struct feat_item *n, *a;
                /* skip over the marks */
                for ( n=f; n!=NULL && n->type == ft_ap && n->u2.ap->type==at_mark; n=n->next );
                    /* omitted irrelevant stuff */
                }
                ltype = fea_LookupTypeFromItem(a);
            } else
                ltype = fea_LookupTypeFromItem(f);
            start = f;
            f = fea_SetLookupLink(start,ltype);
            for ( f=start; f!=NULL && f->ticked; f=f->next );
            otl = fea_ApplyLookupList(tok,start,lookup_flags);
            fea_AttachFeatureToLookup(otl,feature_tag,sl);
    continue;
```
The existing `fea_SetLookupLink`, when used this way, goes through the entries in the list starting with the first argument looking for those of the type of the second argument, and adding them to the `lookup_next` list of the first argument and marking them as `ticked`. It stops when it reaches an element type that indicates the list is finished, and returns that element. 

What is confusing about this is that the outer loop of the switch statement iterates through `f`, and this is setting `f` to the value at the end, while only copying some entries to be processed by `fea_ApplyLookupList()`. But that `f` value is irrelevant because of the loop immediately after, which begins not at the current value of `f` but at `start`. So the overall implementation iterates from the start of the list to the first un`ticked` element, and the next iteration of the loop will start there, collecting together entries of that type, queueing up the third type, and so forth. 

The problem with this is that it groups all substitutions of a given type together, potentially changing their order. There are cases where this won't matter and cases when it will, the latter most clearly with mixed contextual lookups. And regardless regrouping is contrary to the spec, as quoted above. 

This push request doesn't touch this confusing code (perhaps it should, eliminating that assignment to `f`), but alters `fea_ApplyLookupList` to stop on encountering the first (relevant) element with a type different from `ltype`. Because it is still ticking the elements it "consumes", the higher-level function can use it the same way. (It would be more efficient to advance the search with the return value, but the code suggests that some elements (`mark` anchor points) may be needed in multiple lookups, so it's not safe to just advance the list beyond them.) It also, accordingly, removes the single-substitution adjustment and the feature-level type match check. 

I'm a little uneasy about this change because the spec is arguably too permissive here, and it's very likely different implementations will do different things. For example, some may treat a run of 10 multiple substitutions with one single substitution in the middle as a single lookup, while others might break that into three lists. It might therefore be better to force a user to implement their intention rather than just dividing up the list, either with sub-lookups or using the `subtable` keyword. So maybe there should be a flag or preference to influence the behavior. 

This doesn't have that, and simply tries to match the spec as stated. As a result, opening the UFO of the font referenced in the link above now yields the same `frac` subtables as converting it with `ufo2ft` and opening the resulting OpenType font (as far as I can tell). Further verification is warranted. 

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
Go over all the following points and check all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help! Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area. See the list [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#people-to-ask).
- [x] My code follows the code style of this project found [here](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md#coding-style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.
