### PR TITLE
Remove contextual information from translated strings

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3240,7 +3240,7 @@ msgstr "Skriptenliste"
 
 #: ../fontforge/lookups.c:1328 ../fontforgeexe/lookupui.c:191
 msgid "Script|Balinese"
-msgstr "Skript|Balinesisch"
+msgstr "Balinesisch"
 
 #: ../fontforge/lookups.c:1329 ../fontforgeexe/lookupui.c:192
 #, fuzzy
@@ -3459,7 +3459,7 @@ msgstr "Skriptenliste"
 
 #: ../fontforge/lookups.c:1385 ../fontforgeexe/lookupui.c:246
 msgid "Script|Latin"
-msgstr "Skript|Lateinisch"
+msgstr "Lateinisch"
 
 #: ../fontforge/lookups.c:1386 ../fontforgeexe/lookupui.c:247
 msgid "Lepcha (Róng)"
@@ -7292,11 +7292,11 @@ msgstr ""
 
 #: ../fontforge/parsettf.c:4485
 msgid "Script|Japanese"
-msgstr "Skript|Japanisch"
+msgstr "Japanisch"
 
 #: ../fontforge/parsettf.c:4485
 msgid "Script|Korean"
-msgstr "Skript|Koreanisch"
+msgstr "Koreanisch"
 
 #: ../fontforge/parsettf.c:4485
 msgid "Script|Roman"
@@ -12278,7 +12278,7 @@ msgstr "_Scheren..."
 #: ../fontforgeexe/metricsview.c:3497 ../fontforgeexe/metricsview.c:3501
 #: ../fontforgeexe/openfontdlg.c:740
 msgid "Font|_New"
-msgstr "Schriftart|_Neu"
+msgstr "_Neu"
 
 #: ../fontforgeexe/bitmapview.c:2130 ../fontforgeexe/charview.c:11762
 #: ../fontforgeexe/fontview.c:4409 ../fontforgeexe/metricsview.c:3502
@@ -12638,7 +12638,7 @@ msgstr ""
 #: ../fontforgeexe/charinfo.c:164 ../fontforgeexe/fontview.c:4460
 #: ../fontforgeexe/fontview.c:4599 ../fontforgeexe/groupsdlg.c:52
 msgid "Color|Default"
-msgstr "Farbe|Standard"
+msgstr "Standard"
 
 #: ../fontforgeexe/charinfo.c:176
 msgid "New Pair Position"
@@ -12917,7 +12917,7 @@ msgstr ""
 
 #: ../fontforgeexe/charinfo.c:2357
 msgid "PixelSize|New"
-msgstr "Pixelgröße|Neu"
+msgstr "Neu"
 
 #: ../fontforgeexe/charinfo.c:2382 ../fontforgeexe/charinfo.c:2387
 #: ../fontforgeexe/charinfo.c:2392 ../fontforgeexe/charinfo.c:2397
@@ -15360,7 +15360,7 @@ msgstr ""
 
 #: ../fontforgeexe/contextchain.c:1937 ../fontforgeexe/contextchain.c:1942
 msgid "Class|Name"
-msgstr "Klasse|Name"
+msgstr "Name"
 
 #: ../fontforgeexe/contextchain.c:1938 ../fontforgeexe/contextchain.c:1943
 #: ../fontforgeexe/fontinfo.c:1364
@@ -15842,7 +15842,7 @@ msgstr "_Filter"
 #: ../fontforgeexe/cvexportdlg.c:581 ../fontforgeexe/savefontdlg.c:2227
 #: ../gdraw/gsavefiledlg.c:273
 msgid "Directory|_New"
-msgstr "Verzeichnis|_Neu"
+msgstr "_Neu"
 
 #: ../fontforgeexe/cvexportdlg.c:592 ../fontforgeexe/cvimportdlg.c:701
 msgid "Format:"
@@ -18301,7 +18301,7 @@ msgstr ""
 #. GT:  of "Interpretation"
 #: ../fontforgeexe/fontinfo.c:83
 msgid "Interpretation|None"
-msgstr "Interpretation|Keine"
+msgstr "Keine"
 
 #: ../fontforgeexe/fontinfo.c:94
 msgid "MacStyles|Bold"
@@ -18735,7 +18735,7 @@ msgstr "Fett Kursiv"
 
 #: ../fontforgeexe/fontinfo.c:228
 msgid "OS2Version|Automatic"
-msgstr "OS2Version|Automatisch"
+msgstr "Automatisch"
 
 #: ../fontforgeexe/fontinfo.c:229 ../fontforgeexe/fontinfo.c:237
 msgid "1"
@@ -21164,11 +21164,11 @@ msgstr "_Quadratische Ziehpunkte"
 #: ../fontforgeexe/fontinfo.c:1346 ../fontforgeexe/fontview.c:5094
 #: ../fontforgeexe/metricsview.c:3681
 msgid "Layer|Foreground"
-msgstr "Ebene|Vordergrund"
+msgstr "Vordergrund"
 
 #: ../fontforgeexe/fontinfo.c:1347
 msgid "Layer|Background"
-msgstr "Ebene|Hintergrund"
+msgstr "Hintergrund"
 
 #: ../fontforgeexe/fontinfo.c:1352
 msgid "Layer Name"
@@ -21562,7 +21562,7 @@ msgstr "Unterstreichungs_position:"
 
 #: ../fontforgeexe/fontinfo.c:4148 ../fontforgeexe/fontinfo.c:7990
 msgid "Underline|_Height:"
-msgstr "Unterstreichung|_Höhe:"
+msgstr "_Höhe:"
 
 #: ../fontforgeexe/fontinfo.c:4149
 msgid "_Em Size:"
@@ -24640,7 +24640,7 @@ msgstr ""
 
 #: ../fontforgeexe/justifydlg.c:820
 msgid "Language|New"
-msgstr "Sprache|Neu"
+msgstr "Neu"
 
 #: ../fontforgeexe/justifydlg.c:953
 msgid "Justified Scripts"
@@ -24652,7 +24652,7 @@ msgstr ""
 
 #: ../fontforgeexe/justifydlg.c:1016
 msgid "Script|New"
