### PR TITLE
Don’t generate MATH after deleting math data

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -7669,7 +7669,7 @@ return( 0 );
 }
 
 static PyObject *PyFF_Glyph_get_horizontalComponents(PyFF_Glyph *self, void *UNUSED(closure)) {
-    if ( self->sc->horiz_variants==0 || self->sc->horiz_variants->part_cnt==0 )
+    if ( self->sc->horiz_variants==NULL || self->sc->horiz_variants->part_cnt==0 )
 Py_RETURN_NONE;
 
 return( BuildComponentTuple(self->sc->horiz_variants ));
@@ -7697,7 +7697,7 @@ return( 0 );
 }
 
 static PyObject *PyFF_Glyph_get_verticalComponents(PyFF_Glyph *self, void *UNUSED(closure)) {
-    if ( self->sc->vert_variants==0 || self->sc->vert_variants->part_cnt==0 )
+    if ( self->sc->vert_variants==NULL || self->sc->vert_variants->part_cnt==0 )
 Py_RETURN_NONE;
 
 return( BuildComponentTuple(self->sc->vert_variants ));

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -3603,6 +3603,14 @@ enum math_bits { mb_constants=0x01, mb_italic=0x02, mb_topaccent=0x04,
 	mb_gi=(mb_italic|mb_topaccent|mb_extended|mb_mathkern),
 	mb_gv=(mb_vertvariant|mb_horizvariant) };
 
+static int HasVariants(struct glyphvariants *gv) {
+    if ( gv!=NULL && (gv->variants!=NULL || gv->parts!=NULL ||
+	    gv->italic_correction!=0) )
+return( true );
+
+return( false );
+}
+
 static int MathBits(struct alltabs *at, SplineFont *sf) {
     int i, gid, ret;
     SplineChar *sc;
@@ -3619,9 +3627,9 @@ static int MathBits(struct alltabs *at, SplineFont *sf) {
 		ret |= mb_extended;
 	    if ( sc->mathkern!=NULL )
 		ret |= mb_mathkern;
-	    if ( sc->vert_variants!=NULL )
+	    if ( HasVariants(sc->vert_variants) )
 		ret |= mb_vertvariant;
-	    if ( sc->horiz_variants!=NULL )
+	    if ( HasVariants(sc->horiz_variants) )
 		ret |= mb_horizvariant;
 	    if ( ret==mb_all )
 return( mb_all );

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -3955,9 +3955,9 @@ static void ttf_math_dump_glyphvariant(FILE *mathf,struct alltabs *at, SplineFon
     /* Figure out our glyph list (and count) */
     for ( i=vlen=hlen=0; i<at->gi.gcnt; ++i )
 	if ( (gid=at->gi.bygid[i])!=-1 && (sc=sf->glyphs[gid])!=NULL ) {
-	    if ( sc->vert_variants!=NULL )
+	    if ( HasVariants(sc->vert_variants) )
 		++vlen;
-	    if ( sc->horiz_variants!=NULL )
+	    if ( HasVariants(sc->horiz_variants) )
 		++hlen;
 	}
 
@@ -3965,9 +3965,9 @@ static void ttf_math_dump_glyphvariant(FILE *mathf,struct alltabs *at, SplineFon
     hglyphs = malloc((hlen+1)*sizeof(SplineChar *));
     for ( i=vlen=hlen=0; i<at->gi.gcnt; ++i )
 	if ( (gid=at->gi.bygid[i])!=-1 && (sc=sf->glyphs[gid])!=NULL ) {
-	    if ( sc->vert_variants!=NULL )
+	    if ( HasVariants(sc->vert_variants) )
 		vglyphs[vlen++] = sc;
-	    if ( sc->horiz_variants!=NULL )
+	    if ( HasVariants(sc->horiz_variants) )
 		hglyphs[hlen++] = sc;
 	}
     vglyphs[vlen] = NULL;


### PR DESCRIPTION
After removing all `MATH` related data from Python, doing e.g.:

    font.math.clear()
    for glyph in font.glyphs():
        glyph.topaccent = 0x7fff
        glyph.italicCorrection = 0x7fff
        glyph.horizontalComponentItalicCorrection = 0x7fff
        glyph.verticalComponentItalicCorrection = 0x7fff
        glyph.isExtendedShape = False
        glyph.horizontalComponents = None
        glyph.horizontalVariants = None
        glyph.verticalComponents = None
        glyph.verticalVariants = None
        glyph.mathKern.bottomLeft = None
        glyph.mathKern.bottomRight = None
        glyph.mathKern.topLeft = None
        glyph.mathKern.topRight = None

FontForge would still generate a `MATH` table with empty glyph constructions. This seems to be caused by the checks in `MathBits()` that only checks if the constructions are `NULL`, but the Python code does not set them to `NULL` (as they might have other set members). Fix this by doing a deeper check for emptiness.

### Type of change
- **Bug fix**