### PR TITLE
Clean stray control points in stroking logic.

### DIFF
--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -755,6 +755,8 @@ ValidateMListTs_IF_VERBOSE(input1->monos)
   return;
 }
 
+#define evalCubicSpline(spline, t) ((((spline).a * (t) + (spline).b) * (t) + (spline).c) * (t) + (spline).d)
+
 static void AddSpline(Intersection *il,Monotonic *m,extended t) {
     MList *ml;
 
@@ -843,8 +845,13 @@ return;
         else if (Within16RoundingErrors(m->tstart, m->tend))
 	    SOError( "Attempt to subset monotonic rejoin inappropriately: m->tstart and m->tend are very close (%f = %f, t = %f)\n",
 		    m->tstart, m->tend, t );
-	else if (Within4RoundingErrors(m->s->from->me.x,m->s->to->me.x) && Within4RoundingErrors(m->s->from->me.y,m->s->to->me.y))
+	else if (m->s->from->nonextcp && m->s->to->noprevcp &&
+		Within4RoundingErrors(m->s->from->me.x,m->s->to->me.x) &&
+		Within4RoundingErrors(m->s->from->me.y,m->s->to->me.y))
 	    SOError( "The curve is too short.\n");
+	else if (Within4RoundingErrors(evalCubicSpline(m->s->splines[0], m->tstart), evalCubicSpline(m->s->splines[0], m->tend)) &&
+		Within4RoundingErrors(evalCubicSpline(m->s->splines[1], m->tstart), evalCubicSpline(m->s->splines[1], m->tend)))
+	    SOError( "The subcurve is too short.\n");
         else {
 	    /* It is monotonic, so a subset of it must also be */
 	    Monotonic *m2 = chunkalloc(sizeof(Monotonic));

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -848,10 +848,10 @@ return;
 	else if (m->s->from->nonextcp && m->s->to->noprevcp &&
 		Within4RoundingErrors(m->s->from->me.x,m->s->to->me.x) &&
 		Within4RoundingErrors(m->s->from->me.y,m->s->to->me.y))
-	    SOError( "The curve is too short.\n");
+	    SOError( "The spline is straight and is too short to be meaningful.\n");
 	else if (Within4RoundingErrors(evalCubicSpline(m->s->splines[0], m->tstart), evalCubicSpline(m->s->splines[0], m->tend)) &&
 		Within4RoundingErrors(evalCubicSpline(m->s->splines[1], m->tstart), evalCubicSpline(m->s->splines[1], m->tend)))
-	    SOError( "The subcurve is too short.\n");
+	    SOError( "The monotonic curve is too short.\n");
         else {
 	    /* It is monotonic, so a subset of it must also be */
 	    Monotonic *m2 = chunkalloc(sizeof(Monotonic));

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -3298,6 +3298,9 @@ static SplineSet *SSRemoveBackForthLine(SplineSet *contours) {
 	cur_tmp->next = NULL;
 	cur_tmp->first = cur->first;
 	cur_tmp->last = cur->last;
+	// The existing code may produce wild control points that break overlap removal.
+	// We remove those.
+	SplineSetsRemoveWildControlPoints(cur_tmp, 1000);
 	ret = SplineSetRemoveOverlap(NULL, cur_tmp, over_remove);
 	if ( ret==NULL ) {
 	    if ( prev==NULL )

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -7372,7 +7372,7 @@ int SplineRemoveWildControlPoints(Spline *s, bigreal distratio) {
 		bcdisplacement1 = DistanceBetweenPoints(&s->to->me, &s->to->prevcp);
 	if (!s->from->nonextcp && !s->to->noprevcp)
 		ccdisplacement = DistanceBetweenPoints(&s->from->nextcp, &s->to->prevcp);
-	bigreal basis = MIN(pdisplacement, ccdisplacement);
+	bigreal basis = MAX(pdisplacement, ccdisplacement);
 	if (basis == 0 || MAX(bcdisplacement0, bcdisplacement1) / basis > distratio) {
 		changed = s->islinear = s->from->nonextcp = s->to->noprevcp = true;
 		s->from->nextcp = s->from->me;

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -7373,7 +7373,7 @@ int SplineRemoveWildControlPoints(Spline *s, bigreal distratio) {
 	if (!s->from->nonextcp && !s->to->noprevcp)
 		ccdisplacement = DistanceBetweenPoints(&s->from->nextcp, &s->to->prevcp);
 	bigreal basis = MIN(pdisplacement, ccdisplacement);
-	if (basis == 0 || MAX(bcdisplacement0, bcdisplacement1) / pdisplacement > basis) {
+	if (basis == 0 || MAX(bcdisplacement0, bcdisplacement1) / basis > distratio) {
 		changed = s->islinear = s->from->nonextcp = s->to->noprevcp = true;
 		s->from->nextcp = s->from->me;
 		s->to->prevcp = s->to->me;

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -7356,7 +7356,7 @@ return( changed );
 int SplineRemoveWildControlPoints(Spline *s, bigreal distratio) {
 	// If the distance between the control point and its base
 	// exceeds the the distance between the base points 
-	// or the control points by a great factor,
+	// by a great factor,
 	// it is likely erroneous and is likely to cause problems.
 	// So we remove it.
 	if (s->from == NULL || s->to == NULL)

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -7365,15 +7365,11 @@ int SplineRemoveWildControlPoints(Spline *s, bigreal distratio) {
 	bigreal pdisplacement = DistanceBetweenPoints(&s->from->me, &s->to->me);
 	bigreal bcdisplacement0 = 0.0;
 	bigreal bcdisplacement1 = 0.0;
-	bigreal ccdisplacement = 0.0;
 	if (!s->from->nonextcp)
 		bcdisplacement0 = DistanceBetweenPoints(&s->from->me, &s->from->nextcp);
 	if (!s->to->noprevcp)
 		bcdisplacement1 = DistanceBetweenPoints(&s->to->me, &s->to->prevcp);
-	if (!s->from->nonextcp && !s->to->noprevcp)
-		ccdisplacement = DistanceBetweenPoints(&s->from->nextcp, &s->to->prevcp);
-	bigreal basis = MAX(pdisplacement, ccdisplacement);
-	if (basis == 0 || MAX(bcdisplacement0, bcdisplacement1) / basis > distratio) {
+	if (pdisplacement == 0 || MAX(bcdisplacement0, bcdisplacement1) / pdisplacement > distratio) {
 		changed = s->islinear = s->from->nonextcp = s->to->noprevcp = true;
 		s->from->nextcp = s->from->me;
 		s->to->prevcp = s->to->me;

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -7353,6 +7353,52 @@ int SplineSetsRemoveAnnoyingExtrema(SplineSet *ss,bigreal err) {
 return( changed );
 }
 
+int SplineRemoveWildControlPoints(Spline *s, bigreal distratio) {
+	// If the distance between the control point and its base
+	// exceeds the the distance between the base points 
+	// or the control points by a great factor,
+	// it is likely erroneous and is likely to cause problems.
+	// So we remove it.
+	if (s->from == NULL || s->to == NULL)
+		return 0;
+	int changed;
+	bigreal pdisplacement = DistanceBetweenPoints(&s->from->me, &s->to->me);
+	bigreal bcdisplacement0 = 0.0;
+	bigreal bcdisplacement1 = 0.0;
+	bigreal ccdisplacement = 0.0;
+	if (!s->from->nonextcp)
+		bcdisplacement0 = DistanceBetweenPoints(&s->from->me, &s->from->nextcp);
+	if (!s->to->noprevcp)
+		bcdisplacement1 = DistanceBetweenPoints(&s->to->me, &s->to->prevcp);
+	if (!s->from->nonextcp && !s->to->noprevcp)
+		ccdisplacement = DistanceBetweenPoints(&s->from->nextcp, &s->to->prevcp);
+	bigreal basis = MIN(pdisplacement, ccdisplacement);
+	if (basis == 0 || MAX(bcdisplacement0, bcdisplacement1) / pdisplacement > basis) {
+		changed = s->islinear = s->from->nonextcp = s->to->noprevcp = true;
+		s->from->nextcp = s->from->me;
+		s->to->prevcp = s->to->me;
+		SplineRefigure(s);
+	}
+	return changed;
+}
+
+int SplineSetsRemoveWildControlPoints(SplineSet *ss, bigreal distratio) {
+    int changed = false;
+    Spline *s, *first;
+
+
+    while ( ss!=NULL ) {
+	first = NULL;
+	for ( s = ss->first->next; s!=NULL && s!=first; s = s->to->next ) {
+	    if ( first == NULL ) first = s;
+	    if ( SplineRemoveWildControlPoints(s,distratio))
+		changed = true;
+	}
+	ss = ss->next;
+    }
+return( changed );
+}
+
 SplinePoint *SplineBisect(Spline *spline, extended t) {
     Spline1 xstart, xend;
     Spline1 ystart, yend;

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -57,6 +57,8 @@ extern int SplineExistsInSS(Spline *s, SplineSet *ss);
 extern int SplinePointIsACorner(SplinePoint *sp);
 extern int SplineSetIntersect(SplineSet *spl, Spline **_spline, Spline **_spline2);
 extern int SplineSetsRemoveAnnoyingExtrema(SplineSet *ss, bigreal err);
+extern int SplineRemoveWildControlPoints(Spline *s, bigreal distratio);
+extern int SplineSetsRemoveWildControlPoints(SplineSet *ss, bigreal distratio);
 
 /* Two lines intersect in at most 1 point */
 /* Two quadratics intersect in at most 4 points */


### PR DESCRIPTION
Per #3694, the primary overlap removal routines generate wild control points sometimes, and these break overlap removal, which the stroker calls after generating the preliminary strokes. This adds a cleaner to look for those wild control points, based on offset ratios, and to remove them. Only the stroking code calls it, and the valid points generated by the stroking code seem unlikely ever to stray outside the hard-coded offset ratio. So this is likely to be a non-breaking change.

There was another small problem in which the overlap remover would flag a monotonic as being malformed if its containing spline had zero displacement. This replaces that check with one on the displacement of the monotonic.
