### PR TITLE
Sizeof fixes

### DIFF
--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -1354,7 +1354,7 @@ return;
     }
 
     for ( kc = sf->kerns; kc!=NULL; kc=kc->next ) {
-	firsts = malloc(kc->first_cnt*sizeof(SplineChar *));
+	firsts = malloc(kc->first_cnt*sizeof(SplineChar **));
 	map1 = calloc(kc->first_cnt,sizeof(int));
 	seconds = malloc(kc->second_cnt*sizeof(SplineChar **));
 	map2 = calloc(kc->second_cnt,sizeof(int));

--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -181,7 +181,7 @@ static void CheckOutOfBounds(WidthInfo *wi) {
 
 static void ApplyChanges(WidthInfo *wi) {
     EncMap *map = wi->fv->map;
-    uint8 *rsel = calloc(map->enccount,sizeof(char));
+    uint8 *rsel = calloc(map->enccount,sizeof(uint8));
     int i, width;
     real transform[6];
     struct charone *ch;
@@ -1356,7 +1356,7 @@ return;
     for ( kc = sf->kerns; kc!=NULL; kc=kc->next ) {
 	firsts = malloc(kc->first_cnt*sizeof(SplineChar *));
 	map1 = calloc(kc->first_cnt,sizeof(int));
-	seconds = malloc(kc->second_cnt*sizeof(SplineChar *));
+	seconds = malloc(kc->second_cnt*sizeof(SplineChar **));
 	map2 = calloc(kc->second_cnt,sizeof(int));
 	any1=0;
 	for ( i=1; i<kc->first_cnt; ++i ) {

--- a/fontforge/autowidth2.c
+++ b/fontforge/autowidth2.c
@@ -134,7 +134,7 @@ static void aw2_figure_all_sidebearing(AW_Data *all) {
     AW_Glyph *me, *other;
     real transform[6], half;
     int width, changed;
-    uint8 *rsel = calloc(all->fv->map->enccount,sizeof(char));
+    uint8 *rsel = calloc(all->fv->map->enccount,sizeof(uint8));
     real denom = (all->sf->ascent + all->sf->descent)/DENOM_FACTOR_OF_EMSIZE;
     int ldiff, rdiff;
 

--- a/fontforge/bvedit.c
+++ b/fontforge/bvedit.c
@@ -882,10 +882,10 @@ return( NULL );
 	new->vwidth = rint(old->vwidth*dto/from+.5);
     if ( to_depth==1 ) {
 	new->bytes_per_line = (new->xmax-new->xmin)/8+1;
-	new->bitmap = calloc((new->ymax-new->ymin+1)*new->bytes_per_line,sizeof(char));
+	new->bitmap = calloc((new->ymax-new->ymin+1)*new->bytes_per_line,sizeof(uint8));
     } else {
 	new->bytes_per_line = (new->xmax-new->xmin)+1;
-	new->bitmap = calloc((new->ymax-new->ymin+1)*new->bytes_per_line,sizeof(char));
+	new->bitmap = calloc((new->ymax-new->ymin+1)*new->bytes_per_line,sizeof(uint8));
 	new->byte_data = true;
     }
     new->orig_pos = old->orig_pos;

--- a/fontforge/bvedit.c
+++ b/fontforge/bvedit.c
@@ -814,7 +814,7 @@ return( NULL );
     else
 	new->vwidth = rint(old->vwidth*dto/from+.5);
     new->bytes_per_line = (new->xmax-new->xmin)/8+1;
-    new->bitmap = calloc((new->ymax-new->ymin+1)*new->bytes_per_line,sizeof(char));
+    new->bitmap = calloc((new->ymax-new->ymin+1)*new->bytes_per_line,sizeof(uint8));
     new->orig_pos = old->orig_pos;
     new->refs = old->refs;
     new->dependents = old->dependents;

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -1517,7 +1517,7 @@ return(NULL);
 	fvs->cidmaster = NULL;
 	if ( fvs->sf->glyphcnt!=new->glyphcnt ) {
 	    free(fvs->selected);
-	    fvs->selected = calloc(new->glyphcnt,sizeof(char));
+	    fvs->selected = calloc(new->glyphcnt,sizeof(uint8));
 	    if ( fvs->map->encmax < new->glyphcnt )
 		fvs->map->map = realloc(fvs->map->map,(fvs->map->encmax = new->glyphcnt)*sizeof(int32));
 	    fvs->map->enccount = new->glyphcnt;
@@ -1665,7 +1665,7 @@ return( false );
 		map->map = realloc(map->map,(map->encmax = map->enccount = max+extras)*sizeof(int32));
 		memset(map->map,-1,map->enccount*sizeof(int32));
 		memset(map->backmap,-1,sf->glyphcnt*sizeof(int32));
-		fvs->selected = realloc(fvs->selected, map->enccount*sizeof(char));
+		fvs->selected = realloc(fvs->selected, map->enccount*sizeof(uint8));
 		if (map->enccount > sf->glyphcnt) {
 		    memset(fvs->selected+sf->glyphcnt, 0, map->enccount-sf->glyphcnt);
 		}
@@ -1843,7 +1843,7 @@ return(NULL);
 	PSDictChangeEntry(sf->private,"lenIV","1");		/* It's 4 by default, in CIDs the convention seems to be 1 */
     for ( fvs=sf->fv; fvs!=NULL; fvs=fvs->nextsame ) {
 	free(fvs->selected);
-	fvs->selected = calloc(fvs->sf->glyphcnt,sizeof(char));
+	fvs->selected = calloc(fvs->sf->glyphcnt,sizeof(uint8));
 	EncMapFree(fvs->map);
 	fvs->map = EncMap1to1(fvs->sf->glyphcnt);
 	FVSetTitle(fvs);

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2200,7 +2200,7 @@ return -1;
 	SFReplaceEncodingBDFProps(sf,fv->map);
     }
     free(fv->selected);
-    fv->selected = calloc(fv->map->enccount,sizeof(char));
+    fv->selected = calloc(fv->map->enccount,sizeof(uint8));
     if ( !no_windowing_ui )
 	FontViewReformatAll(sf);
 

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -1221,7 +1221,7 @@ void CIDSetEncMap(FontViewBase *fv, SplineFont *new ) {
 	    memset(fv->selected+gcnt,0,fv->map->enccount-gcnt);
 	else {
 	    free(fv->selected);
-	    fv->selected = calloc(gcnt,sizeof(char));
+	    fv->selected = calloc(gcnt,sizeof(uint8));
 	}
 	fv->map->enccount = gcnt;
     }
@@ -1939,7 +1939,7 @@ static FontViewBase *_FontViewBaseCreate(SplineFont *sf) {
 	fv->map = EncMap1to1(sf->glyphcnt);
 	if ( fv->nextsame==NULL ) { sf->map = fv->map; }
     }
-    fv->selected = calloc(fv->map->enccount,sizeof(char));
+    fv->selected = calloc(fv->map->enccount,sizeof(uint8));
 
 #ifndef _NO_PYTHON
     PyFF_InitFontHook(fv);

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -2356,7 +2356,7 @@ static void BCMakeSpace(BDFFont *bdf, int gid, int width, int em) {
 	bc->ymax = 1;
 	bc->bytes_per_line = 1;
 	bc->width = rint(width*bdf->pixelsize/(real) em);
-	bc->bitmap = calloc(bc->bytes_per_line*(bc->ymax-bc->ymin+1),sizeof(char));
+	bc->bitmap = calloc(bc->bytes_per_line*(bc->ymax-bc->ymin+1),sizeof(uint8));
     }
 }
 

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -295,7 +295,7 @@ PST *PSTCopy(PST *base,SplineChar *sc,struct sfmergecontext *mc) {
 	    cur->u.pair.vr[0].adjust = ValDevTabCopy(base->u.pair.vr[0].adjust);
 	    cur->u.pair.vr[1].adjust = ValDevTabCopy(base->u.pair.vr[1].adjust);
 	} else if ( cur->type==pst_lcaret ) {
-	    cur->u.lcaret.carets = malloc(cur->u.lcaret.cnt*sizeof(uint16));
+	    cur->u.lcaret.carets = malloc(cur->u.lcaret.cnt*sizeof(int16));
 	    memcpy(cur->u.lcaret.carets,base->u.lcaret.carets,cur->u.lcaret.cnt*sizeof(uint16));
 	} else if ( cur->type==pst_substitution || cur->type==pst_multiple || cur->type==pst_alternate )
 	    cur->u.subs.variant = copy(cur->u.subs.variant);

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -2342,7 +2342,7 @@ int FVImportBDF(FontViewBase *fv, char *filename, int ispk, int toback) {
 	FontViewBase *fvs;
 	for ( fvs=fv->sf->fv; fvs!=NULL; fvs=fvs->nextsame ) {
 	    free(fvs->selected);
-	    fvs->selected = calloc(fvs->map->enccount,sizeof(char));
+	    fvs->selected = calloc(fvs->map->enccount,sizeof(uint8));
 	}
 	FontViewReformatAll(fv->sf);
     }

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -1967,7 +1967,7 @@ static SplineFont *SearchPostScriptResources(FILE *f,long rlistpos,int subcnt,lo
     SplineFont *sf;
 
     fseek(f,rlistpos,SEEK_SET);
-    rsrcids = calloc(subcnt,sizeof(short));
+    rsrcids = calloc(subcnt,sizeof(unsigned short));
     offsets = calloc(subcnt,sizeof(long));
     for ( i=0; i<subcnt; ++i ) {
 	rsrcids[i] = getushort(f);
@@ -2481,7 +2481,7 @@ static void LoadNFNT(FILE *f,long offset, SplineFont *sf) {
     font.leading = getushort(f);
     font.rowWords = getushort(f);
     if ( font.rowWords!=0 ) {
-	font.fontImage = calloc(font.rowWords*font.fRectHeight,sizeof(short));
+	font.fontImage = calloc(font.rowWords*font.fRectHeight,sizeof(unsigned short));
 	font.locs = calloc(font.lastChar-font.firstChar+3,sizeof(unsigned short));
 	font.offsetWidths = calloc(font.lastChar-font.firstChar+3,sizeof(unsigned short));
 	for ( i=0; i<font.rowWords*font.fRectHeight; ++i )

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -2482,8 +2482,8 @@ static void LoadNFNT(FILE *f,long offset, SplineFont *sf) {
     font.rowWords = getushort(f);
     if ( font.rowWords!=0 ) {
 	font.fontImage = calloc(font.rowWords*font.fRectHeight,sizeof(short));
-	font.locs = calloc(font.lastChar-font.firstChar+3,sizeof(short));
-	font.offsetWidths = calloc(font.lastChar-font.firstChar+3,sizeof(short));
+	font.locs = calloc(font.lastChar-font.firstChar+3,sizeof(unsigned short));
+	font.offsetWidths = calloc(font.lastChar-font.firstChar+3,sizeof(unsigned short));
 	for ( i=0; i<font.rowWords*font.fRectHeight; ++i )
 	    font.fontImage[i] = getushort(f);
 	for ( i=0; i<font.lastChar-font.firstChar+3; ++i )

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -295,7 +295,7 @@ int TTF__getcvtval(SplineFont *sf,int val) {
         cvt_tab = chunkalloc(sizeof(struct ttf_table));
         cvt_tab->tag = CHR('c','v','t',' ');
         cvt_tab->maxlen = 200;
-        cvt_tab->data = malloc(100*sizeof(uint8));
+        cvt_tab->data = malloc(100*sizeof(short));
         cvt_tab->next = sf->ttf_tables;
         sf->ttf_tables = cvt_tab;
     }
@@ -692,7 +692,7 @@ static void init_cvt(GlobalInstrCt *gic) {
     cvtsize += gic->stemsnapvcnt;
     cvtsize += gic->bluecnt * 2; /* possible family blues */
 
-    cvt = calloc(cvtsize, cvtsize * 2 * sizeof(uint8));
+    cvt = calloc(cvtsize, cvtsize * sizeof(int16));
     cvtindex = 0;
 
     /* Assign cvt indices */
@@ -727,7 +727,7 @@ static void init_cvt(GlobalInstrCt *gic) {
     }
 
     cvtsize = cvtindex;
-    cvt = realloc(cvt, cvtsize * 2 * sizeof(uint8));
+    cvt = realloc(cvt, cvtsize * sizeof(int16));
 
     /* Try to implant the new cvt table */
     gic->cvt_done = 0;

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -295,7 +295,7 @@ int TTF__getcvtval(SplineFont *sf,int val) {
         cvt_tab = chunkalloc(sizeof(struct ttf_table));
         cvt_tab->tag = CHR('c','v','t',' ');
         cvt_tab->maxlen = 200;
-        cvt_tab->data = malloc(100*sizeof(short));
+        cvt_tab->data = malloc(100*sizeof(uint8));
         cvt_tab->next = sf->ttf_tables;
         sf->ttf_tables = cvt_tab;
     }
@@ -727,7 +727,7 @@ static void init_cvt(GlobalInstrCt *gic) {
     }
 
     cvtsize = cvtindex;
-    cvt = realloc(cvt, cvtsize * sizeof(int16));
+    cvt = realloc(cvt, cvtsize * sizeof(uint8));
 
     /* Try to implant the new cvt table */
     gic->cvt_done = 0;

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -692,7 +692,7 @@ static void init_cvt(GlobalInstrCt *gic) {
     cvtsize += gic->stemsnapvcnt;
     cvtsize += gic->bluecnt * 2; /* possible family blues */
 
-    cvt = calloc(cvtsize, cvtsize * sizeof(int16));
+    cvt = calloc(cvtsize, cvtsize * 2 * sizeof(uint8));
     cvtindex = 0;
 
     /* Assign cvt indices */
@@ -727,7 +727,7 @@ static void init_cvt(GlobalInstrCt *gic) {
     }
 
     cvtsize = cvtindex;
-    cvt = realloc(cvt, cvtsize * sizeof(uint8));
+    cvt = realloc(cvt, cvtsize * 2 * sizeof(uint8));
 
     /* Try to implant the new cvt table */
     gic->cvt_done = 0;

--- a/fontforge/parsepfa.c
+++ b/fontforge/parsepfa.c
@@ -1059,7 +1059,7 @@ static void InitChars(struct pschars *chars,char *line) {
     chars->cnt = strtol(line,NULL,10);
     if ( chars->cnt>0 ) {
 	chars->keys = calloc(chars->cnt,sizeof(char *));
-	chars->values = calloc(chars->cnt,sizeof(char *));
+	chars->values = calloc(chars->cnt,sizeof(uint8 *));
 	chars->lens = calloc(chars->cnt,sizeof(int));
 	ff_progress_change_total(chars->cnt);
     }
@@ -2459,7 +2459,7 @@ static void figurecids(struct fontparse *fp,FILE *temp) {
 		(sdbytes=strtol(ssdbytes,NULL,10))>0 &&
 		(subrcnt=strtol(ssubrcnt,NULL,10))>0 ) {
 	    private->subrs->cnt = subrcnt;
-	    private->subrs->values = calloc(subrcnt,sizeof(char *));
+	    private->subrs->values = calloc(subrcnt,sizeof(uint8 *));
 	    private->subrs->lens = calloc(subrcnt,sizeof(int));
 	    leniv = private->leniv;
 	    offsets = malloc((subrcnt+1)*sizeof(int));

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -4933,7 +4933,7 @@ return;
 	    cnt = (len-(ftell(ttf)-(info->encoding_start+encoff)))/sizeof(short);
 	    /* The count is the number of glyph indexes to read. it is the */
 	    /*  length of the entire subtable minus that bit we've read so far */
-	    glyphs = malloc(cnt*sizeof(short));
+	    glyphs = malloc(cnt*sizeof(uint16));
 	    for ( i=0; i<cnt; ++i )
 		glyphs[i] = getushort(ttf);
 	    last = -1;

--- a/fontforge/parsettfatt.c
+++ b/fontforge/parsettfatt.c
@@ -3436,7 +3436,7 @@ return;
     sc->possub = pst;
     sc->lig_caret_cnt_fixed = true;
     pst->u.lcaret.cnt = cnt;
-    pst->u.lcaret.carets = malloc(cnt*sizeof(uint16));
+    pst->u.lcaret.carets = malloc(cnt*sizeof(int16));
     for ( i=0; i<cnt; ++i )
 	pst->u.lcaret.carets[i] = getushort(ttf);
     fseek(ttf,here,SEEK_SET);

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -409,8 +409,8 @@ static void pdf_dump_type1(PI *pi,int sfid) {
 
     fd_obj = figure_fontdesc(pi, sfid, &fd,1,font_stream);
 
-    sfbit->our_font_objs = malloc((sfbit->map->enccount/256+1)*sizeof(int *));
-    sfbit->fonts = malloc((sfbit->map->enccount/256+1)*sizeof(int *));
+    sfbit->our_font_objs = malloc((sfbit->map->enccount/256+1)*sizeof(int));
+    sfbit->fonts = malloc((sfbit->map->enccount/256+1)*sizeof(int));
     for ( i=0; i<sfbit->map->enccount; i += 256 ) {
 	sfbit->fonts[i/256] = -1;
 	dump_pfb_encoding(pi,sfid,i,fd_obj);

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -1382,7 +1382,7 @@ static void bUtf8(Context *c) {
 	c->return_val.u.sval = u2utf8_copy(buf);
     } else if ( c->a.vals[1].type==v_arr || c->a.vals[1].type==v_arrfree ) {
 	Array *arr = c->a.vals[1].u.aval;
-	temp = malloc((arr->argc+1)*sizeof(int32));
+	temp = malloc((arr->argc+1)*sizeof(uint32));
 	for ( i=0; i<arr->argc; ++i ) {
 	    if ( arr->vals[i].type!=v_int ) {
 		c->error = ce_badargtype;

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -6113,7 +6113,7 @@ return( 0 );
 	bfc->byte_data = true;
 	bfc->depth = bdf->clut->clut_len==4 ? 2 : bdf->clut->clut_len==16 ? 4 : 8;
     }
-    bfc->bitmap = calloc((bfc->ymax-bfc->ymin+1)*bfc->bytes_per_line,sizeof(char));
+    bfc->bitmap = calloc((bfc->ymax-bfc->ymin+1)*bfc->bytes_per_line,sizeof(uint8));
 
     memset(&dec,'\0', sizeof(dec)); dec.pos = -1;
     dec.sfd = sfd;

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -534,13 +534,13 @@ return( 0 );
 	fclose(file);
 return( 0 );
     }
-    tfmd.kerntab = calloc(tfmd.kern_size,sizeof(int32));
-    tfmd.ligkerntab = calloc(tfmd.ligkern_size,sizeof(int32));
-    tfmd.ext = calloc(tfmd.esize,sizeof(int32));
-    tfmd.ictab = calloc(tfmd.italic_size,sizeof(int32));
-    tfmd.dptab = calloc(tfmd.depth_size,sizeof(int32));
-    tfmd.httab = calloc(tfmd.height_size,sizeof(int32));
-    tfmd.widtab = calloc(tfmd.width_size,sizeof(int32));
+    tfmd.kerntab = calloc(tfmd.kern_size,sizeof(uint8));
+    tfmd.ligkerntab = calloc(tfmd.ligkern_size,sizeof(uint8));
+    tfmd.ext = calloc(tfmd.esize,sizeof(uint8));
+    tfmd.ictab = calloc(tfmd.italic_size,sizeof(uint8));
+    tfmd.dptab = calloc(tfmd.depth_size,sizeof(uint8));
+    tfmd.httab = calloc(tfmd.height_size,sizeof(uint8));
+    tfmd.widtab = calloc(tfmd.width_size,sizeof(uint8));
     tfmd.charlist = charlist;
 
     fseek( file,(6+1)*sizeof(int32),SEEK_SET);
@@ -787,13 +787,13 @@ return( 0 );
 return( 0 );
     }
 
-    tfmd.kerntab = calloc(tfmd.kern_size,sizeof(int32));
-    tfmd.ligkerntab = calloc(tfmd.ligkern_size,2*sizeof(int32));
-    tfmd.ext = calloc(tfmd.esize,2*sizeof(int32));
-    tfmd.ictab = calloc(tfmd.italic_size,sizeof(int32));
-    tfmd.dptab = calloc(tfmd.depth_size,sizeof(int32));
-    tfmd.httab = calloc(tfmd.height_size,sizeof(int32));
-    tfmd.widtab = calloc(tfmd.width_size,sizeof(int32));
+    tfmd.kerntab = calloc(tfmd.kern_size,sizeof(uint8));
+    tfmd.ligkerntab = calloc(tfmd.ligkern_size,2*sizeof(uint8));
+    tfmd.ext = calloc(tfmd.esize,2*sizeof(uint8));
+    tfmd.ictab = calloc(tfmd.italic_size,sizeof(uint8));
+    tfmd.dptab = calloc(tfmd.depth_size,sizeof(uint8));
+    tfmd.httab = calloc(tfmd.height_size,sizeof(uint8));
+    tfmd.widtab = calloc(tfmd.width_size,sizeof(uint8));
     fseek( file,(14+1)*sizeof(int32),SEEK_SET);
     sf->design_size = (5*getlong(file)+(1<<18))>>19;	/* TeX stores as <<20, adobe in decipoints */
     fseek( file,

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -787,8 +787,8 @@ return( 0 );
 return( 0 );
     }
 
-    tfmd.kerntab = calloc(tfmd.kern_size,sizeof(uint8));
-    tfmd.ligkerntab = calloc(tfmd.ligkern_size,2*sizeof(uint8));
+    tfmd.kerntab = calloc(tfmd.kern_size,4*sizeof(uint8));
+    tfmd.ligkerntab = calloc(tfmd.ligkern_size,4*2*sizeof(uint8));
     tfmd.ext = calloc(tfmd.esize,4*2*sizeof(uint8));
     tfmd.ictab = calloc(tfmd.italic_size,4*sizeof(uint8));
     tfmd.dptab = calloc(tfmd.depth_size,4*sizeof(uint8));

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -534,13 +534,13 @@ return( 0 );
 	fclose(file);
 return( 0 );
     }
-    tfmd.kerntab = calloc(tfmd.kern_size,sizeof(uint8));
-    tfmd.ligkerntab = calloc(tfmd.ligkern_size,sizeof(uint8));
-    tfmd.ext = calloc(tfmd.esize,sizeof(uint8));
-    tfmd.ictab = calloc(tfmd.italic_size,sizeof(uint8));
-    tfmd.dptab = calloc(tfmd.depth_size,sizeof(uint8));
-    tfmd.httab = calloc(tfmd.height_size,sizeof(uint8));
-    tfmd.widtab = calloc(tfmd.width_size,sizeof(uint8));
+    tfmd.kerntab = calloc(tfmd.kern_size,4*sizeof(uint8));
+    tfmd.ligkerntab = calloc(tfmd.ligkern_size,4*sizeof(uint8));
+    tfmd.ext = calloc(tfmd.esize,4*sizeof(uint8));
+    tfmd.ictab = calloc(tfmd.italic_size,4*sizeof(uint8));
+    tfmd.dptab = calloc(tfmd.depth_size,4*sizeof(uint8));
+    tfmd.httab = calloc(tfmd.height_size,4*sizeof(uint8));
+    tfmd.widtab = calloc(tfmd.width_size,4*sizeof(uint8));
     tfmd.charlist = charlist;
 
     fseek( file,(6+1)*sizeof(int32),SEEK_SET);
@@ -789,11 +789,11 @@ return( 0 );
 
     tfmd.kerntab = calloc(tfmd.kern_size,sizeof(uint8));
     tfmd.ligkerntab = calloc(tfmd.ligkern_size,2*sizeof(uint8));
-    tfmd.ext = calloc(tfmd.esize,2*sizeof(uint8));
-    tfmd.ictab = calloc(tfmd.italic_size,sizeof(uint8));
-    tfmd.dptab = calloc(tfmd.depth_size,sizeof(uint8));
-    tfmd.httab = calloc(tfmd.height_size,sizeof(uint8));
-    tfmd.widtab = calloc(tfmd.width_size,sizeof(uint8));
+    tfmd.ext = calloc(tfmd.esize,4*2*sizeof(uint8));
+    tfmd.ictab = calloc(tfmd.italic_size,4*sizeof(uint8));
+    tfmd.dptab = calloc(tfmd.depth_size,4*sizeof(uint8));
+    tfmd.httab = calloc(tfmd.height_size,4*sizeof(uint8));
+    tfmd.widtab = calloc(tfmd.width_size,4*sizeof(uint8));
     fseek( file,(14+1)*sizeof(int32),SEEK_SET);
     sf->design_size = (5*getlong(file)+(1<<18))>>19;	/* TeX stores as <<20, adobe in decipoints */
     fseek( file,

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -1800,7 +1800,7 @@ static void dumpcffnames(SplineFont *sf,FILE *cfff) {
 static void dumpcffcharset(SplineFont *sf,struct alltabs *at) {
     int i;
 
-    at->gn_sid = calloc(at->gi.gcnt,sizeof(short));
+    at->gn_sid = calloc(at->gi.gcnt,2*sizeof(short));
     putc(0,at->charset);
     /* I always use a format 0 charset. ie. an array of SIDs in random order */
 

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -1800,7 +1800,7 @@ static void dumpcffnames(SplineFont *sf,FILE *cfff) {
 static void dumpcffcharset(SplineFont *sf,struct alltabs *at) {
     int i;
 
-    at->gn_sid = calloc(at->gi.gcnt,sizeof(uint32));
+    at->gn_sid = calloc(at->gi.gcnt,sizeof(short));
     putc(0,at->charset);
     /* I always use a format 0 charset. ie. an array of SIDs in random order */
 
@@ -4615,7 +4615,7 @@ static FILE *NeedsUCS2Table(SplineFont *sf,int *ucs2len,EncMap *map,int issymbol
 	    j = -1;
     }
     cmapseg = calloc(segcnt+1,sizeof(struct cmapseg));
-    ranges = malloc(cnt*sizeof(int16));
+    ranges = malloc(cnt*sizeof(uint16));
     j = -1;
     for ( i=segcnt=0; i<65536; ++i ) {
 	if ( avail[i]!=0xffffffff && j==-1 ) {
@@ -4705,10 +4705,10 @@ static FILE *NeedsVariationSequenceTable(SplineFont *sf,int *vslen) {
 		if ( i>=vs_cnt ) {
 		    if ( i>=vs_max ) {
 			if ( vses==vsbuf ) {
-			    vses = malloc((vs_max*=2)*sizeof(uint32));
+			    vses = malloc((vs_max*=2)*sizeof(int32));
 			    memcpy(vses,vsbuf,sizeof(vsbuf));
 			} else
-			    vses = realloc(vses,(vs_max+=512)*sizeof(uint32));
+			    vses = realloc(vses,(vs_max+=512)*sizeof(int32));
 		    }
 		    vses[vs_cnt++] = altuni->vs;
 		}

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -1800,7 +1800,7 @@ static void dumpcffnames(SplineFont *sf,FILE *cfff) {
 static void dumpcffcharset(SplineFont *sf,struct alltabs *at) {
     int i;
 
-    at->gn_sid = calloc(at->gi.gcnt,2*sizeof(short));
+    at->gn_sid = calloc(at->gi.gcnt,sizeof(uint32));
     putc(0,at->charset);
     /* I always use a format 0 charset. ie. an array of SIDs in random order */
 

--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -1105,7 +1105,7 @@ static int morx_dumpASM(FILE *temp,ASM *sm, struct alltabs *at, SplineFont *sf )
     stcnt = 0;
     subslookups = NULL; subsins = NULL;
     if ( sm->type==asm_context ) {
-	subslookups = malloc(2*sm->state_cnt*sm->class_cnt*sizeof(OTLookup));
+	subslookups = malloc(2*sm->state_cnt*sm->class_cnt*sizeof(OTLookup*));
 	for ( j=0; j<sm->state_cnt*sm->class_cnt; ++j ) {
 	    struct asm_state *this = &sm->state[j];
 	    transdata[j].mark_index = transdata[j].cur_index = 0xffff;

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -1929,7 +1929,7 @@ static void dumpGSUBligdata(FILE *gsub,SplineFont *sf,
 	putshort(gsub,pcnt);
 	if ( pcnt>=max ) {
 	    max = pcnt+100;
-	    ligoffsets = realloc(ligoffsets,max*sizeof(int));
+	    ligoffsets = realloc(ligoffsets,max*sizeof(uint16));
 	}
 	lig_list_start = ftell(gsub);
 	for ( j=0; j<pcnt; ++j )

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -1929,7 +1929,7 @@ static void dumpGSUBligdata(FILE *gsub,SplineFont *sf,
 	putshort(gsub,pcnt);
 	if ( pcnt>=max ) {
 	    max = pcnt+100;
-	    ligoffsets = realloc(ligoffsets,max*sizeof(uint16));
+	    ligoffsets = realloc(ligoffsets,max*2*sizeof(uint16));
 	}
 	lig_list_start = ftell(gsub);
 	for ( j=0; j<pcnt; ++j )

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -1929,7 +1929,7 @@ static void dumpGSUBligdata(FILE *gsub,SplineFont *sf,
 	putshort(gsub,pcnt);
 	if ( pcnt>=max ) {
 	    max = pcnt+100;
-	    ligoffsets = realloc(ligoffsets,max*2*sizeof(uint16));
+	    ligoffsets = realloc(ligoffsets,max*sizeof(int));
 	}
 	lig_list_start = ftell(gsub);
 	for ( j=0; j<pcnt; ++j )

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -1199,7 +1199,7 @@ static void dumpGPOSpairpos(FILE *gpos,SplineFont *sf,struct lookup_subtable *su
 	}
 	if ( start_cnt!=0 || end_cnt!=cnt ) {
 	    if ( chunk_cnt>=chunk_max )
-		sub->extra_subtables = realloc(sub->extra_subtables,((chunk_max+=10)+1)*sizeof(uint32));
+		sub->extra_subtables = realloc(sub->extra_subtables,((chunk_max+=10)+1)*sizeof(int32));
 	    sub->extra_subtables[chunk_cnt++] = ftell(gpos);
 	    sub->extra_subtables[chunk_cnt] = -1;
 	}
@@ -1918,7 +1918,7 @@ static void dumpGSUBligdata(FILE *gsub,SplineFont *sf,
     putshort(gsub,cnt);
     next_val_pos = ftell(gsub);
     if ( glyphs!=NULL )
-	offsets = malloc(cnt*sizeof(int16));
+	offsets = malloc(cnt*sizeof(uint16));
     for ( i=0; i<cnt; ++i )
 	putshort(gsub,0);
     for ( i=0; i<cnt; ++i ) {

--- a/fontforgeexe/basedlg.c
+++ b/fontforgeexe/basedlg.c
@@ -652,7 +652,7 @@ return( true );
 		int tag = md[cols*r+1].u.md_ival;
 		for ( j=0; stdtags[j]!=0 && stdtags[j]!=tag; ++j );
 		bs->def_baseline = mapping[j];
-		bs->baseline_pos = malloc(cnt*sizeof(uint16));
+		bs->baseline_pos = malloc(cnt*sizeof(int16));
 		for ( i=0; stdtags[i]!=0 ; ++i ) if ( mapping[i]!=-1 )
 		    bs->baseline_pos[mapping[i]] = md[r*cols+i+2].u.md_ival;
 	    }

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -1208,8 +1208,8 @@ static PST *CI_PSTCopy(PST *pst) {
 	    newpst->u.pair.vr[0].adjust = ValDevTabCopy(pst->u.pair.vr[0].adjust);
 	    newpst->u.pair.vr[1].adjust = ValDevTabCopy(pst->u.pair.vr[1].adjust);
 	} else if ( newpst->type==pst_lcaret ) {
-	    newpst->u.lcaret.carets = malloc(pst->u.lcaret.cnt*sizeof(uint16));
-	    memcpy(newpst->u.lcaret.carets,pst->u.lcaret.carets,pst->u.lcaret.cnt*sizeof(uint16));
+	    newpst->u.lcaret.carets = malloc(pst->u.lcaret.cnt*sizeof(int16));
+	    memcpy(newpst->u.lcaret.carets,pst->u.lcaret.carets,pst->u.lcaret.cnt*sizeof(int16));
 	} else if ( newpst->type==pst_substitution || newpst->type==pst_multiple || newpst->type==pst_alternate )
 	    newpst->u.subs.variant = copy(pst->u.subs.variant);
 	newpst->next = NULL;

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -6998,7 +6998,7 @@ static FontView *__FontViewCreate(SplineFont *sf) {
 	    if ( fv->b.nextsame==NULL ) { sf->map = fv->b.map; }
 	}
     }
-    fv->b.selected = calloc((fv->b.map ? fv->b.map->enccount : 0), sizeof(char));
+    fv->b.selected = calloc((fv->b.map ? fv->b.map->enccount : 0), sizeof(uint8));
     fv->user_requested_magnify = -1;
     fv->magnify = (ps<=9)? 3 : (ps<20) ? 2 : 1;
     fv->cbw = (ps*fv->magnify)+1;

--- a/gdraw/gresedit.c
+++ b/gdraw/gresedit.c
@@ -1020,7 +1020,7 @@ static void GResEditDlg(GResInfo *all,const char *def_res_file,void (*change_res
 	cnt = 0;
 	if ( res->extras!=NULL )
 	    for ( extras=res->extras, cnt = 0; extras->name!=NULL; ++cnt, ++extras );
-	tofree[i].earray = calloc(cnt+1,sizeof(GGadgetCreateData[8]));
+	tofree[i].earray = calloc(cnt+1,sizeof(GGadgetCreateData*[8]));
 	tofree[i].extradefs = calloc(cnt+1,sizeof(char *));
 	cnt *= 2;
 	if ( res->initialcomment!=NULL )

--- a/gutils/gimagereadrgb.c
+++ b/gutils/gimagereadrgb.c
@@ -214,7 +214,7 @@ GImage *GImageReadRgb(char *filename) {
 
 	/* First, get offset table info */
 	tablen = header.height*header.chans;
-	if ( (starttab=(unsigned long *)calloc(1,tablen*sizeof(long)))==NULL || \
+	if ( (starttab=(unsigned long *)calloc(1,tablen*sizeof(unsigned long)))==NULL || \
 	   /*(lengthtab=(unsigned long *)calloc(1,tablen*sizeof(long)))==NULL || \ */
 	     (ptrtab=(unsigned char **)calloc(1,tablen*sizeof(unsigned char *)))==NULL ) {
 	    NoMoreMemMessage();


### PR DESCRIPTION
This quiets warnings warnings that the Clang Static Analyzer complains about regarding `sizeof` operations in allocation calls, including `malloc`, `calloc`, and `realloc`:

> Result of '_call_' is converted to a pointer of type '_typeA_', which is incompatible with sizeof operand type '_typeB_'

Most of the changes are minor, such as changing from a signed to an unsigned type. ~~Other changes, however, may cause crashes due to memory changes (such as in fontforge/splinesaveafm.c).~~ Most of the problematic changes have been reverted.
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Code maintenance**