### PR TITLE
Fix macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,9 +126,6 @@ install:
       # 10 billion years later...
       brew install autoconf automake libtool pkg-config ruby
       brew install cairo coreutils fontconfig gettext giflib gtk+3 jpeg libpng libspiro libtiff libtool libuninameslist python@2 python@3 wget woff2
-      # Pin pango to this version, because of issues, see #3343
-      brew unlink pango || true
-      brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/ad91e4df4a843764901811a965a17f650f34e2c1/Formula/pango.rb
       # This *must* be linked or else gettext/intl will be disabled
       brew link --force gettext
       # Until Homebrew fixes their gtk

--- a/fontforge/Makefile.am
+++ b/fontforge/Makefile.am
@@ -194,11 +194,6 @@ splinerefigure.lo: $(srcdir)/splinerefigure.c $(srcdir)/splinefont.h
 
 EXTRA_DIST = generate_codepoint_selector.py
 
-if MACINTOSH
-EXTRA_DIST += MacFontForgeApp.zip
-MOSTLYCLEANFILES = MacFontForgeApp.zip
-endif MACINTOSH
-
 #--------------------------------------------------------------------------
 
 -include $(top_srcdir)/git.mk

--- a/fontforgeexe/Makefile.am
+++ b/fontforgeexe/Makefile.am
@@ -152,7 +152,6 @@ endif PYTHON_SCRIPTING
 EXTRA_DIST = fontimage.pe fontlint.pe sfddiff.pe	\
 	fontimage.1 fontlint.1 sfddiff.1
 
-# MacFontForgeApp.zip
 MOSTLYCLEANFILES = fontimage fontlint sfddiff
 DISTCLEANFILES = $(MOSTLYCLEANFILES)
 


### PR DESCRIPTION
Homebrew updated Pango and now GDK breaks because our outdated Pango library.
