### PR TITLE
Only run WithinMinMax when spline is single-dimensional

### DIFF
--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -276,27 +276,27 @@ return( true );
     if ( RealNear(spline->from->me.x,spline->to->me.x) ) {
 	ret = RealNear(spline->from->me.x,spline->from->nextcp.x) &&
 	    RealNear(spline->from->me.x,spline->to->prevcp.x);
-	if ( ! ((spline->from->nextcp.y >= spline->from->me.y &&
-		  spline->from->nextcp.y <= spline->to->me.y &&
-		  spline->to->prevcp.y >= spline->from->me.y &&
-		  spline->to->prevcp.y <= spline->to->me.y ) ||
-		 (spline->from->nextcp.y <= spline->from->me.y &&
-		  spline->from->nextcp.y >= spline->to->me.y &&
-		  spline->to->prevcp.y <= spline->from->me.y &&
-		  spline->to->prevcp.y >= spline->to->me.y )) )
+	if ( ret && ! ((spline->from->nextcp.y >= spline->from->me.y &&
+		        spline->from->nextcp.y <= spline->to->me.y &&
+		        spline->to->prevcp.y >= spline->from->me.y &&
+		        spline->to->prevcp.y <= spline->to->me.y ) ||
+		       (spline->from->nextcp.y <= spline->from->me.y &&
+		        spline->from->nextcp.y >= spline->to->me.y &&
+		        spline->to->prevcp.y <= spline->from->me.y &&
+		        spline->to->prevcp.y >= spline->to->me.y )) )
 	    ret = MinMaxWithin(spline);
     /* Horizontal lines */
     } else if ( RealNear(spline->from->me.y,spline->to->me.y) ) {
 	ret = RealNear(spline->from->me.y,spline->from->nextcp.y) &&
 	    RealNear(spline->from->me.y,spline->to->prevcp.y);
-	if ( ! ((spline->from->nextcp.x >= spline->from->me.x &&
-		  spline->from->nextcp.x <= spline->to->me.x &&
-		  spline->to->prevcp.x >= spline->from->me.x &&
-		  spline->to->prevcp.x <= spline->to->me.x) ||
-		 (spline->from->nextcp.x <= spline->from->me.x &&
-		  spline->from->nextcp.x >= spline->to->me.x &&
-		  spline->to->prevcp.x <= spline->from->me.x &&
-		  spline->to->prevcp.x >= spline->to->me.x)) )
+	if ( ret && ! ((spline->from->nextcp.x >= spline->from->me.x &&
+		       spline->from->nextcp.x <= spline->to->me.x &&
+		       spline->to->prevcp.x >= spline->from->me.x &&
+		       spline->to->prevcp.x <= spline->to->me.x) ||
+		      (spline->from->nextcp.x <= spline->from->me.x &&
+		       spline->from->nextcp.x >= spline->to->me.x &&
+		       spline->to->prevcp.x <= spline->from->me.x &&
+		       spline->to->prevcp.x >= spline->to->me.x)) )
 	    ret = MinMaxWithin(spline);
     } else {
 	ret = true;


### PR DESCRIPTION
SplineIsLinear is incorrectly marking some splines linear among those that start and end on the same x or y value. As a consequence `SplineRefigure3` zeros out `Spline1D` values `a` and `b`. 

This is another "**How is this possible?!?!**" bug. Who can guess how many crashes and spline distortions, including those with filed issues, trace to it? 

Here is a high-level test: 
[islintest.py.txt](https://github.com/fontforge/fontforge/files/3498785/islintest.py.txt)

This script creates two contours, calls `addExtrema` on each, and saves them in chars "A" and "B" of `islintest.sfd`. The respective point values of each contour are very close, but the second is not modified by `addExtrema`, as evident when looking at the characters in FontForge. After the fix both contours produced by the script are modified.  

- **Bug fix**
