### PR TITLE
ifdef-wrap call to nl_langinfo using HAVE_NL_LANGINFO define, instead of HAVE_LANGINFO_H

### DIFF
--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -648,7 +648,7 @@ static int DefaultEncoding(void) {
     const char *loc;
     int enc;
 
-#if HAVE_LANGINFO_H
+#if HAVE_NL_LANGINFO
     loc = nl_langinfo(CODESET);
     enc = encmatch(loc,false);
     if ( enc!=e_unknown )


### PR DESCRIPTION
Android provides langinfo.h, however, nl_langinfo functions are only
available from Android-26+. Android-25 and earlier produce
HAVE_LANGINFO_H=1
HAVE_NL_LANGINFO=0

This oneliner fixes this particular build error on Android-25 and earlier.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
