### PR TITLE
scripting changes on passing arrays by reference

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -9661,8 +9661,8 @@ docall_expectint:   ScriptError(&sub,"Expected integer argument");
 		}
 		if ( sub.script==NULL )
 		    *pt = '\0';
+		sub.script = fopen(sub.filename,"rb");
 	    }
-	    sub.script = fopen(sub.filename,"rb");
 	    if ( sub.script==NULL ) {
 		ScriptErrorString(c, "No built-in function or script file", name);
 	    } else {

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -10776,11 +10776,16 @@ _Noreturn void ProcessNativeScript(int argc, char *argv[], FILE *script) {
 			ff_backuptok(&c);
 			ff_statement(&c);
 		}
-		if ((c.script != stdin) && (c.script != script) && (c.script !=NULL)) fclose(c.script);
+		// calldatafree will close c.script; don't do that in these cases
+		if (c.script == stdin || c.script == script) c.script = NULL;
     }
-	// Free previously copied arguments.
-    for ( i=0; i<c.a.argc; ++i )
-		free(c.a.vals[i].u.sval);
+
+    calldatafree(&c);
+    // calldatafree doesn't free the first arg
+    if (c.a.vals[0].type == v_str)
+	free(c.a.vals[0].u.sval);
+    else if (c.a.vals[0].type == v_arr || c.a.vals[0].type == v_arrfree)
+	arrayfree(c.a.vals[0].u.aval);
     free(c.a.vals);
     free(c.dontfree);
     exit(0);

--- a/fontforge/scripting.h
+++ b/fontforge/scripting.h
@@ -112,6 +112,7 @@ typedef struct context {
     jmp_buf *err_env;			/* place to longjump to on an error */
 } Context;
 
+Array* arraynew(int sz);
 void arrayfree(Array *);
 
 void FontImage(SplineFont *sf,char *filename,Array *arr,int width,int height);

