### PR TITLE
Copy prefs and hotkey defaults into the build folder if they don't exist

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -2,3 +2,13 @@
 
 install(FILES default DESTINATION ${CMAKE_INSTALL_DATADIR}/fontforge/hotkeys)
 install(FILES prefs DESTINATION ${CMAKE_INSTALL_DATADIR}/fontforge)
+
+# The following is merely to make it easier to run fontforge directly
+# from the build folder to assist in debugging
+
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/fontforge/prefs")
+  file(COPY prefs DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/fontforge")
+endif()
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/fontforge/hotkeys/default")
+  file(COPY default DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/fontforge/hotkeys")
+endif()


### PR DESCRIPTION
For easier debugging. I was contemplating doing something similar with the theme, but I reckon it would slow down the configuration time too much, as there's so many pixmaps. Symlinking doesn't really work either as the resources file is a configured file.

Note that personally, because of that I just copy the whole share/fontforge folder from an installed instance of fontforge into the build/share/ folder to make my life easier when running directly from the build folder.

Relates to #3880

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
