### PR TITLE
Add settings options: Splash DIsplay Time in Seconds

### DIFF
--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -113,6 +113,7 @@ extern int use_freetype_to_rasterize_fv;	/* in bitmapchar.c */
 /*  UI preference files without loss of data */
 static char *xdefs_filename;
 static int splash=1;
+static int splashSeconds=7000;
 static int cv_auto_goto=1;
 static int OpenCharsInNewWindow=1;
 static float arrowAmount=1;
@@ -249,6 +250,7 @@ static struct prefs_list {
 extras[] = {
     { N_("ResourceFile"), pr_file, &xdefs_filename, NULL, NULL, 'R', NULL, 0, N_("When FontForge starts up, it loads the user interface theme from\nthis file. Any changes will only take effect the next time you start FontForge.") },
     { N_("SplashScreen"), pr_bool, &splash, NULL, NULL, 'S', NULL, 0, N_("Show splash screen on start-up") },
+	 { N_("SplashScreenSeconds"), pr_bool, &splashSeconds, NULL, NULL, 'S', NULL, 0, N_("How many seconds to show splash screen") },         
     { N_("GlyphAutoGoto"), pr_bool, &cv_auto_goto, NULL, NULL, '\0', NULL, 0, N_("Typing a normal character in the glyph view window changes the window to look at that character") },
     { N_("OpenCharsInNewWindow"), pr_bool, &OpenCharsInNewWindow, NULL, NULL, '\0', NULL, 0, N_("When double clicking on a character in the font view\nopen that character in a new window, otherwise\nreuse an existing one.") },
     { N_("ArrowMoveSize"), pr_real, &arrowAmount, NULL, NULL, '\0', NULL, 0, N_("The number of em-units by which an arrow key will move a selected point") },

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -63,6 +63,7 @@
 static void change_res_filename(const char *newname);
 
 extern int splash;
+extern int splashSeconds;
 extern int adjustwidth;
 extern int adjustlbearing;
 extern Encoding *default_encoding;
@@ -301,6 +302,7 @@ static struct prefs_list {
 	{ N_("FreeTypeInFontView"), pr_bool, &use_freetype_to_rasterize_fv, NULL, NULL, 'O', NULL, 0, N_("Use the FreeType rasterizer (when available)\nto rasterize glyphs in the font view.\nThis generally results in better quality.") },
 	{ N_("FreeTypeAAFillInOutlineView"), pr_bool, &use_freetype_with_aa_fill_cv, NULL, NULL, 'O', NULL, 0, N_("When filling using freetype in the outline view,\nhave freetype render the glyph antialiased.") },
 	{ N_("SplashScreen"), pr_bool, &splash, NULL, NULL, 'S', NULL, 0, N_("Show splash screen on start-up") },
+	{ N_("SplashScreenSeconds"), pr_int, &splashSeconds, NULL, NULL, 'S', NULL, 0, N_("How many seconds to show splash screen") },
 #ifndef _NO_LIBCAIRO
 	{ N_("UseCairoDrawing"), pr_bool, &prefs_usecairo, NULL, NULL, '\0', NULL, 0, N_("Use the cairo library for drawing (if available)\nThis makes for prettier (anti-aliased) but slower drawing\nThis applies to any windows created AFTER this is set.\nAlready existing windows will continue as they are.") },
 #endif

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -103,6 +103,7 @@ extern void setup_cocoa_app();
 
 extern int AutoSaveFrequency;
 int splash = 1;
+int splashSeconds = 7;
 static int localsplash;
 static int unique = 0;
 
@@ -398,7 +399,10 @@ static void start_splash_screen(void){
     GDrawProcessPendingEvents(NULL);
     GDrawProcessPendingEvents(NULL);
 
-    splasht = GDrawRequestTimer(splashw,7000,1000,NULL);
+    int slpashDelayTime = 7000;
+    if( splashSeconds > 0 && splashSeconds < 60 )
+      slpashDelayTime = splashSeconds * 1000;
+    splasht = GDrawRequestTimer(splashw,slpashDelayTime,1000,NULL);
 
     localsplash = false;
 }


### PR DESCRIPTION
Providing a new settings option 

"Splash Screen Seconds"

To allow more complete user preference regaring splash time