### PR TITLE
Fix tolower usage on the `endswithi` functions.

### DIFF
--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -28,6 +28,7 @@
 #include <fontforge-config.h>
 
 #include "chardata.h"
+#include "ffglib.h"
 #include "ustring.h"
 #include "utype.h"
 
@@ -974,17 +975,6 @@ char *chomp( char *line ) {
     return( line );
 }
 
-char *copytolower(const char *input)
-{
-    char* ret = copy(input);
-    char* p = ret;
-    for( ; *p; ++p ) {
-	*p = tolower(*p);
-    }
-    return ret;
-}
-
-
 int endswith(const char *haystack,const char *needle) {
     int haylen = strlen( haystack );
     int nedlen = strlen( needle );
@@ -995,11 +985,11 @@ int endswith(const char *haystack,const char *needle) {
 }
 
 int endswithi(const char *haystackZ,const char *needleZ) {
-    char* haystack = copytolower(haystackZ);
-    char* needle   = copytolower(needleZ);
+    gchar* haystack = g_ascii_strdown(haystackZ,-1);
+    gchar* needle   = g_ascii_strdown(needleZ,-1);
     int ret = endswith( haystack, needle );
-    free( haystack );
-    free( needle );
+    g_free( haystack );
+    g_free( needle );
     return ret;
 }
 
@@ -1008,8 +998,8 @@ int endswithi_partialExtension( const char *haystackZ,const char *needleZ) {
     if( nedlen == 0 ) {
 	return 0;
     }
-    char* haystack = copytolower(haystackZ);
-    char* needle   = copytolower(needleZ);
+    gchar* haystack = g_ascii_strdown(haystackZ,-1);
+    gchar* needle   = g_ascii_strdown(needleZ,-1);
     int ret = 0;
     int i = nedlen-1;
     ret |= endswith( haystack, needle );
@@ -1017,8 +1007,8 @@ int endswithi_partialExtension( const char *haystackZ,const char *needleZ) {
 	needle[i] = '\0';
 	ret |= endswith( haystack, needle );
     }
-    free( haystack );
-    free( needle );
+    g_free( haystack );
+    g_free( needle );
     return ret;
 }
 


### PR DESCRIPTION
You cannot expect `tolower` to work if it's operating on a multibyte (e.g.
UTF-8) string.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

Supersedes #3769. Sorry @ctrlcctrlv on the duplicated effort