-msgstr "Skript|Neu"
+msgstr "Neu"
 
 #: ../fontforgeexe/kernclass.c:252 ../fontforgeexe/kernclass.c:302
 #: ../fontforgeexe/kernclass.c:1211 ../fontforgeexe/lookupui.c:3474
@@ -25227,7 +25227,7 @@ msgstr ""
 
 #: ../fontforgeexe/lookupui.c:374
 msgid "Lang|Default"
-msgstr "Sprache|Standard"
+msgstr "Standard"
 
 #: ../fontforgeexe/lookupui.c:375
 msgid "Woods Cree"
@@ -27452,7 +27452,7 @@ msgstr ""
 
 #: ../fontforgeexe/mmdlg.c:1699
 msgid "Font|New"
-msgstr "Schriftart|Neu"
+msgstr "Neu"
 
 #: ../fontforgeexe/mmdlg.c:1780 ../fontforgeexe/mmdlg.c:3081
 msgid "Force Bold Threshold:"
@@ -27770,7 +27770,7 @@ msgstr "Schriftartfilter bearbeiten"
 
 #: ../fontforgeexe/openfontdlg.c:425
 msgid "Filter|New"
-msgstr "Filter|Neu"
+msgstr "Neu"
 
 #: ../fontforgeexe/openfontdlg.c:663
 msgid "Filter:"
@@ -33911,7 +33911,7 @@ msgstr "Ausgewählte Lesezeichen entfernen"
 
 #: ../gdraw/gfilechooser.c:1030
 msgid "Directory|Back"
-msgstr "Verzeichnis|Zurück"
+msgstr "Zurück"
 
 #: ../gdraw/gfilechooser.c:1031
 #, fuzzy
@@ -34130,7 +34130,7 @@ msgstr ""
 
 #: ../gdraw/gmatrixedit.c:1630
 msgid "Row|New"
-msgstr "Reihe|Neu"
+msgstr "Neu"
 
 #: ../gdraw/gmenu.c:73 ../gdraw/gmenu.c:74
 msgid "Menu Bar"

--- a/po/el.po
+++ b/po/el.po
@@ -3191,7 +3191,7 @@ msgstr ""
 #: ../fontforge/lookups.c:1328 ../fontforgeexe/lookupui.c:190
 #, fuzzy
 msgid "Script|Bengali2"
-msgstr "Lang|Bengali"
+msgstr "Bengali"
 
 #: ../fontforge/lookups.c:1329 ../fontforgeexe/lookupui.c:191
 msgid "Bliss Symbolics"
@@ -3235,7 +3235,7 @@ msgstr "Βουλγαρική"
 #: ../fontforgeexe/fontinfo.c:1172
 #, fuzzy
 msgid "Cherokee"
-msgstr "Lang|Cherokee"
+msgstr "Cherokee"
 
 #: ../fontforge/lookups.c:1339 ../fontforgeexe/lookupui.c:199
 msgid "Script|Cham"
@@ -3256,7 +3256,7 @@ msgstr "Ασιατικά Ιδεογράμματα"
 #: ../fontforge/lookups.c:1343 ../fontforgeexe/lookupui.c:203
 #, fuzzy
 msgid "Script|Coptic"
-msgstr "Lang|Coptic"
+msgstr "Coptic"
 
 #: ../fontforge/lookups.c:1344 ../fontforgeexe/lookupui.c:204
 msgid "Cypro-Minoan"
@@ -3385,7 +3385,7 @@ msgstr ""
 #: ../fontforge/lookups.c:1378 ../fontforgeexe/lookupui.c:238
 #, fuzzy
 msgid "Script|Kannada2"
-msgstr "Lang|Kannada"
+msgstr "Kannada"
 
 #: ../fontforge/lookups.c:1379 ../fontforgeexe/lookupui.c:239
 msgid "Script|Khmer"
@@ -3436,12 +3436,12 @@ msgstr ""
 #: ../fontforge/lookups.c:1391 ../fontforgeexe/lookupui.c:249
 #, fuzzy
 msgid "Script|Malayālam"
-msgstr "Lang|Kannada"
+msgstr "Kannada"
 
 #: ../fontforge/lookups.c:1392 ../fontforgeexe/lookupui.c:250
 #, fuzzy
 msgid "Script|Malayālam2"
-msgstr "Lang|Kannada"
+msgstr "Kannada"
 
 #: ../fontforge/lookups.c:1393 ../fontforge/unicoderange.c:404
 #: ../fontforgeexe/fontinfo.c:1185 ../fontforgeexe/lookupui.c:251
@@ -10108,22 +10108,22 @@ msgstr "Συμπληρωματικά κυριλλικά"
 #: ../fontforge/unicoderange.c:61 ../fontforgeexe/fontinfo.c:1105
 #, fuzzy
 msgid "Armenian"
-msgstr "Lang|Armenian"
+msgstr "Armenian"
 
 #: ../fontforge/unicoderange.c:62 ../fontforgeexe/fontinfo.c:1106
 #, fuzzy
 msgid "Hebrew"
-msgstr "Lang|Hebrew"
+msgstr "Hebrew"
 
 #: ../fontforge/unicoderange.c:63 ../fontforgeexe/fontinfo.c:1108
 #, fuzzy
 msgid "Arabic"
-msgstr "Lang|Arabic"
+msgstr "Arabic"
 
 #: ../fontforge/unicoderange.c:64 ../fontforgeexe/fontinfo.c:1167
 #, fuzzy
 msgid "Syriac"
-msgstr "Lang|Syriac"
+msgstr "Syriac"
 
 #: ../fontforge/unicoderange.c:65
 #, fuzzy
@@ -10161,7 +10161,7 @@ msgstr "Πολυτονικά Ελληνικά"
 #: ../fontforge/unicoderange.c:75 ../fontforgeexe/fontinfo.c:1111
 #, fuzzy
 msgid "Bengali"
-msgstr "Lang|Bengali"
+msgstr "Bengali"
 
 #: ../fontforge/unicoderange.c:77 ../fontforgeexe/fontinfo.c:1113
 #, fuzzy
@@ -10171,7 +10171,7 @@ msgstr "Guarani"
 #: ../fontforge/unicoderange.c:78 ../fontforgeexe/fontinfo.c:1114
 #, fuzzy
 msgid "Oriya"
