### PR TITLE
Fix compilation of gdraw.c on modern BSD systems.

### DIFF
--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -2397,7 +2397,7 @@ static void bWritePfm(Context *c) {
 
     t = script2utf8_copy(c->a.vals[1].u.sval);
     locfilename = utf82def_copy(t);
-    if ( !WritePfmFile(c->a.vals[1].u.sval,sf,0,c->curfv->map) )
+    if ( !WritePfmFile(c->a.vals[1].u.sval,sf,c->curfv->map,0) )
 	ScriptError(c,"Save failed");
     free(locfilename); free(t);
 }

--- a/gdraw/gdraw.c
+++ b/gdraw/gdraw.c
@@ -32,7 +32,7 @@
 #include "gkeysym.h"
 #include "ustring.h"
 
-#if __Mac
+#if __Mac || __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __DragonFly__
 #  include <sys/select.h>
 #endif
 


### PR DESCRIPTION
All modern BSD derivatives, namely FreeBSD, NetBSD, OpenBSD, and DragonFly
require <sys/select.h> to be included.