### PR TITLE
Fix "Expand Stroke" crash w/simple "T" shape

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -716,7 +716,7 @@ return;		/* Essentially colinear */ /* Won't be perfect because control points l
 	    p->needs_point_left = p->needs_point_right = false;
 	    p->left_hidden = bends_left;
 	    p->right_hidden = !bends_left;
-	    if ( rot.x<=diff_angle.x || (diff_angle.x <= -1 && rot.x <= -0.999999) ) { /* close enough */
+	    if ( rot.x<=diff_angle.x || (diff_angle.x <= -0.999999 && rot.x <= -0.999999) ) { /* close enough */
 		p->right = done.right;
 		p->left = done.left;
 		p->needs_point_left = p->needs_point_right = true;


### PR DESCRIPTION
This closes #3684; @skef and I jointly figured this out. (But to be
honest, as usual, he outshines me 😁 )

For the test case, see #3684

- [x] Bug fix
- [x] No doc change needed

