### PR TITLE
Fix metrics view update bug

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -1548,6 +1548,7 @@ return( true );
 	    GDrawBeep(NULL);
 	else {
 	    MV_ChangeKerning(mv,which,val, false);
+	    MVRemetric(mv);
 	}
     } else if ( e->u.control.subtype == et_textfocuschanged &&
 	    e->u.control.u.tf_focus.gained_focus ) {


### PR DESCRIPTION
This closes #3720.

This copies the MVRemetric function, already used in MVTextChanged, to
MV_KernChanged. I tested it with my Chomsky font and it works as
expected, no more having to change the text to see the new kern.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**