### PR TITLE
Fix the Unicode names of Hangul syllables

### DIFF
--- a/gutils/unicodelibinfo.c
+++ b/gutils/unicodelibinfo.c
@@ -125,24 +125,16 @@ char *unicode_name(int32 unienc) {
     //fprintf(stderr,"libunicodes library ->%s<-\n",name_data);
 #endif
 
-    /* George Williams' improvisation on Hangul Syllable range
-     * As of Unicode 6.3.0 0xAC00 - 0xD7A3 is defined as a block
-     * without individual code point names.
+    /* Unicode name derivation rule NR1
      * Code moved here from fontforgeexe/fontview.c
      * FIXME: maybe this belongs to lower library stack instead,
      * revisit later.
      */
     if( ( unienc >= 0xAC00 && unienc <= 0xD7A3 ) && ( name_data == NULL ) ) {
-	if( ( ( unienc - 0xAC00 ) % 28 ) == 0 ) {
-	    name_data = smprintf( "Hangul Syllable %s-%s",
-		    chosung [ (unienc - 0xAC00) / (21*28) ],
-		    jungsung[ ((unienc - 0xAC00) / 28 ) % 21 ] );
-	} else {
-	    name_data = smprintf( "Hangul Syllable %s-%s-%s",
-		    chosung [ (unienc - 0xAC00) / (21*28) ],
-		    jungsung[ ((unienc - 0xAC00) / 28 ) % 21 ],
-		    jongsung[ (unienc - 0xAC00) % 28 ] );
-	}
+	name_data = smprintf( "HANGUL SYLLABLE %s%s%s",
+		chosung [ (unienc - 0xAC00) / (21*28) ],
+		jungsung[ ((unienc - 0xAC00) / 28 ) % 21 ],
+		jongsung[ (unienc - 0xAC00) % 28 ] );
     }
 
     return( name_data );


### PR DESCRIPTION
For Hangul syllables with null onsets, the function `unicode_name` was returning names with leading hyphens, as in `"Hangul Syllable -A"` instead of `"HANGUL SYLLABLE A"`. Per [UAX44-LM2](https://www.unicode.org/reports/tr44/#UAX44-LM2), those are different names, so the function is wrong.

The other syllables were merely unnormalized, like `"Hangul Syllable G-A"` instead of `"HANGUL SYLLABLE GA"`. This was inconsistent with other characters’ names, which are returned as Unicode defines them.

I added a reference to the Unicode rule that defines Hangul names, and removed the implication that George Williams developed this algorithm.

### Type of change
- **Bug fix**