### PR TITLE
SetOS2Value("StyleMap", integer) and GetOS2Value("StyleMap") are adde…

### DIFF
--- a/doc/html/scripting-alpha.html
+++ b/doc/html/scripting-alpha.html
@@ -2927,6 +2927,13 @@ SetGasp([8,2,16,1,65535,3])
 	    <P>
 	    <CODE>StrikeOutSize, StrikeOutPos</CODE>
 	    <P>
+	    <CODE>StyleMap</CODE>
+	    <P>
+	    This is equivalent to the "Style Map" pull-down list in
+	    <A HREF="fontinfo.html#TTF-Values">Font Info-&gt;OS/2-&gt;Misc. </A>
+	    Typical values are 0x01 (Italic), 0x20 (Bold), 0x21 (Bold Italic) and 0x40 (Regular).
+	    If the second argument is not a positive value less than 0x400, error flag is set.
+	    <P>
 	    <P>
 	    Usually the second argument is an integer but <CODE>VendorID</CODE> takes
 	    a 4 character ASCII string, and <CODE>Panose</CODE> takes a 10 element integer

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -3747,6 +3747,15 @@ static void bSetOS2Value(Context *c) {
 	setint16(&sf->pfminfo.weight,c);
     } else if ( strmatch(c->a.vals[1].u.sval,"Width")==0 ) {
 	setint16(&sf->pfminfo.width,c);
+    } else if ( strmatch(c->a.vals[1].u.sval,"StyleMap")==0 ) {
+	if ( c->a.vals[2].type!=v_int )
+	    c->error = ce_badargtype;
+	else if ( c->a.vals[2].u.ival<0 || c->a.vals[2].u.ival>=0x400 )
+	    ScriptError(c,"StyleMap value should be a positive value less than 0x400");
+	    // In OpenType font spec ( https://docs.microsoft.com/ja-jp/typography/opentype/spec/os2#fss ),
+	    // Bits 0 to 9 of fsSelection have meanings and Bits 10 to 15 are reserved.
+	else
+	    sf->pfminfo.stylemap = c->a.vals[2].u.ival;
     } else if ( strmatch(c->a.vals[1].u.sval,"FSType")==0 ) {
 	setint16(&sf->pfminfo.fstype,c);
     } else if ( strmatch(c->a.vals[1].u.sval,"IBMFamily")==0 ) {
@@ -3864,6 +3873,8 @@ static void bGetOS2Value(Context *c) {
 	os2getint(sf->pfminfo.weight,c);
     } else if ( strmatch(c->a.vals[1].u.sval,"Width")==0 ) {
 	os2getint(sf->pfminfo.width,c);
+    } else if ( strmatch(c->a.vals[1].u.sval,"StyleMap")==0 ) {
+	os2getint(sf->pfminfo.stylemap,c);
     } else if ( strmatch(c->a.vals[1].u.sval,"FSType")==0 ) {
 	os2getint(sf->pfminfo.fstype,c);
     } else if ( strmatch(c->a.vals[1].u.sval,"IBMFamily")==0 ) {


### PR DESCRIPTION
…d in native script

This closes #3750 .

SetOS2Value("StyleMap", integer) and GetOS2Value("StyleMap") are added in native script.
These enable to access OS/2 style map from native script.

In SetOS2Value("StyleMap", integer), range check of the second argument is done.

Document in doc/html/scripting-alpha.html is also provided and I request a review.

### Type of change
- **New feature**
