### PR TITLE
Remove OpenType Feature, Script, and Lookup limits (issue #3734)

### DIFF
--- a/fontforge/parsettfatt.c
+++ b/fontforge/parsettfatt.c
@@ -46,6 +46,11 @@
 #include <math.h>
 #include <stdlib.h>
 
+// Disable maximum for these
+#define FF_TTF_SCRIPT_MAX -1
+#define FF_TTF_FEATURE_MAX -1
+#define FF_TTF_LOOKUP_MAX -1
+
 static uint16 *getAppleClassTable(FILE *ttf, int classdef_offset, int cnt, int sub, int div, struct ttfinfo *info) {
     uint16 *class = calloc(cnt,sizeof(uint16));
     int first, i, n;
@@ -2465,7 +2470,7 @@ return( NULL );
     cnt = getushort(ttf);
     if ( cnt<=0 )
 return( NULL );
-    else if ( cnt>1000 ) {
+    else if ( FF_TTF_SCRIPT_MAX>=0 && cnt>FF_TTF_SCRIPT_MAX ) {
 	LogError( _("Too many scripts %d\n"), cnt );
 	info->bad_ot = true;
 return( NULL );
@@ -2540,7 +2545,7 @@ return( NULL );
     info->feature_cnt = cnt = getushort(ttf);
     if ( cnt<=0 )
 return( NULL );
-    else if ( cnt>1000 ) {
+    else if ( FF_TTF_FEATURE_MAX>=0 && cnt>FF_TTF_FEATURE_MAX ) {
 	LogError( _("Too many features %d\n"), cnt );
 	info->bad_ot = true;
 return( NULL );
@@ -2602,7 +2607,7 @@ return( NULL );
     info->cur_lookups = NULL;
     if ( cnt<=0 )
 return( NULL );
-    else if ( cnt>1000 ) {
+    else if ( FF_TTF_LOOKUP_MAX>=0 && cnt>FF_TTF_LOOKUP_MAX ) {
 	LogError( _("Too many lookups %d\n"), cnt );
 	info->bad_ot = true;
 return( NULL );


### PR DESCRIPTION
This quick fix removes the stated arbitrary limits from `parsettfatt.c`. This could increase the chance of memory problems and such when opening fonts, although the chance of hitting a well-enough-formed encoding of such a large size seems remote. 

I didn't touch the limits on Apple-specific tables because I know nothing about those. (The 10000 limit on `mort` and `morx` is a bit mysterious given when the error is printed.)

Closes #3734