### PR TITLE
travis: Another fix attempt for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,12 +112,13 @@ install:
     else
       export FFCONFIG="$FFCONFIG --enable-gdk=gdk3 --enable-woff2"
       export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig
+      export PATH="/usr/local/opt/ruby/bin:$PATH"
       export MSGFMT=/usr/local/opt/gettext/bin/msgfmt
       export HOMEBREW_NO_AUTO_UPDATE=1
       # Disable fc-cache on fontconfig install. Because it's slow.
       sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb"
       # 10 billion years later...
-      brew install autoconf automake libtool pkg-config
+      brew install autoconf automake libtool pkg-config ruby
       brew install cairo coreutils fontconfig gettext giflib gtk+3 jpeg libpng libspiro libtiff libtool libuninameslist python@3 wget woff2
       # Pin pango to this version, because of issues, see #3343
       brew unlink pango || true


### PR DESCRIPTION
This time I swear, it fixes the build (well, passes travis, discounting the gtk/gdk bug).

Tested on the travis branch with publishing off that branch enabled

https://travis-ci.org/fontforge/fontforge/jobs/561317510