### PR TITLE
Use SplashScreen as pr_int to indicate splash delay in seconds

### DIFF
--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -112,7 +112,7 @@ extern int use_freetype_to_rasterize_fv;	/* in bitmapchar.c */
 /* UI preferences which we don't use, but will preserve to so we can read/write */
 /*  UI preference files without loss of data */
 static char *xdefs_filename;
-static int splash=1;
+static int splash=7;
 static int cv_auto_goto=1;
 static int OpenCharsInNewWindow=1;
 static float arrowAmount=1;
@@ -248,7 +248,7 @@ static struct prefs_list {
 },
 extras[] = {
     { N_("ResourceFile"), pr_file, &xdefs_filename, NULL, NULL, 'R', NULL, 0, N_("When FontForge starts up, it loads the user interface theme from\nthis file. Any changes will only take effect the next time you start FontForge.") },
-    { N_("SplashScreen"), pr_bool, &splash, NULL, NULL, 'S', NULL, 0, N_("Show splash screen on start-up") },
+    { N_("SplashScreen"), pr_int, &splash, NULL, NULL, 'S', NULL, 0, N_("Show splash screen on start-up for this many seconds (set to 0 to hide splash screen completely)") },
     { N_("GlyphAutoGoto"), pr_bool, &cv_auto_goto, NULL, NULL, '\0', NULL, 0, N_("Typing a normal character in the glyph view window changes the window to look at that character") },
     { N_("OpenCharsInNewWindow"), pr_bool, &OpenCharsInNewWindow, NULL, NULL, '\0', NULL, 0, N_("When double clicking on a character in the font view\nopen that character in a new window, otherwise\nreuse an existing one.") },
     { N_("ArrowMoveSize"), pr_real, &arrowAmount, NULL, NULL, '\0', NULL, 0, N_("The number of em-units by which an arrow key will move a selected point") },

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -303,7 +303,7 @@ static struct prefs_list {
 	{ N_("OtherSubrsFile"), pr_file, &othersubrsfile, NULL, NULL, 'O', NULL, 0, N_("If you wish to replace Adobe's OtherSubrs array (for Type1 fonts)\nwith an array of your own, set this to point to a file containing\na list of up to 14 PostScript subroutines. Each subroutine must\nbe preceded by a line starting with '%%%%' (any text before the\nfirst '%%%%' line will be treated as an initial copyright notice).\nThe first three subroutines are for flex hints, the next for hint\nsubstitution (this MUST be present), the 14th (or 13 as the\nnumbering actually starts with 0) is for counter hints.\nThe subroutines should not be enclosed in a [ ] pair.") },
 	{ N_("FreeTypeInFontView"), pr_bool, &use_freetype_to_rasterize_fv, NULL, NULL, 'O', NULL, 0, N_("Use the FreeType rasterizer (when available)\nto rasterize glyphs in the font view.\nThis generally results in better quality.") },
 	{ N_("FreeTypeAAFillInOutlineView"), pr_bool, &use_freetype_with_aa_fill_cv, NULL, NULL, 'O', NULL, 0, N_("When filling using freetype in the outline view,\nhave freetype render the glyph antialiased.") },
-	{ N_("SplashScreen"), pr_bool, &splash, NULL, NULL, 'S', NULL, 0, N_("Show splash screen on start-up") },
+	{ N_("SplashScreen"), pr_int, &splash, NULL, NULL, 'S', NULL, 0, N_("Show splash screen on start-up for this many seconds (set to 0 to hide splash screen completely)") },
 #ifndef _NO_LIBCAIRO
 	{ N_("UseCairoDrawing"), pr_bool, &prefs_usecairo, NULL, NULL, '\0', NULL, 0, N_("Use the cairo library for drawing (if available)\nThis makes for prettier (anti-aliased) but slower drawing\nThis applies to any windows created AFTER this is set.\nAlready existing windows will continue as they are.") },
 #endif

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -102,7 +102,7 @@ extern void setup_cocoa_app();
 #include "scripting.h"
 
 extern int AutoSaveFrequency;
-int splash = 1;
+int splash = 7;
 static int localsplash;
 static int unique = 0;
 
@@ -398,9 +398,12 @@ static void start_splash_screen(void){
     GDrawProcessPendingEvents(NULL);
     GDrawProcessPendingEvents(NULL);
 
-    splasht = GDrawRequestTimer(splashw,7000,1000,NULL);
+    int slpashDelayTime = 7000;
+    if( localsplash > 0 && localsplash < 60 )
+      slpashDelayTime = localsplash * 1000;
+    splasht = GDrawRequestTimer(splashw,slpashDelayTime,1000,NULL);
 
-    localsplash = false;
+    localsplash = 0;
 }
 
 #if defined(__Mac)
@@ -410,7 +413,7 @@ static FILE *logfile;
 static pascal OSErr OpenApplicationAE( const AppleEvent * theAppleEvent,
 	AppleEvent * reply, SRefCon handlerRefcon) {
  fprintf( logfile, "OPENAPP event received.\n" ); fflush( logfile );
-    if ( localsplash )
+    if ( localsplash > 0 )
 	start_splash_screen();
 #ifndef FONTFORGE_CAN_USE_GDK
     system( "DYLD_LIBRARY_PATH=\"\"; osascript -e 'tell application \"X11\" to activate'" );
@@ -424,7 +427,7 @@ return( noErr );
 static pascal OSErr ReopenApplicationAE( const AppleEvent * theAppleEvent,
 	AppleEvent * reply, SRefCon handlerRefcon) {
  fprintf( logfile, "ReOPEN event received.\n" ); fflush( logfile );
-    if ( localsplash )
+    if ( localsplash > 0 )
 	start_splash_screen();
 #ifndef FONTFORGE_CAN_USE_GDK
     system( "DYLD_LIBRARY_PATH=\"\"; osascript -e 'tell application \"X11\" to activate'" );
@@ -438,7 +441,7 @@ return( noErr );
 static pascal OSErr ShowPreferencesAE( const AppleEvent * theAppleEvent,
 	AppleEvent * reply, SRefCon handlerRefcon) {
  fprintf( logfile, "PREFS event received.\n" ); fflush( logfile );
-    if ( localsplash )
+    if ( localsplash > 0 )
 	start_splash_screen();
 #ifndef FONTFORGE_CAN_USE_GDK
     system( "DYLD_LIBRARY_PATH=\"\"; osascript -e 'tell application \"X11\" to activate'" );
@@ -457,7 +460,7 @@ static pascal OSErr OpenDocumentsAE( const AppleEvent * theAppleEvent,
     char	buffer[2048];
 
  fprintf( logfile, "OPEN event received.\n" ); fflush( logfile );
-    if ( localsplash )
+    if ( localsplash > 0 )
 	start_splash_screen();
 
     err = AEGetParamDesc(theAppleEvent, keyDirectObject,
@@ -1292,7 +1295,7 @@ exit( 0 );
     SplashLayout();
     localsplash = splash;
 
-   if ( localsplash && !listen_to_apple_events )
+   if ( localsplash > 0 && !listen_to_apple_events )
 	start_splash_screen();
 
     //


### PR DESCRIPTION
Allow the user to set the time in seconds that the Splash Screen (.. so called, that thing really needs to be de-coupled from other logic, its a combined everything ..) will last.

Let user know via hover message that setting to 0 is equivalent to turning Splash Screen off