### PR TITLE
Make comb. chars always superior to spacing chars

### DIFF
--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -977,8 +977,8 @@ void SC_PSDump(void (*dumpchar)(int ch,void *data), void *data,
     int i, last, first;
     SplineSet *temp;
 
-    if ( sc==NULL ) return;
-
+    if ( sc==NULL )
+return;
     last = first = layer;
     if ( layer==ly_all )
 	first = last = ly_fore;
@@ -986,21 +986,7 @@ void SC_PSDump(void (*dumpchar)(int ch,void *data), void *data,
 	first = ly_fore;
 	last = sc->layer_cnt-1;
     }
-
     for ( i=first; i<=last; ++i ) {
-
-    // Before we do anything, convert references to glyphs between 0x300 and
-    // 0x345 to splines. This is because Type1 fonts don't support references
-    // to them—or at least didn't in 2001—this format is ancient and retained
-    // primarily for backwards compatibility.
-    if ( sc->layers[i].refs!=NULL ) {
-        for ( ref = sc->layers[i].refs; ref!=NULL; ref=ref->next ) {
-            if (ref->unicode_enc >= 0x300 || ref->unicode_enc <= 0x345) {
-                SCRefToSplines(sc, ref, i);
-            }
-        }
-    }
-
 	if ( sc->layers[i].splines!=NULL ) {
 	    temp = sc->layers[i].splines;
 	    if ( sc->layers[i].order2 ) temp = SplineSetsPSApprox(temp);

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -977,8 +977,8 @@ void SC_PSDump(void (*dumpchar)(int ch,void *data), void *data,
     int i, last, first;
     SplineSet *temp;
 
-    if ( sc==NULL )
-return;
+    if ( sc==NULL ) return;
+
     last = first = layer;
     if ( layer==ly_all )
 	first = last = ly_fore;
@@ -986,7 +986,21 @@ return;
 	first = ly_fore;
 	last = sc->layer_cnt-1;
     }
+
     for ( i=first; i<=last; ++i ) {
+
+    // Before we do anything, convert references to glyphs between 0x300 and
+    // 0x345 to splines. This is because Type1 fonts don't support references
+    // to them—or at least didn't in 2001—this format is ancient and retained
+    // primarily for backwards compatibility.
+    if ( sc->layers[i].refs!=NULL ) {
+        for ( ref = sc->layers[i].refs; ref!=NULL; ref=ref->next ) {
+            if (ref->unicode_enc >= 0x300 || ref->unicode_enc <= 0x345) {
+                SCRefToSplines(sc, ref, i);
+            }
+        }
+    }
+
 	if ( sc->layers[i].splines!=NULL ) {
 	    temp = sc->layers[i].splines;
 	    if ( sc->layers[i].order2 ) temp = SplineSetsPSApprox(temp);

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -50,20 +50,17 @@ int CharCenterHighest = 1;
 #define BottomAccent	0x300
 #define TopAccent	0x345
 
-/* for accents between 0x300 and 345 these are some synonyms */
-/* type1 wants accented chars built with accents in the 0x2c? range */
-/*  except for grave and acute which live in iso8859-1 range */
 /*  this table is ordered on a best try basis */
 static const unichar_t accents[][4] = {
-    { 0x2cb, 0x300, 0x60 },	/* grave */
-    { 0x2ca, 0x301, 0xb4 },	/* acute */
-    { 0x2c6, 0x302, 0x5e },	/* circumflex */
-    { 0x2dc, 0x303, 0x7e },	/* tilde */
-    { 0x2c9, 0x304, 0xaf },	/* macron */
+    { 0x300, 0x2cb, 0x60 },	/* grave */
+    { 0x301, 0x2ca, 0xb4 },	/* acute */
+    { 0x302, 0x2c6, 0x5e },	/* circumflex */
+    { 0x303, 0x2dc, 0x7e },	/* tilde */
+    { 0x304, 0x2c9, 0xaf },	/* macron */
     { 0x305, 0xaf },		/* overline, (macron is suggested as a syn, but it's not quite right) */
-    { 0x2d8, 0x306 },		/* breve */
-    { 0x2d9, 0x307, '.' },	/* dot above */
-    { 0xa8,  0x308 },		/* diaeresis */
+    { 0x306, 0x2d8 },		/* breve */
+    { 0x307, 0x2d9, '.' },	/* dot above */
+    { 0x308, 0xa8 },		/* diaeresis */
     { 0x2c0 },			/* hook above */
     { 0x2da, 0xb0 },		/* ring above */
     { 0x2dd },			/* real acute */
@@ -74,9 +71,9 @@ static const unichar_t accents[][4] = {
     { 0 },			/* cand... */		/* 310 */
     { 0 },			/* inverted breve */
     { 0x2bb },			/* turned comma */
-    { 0x2bc, 0x313, ',' },	/* comma above */
+    { 0x313, 0x2bc, ',' },	/* comma above */
     { 0x2bd },			/* reversed comma */
-    { 0x2bc, 0x315, ',' },	/* comma above right */
+    { 0x315, 0x2bc, ',' },	/* comma above right */
     { 0x316, 0x60, 0x2cb },	/* grave below */
     { 0x317, 0xb4, 0x2ca },	/* acute below */
     { 0 },			/* left tack */
@@ -86,8 +83,8 @@ static const unichar_t accents[][4] = {
     { 0 },			/* half ring */
     { 0x2d4 },			/* up tack */
     { 0x2d5 },			/* down tack */
-    { 0x2d6, 0x31f, '+' },	/* plus below */
-    { 0x2d7, 0x320, '-' },	/* minus below */	/* 320 */
+    { 0x31f, 0x2d6, '+' },	/* plus below */
+    { 0x320, 0x2d7, '-' },	/* minus below */	/* 320 */
     { 0x2b2 },			/* hook */
     { 0 },			/* back hook */
     { 0x323, 0x2d9, '.' },	/* dot below */

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -61,67 +61,67 @@ static const unichar_t accents[][4] = {
     { 0x306, 0x2d8 },		/* breve */
     { 0x307, 0x2d9, '.' },	/* dot above */
     { 0x308, 0xa8 },		/* diaeresis */
-    { 0x2c0 },			/* hook above */
-    { 0x2da, 0xb0 },		/* ring above */
-    { 0x2dd },			/* real acute */
-    { 0x2c7 },			/* caron */
-    { 0x2c8, 0x384, 0x30d, '\''  },	/* vertical line, tonos */
+    { 0x309, 0x2c0 },			/* hook above */
+    { 0x30a, 0x2da, 0xb0 },		/* ring above */
+    { 0x30b, 0x2dd },			/* real acute */
+    { 0x30c, 0x2c7 },			/* caron */
+    { 0x30d, 0x2c8, 0x384, '\'' },	/* vertical line, tonos */
     { 0x30e, '"' },		/* real vertical line */
-    { 0 },			/* real grave */
-    { 0 },			/* cand... */		/* 310 */
-    { 0 },			/* inverted breve */
-    { 0x2bb },			/* turned comma */
+    { 0x30f },			/* real grave */
+    { 0x310 },			/* cand... */		/* 310 */
+    { 0x311 },			/* inverted breve */
+    { 0x312 },			/* turned comma */
     { 0x313, 0x2bc, ',' },	/* comma above */
-    { 0x2bd },			/* reversed comma */
+    { 0x314, 0x2bd },			/* reversed comma */
     { 0x315, 0x2bc, ',' },	/* comma above right */
     { 0x316, 0x60, 0x2cb },	/* grave below */
     { 0x317, 0xb4, 0x2ca },	/* acute below */
-    { 0 },			/* left tack */
-    { 0 },			/* right tack */
-    { 0 },			/* left angle */
-    { 0 },			/* horn, sometimes comma but only if nothing better */
-    { 0 },			/* half ring */
-    { 0x2d4 },			/* up tack */
-    { 0x2d5 },			/* down tack */
+    { 0x318 },			/* left tack */
+    { 0x319 },			/* right tack */
+    { 0x31a },			/* left angle */
+    { 0x31b },			/* horn, sometimes comma but only if nothing better */
+    { 0x31c },			/* half ring */
+    { 0x31d, 0x2d4 },			/* up tack */
+    { 0x31e, 0x2d5 },			/* down tack */
     { 0x31f, 0x2d6, '+' },	/* plus below */
     { 0x320, 0x2d7, '-' },	/* minus below */	/* 320 */
-    { 0x2b2 },			/* hook */
-    { 0 },			/* back hook */
+    { 0x321, 0x2b2 },			/* hook */
+    { 0x322 },			/* back hook */
     { 0x323, 0x2d9, '.' },	/* dot below */
     { 0x324, 0xa8 },		/* diaeresis below */
     { 0x325, 0x2da, 0xb0 },	/* ring below */
     { 0x326, 0x2bc, ',' },	/* comma below */
-    { 0xb8 },			/* cedilla */
-    { 0x2db },			/* ogonek */		/* 0x328 */
+    { 0x327, 0xb8 },			/* cedilla */
+    { 0x328, 0x2db },			/* ogonek */		/* 0x328 */
     { 0x329, 0x2c8, 0x384, '\''  },	/* vertical line below */
-    { 0 },			/* bridge below */
-    { 0 },			/* real arch below */
+    { 0x32a },			/* bridge below */
+    { 0x32b },			/* real arch below */
     { 0x32c, 0x2c7 },		/* caron below */
     { 0x32d, 0x2c6, 0x52 },	/* circumflex below */
     { 0x32e, 0x2d8 },		/* breve below */
-    { 0 },			/* inverted breve below */
+    { 0x32f },			/* inverted breve below */
     { 0x330, 0x2dc, 0x7e },	/* tilde below */	/* 0x330 */
     { 0x331, 0xaf, 0x2c9 },	/* macron below */
     { 0x332, '_' },		/* low line */
-    { 0 },			/* real low line */
+    { 0x333 },			/* real low line */
     { 0x334, 0x2dc, 0x7e },	/* tilde overstrike */
     { 0x335, '-' },		/* line overstrike */
     { 0x336, '_' },		/* long line overstrike */
     { 0x337, '/' },		/* short solidus overstrike */
     { 0x338, '/' },		/* long solidus overstrike */	/* 0x338 */
-    { 0 },
-    { 0 },
-    { 0 },
-    { 0 },
-    { 0 },
-    { 0 },
-    { 0 },
+    { 0x339 },
+    { 0x33a },
+    { 0x33b },
+    { 0x33c },
+    { 0x33d },
+    { 0x33e },
+    { 0x33f },
     { 0x340, 0x60, 0x2cb },	/* tone mark, left of circumflex */ /* 0x340 */
     { 0x341, 0xb4, 0x2ca },	/* tone mark, right of circumflex */
     { 0x342, 0x2dc, 0x7e },	/* perispomeni (tilde) */
     { 0x343, 0x2bc, ',' },	/* koronis */
-    { 0 },			/* dialytika tonos (two accents) */
-    { 0x37a },			/* ypogegrammeni */
+    { 0x344 },			/* dialytika tonos (two accents) */
+    { 0x345, 0x37a },			/* ypogegrammeni */
     { 0xffff }
 };
 


### PR DESCRIPTION
Combining characters are superior in some cases to spacing characters
but not others. For example, combining macron (U+304) is superior to
macron (U+AF), yet combining dieresis (U+308) is inferior to dieresis
(U+A8).

This situation is untenable. It makes it impossible, while designing a
font, to know which character will be used when FontForge builds an
accented glyph without digging through the source code. Furthermore, the
logical case, to use the combining character first, is rarely done.

Apparently this is due to some restriction of Type1 fonts according to
George in 2001. I fixed his reported restriction in this same commit by
just dissolving the reference if the character referred to is between
0x300 and 0x345.

Some, such as @frank-trampe, might say that dissolving the reference
“breaks” something. But nothing is broken. No function of a Type 1 font
changes if a reference is used or not. Type 1 fonts never were a first
class format for storing font data—and certainly haven't become one—
that's what SFD is for. The only discernible difference therefore is a
small increase in filesize.

I confirmed:
* generated PFA (PostScript type 1) fonts still work; FontForge shows
the dissolved references as expected when a problem character is
referred to.
* if you want to use `dieresis` you can tell FontForge to in “Glyph Info
→ Components” and it will work.
* that this closes #3708, the issue is solved.

I encourage my fellow members to support this change. As an author of
five and counting open source fonts made only using FontForge and
FontTools, I can unequivocally say that sacrificing the file size of a
subset of Type 1 fonts is worth the benefit this change provides.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md) guidelines.