### PR TITLE
Make PreferSpacingAccents false by default

### DIFF
--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -48,7 +48,7 @@
 
 int accent_offset = 6;
 int GraveAcuteCenterBottom = 1;
-int PreferSpacingAccents = true;
+int PreferSpacingAccents = false;
 int CharCenterHighest = 1;
 
 #define BottomAccent	0x300


### PR DESCRIPTION
The assumption that most people will want spacing accents to be used when building combining characters is wrong; this feature, which many interpret as a bug, should be false by default.

See also:
https://github.com/fontforge/fontforge/pull/3774#issuecomment-514072799
\#3712
\#3708