-msgstr "Lang|Oriya"
+msgstr "Oriya"
 
 #: ../fontforge/unicoderange.c:79 ../fontforgeexe/fontinfo.c:1115
 #, fuzzy
@@ -10181,12 +10181,12 @@ msgstr "Family"
 #: ../fontforge/unicoderange.c:80 ../fontforgeexe/fontinfo.c:1116
 #, fuzzy
 msgid "Telugu"
-msgstr "Lang|Telugu"
+msgstr "Telugu"
 
 #: ../fontforge/unicoderange.c:81 ../fontforgeexe/fontinfo.c:1117
 #, fuzzy
 msgid "Kannada"
-msgstr "Lang|Kannada"
+msgstr "Kannada"
 
 #: ../fontforge/unicoderange.c:82 ../fontforgeexe/fontinfo.c:1118
 #, fuzzy
@@ -10212,17 +10212,17 @@ msgstr "Lak"
 #: ../fontforge/unicoderange.c:86 ../fontforgeexe/fontinfo.c:1166
 #, fuzzy
 msgid "Tibetan"
-msgstr "Lang|Tibetan"
+msgstr "Tibetan"
 
 #: ../fontforge/unicoderange.c:87 ../fontforgeexe/fontinfo.c:1170
 #, fuzzy
 msgid "Myanmar"
-msgstr "Script|Myanmar"
+msgstr "Myanmar"
 
 #: ../fontforge/unicoderange.c:88 ../fontforgeexe/fontinfo.c:1121
 #, fuzzy
 msgid "Georgian"
-msgstr "Lang|Georgian"
+msgstr "Georgian"
 
 #: ../fontforge/unicoderange.c:89
 #, fuzzy
@@ -10242,7 +10242,7 @@ msgstr "Hangul Jamo"
 #: ../fontforge/unicoderange.c:92 ../fontforgeexe/fontinfo.c:1171
 #, fuzzy
 msgid "Ethiopic"
-msgstr "Script|Ethiopic"
+msgstr "Ethiopic"
 
 #: ../fontforge/unicoderange.c:93
 #, fuzzy
@@ -10257,7 +10257,7 @@ msgstr "Canadian Syllabics"
 #: ../fontforge/unicoderange.c:98
 #, fuzzy
 msgid "Tagalog"
-msgstr "Lang|Tagalog"
+msgstr "Tagalog"
 
 #: ../fontforge/unicoderange.c:99
 msgid "Hanunóo"
@@ -10276,7 +10276,7 @@ msgstr "Thaana"
 #: ../fontforge/unicoderange.c:102 ../fontforgeexe/fontinfo.c:1176
 #, fuzzy
 msgid "Khmer"
-msgstr "Lang|Khmer"
+msgstr "Khmer"
 
 #: ../fontforge/unicoderange.c:103 ../fontforgeexe/fontinfo.c:1177
 #, fuzzy
@@ -10291,7 +10291,7 @@ msgstr "Canadian Syllabics"
 #: ../fontforge/unicoderange.c:105 ../fontforgeexe/fontinfo.c:1189
 #, fuzzy
 msgid "Limbu"
-msgstr "Lang|Limbu"
+msgstr "Limbu"
 
 #: ../fontforge/unicoderange.c:108
 #, fuzzy
@@ -10301,7 +10301,7 @@ msgstr "Σύμβολα Χμερ"
 #: ../fontforge/unicoderange.c:109 ../fontforgeexe/fontinfo.c:1192
 #, fuzzy
 msgid "Buginese"
-msgstr "Script|Buginese"
+msgstr "Buginese"
 
 #: ../fontforge/unicoderange.c:110
 msgid "Tai Tham"
@@ -10574,7 +10574,7 @@ msgstr ""
 #: ../fontforge/unicoderange.c:170 ../fontforgeexe/fontinfo.c:1103
 #, fuzzy
 msgid "Coptic"
-msgstr "Lang|Coptic"
+msgstr "Coptic"
 
 #: ../fontforge/unicoderange.c:171
 #, fuzzy
@@ -11016,7 +11016,7 @@ msgstr ""
 #: ../fontforge/unicoderange.c:303 ../fontforgeexe/fontinfo.c:1199
 #, fuzzy
 msgid "Ugaritic"
-msgstr "Script|Ugaritic"
+msgstr "Ugaritic"
 
 #: ../fontforge/unicoderange.c:304 ../fontforgeexe/fontinfo.c:1200
 #, fuzzy
@@ -11069,7 +11069,7 @@ msgstr ""
 #: ../fontforge/unicoderange.c:318 ../fontforgeexe/fontinfo.c:1153
 #, fuzzy
 msgid "Phoenician"
-msgstr "Γραφή|Φοινικική"
+msgstr "Φοινικική"
 
 #: ../fontforge/unicoderange.c:320
 msgid "Meroitic Hieroglyphs"
@@ -12164,7 +12164,7 @@ msgstr "Θα πρέπει να είναι αριθμός"
 #. GT:      <pfaedit@users.sourceforge.net>
 #: ../fontforgeexe/bdfinfo.c:539
 msgid "Property|New..."
-msgstr "Ιδιότητα|Νέο..."
+msgstr "Νέο..."
 
 #: ../fontforgeexe/bdfinfo.c:590 ../fontforgeexe/statemachine.c:215
 msgid "No Change"
@@ -12377,7 +12377,7 @@ msgstr "Στρέβλωση..."
 #: ../fontforgeexe/openfontdlg.c:736
 #, fuzzy
 msgid "Font|_New"
-msgstr "Γραμματοσειρά|_Νέα"
+msgstr "_Νέα"
 
 #: ../fontforgeexe/bitmapview.c:2124 ../fontforgeexe/charview.c:11703
 #: ../fontforgeexe/fontview.c:4408 ../fontforgeexe/metricsview.c:3499
@@ -12736,7 +12736,7 @@ msgstr ""
 #: ../fontforgeexe/charinfo.c:161 ../fontforgeexe/fontview.c:4459
 #: ../fontforgeexe/fontview.c:4598 ../fontforgeexe/groupsdlg.c:48
 msgid "Color|Default"
