### PR TITLE
Use getShareDir/getHelpDir everywhere

### DIFF
--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -449,36 +449,7 @@ return( prefs );
 }
 
 static char *NOUI_getFontForgeShareDir(void) {
-#if defined(__MINGW32__)
-    #ifndef MAX_PATH
-    #define MAX_PATH 4096
-    #endif
-    
-    static char* sharedir = NULL;
-    if(!sharedir){
-	char path[MAX_PATH+32];
-	char* c = path;
-	char* tail = 0;
-	unsigned int  len = GetModuleFileNameA(NULL, path, MAX_PATH);
-	path[len] = '\0';
-	for(; *c; *c++){
-	    if(*c == '\\'){
-		tail=c;
-		*c = '/';
-	    }
-	}
-	if(!tail) tail=c;
-	strcpy(tail, "/share/fontforge");
-	sharedir = copy(path);
-    }
-    return sharedir;
-#elif defined(SHAREDIR)
-return( SHAREDIR "/fontforge" );
-#elif defined(PREFIX)
-return( PREFIX "/share/fontforge" );
-#else
-return( NULL );
-#endif
+	return getShareDir();
 }
 
 static int encmatch(const char *enc,int subok) {

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -773,45 +773,7 @@ static char *getPfaEditPrefs(void) {
 }
 
 static char *PrefsUI_getFontForgeShareDir(void) {
-    static char *sharedir=NULL;
-    static int set=false;
-    char *pt;
-    int len;
-
-    if ( set )
-return( sharedir );
-
-    set = true;
-
-#if defined(__MINGW32__)
-
-    len = strlen(GResourceProgramDir) + strlen("/share/fontforge") +1;
-    sharedir = malloc(len);
-    strcpy(sharedir, GResourceProgramDir);
-    strcat(sharedir, "/share/fontforge");
-    return sharedir;
-
-#else
-
-    pt = strstr(GResourceProgramDir,"/bin");
-    if ( pt==NULL ) {
-#if defined(SHAREDIR)
-	sharedir = copy(SHAREDIR "/fontforge" );
-return( sharedir );
-#elif defined(PREFIX)
-	sharedir = copy( PREFIX "/share/fontforge" );
-return( sharedir );
-#else
-return( NULL );
-#endif
-    }
-    len = (pt-GResourceProgramDir)+strlen("/share/fontforge")+1;
-    sharedir = malloc(len);
-    strncpy(sharedir,GResourceProgramDir,pt-GResourceProgramDir);
-    strcpy(sharedir+(pt-GResourceProgramDir),"/share/fontforge");
-return( sharedir );
-
-#endif
+    return getShareDir();
 }
 
 static int encmatch(const char *enc,int subok) {

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1065,19 +1065,11 @@ int fontforge_main( int argc, char **argv ) {
     textdomain("FontForge");
     GResourceUseGetText();
     {
-	char shareDir[PATH_MAX];
-	char* sd = getShareDir();
-	strncpy( shareDir, sd, PATH_MAX );
-    shareDir[PATH_MAX-1] = '\0';
-	if(!sd) {
-	    strcpy( shareDir, SHAREDIR );
-	}
-
 	char path[PATH_MAX];
-	snprintf(path, PATH_MAX, "%s%s", shareDir, "/pixmaps" );
+	snprintf(path, PATH_MAX, "%s%s", getShareDir(), "/pixmaps" );
 	GGadgetSetImageDir( path );
 
-	snprintf(path, PATH_MAX, "%s%s", shareDir, "/resources/fontforge.resource" );
+	snprintf(path, PATH_MAX, "%s%s", getShareDir(), "/resources/fontforge.resource" );
 	GResourceAddResourceFile(path, GResourceProgramName,false);
     }
     hotkeysLoad();

--- a/fontforgeexe/uiutil.c
+++ b/fontforgeexe/uiutil.c
@@ -169,24 +169,7 @@ void help(char *file) {
 	strcpy(p_uri, p_file);
 
 	if(! GFileIsAbsolute(p_uri)){
-	    char* p_helpdir = (char*) malloc(1024);
-
-	    #if __CygWin
-	    {   /* cygwin */
-		#if defined(DOCDIR)
-		strncpy( p_helpdir, DOCDIR "/", 1024 );
-		#elif defined(SHAREDIR)
-		strncpy( p_helpdir, SHAREDIR "/doc/fontforge/", 1024 );
-		#else
-		strncpy( p_helpdir, "/usr/local/share/doc/fontforge/", 1024 );
-		#endif
-	    }
-	    #else
-	    {   /* mingw */
-		strcpy( p_helpdir, GResourceProgramDir );
-		strcat( p_helpdir, "/doc/fontforge/");
-	    }
-	    #endif
+	    char* p_helpdir = getHelpDir();
 
 	    /* /usr/share/fontforge/doc/ja/file */
 	    strcpy(p_uri, p_helpdir);
@@ -203,7 +186,6 @@ void help(char *file) {
 		    strcat(p_uri, p_file);
 		}
 	    }
-	    free(p_helpdir);
 	}
 
 	#if __CygWin


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

This consolidates the use of SHAREDIR/DOCDIR to gutils/fsys.c

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