--- a/fontforge/scripting.h
+++ b/fontforge/scripting.h
@@ -88,7 +88,6 @@ enum ce_type { /* (found->func)(&sub) context err codes */
 typedef struct context {
     struct context *caller;		/* The context of the script that called us */
     Array a;				/* The argument array */
-    Array **dontfree;			/* Irrelevant for user defined funcs */
     struct dictionary locals;		/* Irrelevant for user defined funcs */
     FILE *script;			/* Irrelevant for user defined funcs */
     unsigned int backedup: 1;		/* Irrelevant for user defined funcs */

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -1162,9 +1162,7 @@ static Array *SFDefaultScriptsLines(Array *arr,SplineFont *sf) {
 	  }
       }
 
-      ret = calloc(1,sizeof(Array));
-      ret->argc = 2*lcnt;
-      ret->vals = calloc(2*lcnt,sizeof(Val));
+      ret = arraynew(2 * lcnt);
       for ( i=0; i<lcnt; ++i ) {
 	  ret->vals[2*i+0].type = v_int;
 	  ret->vals[2*i+0].u.ival = pixelsize;

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -127,19 +127,22 @@ typedef struct ibounds {
 
 
 enum val_type { v_int, v_real, v_str, v_unicode, v_lval, v_arr, v_arrfree,
-		v_int32pt, v_int16pt, v_int8pt, v_void };
+		v_void };
+
+enum val_flags {
+    vf_none = 0,
+    vf_dontfree = (1 << 1)
+};
 
 typedef struct val {
     enum val_type type;
+    enum val_flags flags;
     union {
 	int ival;
 	real fval;
 	char *sval;
 	struct val *lval;
 	struct array *aval;
-	uint32 *u32ptval;
-	uint16 *u16ptval;
-	uint8  *u8ptval;
     } u;
 } Val;		/* Used by scripting */
 

--- a/fontforgeexe/scriptingdlg.c
+++ b/fontforgeexe/scriptingdlg.c
@@ -82,16 +82,13 @@ static void ExecNative(GGadget *g, GEvent *e) {
     struct sd_data *sd = GDrawGetUserData(GGadgetGetWindow(g));
     Context c;
     Val args[1];
-    Array *dontfree[1];
     jmp_buf env;
 
     memset( &c,0,sizeof(c));
     memset( args,0,sizeof(args));
-    memset( dontfree,0,sizeof(dontfree));
     running_script = true;
     c.a.argc = 1;
     c.a.vals = args;
-    c.dontfree = dontfree;
     c.filename = args[0].u.sval = "ScriptDlg";
     args[0].type = v_str;
     c.return_val.type = v_void;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -169,7 +169,8 @@ EXTRA_DIST += helper107.pe helper118A.pe helper118B.pe		\
 	test122.pe test123.pe test124.pe test125.pe		\
 	test126.pe test127.pe test128.pe test129.pe		\
 	test130.pe test131.pe test132.pe test133.pe		\
-	test134.pe test135.pe test136.pe test137.pe
+	test134.pe test135.pe test136.pe test137.pe		\
+	test138.pe helper138.pe
 
 # python test scripts
 EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\

--- a/tests/helper138.pe
+++ b/tests/helper138.pe
@@ -1,0 +1,25 @@
+# Inputs to functions are passed by reference
+Print("input:", $1)
+
+copy2 = $1
+
+$1[0] = 10
+$1[1] = 11
+$1[2][0] = "reference"
+$1[2][1] = "passed"
+Print("updated:", $1)
+
+if ($1[0] != 10)
+    Error("Bad array value helper 1")
+elseif ($1[1] != 11)
+    Error("Bad array value helper 2")
+elseif ($1[2][0] != "reference")
+    Error("Bad array value helper 3")
+elseif ($1[2][1] != "passed")
+    Error("Bad array value helper 4")
+endif
+
+$1 = "abcdef"
+Print("assigned:", $1)
+
+Print("copy2:", copy2)

--- a/tests/test138.pe
+++ b/tests/test138.pe
@@ -1,0 +1,50 @@
+# Test some basic properties of arrays
+
+arr = Array(3)
+arr[0] = 1
+arr[1] = "abc"
+arr[2] = Array(2)
+arr[2][0] = 2
+arr[2][1] = 2.5
+
+# on assignment, arrays are passed by value
+copy = arr
+copy[0] = "def"
+copy[1] = 3
+copy[2][0] = 4
+copy[2][1] = 5
+
+if (arr[0] != 1)
+    Error("Bad array value 1")
+elseif (arr[1] != "abc")
+    Error("Bad array value 2")
+elseif (arr[2][0] != 2)
+    Error("Bad array value 3")
+elseif (arr[2][1] != 2.5)
+    Error("Bad array value 4")
+endif
+
+if (copy[0] != "def")
+    Error("Bad array value 5")
+elseif (copy[1] != 3)
+    Error("Bad array value 6")
+elseif (copy[2][0] != 4)
+    Error("Bad array value 7")
+elseif (copy[2][1] != 5)
+    Error("Bad array value 8")
+endif
+
+Print("calling helper")
+helper138.pe(arr)
+Print("returned")
+
+if (arr[0] != 10)
+    Error("Bad array value 9")
+elseif (arr[1] != 11)
+    Error("Bad array value 10")
+elseif (arr[2][0] != "reference")
+    Error("Bad array value 11")
+elseif (arr[2][1] != "passed")
+    Error("Bad array value 12")
+endif
+

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -126,6 +126,7 @@ check_pedit([Short-hand contextual multiple substitution],[test134.pe],[test134.
 check_pedit([GDEF glyph classes],[test135.pe],[test135.fea])
 check_pedit([Re-using mark filtering set],[test136.pe],[test136.fea])
 check_pedit([file:// protocol],[test137.pe],[Ambrosia.sfd])
+check_pedit([Array sanity checking], [test138.pe])
 
 AT_BANNER([FontForge Python Scripting Tests])
 


### PR DESCRIPTION
It's probably easiest to review this commit by commit.

I was contemplating a few approaches to fixing the issue mentioned in #3566, but they were just too involved to get right. The `arraynew` method I added isn't strictly required; it was a leftover from another approach, but I left it in because it reduced the amount of code that was floating around to initialise arrays.

I've opted for just adding a flag to the `Val` struct to replace the `dontfree` array. It serves a similar purpose, but means that dodgy pointer arithmetic isn't required.

The `v_arrfree` type could also probably be removed (so there's just one array type, `v_arr`) by adding a similar flag for it, but it's just too much effort to match the same semantics, so I'm leaving that alone for now.

As a side note, this has zero memory overhead on 64-bit operating systems, because the flag now occupies what was previously padding in the struct. I could have made it zero overhead for 32-bit too by making the type and flag 2 byte values, but ¯\\_(ツ)_/¯