-msgstr "Χρώμα|«Εξ ορισμού»"
+msgstr "«Εξ ορισμού»"
 
 #: ../fontforgeexe/charinfo.c:173
 msgid "New Pair Position"
@@ -13283,7 +13283,7 @@ msgstr ""
 #: ../fontforgeexe/charinfo.c:4562
 #, fuzzy
 msgid "CounterHint|_New..."
-msgstr "Ιδιότητα|Νέο..."
+msgstr "Νέο..."
 
 #: ../fontforgeexe/charinfo.c:4586 ../fontforgeexe/kernclass.c:3394
 #: ../fontforgeexe/macencui.c:678 ../fontforgeexe/macencui.c:1196
@@ -20971,12 +20971,12 @@ msgstr "Τουρκική"
 #: ../fontforgeexe/fontinfo.c:1232
 #, fuzzy
 msgid "1255, Hebrew"
-msgstr "Lang|Hebrew"
+msgstr "Hebrew"
 
 #: ../fontforgeexe/fontinfo.c:1233
 #, fuzzy
 msgid "1256, Arabic"
-msgstr "Lang|Arabic"
+msgstr "Arabic"
 
 #: ../fontforgeexe/fontinfo.c:1234
 msgid "1257, Windows Baltic"
@@ -21162,7 +21162,7 @@ msgstr ""
 #: ../fontforgeexe/fontinfo.c:1278
 #, fuzzy
 msgid "864, Arabic"
-msgstr "Lang|Arabic"
+msgstr "Arabic"
 
 #: ../fontforgeexe/fontinfo.c:1279
 msgid "863, MS-DOS Canadian French"
@@ -21171,7 +21171,7 @@ msgstr ""
 #: ../fontforgeexe/fontinfo.c:1280
 #, fuzzy
 msgid "862, Hebrew"
-msgstr "Lang|Hebrew"
+msgstr "Hebrew"
 
 #: ../fontforgeexe/fontinfo.c:1281
 #, fuzzy
@@ -24240,7 +24240,7 @@ msgstr ""
 #: ../fontforgeexe/fontview.c:7382
 #, fuzzy
 msgid "FontView"
-msgstr "Γραμματοσειρά|_Νέα"
+msgstr "_Νέα"
 
 #: ../fontforgeexe/fontview.c:7383
 msgid "This is the main fontforge window displaying a font"
@@ -28543,12 +28543,12 @@ msgstr ""
 #: ../fontforgeexe/prefs.c:2424
 #, fuzzy
 msgid "Prefs_App|FontForge recognizes BROWSER, MF and AUTOTRACE."
-msgstr "Επιλογ.|Εφάρμ.|Το FontForge αναγνωρίζει την BROWSER, MF και AUTOTRACE."
+msgstr "Το FontForge αναγνωρίζει την BROWSER, MF και AUTOTRACE."
 
 #: ../fontforgeexe/prefs.c:2425
 #, fuzzy
 msgid "Prefs_App| "
-msgstr "Επιλογ.|Εφαρμ. "
+msgstr " "
 
 #: ../fontforgeexe/prefs.c:2456
 msgid "Features"
@@ -34382,7 +34382,7 @@ msgstr ""
 
 #: ../gdraw/gmatrixedit.c:1629
 msgid "Row|New"
-msgstr "Γραμμή|Νέα"
+msgstr "Νέα"
 
 #: ../gdraw/gmenu.c:71 ../gdraw/gmenu.c:72
 msgid "Menu Bar"

--- a/po/ko.po
+++ b/po/ko.po
@@ -3785,7 +3785,7 @@ msgstr "우가리트 설형 자"
 
 #: ../fontforge/lookups.c:1442 ../fontforgeexe/lookupui.c:296
 msgid "Script|Yi"
-msgstr "Script|Yi"
+msgstr "Yi"
 
 #: ../fontforge/lookups.c:1487
 msgid "Required Feature"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7774,7 +7774,7 @@ msgstr "Dewanagari"
 
 #: ../fontforge/parsettf.c:4489
 msgid "Script|RSymbol"
-msgstr "Script|RSymbol"
+msgstr "RSymbol"
 
 #: ../fontforge/parsettf.c:4490
 msgid "Script|Gurmukhi"

--- a/po/pt.po
+++ b/po/pt.po
@@ -686,7 +686,7 @@ msgstr "Grava..."
 #: ../fontforge/dumppfa.c:1545 ../fontforge/dumppfa.c:2436
 #, fuzzy
 msgid "Converting PostScript"
-msgstr "sistema de escrita|Script"
+msgstr "Script"
 
 #: ../fontforge/dumppfa.c:1552 ../fontforge/dumppfa.c:2440
 #: ../fontforge/savefont.c:826
@@ -11837,7 +11837,7 @@ msgstr "Definir Extensões de Função"
 #: ../fontforgeexe/lookupui.c:708 ../fontforgeexe/showatt.c:1883
 #: ../fontforgeexe/showatt.c:1921
 msgid "writing system|Script"
-msgstr "sistema de escrita|Script"
+msgstr "Script"
 
 #: ../fontforgeexe/basedlg.c:419
 msgid "Default Baseline"
@@ -11974,7 +11974,7 @@ msgstr "Deve ser um número"
 #. GT:      <pfaedit@users.sourceforge.net>
 #: ../fontforgeexe/bdfinfo.c:542
 msgid "Property|New..."
-msgstr "Propriedade|Novo..."
+msgstr "Novo..."
 
 #: ../fontforgeexe/bdfinfo.c:593 ../fontforgeexe/statemachine.c:218
 msgid "No Change"
@@ -13080,7 +13080,7 @@ msgstr ""
 #: ../fontforgeexe/charinfo.c:4565
 #, fuzzy
 msgid "CounterHint|_New..."
-msgstr "Propriedade|Novo..."
+msgstr "Novo..."
 
 #: ../fontforgeexe/charinfo.c:4589 ../fontforgeexe/kernclass.c:3398
 #: ../fontforgeexe/macencui.c:681 ../fontforgeexe/macencui.c:1199
@@ -28589,7 +28589,7 @@ msgstr ""
 #: ../fontforgeexe/problems.c:2626
 #, fuzzy
 msgid "Missing Script"
