### PR TITLE
travis: Use master for libuninameslist/libspiro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,14 +92,14 @@ install:
       # This block only runs if the cache isn't present.
       if [ ! "$(ls -A $DEPSPREFIX)" ]; then
         mkdir -p work && pushd work
-        wget 'https://github.com/fontforge/libspiro/releases/download/0.5.20150702/libspiro-0.5.20150702.tar.gz' -O - | tar -zxf -
-        wget 'https://github.com/fontforge/libuninameslist/releases/download/20190305/libuninameslist-dist-20190305.tar.gz' -O - | tar -zxf -
-        git clone --branch v1.0.2 https://github.com/google/woff2 --depth 1
+        git clone --depth 1 https://github.com/fontforge/libspiro
+        git clone --depth 1 https://github.com/fontforge/libuninameslist
+        git clone --depth 1 --branch v1.0.2 https://github.com/google/woff2
         wget --tries 1 "http://download.savannah.gnu.org/releases/freetype/freetype-$FTVER.tar.gz" || \
           wget "https://sourceforge.net/projects/freetype/files/freetype2/$SFFTVER/freetype-$FTVER.tar.gz"
 
-        pushd libspiro-0.5.20150702 && ./configure --prefix=$DEPSPREFIX && make && make install && popd
-        pushd libuninameslist-20190305 && ./configure --enable-pscript --prefix=$DEPSPREFIX && make && make install && popd
+        pushd libspiro && autoreconf -fiv && ./configure --prefix=$DEPSPREFIX && make && make install && popd
+        pushd libuninameslist && autoreconf -fiv && ./configure --enable-pscript --prefix=$DEPSPREFIX && make && make install && popd
         pushd woff2 && mkdir build && cd build && cmake -GNinja .. -DCMAKE_INSTALL_PREFIX=$DEPSPREFIX -DCMAKE_INSTALL_LIBDIR=lib && ninja install && popd
         tar -zxf freetype-$FTVER.tar.gz -C $DEPSPREFIX
         popd


### PR DESCRIPTION
FontForge is a primary user of these packages; this acts like a
canary for any issues with integrations with those packages
because of changes made on them

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
