### PR TITLE
 Save quadratic spline in quadratic layer 

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -669,12 +669,15 @@ static void SFDDumpHintMask(FILE *sfd,HintMask *hintmask) {
     }
 }
 
-static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int order2) {
+static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int want_order2) {
     SplinePoint *first, *sp;
+    int order2 = spl->first->next==NULL || spl->first->next->order2;
+    int reduce = (want_order2 && !order2);
+    if (order2 && !want_order2) IError("Asked for cubic when had quadratic");
     SplineSet *nspl;
 
     for ( ; spl!=NULL; spl=spl->next ) {
-	if (order2) {
+	if (reduce) {
 	    nspl = SSttfApprox(spl);
 	} else {
 	    nspl = spl;
@@ -769,7 +772,7 @@ static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int order2) {
 	if ( spl->start_offset ) {
 	    fprintf( sfd, "  PathStart: %d\n", spl->start_offset );
 	}
-    if (order2) free(nspl);
+    if (reduce) SplinePointListFree(nspl);
     }
     fprintf( sfd, "EndSplineSet\n" );
 }

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -668,9 +668,8 @@ static void SFDDumpHintMask(FILE *sfd,HintMask *hintmask) {
     }
 }
 
-static void SFDDumpSplineSet(FILE *sfd,SplineSet *spl) {
+static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int order2) {
     SplinePoint *first, *sp;
-    int order2 = spl->first->next==NULL || spl->first->next->order2;
 
     for ( ; spl!=NULL; spl=spl->next ) {
 	first = NULL;
@@ -937,7 +936,7 @@ void SFDDumpUndo(FILE *sfd,SplineChar *sc,Undoes *u, const char* keyPrefix, int 
             }
 	    if( u->u.state.splines ) {
                 fprintf(sfd, "SplineSet\n" );
-                SFDDumpSplineSet( sfd, u->u.state.splines );
+                SFDDumpSplineSet( sfd, u->u.state.splines, u->was_order2 );
             }
             break;
 
@@ -1637,7 +1636,7 @@ static void SFDDumpChar(FILE *sfd,SplineChar *sc,EncMap *map,int *newgids,int to
 	    SFDDumpImage(sfd,img);
 	if ( sc->layers[i].splines!=NULL ) {
 	    fprintf(sfd, "SplineSet\n" );
-	    SFDDumpSplineSet(sfd,sc->layers[i].splines);
+	    SFDDumpSplineSet(sfd,sc->layers[i].splines,sc->layers[i].order2);
 	}
 	SFDDumpRefs(sfd,sc->layers[i].refs,newgids);
 	SFDDumpGuidelines(sfd, sc->layers[i].guidelines);
@@ -2782,7 +2781,7 @@ static int SFD_Dump( FILE *sfd, SplineFont *sf, EncMap *map, EncMap *normal,
 	if ( sf->grid.order2 )
 	    fprintf(sfd, "GridOrder2: %d\n", sf->grid.order2 );
 	fprintf(sfd, "Grid\n" );
-	SFDDumpSplineSet(sfd,sf->grid.splines);
+	SFDDumpSplineSet(sfd,sf->grid.splines,false);
     }
     if ( sf->texdata.type!=tex_unset ) {
 	fprintf(sfd, "TeXData: %d %d", (int) sf->texdata.type, (int) ((sf->design_size<<19)+2)/5 );

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -679,6 +679,7 @@ static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int want_order2) {
     for ( ; spl!=NULL; spl=spl->next ) {
 	if (reduce) {
 	    nspl = SSttfApprox(spl);
+	    order2 = true;
 	} else {
 	    nspl = spl;
 	}

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -769,8 +769,8 @@ static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int order2) {
 	if ( spl->start_offset ) {
 	    fprintf( sfd, "  PathStart: %d\n", spl->start_offset );
 	}
-    }
     if (order2) free(nspl);
+    }
     fprintf( sfd, "EndSplineSet\n" );
 }
 

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -2789,7 +2789,7 @@ static int SFD_Dump( FILE *sfd, SplineFont *sf, EncMap *map, EncMap *normal,
 	if ( sf->grid.order2 )
 	    fprintf(sfd, "GridOrder2: %d\n", sf->grid.order2 );
 	fprintf(sfd, "Grid\n" );
-	SFDDumpSplineSet(sfd,sf->grid.splines,false);
+	SFDDumpSplineSet(sfd,sf->grid.splines,sf->grid.order2);
     }
     if ( sf->texdata.type!=tex_unset ) {
 	fprintf(sfd, "TeXData: %d %d", (int) sf->texdata.type, (int) ((sf->design_size<<19)+2)/5 );

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -41,6 +41,7 @@
 #include "psread.h"
 #include "splinefont.h"
 #include "splinefill.h"
+#include "splineorder2.h"
 #include "splinesaveafm.h"
 #include "splineutil.h"
 #include "splineutil2.h"
@@ -670,10 +671,16 @@ static void SFDDumpHintMask(FILE *sfd,HintMask *hintmask) {
 
 static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int order2) {
     SplinePoint *first, *sp;
+    SplineSet *nspl;
 
     for ( ; spl!=NULL; spl=spl->next ) {
+	if (order2) {
+	    nspl = SSttfApprox(spl);
+	} else {
+	    nspl = spl;
+	}
 	first = NULL;
-	for ( sp = spl->first; ; sp=sp->next->to ) {
+	for ( sp = nspl->first; ; sp=sp->next->to ) {
 #ifndef FONTFORGE_CONFIG_USE_DOUBLE
 	    if ( first==NULL )
 		fprintf( sfd, "%g %g m ", (double) sp->me.x, (double) sp->me.y );
@@ -763,6 +770,7 @@ static void SFDDumpSplineSet(FILE *sfd, SplineSet *spl, int order2) {
 	    fprintf( sfd, "  PathStart: %d\n", spl->start_offset );
 	}
     }
+    if (order2) free(nspl);
     fprintf( sfd, "EndSplineSet\n" );
 }
 


### PR DESCRIPTION
This closes #3670.
This closes #3667.
\#3668 remains outstanding for now.

This patch makes sure that quadratic splines are saved in quadratic
layers, and that the splines associated with a Spiro are quadratic if
the layer is quadratic.

This patch works when the file is saved, so old files will remain broken
until saved over. Doing it this way side steps the performance issues
@skef brought up in #3670, but it also doesn't fi​x #3668—I'll have to do
that another time.

- [x] Bug fix (non-breaking change which fixes an issue)