-msgstr "sistema de escrita|Script"
+msgstr "Script"
 
 #: ../fontforgeexe/problems.c:2824
 msgid "This blank outline glyph has an unexpected bitmap version"

--- a/po/uk.po
+++ b/po/uk.po
@@ -20556,7 +20556,7 @@ msgstr ""
 
 #: ../fontforgeexe/fontinfo.c:705
 msgid "PanoseLining|Any"
-msgstr "PanoseLining|Будь-яке"
+msgstr "Будь-яке"
 
 #: ../fontforgeexe/fontinfo.c:706
 msgid "PanoseLining|No Fit"
@@ -29785,7 +29785,7 @@ msgstr "FontForge визначає BROWSER, MF і AUTOTRACE."
 
 #: ../fontforgeexe/prefs.c:2392
 msgid "Prefs_App| "
-msgstr "Prefs_App| "
+msgstr " "
 
 #: ../fontforgeexe/prefs.c:2423
 msgid "Features"

--- a/po/vi.po
+++ b/po/vi.po
@@ -25586,11 +25586,10 @@ msgstr "Chiều rộng sớm không thay đổi."
 msgid "Left Side Bearing does not change."
 msgstr "Vị trí phương hướng bên trái không thay đổi."
 
-# Có nên dịch không? Và ký tự ống dẫn như thế nào? Tôi đã hỏi nhà phát triển.
 #: ../fontforgeexe/fvmetricsdlg.c:49
 #, fuzzy
 msgid "ThisSpaceIntentionallyLeftBlank-PleaseDoNotTranslate-LeaveThisOut|"
-msgstr "KhoảngNàyDựĐịnhBỏTrống|"
+msgstr ""
 
 #: ../fontforgeexe/fvmetricsdlg.c:49
 msgid "Top Bearing does not change."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3811,7 +3811,7 @@ msgstr "希伯来语"
 #
 #: ../fontforge/lookups.c:1376 ../fontforgeexe/lookupui.c:237
 msgid "Script|Javanese"
-msgstr "Script|Javanese"
+msgstr "Javanese"
 
 #
 #: ../fontforge/lookups.c:1377 ../fontforge/unicoderange.c:223
@@ -3832,22 +3832,22 @@ msgstr "Kharoṣṭhī"
 #
 #: ../fontforge/lookups.c:1380 ../fontforgeexe/lookupui.c:241
 msgid "Script|Kannada"
-msgstr "Script|Kannada"
+msgstr "Kannada"
 
 #
 #: ../fontforge/lookups.c:1381 ../fontforgeexe/lookupui.c:242
 msgid "Script|Kannada2"
-msgstr "Script|Kannada2"
+msgstr "Kannada2"
 
 #
 #: ../fontforge/lookups.c:1382 ../fontforgeexe/lookupui.c:243
 msgid "Script|Khmer"
-msgstr "Script|Khmer"
+msgstr "Khmer"
 
 #
 #: ../fontforge/lookups.c:1383 ../fontforgeexe/lookupui.c:244
 msgid "Script|Kharosthi"
-msgstr "Script|Kharosthi"
+msgstr "Kharosthi"
 
 #
 #: ../fontforge/lookups.c:1384 ../fontforgeexe/lookupui.c:245
@@ -3867,7 +3867,7 @@ msgstr "Lepcha (Róng)"
 #
 #: ../fontforge/lookups.c:1387 ../fontforgeexe/lookupui.c:248
 msgid "Script|Limbu"
-msgstr "Script|Limbu"
+msgstr "Limbu"
 
 #
 #: ../fontforge/lookups.c:1388 ../fontforge/unicoderange.c:314
@@ -3893,17 +3893,17 @@ msgstr "利西亚语"
 #
 #: ../fontforge/lookups.c:1392 ../fontforgeexe/lookupui.c:251
 msgid "Script|Mandaean"
-msgstr "Script|Mandaean"
+msgstr "Mandaean"
 
 #
 #: ../fontforge/lookups.c:1394 ../fontforgeexe/lookupui.c:253
 msgid "Script|Malayālam"
-msgstr "Script|Malayālam"
+msgstr "Malayālam"
 
 #
 #: ../fontforge/lookups.c:1395 ../fontforgeexe/lookupui.c:254
 msgid "Script|Malayālam2"
-msgstr "Script|Malayālam2"
+msgstr "Malayālam2"
 
 #
 #: ../fontforge/lookups.c:1396 ../fontforge/unicoderange.c:407
@@ -3924,7 +3924,7 @@ msgstr "乐符"
 #
 #: ../fontforge/lookups.c:1399 ../fontforgeexe/lookupui.c:258
 msgid "Script|Myanmar"
-msgstr "Script|Myanmar"
+msgstr "Myanmar"
 
 #
 #: ../fontforge/lookups.c:1400 ../fontforge/unicoderange.c:110
@@ -3958,7 +3958,7 @@ msgstr "老意大利文 (Etruscan, Oscan 等)"
 #
 #: ../fontforge/lookups.c:1405 ../fontforgeexe/lookupui.c:262
 msgid "Script|Old Permic"
-msgstr "Script|Old Permic"
+msgstr "Old Permic"
 
 #
 #: ../fontforge/lookups.c:1406 ../fontforgeexe/lookupui.c:263
@@ -3968,12 +3968,12 @@ msgstr "Old Persian cuneiform"
 #
 #: ../fontforge/lookups.c:1407 ../fontforgeexe/lookupui.c:264
 msgid "Script|Oriya"
-msgstr "Script|Oriya"
+msgstr "Oriya"
 
 #
 #: ../fontforge/lookups.c:1408 ../fontforgeexe/lookupui.c:265
 msgid "Script|Oriya2"
-msgstr "Script|Oriya2"
+msgstr "Oriya2"
 
 #
 #: ../fontforge/lookups.c:1409 ../fontforge/unicoderange.c:310
@@ -3984,17 +3984,17 @@ msgstr "Osmanya"
 #
 #: ../fontforge/lookups.c:1410 ../fontforgeexe/lookupui.c:267
 msgid "Script|Pahlavi"
-msgstr "Script|Pahlavi"
+msgstr "Pahlavi"
 
 #
 #: ../fontforge/lookups.c:1411 ../fontforgeexe/lookupui.c:268
 msgid "Script|Phags-pa"
