### PR TITLE
Fix saving via «Save as…» w/Unicode file names

### DIFF
--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -974,6 +974,16 @@ char *chomp( char *line ) {
     return( line );
 }
 
+unichar_t *u_copytolower(const unichar_t *input)
+{
+    unichar_t* ret = u_copy(input);
+    unichar_t* p = ret;
+    for( ; *p; ++p ) {
+	*p = tolower(*p);
+    }
+    return ret;
+}
+
 char *copytolower(const char *input)
 {
     char* ret = copy(input);
@@ -1027,6 +1037,18 @@ int u_endswith(const unichar_t *haystack,const unichar_t *needle) {
     int nedlen = u_strlen( needle );
     if( haylen < nedlen )
 	return 0;
+    unichar_t* p = u_strstr( haystack + haylen - nedlen, needle );
+    return p == ( haystack + haylen - nedlen );
+}
+
+int u_endswithi(const unichar_t *haystackZ,const unichar_t *needleZ) {
+    unichar_t* haystack = u_copytolower(haystackZ);
+    unichar_t* needle   = u_copytolower(needleZ);
+    int haylen = u_strlen( haystack );
+    int nedlen = u_strlen( needle );
+
+    if( haylen < nedlen ) return 0;
+
     unichar_t* p = u_strstr( haystack + haylen - nedlen, needle );
     return p == ( haystack + haylen - nedlen );
 }

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -593,7 +593,7 @@ static enum fchooserret _FVSaveAsFilterFunc(GGadget *g,struct gdirentry *ent, co
 
 int _FVMenuSaveAs(FontView *fv) {
     char *temp;
-    char *ret;
+    unichar_t *ret, *utemp;
     char *filename;
     int ok;
     int s2d = fv->b.cidmaster!=NULL ? fv->b.cidmaster->save_to_dir :
@@ -656,16 +656,19 @@ int _FVMenuSaveAs(FontView *fv) {
     }
 #endif
 
-    ret = GWidgetSaveAsFileWithGadget8(_("Save as..."),temp,0,NULL,
+    utemp = utf82u_copy(temp);
+    ret = GWidgetSaveAsFileWithGadget((unichar_t*)_("Save as..."),utemp,0,NULL,
 				       _FVSaveAsFilterFunc, FilenameFunc,
 				       &gcd );
-    free(temp);
+    free(temp); free(utemp);
     if ( ret==NULL )
 return( 0 );
-    filename = utf82def_copy(ret);
-    free(ret);
+    filename = u2utf8_copy(ret);
 
-    if(!(endswithi( filename, ".sfdir") || endswithi( filename, ".sfd")))
+    const unichar_t *u_sfdir = utf82u_copy(".sfdir");
+    const unichar_t *u_sfd = utf82u_copy(".sfd");
+
+    if(!(u_endswith( ret, u_sfdir ) || u_endswith( ret, u_sfd )))
     {
 	// they forgot the extension, so we force the default of .sfd
 	// and alert them to the fact that we have done this and we
@@ -685,6 +688,7 @@ return( 0 );
 	free(filename);
 	filename = newpath;
     }
+    free(ret);
     
     FVFlattenAllBitmapSelections(fv);
     fv->b.sf->compression = 0;

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -668,7 +668,7 @@ return( 0 );
     const unichar_t *u_sfdir = utf82u_copy(".sfdir");
     const unichar_t *u_sfd = utf82u_copy(".sfd");
 
-    if(!(u_endswith( ret, u_sfdir ) || u_endswith( ret, u_sfd )))
+    if(!(u_endswithi( ret, u_sfdir ) || u_endswithi( ret, u_sfd )))
     {
 	// they forgot the extension, so we force the default of .sfd
 	// and alert them to the fact that we have done this and we

--- a/inc/ustring.h
+++ b/inc/ustring.h
@@ -201,6 +201,7 @@ int endswith(const char *haystack,const char *needle);
  * No new strings are allocated, freed, or returned.
  */
 extern int u_endswith(const unichar_t *haystack,const unichar_t *needle);
+extern int u_endswithi(const unichar_t *haystack,const unichar_t *needle);
 
 extern int u_startswith(const unichar_t *haystack,const unichar_t *needle);
 extern int uc_startswith(const unichar_t *haystack,const char* needle);


### PR DESCRIPTION
This closes #3768.

Unicode in file names saved via «File&rarr;Save as…» names led to an extraneous `.sfd` always being added. This was because #1572 was using `char*` instead of `unichar_t` to deal with Unicode&hellip;which is a big no-no, at least in FontForge's codebase. 