### PR TITLE
Fix moving Spiros between layers

### DIFF
--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -3021,7 +3021,7 @@ return;
 	}
 	if ( paster->u.state.splines!=NULL ) {
 	    SplinePointList *spl, *new = SplinePointListCopy(paster->u.state.splines);
-	    if ( paster->was_order2 != cv->layerheads[cv->drawmode]->order2 )
+	    if ( paster->was_order2 != cv->layerheads[cv->drawmode]->order2 && paster->u.state.splines->spiro_cnt <= 0 )
 		new = SplineSetsConvertOrder(new,cv->layerheads[cv->drawmode]->order2 );
 	    SplinePointListSelect(new,true);
 	    for ( spl = new; spl->next!=NULL; spl = spl->next );

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -1049,9 +1049,12 @@ void SCConvertLayerToOrder2(SplineChar *sc,int layer) {
     if ( sc==NULL )
 return;
 
-    new = SplineSetsTTFApprox(sc->layers[layer].splines);
-    SplinePointListsFree(sc->layers[layer].splines);
-    sc->layers[layer].splines = new;
+    if ( sc->layers[layer].splines != NULL && 
+         sc->layers[layer].splines->spiro_cnt <= 0 ) {
+        new = SplineSetsTTFApprox(sc->layers[layer].splines);
+        SplinePointListsFree(sc->layers[layer].splines);
+        sc->layers[layer].splines = new;
+    }
 
     UndoesFree(sc->layers[layer].undoes);
     UndoesFree(sc->layers[layer].redoes);
@@ -1144,9 +1147,12 @@ void SCConvertLayerToOrder3(SplineChar *sc,int layer) {
     AnchorPoint *ap;
     int has_order2_layer_still, i;
 
-    new = SplineSetsPSApprox(sc->layers[layer].splines);
-    SplinePointListsFree(sc->layers[layer].splines);
-    sc->layers[layer].splines = new;
+    if ( sc->layers[layer].splines != NULL && 
+         sc->layers[layer].splines->spiro_cnt <= 0 ) {
+        new = SplineSetsPSApprox(sc->layers[layer].splines);
+        SplinePointListsFree(sc->layers[layer].splines);
+        sc->layers[layer].splines = new;
+    }
 
     UndoesFree(sc->layers[layer].undoes);
     UndoesFree(sc->layers[layer].redoes);

--- a/fontforgeexe/cvshapes.c
+++ b/fontforgeexe/cvshapes.c
@@ -307,10 +307,12 @@ void CVMouseUpShape(CharView *cv) {
     if ( cv->active_shape==NULL )
 return;
 
-    if ( cv->b.layerheads[cv->b.drawmode]->order2 ) {
-	SplineSet *prev, *new, *ss;
+    SplineSet *ss = cv->b.layerheads[cv->b.drawmode]->splines;
+    if ( cv->b.layerheads[cv->b.drawmode]->order2 && 
+         ss != NULL && ss->spiro_cnt <= 0 ) {
+	SplineSet *prev, *new;
 	new = SplineSetsTTFApprox(cv->active_shape);
-	for ( ss=cv->b.layerheads[cv->b.drawmode]->splines, prev=NULL;
+	for ( prev=NULL;
 		ss!=NULL && ss!=cv->active_shape;
 		prev = ss, ss=ss->next );
 	if ( ss==NULL )


### PR DESCRIPTION
This closes #3668.

With this patch, Spiros can be cleanly copied between layers of
different types («Q»uadratic vs «C»ubic).

- [x] Bug fix (non-breaking change which fixes an issue)