### PR TITLE
Fix wordlist error w/glyph name matching ^uni & \.

### DIFF
--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -289,16 +289,17 @@ u_WordlistEscapedInputStringToRealString_readGlyphName(
 	    {
 		unichar_t* endptr = 0;
 		long unicodepoint = u_strtoul( glyphname+3, &endptr, 16 );
-	            SplineChar* tmp = 0;
+		char c;
+		SplineChar* tmp = 0;
 		TRACE("uni prefix, codepoint: %ld\n", unicodepoint );
 		sc = SFGetChar( sf, unicodepoint, 0 );
 
-		for (int i = u_strlen(glyphname); i>=0; i--) {
-		    unichar_t* substr = calloc(i+1, sizeof(unichar_t));
-		    u_strncpy(substr, glyphname, i);
-		    tmp = SFGetChar( sf, -1, u_to_c(substr) );
-		    TRACE("looking for subst. char: %s\n", u_to_c(substr));
-		    free(substr);
+		for (int i = u_strlen(glyphname); i>0; i--) {
+		    c = glyphname[i+1];
+		    glyphname[i+1] = 0;
+		    tmp = SFGetChar( sf, -1, u_to_c(glyphname) );
+		    TRACE("looking for subst. char: %s\n", u_to_c(glyphname));
+		    glyphname[i+1] = c;
 		    if (tmp != NULL) {
 			TRACE("have subst. char: %s\n", tmp->name ); break;
 		    }

--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -289,25 +289,35 @@ u_WordlistEscapedInputStringToRealString_readGlyphName(
 	    {
 		unichar_t* endptr = 0;
 		long unicodepoint = u_strtoul( glyphname+3, &endptr, 16 );
-                SplineChar* tmp = 0;
+	            SplineChar* tmp = 0;
 		TRACE("uni prefix, codepoint: %ld\n", unicodepoint );
 		sc = SFGetChar( sf, unicodepoint, 0 );
-                if ((tmp = SFGetChar( sf, -1, u_to_c(glyphname) ))) {
-		    TRACE("have subst. char: %s\n", tmp->name );
-                    sc = tmp;
-                } else {
+
+		for (int i = u_strlen(glyphname); i>=0; i--) {
+		    unichar_t* substr = calloc(i+1, sizeof(unichar_t));
+		    u_strncpy(substr, glyphname, i);
+		    tmp = SFGetChar( sf, -1, u_to_c(substr) );
+		    TRACE("looking for subst. char: %s\n", u_to_c(substr));
+		    free(substr);
+		    if (tmp != NULL) {
+			TRACE("have subst. char: %s\n", tmp->name ); break;
+		    }
+		}
+
+		if (tmp != NULL){
+		    sc = tmp;
+		} else {
 		    if( sc && endptr )
 		    {
 		        unichar_t* endofglyphname = glyphname + u_strlen(glyphname);
-//		        printf("endptr:%p endofglyphname:%p\n", endptr, endofglyphname );
-		        for( ; endptr < endofglyphname; endptr++ )
-                            --endpos;
+		        //printf("endptr:%p endofglyphname:%p\n", endptr, endofglyphname );
+		        for( ; endptr < endofglyphname; endptr++ ) --endpos;
 		    }
-                }
-	    }
-	    
-	    if( firstLookup && glyphname[0] == '#' )
-	    {
+		}
+		}
+
+		if( firstLookup && glyphname[0] == '#' )
+		{
 		unichar_t* endptr = 0;
 		long unicodepoint = u_strtoul( glyphname+1, &endptr, 16 );
 //		printf("WordlistEscapedInputStringToRealString_readGlyphName() unicodepoint:%ld\n", unicodepoint );

--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -287,7 +287,8 @@ u_WordlistEscapedInputStringToRealString_readGlyphName(
 	{
 	    if( uc_startswith( glyphname, "uni"))
 	    {
-		unichar_t* endptr = 0;
+		unichar_t* endptr = 0, *tmp_gn;
+		int gn_len;
 		long unicodepoint = u_strtoul( glyphname+3, &endptr, 16 );
 		char c;
 		SplineChar* tmp = 0;
@@ -299,16 +300,20 @@ u_WordlistEscapedInputStringToRealString_readGlyphName(
 		 * and split the string. Here we search for the glyphname trimming off 
 		 * characters at the end in order to find the glyph
 		 */
-		for (int i = u_strlen(glyphname); i>0; i--) {
-		    c = glyphname[i+1];
-		    glyphname[i+1] = 0;
-		    tmp = SFGetChar( sf, -1, u_to_c(glyphname) );
-		    TRACE("looking for subst. char: %s\n", u_to_c(glyphname));
-		    glyphname[i+1] = c;
+		gn_len = u_strlen(glyphname);
+		tmp_gn = malloc((gn_len+1)*sizeof(unichar_t));
+		u_strncpy(tmp_gn, glyphname, gn_len);
+		for (int i = gn_len; i>0; i--) {
+		    c = tmp_gn[i+1];
+		    tmp_gn[i+1] = 0;
+		    tmp = SFGetChar( sf, -1, u_to_c(tmp_gn) );
+		    TRACE("looking for subst. char: %s\n", u_to_c(tmp_gn));
+		    tmp_gn[i+1] = c;
 		    if (tmp != NULL) {
 			TRACE("have subst. char: %s\n", tmp->name ); break;
 		    }
 		}
+		free(tmp_gn);
 
 		if (tmp != NULL){
 		    sc = tmp;

--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -294,6 +294,11 @@ u_WordlistEscapedInputStringToRealString_readGlyphName(
 		TRACE("uni prefix, codepoint: %ld\n", unicodepoint );
 		sc = SFGetChar( sf, unicodepoint, 0 );
 
+		/* When text is added after a glyphname with a period (such as "uni1234.alt"
+		 * the other search heuristics will tend to interpret the period as a glyph
+		 * and split the string. Here we search for the glyphname trimming off 
+		 * characters at the end in order to find the glyph
+		 */
 		for (int i = u_strlen(glyphname); i>0; i--) {
 		    c = glyphname[i+1];
 		    glyphname[i+1] = 0;


### PR DESCRIPTION
This fixes a bug wherein the word list input in CharView was unable to understand input like `[/uni043b.alt]a`, fudging it into `[/uni043B]/periodalta`. This is because the parser was simply giving up after trying to find "uni043b.alta", instead of searching for "uni043b.alt", "uni043b.al" etc.

The meat and potatoes of this commit is the added for loop. The rest is just whitespace fixes to make this part of the code actually readable, the `if` statement under it was all messed up.

This closes #3820

### Type of change
- **Bug fix**

