### PR TITLE
Clean stray control points in stroking logic (final).

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -3298,6 +3298,9 @@ static SplineSet *SSRemoveBackForthLine(SplineSet *contours) {
 	cur_tmp->next = NULL;
 	cur_tmp->first = cur->first;
 	cur_tmp->last = cur->last;
+	// The existing code may produce wild control points that break overlap removal.
+	// We remove those.
+	SplineSetsRemoveWildControlPoints(cur_tmp, 1000);
 	ret = SplineSetRemoveOverlap(NULL, cur_tmp, over_remove);
 	if ( ret==NULL ) {
 	    if ( prev==NULL )

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -57,6 +57,8 @@ extern int SplineExistsInSS(Spline *s, SplineSet *ss);
 extern int SplinePointIsACorner(SplinePoint *sp);
 extern int SplineSetIntersect(SplineSet *spl, Spline **_spline, Spline **_spline2);
 extern int SplineSetsRemoveAnnoyingExtrema(SplineSet *ss, bigreal err);
+extern int SplineRemoveWildControlPoints(Spline *s, bigreal distratio);
+extern int SplineSetsRemoveWildControlPoints(SplineSet *ss, bigreal distratio);
 
 /* Two lines intersect in at most 1 point */
 /* Two quadratics intersect in at most 4 points */


### PR DESCRIPTION
This closes #3742 and #3694 with squashed commits. Original text follows.

Per #3694, the primary overlap removal routines generate wild control points sometimes, and these break overlap removal, which the stroker calls after generating the preliminary strokes. This adds a cleaner to look for those wild control points, based on offset ratios, and to remove them. Only the stroking code calls it, and the valid points generated by the stroking code seem unlikely ever to stray outside the hard-coded offset ratio. So this is likely to be a non-breaking change.

There was another small problem in which the overlap remover would flag a monotonic as being malformed if its containing spline had zero displacement. This replaces that check with one on the displacement of the monotonic.