-msgstr "Script|Phags-pa"
+msgstr "Phags-pa"
 
 #
 #: ../fontforge/lookups.c:1412 ../fontforgeexe/lookupui.c:269
 msgid "Script|Phoenician"
-msgstr "Script|Phoenician"
+msgstr "Phoenician"
 
 #
 #: ../fontforge/lookups.c:1413 ../fontforgeexe/lookupui.c:270
@@ -4037,12 +4037,12 @@ msgstr "Shavian"
 #
 #: ../fontforge/lookups.c:1420 ../fontforgeexe/lookupui.c:275
 msgid "Script|Sinhala"
-msgstr "Script|Sinhala"
+msgstr "Sinhala"
 
 #
 #: ../fontforge/lookups.c:1421 ../fontforgeexe/lookupui.c:276
 msgid "Script|Sumero-Akkadian Cuneiform"
-msgstr "Script|Sumero-Akkadian Cuneiform"
+msgstr "Sumero-Akkadian Cuneiform"
 
 #
 #: ../fontforge/lookups.c:1422
@@ -4052,22 +4052,22 @@ msgstr "巽他语"
 #
 #: ../fontforge/lookups.c:1423 ../fontforgeexe/lookupui.c:277
 msgid "Script|Syloti Nagri"
-msgstr "Script|Syloti Nagri"
+msgstr "Syloti Nagri"
 
 #
 #: ../fontforge/lookups.c:1424 ../fontforgeexe/lookupui.c:278
 msgid "Script|Syriac"
-msgstr "Script|Syriac"
+msgstr "Syriac"
 
 #
 #: ../fontforge/lookups.c:1425 ../fontforgeexe/lookupui.c:279
 msgid "Script|Tagalog"
-msgstr "Script|Tagalog"
+msgstr "Tagalog"
 
 #
 #: ../fontforge/lookups.c:1426 ../fontforgeexe/lookupui.c:280
 msgid "Script|Tagbanwa"
-msgstr "Script|Tagbanwa"
+msgstr "Tagbanwa"
 
 #
 #: ../fontforge/lookups.c:1427 ../fontforge/unicoderange.c:109
@@ -4083,22 +4083,22 @@ msgstr "Tai Lu"
 #
 #: ../fontforge/lookups.c:1429 ../fontforgeexe/lookupui.c:283
 msgid "Script|Tamil"
-msgstr "Script|Tamil"
+msgstr "Tamil"
 
 #
 #: ../fontforge/lookups.c:1430 ../fontforgeexe/lookupui.c:284
 msgid "Script|Tamil2"
-msgstr "Script|Tamil2"
+msgstr "Tamil2"
 
 #
 #: ../fontforge/lookups.c:1431 ../fontforgeexe/lookupui.c:285
 msgid "Script|Telugu"
-msgstr "Script|Telugu"
+msgstr "Telugu"
 
 #
 #: ../fontforge/lookups.c:1432 ../fontforgeexe/lookupui.c:286
 msgid "Script|Telugu2"
-msgstr "Script|Telugu2"
+msgstr "Telugu2"
 
 #
 #: ../fontforge/lookups.c:1433 ../fontforgeexe/lookupui.c:287
@@ -4115,7 +4115,7 @@ msgstr "塔安那文"
 #: ../fontforge/lookups.c:1435 ../fontforge/parsettf.c:4492
 #: ../fontforgeexe/lookupui.c:289
 msgid "Script|Thai"
-msgstr "Script|Thai"
+msgstr "Thai"
 
 #
 #: ../fontforge/lookups.c:1436 ../fontforgeexe/lookupui.c:290
@@ -4130,12 +4130,12 @@ msgstr "Tifinagh (Berber)"
 #
 #: ../fontforge/lookups.c:1438 ../fontforgeexe/lookupui.c:292
 msgid "Script|Ugaritic"
-msgstr "Script|Ugaritic"
+msgstr "Ugaritic"
 
 #
 #: ../fontforge/lookups.c:1439 ../fontforgeexe/lookupui.c:293
 msgid "Script|Vai"
-msgstr "Script|Vai"
+msgstr "Vai"
 
 #
 #: ../fontforge/lookups.c:1441 ../fontforgeexe/lookupui.c:295
@@ -4145,7 +4145,7 @@ msgstr "Cuneiform, Ugaritic"
 #
 #: ../fontforge/lookups.c:1442 ../fontforgeexe/lookupui.c:296
 msgid "Script|Yi"
-msgstr "Script|彝文字符"
+msgstr "彝文字符"
 
 #
 #: ../fontforge/lookups.c:1487
@@ -4586,7 +4586,7 @@ msgstr "乌尔都语"
 #: ../fontforge/macenc.c:2252 ../fontforgeexe/fontinfo.c:1018
 #: ../fontforgeexe/lookupui.c:659 ../fontforgeexe/macencui.c:105
 msgid "Lang|Thai"
-msgstr "Lang|Thai"
+msgstr "Thai"
 
 #
 #: ../fontforge/macenc.c:2253 ../fontforgeexe/fontinfo.c:89
@@ -4730,13 +4730,13 @@ msgstr "阿塞拜疆语(阿拉伯字母)"
 #: ../fontforge/macenc.c:2283 ../fontforgeexe/fontinfo.c:837
 #: ../fontforgeexe/lookupui.c:440 ../fontforgeexe/macencui.c:136
 msgid "Lang|Armenian"
-msgstr "Lang|Armenian"
+msgstr "Armenian"
 
 #
 #: ../fontforge/macenc.c:2284 ../fontforgeexe/fontinfo.c:906
 #: ../fontforgeexe/lookupui.c:464 ../fontforgeexe/macencui.c:137
 msgid "Lang|Georgian"
-msgstr "Lang|Georgian"
+msgstr "Georgian"
 
 #
 #: ../fontforge/macenc.c:2285 ../fontforgeexe/lookupui.c:557
@@ -4819,7 +4819,7 @@ msgstr "马拉地语"
 #: ../fontforge/macenc.c:2299 ../fontforgeexe/fontinfo.c:843
 #: ../fontforgeexe/lookupui.c:335 ../fontforgeexe/macencui.c:152
 msgid "Lang|Bengali"
