### PR TITLE
Fix exporting/applying kerning with RTL flag

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -509,9 +509,6 @@ return( NULL );
 		/* !!! Bug. Lose device tables here */
 		if ( isv )
 		    space->u.pair.vr[0].v_adv_off = kp->off;
-		else if ( otl->lookup_flags&pst_r2l )
-		    space->u.pair.vr[1].h_adv_off = kp->off;
-		else
 		    space->u.pair.vr[0].h_adv_off = kp->off;
 return( space );
 	    }
@@ -1466,13 +1463,6 @@ return;					/* No support for apple "lookups" */
 			            fprintf( out, " > " );
 			            dump_glyphname(out,kp->sc);
 			            fprintf( out, " < 0 0 0 0 >;\n" );
-				} else if ( otl->lookup_flags&pst_r2l ) {
-				    fprintf( out, " < 0 0 0 0 > " );
-			            dump_glyphname(out,kp->sc);
-				    fprintf( out," < 0 0 %d 0 <device NULL> <device NULL> ",
-					    kp->off );
-				    dumpdevice(out,kp->adjust);
-			            fprintf( out, " <device NULL>>;\n" );
 				} else {
 				    fprintf( out," < 0 0 %d 0 <device NULL> <device NULL> ",
 					    kp->off );
@@ -1482,15 +1472,9 @@ return;					/* No support for apple "lookups" */
 			            fprintf( out, " < 0 0 0 0 >;\n" );
 				}
 			    } else
-			    if ( otl->lookup_flags&pst_r2l ) {
-				fprintf( out, " < 0 0 0 0 > " );
-				dump_glyphname(out,kp->sc);
-				fprintf( out," < 0 0 %d 0 >;\n", kp->off );
-			    } else {
-				dump_glyphname(out,kp->sc);
-				putc(' ',out);
-			        fprintf( out, "%d;\n", kp->off );
-			    }
+			    dump_glyphname(out,kp->sc);
+			    putc(' ',out);
+			    fprintf( out, "%d;\n", kp->off );
 			}
 		    }		/* End isv/kp loops */
 		}
