### PR TITLE
tottf.c: AssignTTFBitGlyph: Don't clobber assignments made by AssignNotdefNull

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -1443,7 +1443,12 @@ static int AssignTTFBitGlyph(struct glyphinfo *gi,SplineFont *sf,EncMap *map,int
 	for ( j=0; bsizes[j]!=0 && ((bsizes[j]&0xffff)!=bdf->pixelsize || (bsizes[j]>>16)!=BDFDepth(bdf)); ++j );
 	if ( bsizes[j]==0 )
     continue;
-	for ( i=0; i<bdf->glyphcnt; ++i ) if ( !IsntBDFChar(bdf->glyphs[i]) )
+	/* 
+	 * All ttf_glyphs are -1, unless they have been set by
+	 * AssignNotdefNull. If already set by AssignNotdefNull, then
+	 * do not overwrite that.
+	 */
+	for ( i=0; i<bdf->glyphcnt; ++i ) if ( !IsntBDFChar(bdf->glyphs[i]) && sf->glyphs[i]->ttf_glyph==-1 )
 	    sf->glyphs[i]->ttf_glyph = -2;
     }
 


### PR DESCRIPTION
Fixes #3692

For reference, there's a similar check in `AssignTTFGlyph` (the non-bitmap path equivalent).

When writing out the cmap, FF always adds .null, .notdef and .nonmarkingreturn, even if they're not explicitly defined. However, in this case, two out of the three *are* defined. `AssignNotdefNull` correctly sets `ttf_glyph`  and `bygid` based on this, but this gets clobbered right after, causing the gid assigned to be off by 2.