-msgstr "Lang|Bengali"
+msgstr "Bengali"
 
 #
 #: ../fontforge/macenc.c:2300 ../fontforgeexe/fontinfo.c:838
@@ -4831,7 +4831,7 @@ msgstr "阿萨姆语"
 #: ../fontforge/macenc.c:2301 ../fontforgeexe/fontinfo.c:914
 #: ../fontforgeexe/lookupui.c:425 ../fontforgeexe/macencui.c:154
 msgid "Lang|Gujarati"
-msgstr "Lang|Gujarati"
+msgstr "Gujarati"
 
 #
 #: ../fontforge/macenc.c:2302 ../fontforgeexe/lookupui.c:593
@@ -4843,7 +4843,7 @@ msgstr "旁遮普语"
 #: ../fontforge/macenc.c:2303 ../fontforgeexe/fontinfo.c:956
 #: ../fontforgeexe/lookupui.c:588 ../fontforgeexe/macencui.c:156
 msgid "Lang|Oriya"
-msgstr "Lang|Oriya"
+msgstr "Oriya"
 
 #
 #: ../fontforge/macenc.c:2304 ../fontforgeexe/fontinfo.c:945
@@ -4855,25 +4855,25 @@ msgstr "马来语"
 #: ../fontforge/macenc.c:2305 ../fontforgeexe/fontinfo.c:928
 #: ../fontforgeexe/lookupui.c:462 ../fontforgeexe/macencui.c:158
 msgid "Lang|Kannada"
-msgstr "Lang|Kannada"
+msgstr "Kannada"
 
 #
 #: ../fontforge/macenc.c:2306 ../fontforgeexe/fontinfo.c:1015
 #: ../fontforgeexe/lookupui.c:652 ../fontforgeexe/macencui.c:159
 msgid "Lang|Tamil"
-msgstr "Lang|Tamil"
+msgstr "Tamil"
 
 #
 #: ../fontforge/macenc.c:2307 ../fontforgeexe/fontinfo.c:1017
 #: ../fontforgeexe/lookupui.c:655 ../fontforgeexe/macencui.c:160
 msgid "Lang|Telugu"
-msgstr "Lang|Telugu"
+msgstr "Telugu"
 
 #
 #: ../fontforge/macenc.c:2308 ../fontforgeexe/fontinfo.c:980
 #: ../fontforgeexe/lookupui.c:632 ../fontforgeexe/macencui.c:161
 msgid "Lang|Sinhalese"
-msgstr "Lang|Sinhalese"
+msgstr "Sinhalese"
 
 #
 #: ../fontforge/macenc.c:2309 ../fontforgeexe/fontinfo.c:846
@@ -4885,7 +4885,7 @@ msgstr "缅甸语"
 #: ../fontforge/macenc.c:2310 ../fontforgeexe/fontinfo.c:932
 #: ../fontforgeexe/lookupui.c:470 ../fontforgeexe/macencui.c:163
 msgid "Lang|Khmer"
-msgstr "Lang|Khmer"
+msgstr "Khmer"
 
 #
 #: ../fontforge/macenc.c:2311 ../fontforgeexe/lookupui.c:512
@@ -4929,7 +4929,7 @@ msgstr "Malay (阿拉伯字母)"
 #: ../fontforge/macenc.c:2317 ../fontforgeexe/fontinfo.c:820
 #: ../fontforgeexe/lookupui.c:316 ../fontforgeexe/macencui.c:170
 msgid "Lang|Amharic"
-msgstr "Lang|Amharic"
+msgstr "Amharic"
 
 #
 #: ../fontforge/macenc.c:2318 ../fontforgeexe/lookupui.c:658
@@ -4997,7 +4997,7 @@ msgstr "加泰罗尼亚语"
 #: ../fontforge/macenc.c:2330 ../fontforgeexe/fontinfo.c:939
 #: ../fontforgeexe/lookupui.c:513 ../fontforgeexe/macencui.c:183
 msgid "Lang|Latin"
-msgstr "Lang|拉丁语"
+msgstr "拉丁语"
 
 #
 #: ../fontforge/macenc.c:2331 ../fontforgeexe/macencui.c:184
@@ -8189,7 +8189,7 @@ msgstr "朝鲜文"
 #
 #: ../fontforge/parsettf.c:4485
 msgid "Script|Roman"
-msgstr "Script|Roman"
+msgstr "Roman"
 
 #
 #: ../fontforge/parsettf.c:4485
@@ -8201,22 +8201,22 @@ msgstr "繁体中文"
 #. GT:  docs though
 #: ../fontforge/parsettf.c:4489
 msgid "Script|Cyrillic"
-msgstr "Script|Cyrillic"
+msgstr "Cyrillic"
 
 #
 #: ../fontforge/parsettf.c:4489
 msgid "Script|Devanagari"
-msgstr "Script|Devanagari"
+msgstr "Devanagari"
 
 #
 #: ../fontforge/parsettf.c:4489
 msgid "Script|RSymbol"
-msgstr "Script|RSymbol"
+msgstr "RSymbol"
 
 #
 #: ../fontforge/parsettf.c:4490
 msgid "Script|Gurmukhi"
-msgstr "Script|Gurmukhi"
+msgstr "Gurmukhi"
 
 #
 #: ../fontforge/parsettf.c:4492
@@ -14342,7 +14342,7 @@ msgstr "组成"
 #: ../fontforgeexe/charinfo.c:163 ../fontforgeexe/fontview.c:4459
 #: ../fontforgeexe/fontview.c:4598 ../fontforgeexe/groupsdlg.c:51
 msgid "Color|Choose..."
-msgstr "Color|选择颜色..."
+msgstr "选择颜色..."
 
 #
 #: ../fontforgeexe/charinfo.c:164 ../fontforgeexe/fontview.c:4460
@@ -17445,16 +17445,16 @@ msgstr "名字 \"%s\" 已被使用，请使用不同名字。"
 #
 #: ../fontforgeexe/contextchain.c:1932
 msgid "Section|Continue"
-msgstr "Section|继续"
+msgstr "继续"
 
 #: ../fontforgeexe/contextchain.c:1933
 msgid "Section|Start"
