### PR TITLE
Always write a layercontents.plist when outputting UFO

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -2112,7 +2112,8 @@ int WriteUFOFontFlex(const char *basedir, SplineFont *sf, enum fontformat ff, in
       free(glyphdir); glyphdir = NULL;
     }
     char *fname = buildname(basedir, "layercontents.plist"); // Build the file name for the contents.
-    xmlSaveFormatFileEnc(fname, plistdoc, "UTF-8", 1); // Store the document.
+    if (version >= 3)
+      xmlSaveFormatFileEnc(fname, plistdoc, "UTF-8", 1); // Store the document.
     free(fname); fname = NULL;
     xmlFreeDoc(plistdoc); // Free the memory.
     xmlCleanupParser();


### PR DESCRIPTION
According to http://unifiedfontobject.org/versions/ufo3/layercontents.plist/ the `layercontents.plist` file is mandatory. This change just removes the `if (all_layers)` branch and changes the `for` loop over layers from 

```for (layer_pos = 0; layer_pos < sf->layer_cnt; layer_pos++) {```

to 

```for (layer_pos = (all_layers ? 0 : ly_fore); layer_pos < (all_layers ? sf->layer_cnt : ly_fore+1); layer_pos++) {```

I've tested with a single-layer font (the usual case) and the resulting output looks about right. @frank-trampe feel free to edit the branch as you see fit. 

Closes #3726 

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

