### PR TITLE
appdata: add name and summary to appdata file

### DIFF
--- a/desktop/org.fontforge.FontForge.appdata.xml
+++ b/desktop/org.fontforge.FontForge.appdata.xml
@@ -2,6 +2,20 @@
 <!-- Copyright 2014 Joe Da Silva <digital@joescat.com> -->
 <component type="desktop">
   <id>org.fontforge.FontForge</id>
+  <name>FontForge</name>
+  <name xml:lang="zh-TW">=字型鍛造廠</name>
+  <summary>An outline font editor</summary>
+  <summary xml:lang="de">Ein Font-Editor</summary>
+  <summary xml:lang="eo">Tipar dosiero-redaktilo</summary>
+  <summary xml:lang="es">Un editor de fuentes</summary>
+  <summary xml:lang="fr">Un constructeur des polices</summary>
+  <summary xml:lang="hr">Uređivač za fontove</summary>
+  <summary xml:lang="it">Un profilo editor di font</summary>
+  <summary xml:lang="pt">Um editor de fontes</summary>
+  <summary xml:lang="pl_PL">Edytor fontów</summary>
+  <summary xml:lang="ru">Редактор шрифтов</summary>
+  <summary xml:lang="uk">Редактор шрифтів</summary>
+  <summary xml:lang="zh-TW">FontForge 描邊字型編輯器</summary>
   <launchable type="desktop-id">org.fontforge.FontForge.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <description>


### PR DESCRIPTION
It seems a name and a summary is required in order to pass validation.
This is copy and pasted from the metainfo file, which I think is highly redundant.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **New feature**
- **Breaking change**
- **Non-breaking change**