-msgstr "Section|开始"
+msgstr "开始"
 
 #
 #: ../fontforgeexe/contextchain.c:1937 ../fontforgeexe/contextchain.c:1942
 msgid "Class|Name"
-msgstr "Class|名称"
+msgstr "名称"
 
 #
 #: ../fontforgeexe/contextchain.c:1938 ../fontforgeexe/contextchain.c:1943
@@ -17673,7 +17673,7 @@ msgstr "同匹配类属"
 #. GT: contain spaces. Use an underscore or something similar instead
 #: ../fontforgeexe/contextchain.c:2825 ../fontforgeexe/contextchain.c:3002
 msgid "Glyphs|All_Others"
-msgstr "Glyphs|其他"
+msgstr "其他"
 
 #
 #: ../fontforgeexe/contextchain.c:2865 ../fontforgeexe/contextchain.c:3040
@@ -20254,7 +20254,7 @@ msgstr "尺寸, 字形, 点数"
 #
 #: ../fontforgeexe/deltaui.c:410
 msgid "Sort|Alphabetic"
-msgstr "Sort|字母"
+msgstr "字母"
 
 #
 #: ../fontforgeexe/deltaui.c:411
@@ -22985,7 +22985,7 @@ msgstr "柬埔寨语"
 #
 #: ../fontforgeexe/fontinfo.c:849 ../fontforgeexe/lookupui.c:362
 msgid "Lang|Cherokee"
-msgstr "Lang|Cherokee"
+msgstr "Cherokee"
 
 #
 #: ../fontforgeexe/fontinfo.c:850
@@ -23570,7 +23570,7 @@ msgstr "瑞典语(芬兰)"
 #
 #: ../fontforgeexe/fontinfo.c:1010 ../fontforgeexe/lookupui.c:649
 msgid "Lang|Syriac"
-msgstr "Lang|Syriac"
+msgstr "Syriac"
 
 #
 #: ../fontforgeexe/fontinfo.c:1012
@@ -28710,7 +28710,7 @@ msgstr "Athapaskan"
 #
 #: ../fontforgeexe/lookupui.c:322
 msgid "Lang|Avar"
-msgstr "Lang|Avar"
+msgstr "Avar"
 
 #
 #: ../fontforgeexe/lookupui.c:323
@@ -28745,7 +28745,7 @@ msgstr "Baule"
 #
 #: ../fontforgeexe/lookupui.c:330
 msgid "Lang|Berber"
-msgstr "Lang|Berber"
+msgstr "Berber"
 
 #
 #: ../fontforgeexe/lookupui.c:331
@@ -28890,7 +28890,7 @@ msgstr "Comorian"
 #
 #: ../fontforgeexe/lookupui.c:365
 msgid "Lang|Coptic"
-msgstr "Lang|Coptic"
+msgstr "Coptic"
 
 #
 #: ../fontforgeexe/lookupui.c:366
@@ -29084,7 +29084,7 @@ msgstr "Garhwali"
 #
 #: ../fontforgeexe/lookupui.c:418
 msgid "Lang|Ge'ez"
-msgstr "Lang|Ge'ez"
+msgstr "Ge'ez"
 
 #
 #: ../fontforgeexe/lookupui.c:419
@@ -29193,7 +29193,7 @@ msgstr "Inari Sami"
 #
 #: ../fontforgeexe/lookupui.c:454
 msgid "Lang|Javanese"
-msgstr "Lang|Javanese"
+msgstr "Javanese"
 
 #
 #: ../fontforgeexe/lookupui.c:457
@@ -29453,7 +29453,7 @@ msgstr "Low Mari"
 #
 #: ../fontforgeexe/lookupui.c:520
 msgid "Lang|Limbu"
-msgstr "Lang|Limbu"
+msgstr "Limbu"
 
 #
 #: ../fontforgeexe/lookupui.c:521
@@ -29532,7 +29532,7 @@ msgstr "Mbundu"
 #
 #: ../fontforgeexe/lookupui.c:539
 msgid "Lang|Manchu"
-msgstr "Lang|Manchu"
+msgstr "Manchu"
 
 #
 #: ../fontforgeexe/lookupui.c:540
@@ -32623,7 +32623,7 @@ msgstr " BROWSER, MF 及 AUTOTRACE。"
 #
 #: ../fontforgeexe/prefs.c:2392
 msgid "Prefs_App| "
-msgstr "Prefs_App| "
+msgstr " "
 
 #
 #: ../fontforgeexe/prefs.c:2423
@@ -39545,7 +39545,7 @@ msgstr "存为_UCS2"
 #. GT: (in their translated forms of course).
 #: ../gdraw/gtextinfo.c:1207
 msgid "GGadget|ButtonSize|55"
-msgstr "GGadget|ButtonSize|55"
+msgstr "55"
 
 #
 #. GT: This is an unusual string. It is used to get around a limitation in
@@ -39558,7 +39558,7 @@ msgstr "GGadget|ButtonSize|55"
 #. GT: might be 116*100/67 = 173
 #: ../gdraw/gtextinfo.c:1219
 msgid "GGadget|ScaleFactor|100"
-msgstr "GGadget|ScaleFactor|100"
+msgstr "100"
 
 #: ../gdraw/hotkeys.c:164
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -20255,19 +20255,19 @@ msgstr "外描邊"
 
 #: ../fontforgeexe/fontinfo.c:710
 msgid "PanoseLining|Engraved (Multiple Lines)"
-msgstr "PanoseLining|雕刻 (多重線條)"
+msgstr "雕刻 (多重線條)"
 
 #: ../fontforgeexe/fontinfo.c:711
 msgid "PanoseLining|Shadow"
-msgstr "PanoseLining|陰影"
+msgstr "陰影"
 
 #: ../fontforgeexe/fontinfo.c:712
 msgid "PanoseLining|Relief"
-msgstr "PanoseLining|浮出"
+msgstr "浮出"
 
 #: ../fontforgeexe/fontinfo.c:713
 msgid "PanoseLining|Backdrop"
-msgstr "PanoseLining|背景"
+msgstr "背景"
 
 #: ../fontforgeexe/fontinfo.c:726
 msgid "Standard"


### PR DESCRIPTION
`msgstr`s shouldn’t include the contextual information preceding vertical bars.

### Type of change
- **Non-breaking change**