@@ -6602,14 +6586,7 @@ static void fea_ApplyLookupListPair(struct parseState *tok,
 			pst->u.pair.vr[1].xoff==0 && pst->u.pair.vr[1].yoff==0 &&
 			pst->u.pair.vr[1].v_adv_off==0 &&
 			other!=NULL ) {
-		    if ( (otl->lookup_flags&pst_r2l) &&
-			    (pst->u.pair.vr[0].h_adv_off==0 && pst->u.pair.vr[0].v_adv_off==0 )) {
-			kp = chunkalloc(sizeof(KernPair));
-			kp->off = pst->u.pair.vr[1].h_adv_off;
-			if ( pst->u.pair.vr[1].adjust!=NULL )
-			    KPFillDevTab(kp,&pst->u.pair.vr[1].adjust->xadv);
-		    } else if ( !(otl->lookup_flags&pst_r2l) &&
-			    (pst->u.pair.vr[1].h_adv_off==0 && pst->u.pair.vr[0].v_adv_off==0 )) {
+		    if ( pst->u.pair.vr[1].h_adv_off==0 && pst->u.pair.vr[0].v_adv_off==0 ) {
 			kp = chunkalloc(sizeof(KernPair));
 			kp->off = pst->u.pair.vr[0].h_adv_off;
 			if ( pst->u.pair.vr[0].adjust!=NULL )

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -509,6 +509,7 @@ return( NULL );
 		/* !!! Bug. Lose device tables here */
 		if ( isv )
 		    space->u.pair.vr[0].v_adv_off = kp->off;
+		else
 		    space->u.pair.vr[0].h_adv_off = kp->off;
 return( space );
 	    }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -97,7 +97,7 @@ EXTRA_DIST += fonts/AddExtremaTest2.sfd fonts/AddExtremumTest.sfd	\
 	fonts/StrokeTests.sfd fonts/VKern.sfd fonts/MunhwaGothic-Bold \
 	fonts/NotoSans-Regular.ttc fonts/n019003l.pfb fonts/cmbsy10.pfb	\
 	fonts/test133.fea fonts/test134.fea fonts/test135.fea		\
-	fonts/test136.fea						\
+	fonts/test136.fea fonts/test1011.fea				\
 	README
 
 # generated test inputs
@@ -176,7 +176,7 @@ EXTRA_DIST += findoverlapbugs.py test0001.py test0101.py	\
 	test1001.py test1001a.py test1001b.py test1001c.py	\
 	test1002.py test1003.py test1004.py test1005.py		\
 	test1006.py test1007.py test1008.py test1009.py         \
-	test1010.py test926.py test927.py test928.py test929.py \
+	test1010.py test1011.py test926.py test927.py test928.py test929.py \
 	test0002.py test930.py test931.py test932.py 
 
 EXTRA_DIST += link_test.c randomtest.c build-aux/missing

--- a/tests/fonts/test1011.fea
+++ b/tests/fonts/test1011.fea
@@ -1,0 +1,31 @@
+languagesystem latn dflt;
+
+
+# GPOS 
+
+
+lookup ltr {
+  lookupflag 0;
+    pos \A \B 100;
+} ltr;
+
+lookup rtl {
+  lookupflag RightToLeft;
+    pos \A \B 100;
+} rtl;
+
+feature kern {
+
+ script latn;
+     language dflt ;
+      lookup ltr;
+      lookup rtl;
+} kern;
+
+@GDEF_Simple = [\A \B ];
+
+table GDEF {
+  GlyphClassDef @GDEF_Simple, , , ;
+
+} GDEF;
+

--- a/tests/test1011.py
+++ b/tests/test1011.py
@@ -1,0 +1,39 @@
+import sys, fontforge
+
+font = fontforge.font()
+feat = sys.argv[1]
+
+A = font.createChar(ord("A"), "A")
+pen = A.glyphPen()
+pen.moveTo((100,100))
+pen.lineTo((100,200))
+pen.lineTo((200,200))
+pen.lineTo((200,100))
+pen.closePath()
+
+B = font.createChar(ord("B"), "B")
+pen = B.glyphPen()
+pen.moveTo((100,100))
+pen.lineTo((100,200))
+pen.lineTo((200,200))
+pen.lineTo((200,100))
+pen.closePath()
+
+font.mergeFeature(feat)
+
+expected = (0, 0, 100, 0, 0, 0, 0, 0)
+assert A.getPosSub(font.getLookupSubtables("ltr")[0])[0][3:] == expected
+assert A.getPosSub(font.getLookupSubtables("rtl")[0])[0][3:] == expected
+
+font.generateFeatureFile("test1011.result.fea")
+
+with open(feat) as expected_file:
+    with open("test1011.result.fea") as result_file:
+        expected = expected_file.readlines()
+        result = result_file.readlines()
+        if result != expected:
+            from difflib import Differ
+            d = Differ()
+            sys.stderr.writelines(list(d.compare(result, expected)))
+            sys.exit(1)
+sys.exit(0)

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -51,7 +51,7 @@ m4_defun([run_python_ff],[(${abs_top_builddir}/fontforgeexe/fontforge -lang py -
 # $2 is test to run (skipped if FontForge built without python scripting)
 # $3 test for this file
 m4_defun([check_python_ff],[
-AT_SETUP([$1 "(with FontForge)"])
+AT_SETUP([$1 [(with FontForge)]])
 AT_SKIP_IF([test ! -r "${abs_srcdir}/$2"])
 AT_SKIP_IF([test ! -z "$FONTFORGE_NO_PYTHON"])
 check_file([test_input], [$3])
@@ -62,7 +62,7 @@ AT_CLEANUP
 m4_defun([run_python_py],[(PATH="${abs_top_builddir}/fontforge/.libs:${abs_top_builddir}/gutils/.libs:${abs_top_builddir}/Unicode/.libs:$PATH" PYTHONPATH="${abs_top_builddir}/pyhook/.libs" ${python_exec} -Ss "${abs_srcdir}/$1" "$2" || /bin/false)])
 
 m4_defun([check_python_py],[
-AT_SETUP([$1 "(with Python)"])
+AT_SETUP([$1 [(with Python)]])
 AT_SKIP_IF([test ! -r "${abs_srcdir}/$2"])
 AT_SKIP_IF([test ! -z "$FONTFORGE_NO_PYTHON_EXTENSION"])
 check_file([test_input], [$3])

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -145,6 +145,7 @@ check_python([Check for splinestroke 0 len fail],[test1007.py],[ayn+meem.init.sv
 check_python([PythonAPI: font glyph iteration],[test1008.py],[OverlapBugs.sfd])
 check_python([Ligatures and Fractions Table Lookups],[test1009.py])
 check_python([libnameslist checks],[test1010.py])
+check_python([kerning with r2l lookup flag],[test1011.py],[test1011.fea])
 #check_python([find overlap bug],[findoverlapbugs.py])
 check_python([Validate WOFF output],[test926.py],[DejaVuSerif.sfd])
 check_python([WOFF2 round tripping],[test927.py],[Ambrosia.woff2])


### PR DESCRIPTION
FontForge is incorrectly interpreting RightToLeft lookup flag to have some effect on pair positioning lookups (kerning), however the spec is clear that it only affects cursive positioning:

From [OpenType spec][1]
> This bit relates only to the correct processing of the cursive attachment lookup type (GPOS lookup type 3). When this bit is set, the last glyph in a given sequence to which the cursive attachment lookup is applied, will be positioned on the baseline.
> Note: Setting of this bit is not intended to be used by operating systems or applications to determine text direction.

The [feature file specification][2] does not have any text that would suggest this flag affects kerning and both makeotf and feaLib don’t interpret it in any special way.

With the current code FontForge is incorrectly exporting and applying pair positioning lookups that has this flag set (setting this flag on non-cursive positioning lookups is pointless but should be harmless as
well).

Proper right to left kerning has to be set up by the user manually since OpenType model requires different handling for RTL and LTR kerning, but FontForge already provides enough flexibility to set the right pair positioning values, and there is no need for the current incorrect magic.

[1]: https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#lookupTbl:
[2]: https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#4.d

### Type of change
- **Bug fix**
- **Breaking change**
