### PR TITLE
Create only one undo when adjusting the lbearing

### DIFF
--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -39,7 +39,7 @@ enum widthtype { wt_width, wt_lbearing, wt_rbearing, wt_bearings, wt_vwidth };
 enum fvtrans_flags { fvt_alllayers=1, fvt_round_to_int=2,
 	fvt_dontsetwidth=4, fvt_dontmovewidth=8, fvt_scalekernclasses=0x10,
 	fvt_scalepstpos=0x20, fvt_dogrid=0x40, fvt_partialreftrans=0x80,
-	fvt_justapply=0x100, fvt_revert=0x200 };
+	fvt_justapply=0x100, fvt_revert=0x200, fvt_nopreserve=0x400 };
 
 typedef struct drect {
     real x, y;

--- a/fontforge/cvundoes.c
+++ b/fontforge/cvundoes.c
@@ -1120,6 +1120,9 @@ void _CVUndoCleanup(CharViewBase *cv,PressedOn *p) {
 void CVRemoveTopUndo(CharViewBase *cv) {
     Undoes * undo = cv->layerheads[cv->drawmode]->undoes;
 
+    if (undo == NULL)
+	return; // Shouldn't happen
+
     cv->layerheads[cv->drawmode]->undoes = undo->next;
     undo->next = NULL;
     UndoesFree(undo);

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -682,13 +682,15 @@ void FVTrans(FontViewBase *fv,SplineChar *sc,real transform[6], uint8 *sel,
 	    FVTrans(fv,mm->instances[j]->glyphs[sc->orig_pos],transform,sel,flags);
     }
 
-    if ( flags&fvt_alllayers ) {
-	for ( i=0; i<sc->layer_cnt; ++i )
-	    SCPreserveLayer(sc,i,fv->active_layer==i);
-    } else if ( fv->sf->multilayer )
-	SCPreserveState(sc,true);
-    else
-	SCPreserveLayer(sc,fv->active_layer,true);
+    if (!(flags & fvt_nopreserve)) {
+	if ( flags&fvt_alllayers ) {
+	    for ( i=0; i<sc->layer_cnt; ++i )
+		SCPreserveLayer(sc,i,fv->active_layer==i);
+	} else if ( fv->sf->multilayer )
+	    SCPreserveState(sc,true);
+	else
+	    SCPreserveLayer(sc,fv->active_layer,true);
+    }
     if ( !(flags&fvt_dontmovewidth) )
 	if ( transform[0]>0 && transform[3]>0 && transform[1]==0 && transform[2]==0 ) {
 	    int widthset = sc->widthset;

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -64,7 +64,6 @@
 
 #include <locale.h>
 #include <math.h>
-extern int _GScrollBar_Width;
 
 #ifdef HAVE_IEEEFP_H
 # include <ieeefp.h>		/* Solaris defines isnan in ieeefp rather than math.h */
@@ -79,6 +78,8 @@ extern int _GScrollBar_Width;
 extern void UndoesFreeButRetainFirstN( Undoes** undopp, int retainAmount );
 static void CVMoveInWordListByOffset( CharView* cv, int offset );
 extern void CVDebugFree( DebugView *dv );
+
+extern int _GScrollBar_Width;
 
 int additionalCharsToShowLimit = 50;
 
@@ -8460,16 +8461,12 @@ static void tablistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
 static void CVUndo(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
 
-    Undoes *undo = cv->b.layerheads[cv->b.drawmode]->undoes;
-
     CVDoUndo(&cv->b);
     cv->lastselpt = NULL;
 }
 
 static void CVRedo(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
     CharView *cv = (CharView *) GDrawGetUserData(gw);
-
-    Undoes *undo = cv->b.layerheads[cv->b.drawmode]->redoes;
 
     CVDoRedo(&cv->b);
     cv->lastselpt = NULL;

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -1201,12 +1201,20 @@ static void adjustLBearing( CharView *cv, SplineChar *sc, real val )
     SplineCharFindBounds(sc,&bb);
     if ( val != 0 )
     {
+	enum fvtrans_flags flags = fvt_alllayers | fvt_nopreserve;
 	real transform[6];
 	transform[0] = transform[3] = 1.0;
 	transform[1] = transform[2] = transform[5] = 0;
 	transform[4] = val;
+	// With no recent change, assume CVPreserveState was called.
+	// Remove it, as it doesn't preserve hints or other layers
+	// Instead, delegate to FVTrans to do this.
+	if (!cv->recentchange) {
+	    CVRemoveTopUndo(&cv->b);
+	    flags &= ~fvt_nopreserve;
+	}
 //	printf("adjustLBearing val:%f min:%f v-min:%f\n",val,bb.minx,(bb.minx+val));
-	FVTrans( (FontViewBase *) cv->b.fv, sc, transform, NULL, 0 | fvt_alllayers );
+	FVTrans( (FontViewBase *) cv->b.fv, sc, transform, NULL, flags );
 	// We copy and adapt some code from FVTrans in order to adjust the CharView carets.
 	// We omit the fvt_scalepstpos for FVTrans since other CharView code seems to skip updating the SplineChar.
 	PST *pst;


### PR DESCRIPTION
Adjusting the lbearing via dragging it is a little bit special, because we're reusing just calling into FVTrans, which sets up the undo state itself. 

When the mouse is dragged in the charview, CVMouseMovePointer already [preserves an undo state](https://github.com/fontforge/fontforge/blob/master/fontforgeexe/cvpointer.c#L1489-L1490), so ideally there's no need for the state preservation that FVTrans adds.

But when FVTrans is called, we make it adjust all the layers, and it also moves all the hints. CVMouseMovePointer  only preserves the active layer, and doesn't preserve the hint state.

So what I do is just remove the undo state added by CVMouseMovePointer, and get FVTrans to set up the state itself - but only once. Not the prettiest...

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

Related issues: #2648
