### PR TITLE
Drop GDK 2 support and explcitly specify the backends supported

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1098,6 +1098,7 @@ int fontforge_main( int argc, char **argv ) {
 			                /*  and we will never return from the above */
 #ifdef FONTFORGE_CAN_USE_GDK
     gdk_init(&argc, &argv);
+    gdk_set_allowed_backends("win32,quartz,x11");
 #endif
     if ( load_prefs==NULL ||
 	    (strcasecmp(load_prefs,"Always")!=0 &&	/* Already loaded */

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -280,11 +280,7 @@ static void SplashLayout() {
     uc_strcat(pt,"-D");
 #endif
 #ifdef FONTFORGE_CAN_USE_GDK
-#  if GDK_MAJOR_VERSION >= 3
-    uc_strcat(pt,"-GDK3");
-#  else
-    uc_strcat(pt,"-GDK2");
-#  endif
+    uc_strcat(pt, "-GDK3");
 #else
     uc_strcat(pt,"-X11");
 #endif
@@ -945,10 +941,7 @@ int fontforge_main( int argc, char **argv ) {
 #ifdef FONTFORGE_CONFIG_USE_DOUBLE
 	        "-D"
 #endif
-#ifdef BUILT_WITH_GDK2
-            "-GDK2"
-#endif
-#ifdef BUILT_WITH_GDK3
+#ifdef FONTFORGE_CAN_USE_GDK
             "-GDK3"
 #endif
 #ifdef BUILT_WITH_XORG

--- a/gdraw/ggdkdrawP.h
+++ b/gdraw/ggdkdrawP.h
@@ -45,10 +45,6 @@
 #    define GGDKDRAW_GDK_3_20
 #endif
 
-#if !defined(GDK_MAJOR_VERSION) || (GDK_MAJOR_VERSION <= 2)
-#    define GGDKDRAW_GDK_2
-#endif
-
 #define GGDKDRAW_ADDREF(x) do { \
     assert((x)->reference_count >= 0); \
     (x)->reference_count++; \

--- a/gdraw/ggdkdrawlogger.c
+++ b/gdraw/ggdkdrawlogger.c
@@ -225,7 +225,6 @@ const char *GdkEventName(int code) {
         case GDK_DAMAGE:
             return "GDK_DAMAGE";
             break;
-#ifndef GGDKDRAW_GDK_2
         case GDK_TOUCH_BEGIN:
             return "GDK_TOUCH_BEGIN";
             break;
@@ -238,7 +237,6 @@ const char *GdkEventName(int code) {
         case GDK_TOUCH_CANCEL:
             return "GDK_TOUCH_CANCEL";
             break;
-#endif
 #ifdef GGDKDRAW_GDK_3_20
         case GDK_TOUCHPAD_SWIPE:
             return "GDK_TOUCHPAD_SWIPE";

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -199,29 +199,18 @@ fi
 dnl FONTFORGE_ARG_ENABLE_GDK
 dnl ------------------------
 dnl The default action  is to check for Xwindows and use it if available,
-dnl but this can be overridden by using --enable-gdk to use gdk2 or gdk3.
-dnl If no option {gdk2/gdk3} is specified, then the default is to try use
-dnl gdk3. If no gdk development module is found then come to a hard stop.
+dnl but this can be overridden by using --enable-gdk.
+dnl If no gdk development module is found then come to a hard stop.
 AC_DEFUN([FONTFORGE_ARG_ENABLE_GDK],
 [
 fontforge_gdk_version=no
 fontforge_can_use_gdk=no
 AC_ARG_ENABLE([gdk],
-        [AS_HELP_STRING([--enable-gdk=TYPE],
-                [Enable the GDK GUI backend. TYPE is either gdk2 or gdk3.])],
+        [AS_HELP_STRING([--enable-gdk=yes/no],
+                [Enable the GDK GUI backend. GDK 3.10 or higher is required.])],
         [],
         [enable_gdk=no])
-if test "x$enable_gdk" = "xgdk2"; then
-    PKG_CHECK_MODULES([GDK], [gdk-2.0 >= 2.10],
-    [
-        fontforge_gdk_version=GDK2
-        AC_DEFINE(FONTFORGE_CAN_USE_GDK,[],[FontForge will build the GUI with the GDK2 backend])
-        AC_MSG_NOTICE([building the GUI with the GDK2 backend...])
-    ],
-    [
-        AC_MSG_ERROR([Cannot build GDK backend without GDK installed. Please install the GTK+ Developer Package.])
-    ])
-elif ! test "x$enable_gdk" = "xno"; then
+if ! test "x$enable_gdk" = "xno"; then
     PKG_CHECK_MODULES([GDK],[gdk-3.0 >= 3.10],
     [
         fontforge_can_use_gdk=yes


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->
Dropping GDK2 as otherwise there's too many possibilities for how this can be built; I don't want to support that.

I've also added a call to `gdk_set_allowed_backends` to explicitly prevent wayland from being used, since it's not supported.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Breaking change**
