### PR TITLE
Allow import of ".py" scripts to Execute dialog

### DIFF
--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -874,7 +874,7 @@ return( NULL );
 return( space );
 }
 
-static unichar_t txt[] = { '*','.','t','x','t',  '\0' };
+static unichar_t txt[] = { '*','.','{','t','x','t',',','p','y','}',  '\0' };
 static unichar_t errort[] = { 'C','o','u','l','d',' ','n','o','t',' ','o','p','e','n',  '\0' };
 static unichar_t error[] = { 'C','o','u','l','d',' ','n','o','t',' ','o','p','e','n',' ','%','.','1','0','0','h','s',  '\0' };
 
@@ -884,7 +884,7 @@ static void GTextFieldImport(GTextField *gt) {
     unichar_t *str;
 
     if ( _ggadget_use_gettext ) {
-	char *temp = GWidgetOpenFile8(_("Open"),NULL,"*.txt",NULL,NULL);
+	char *temp = GWidgetOpenFile8(_("Open"),NULL,"*.{txt,py}",NULL,NULL);
 	ret = utf82u_copy(temp);
 	free(temp);
     } else {

--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -917,7 +917,7 @@ static void GTextFieldSave(GTextField *gt,int utf8) {
     unichar_t *pt;
 
     if ( _ggadget_use_gettext ) {
-	char *temp = GWidgetOpenFile8(_("Save"),NULL,"*.txt",NULL,NULL);
+	char *temp = GWidgetOpenFile8(_("Save"),NULL,"*.{txt,py}",NULL,NULL);
 	ret = utf82u_copy(temp);
 	free(temp);
     } else


### PR DESCRIPTION
Previously, it was not possible to import files ending in ".py" in the
Execute Script dialog, only ".txt" files. This is despite the fact that
that dialog explicitly supports Python scripts.

More could be done certainly; it shouldn't be based on file extension at
all but rather whether or not a file is plaintext. However, that's not
really reasonable to implement, so this kludge works for now.

This has a side effect of allowing you to import Python scripts to any text area...I find that to be no big deal personally, but be aware of it during review.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

