### PR TITLE
Fix AddressSanitizer: global-buffer-overflow

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -80,7 +80,7 @@ char *script_filenames[SCRIPT_MENU_MAX];
 extern int onlycopydisplayed, copymetadata, copyttfinstr, add_char_to_name_list;
 int home_char='A';
 int compact_font_on_open=0;
-bool warn_script_unsaved = true;
+int warn_script_unsaved = 0;
 int navigation_mask = 0;		/* Initialized in startui.c */
 
 static char *fv_fontnames = MONO_UI_FAMILIES;
@@ -545,7 +545,7 @@ static int AskScriptChanged() {
     buts[3] = NULL;
     ret = gwwv_ask( _("Unsaved script"),(const char **) buts,0,2,_("You have an unsaved script in the «Execute Script» dialog. Do you intend to discard it?"));
     if (ret == 1) {
-        warn_script_unsaved = false;
+        warn_script_unsaved = 0;
         SavePrefs(true);
     }
 return( ret );

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -194,7 +194,7 @@ extern int prefs_cv_outline_thickness; /* from charview.c */
 
 extern float OpenTypeLoadHintEqualityTolerance;  /* autohint.c */
 extern float GenerateHintWidthEqualityTolerance; /* splinesave.c */
-extern bool warn_script_unsaved; /* fontview.c */
+extern int warn_script_unsaved; /* fontview.c */
 extern NameList *force_names_when_opening;
 extern NameList *force_names_when_saving;
 extern NameList *namelist_for_new_fonts;


### PR DESCRIPTION
```
==10627==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00010e2239c1 at pc 0x000111258c3d bp 0x7ffee286c210 sp 0x7ffee286b988
WRITE of size 4 at 0x00010e2239c1 thread T0
    #0 0x111258c3c in scanf_common(void*, int, bool, char const*, __va_list_tag*) (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x27c3c)
    #1 0x111258d6d in wrap_vsscanf (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x27d6d)
    #2 0x11125902c in wrap_sscanf (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x2802c)
    #3 0x10de70b21 in PrefsUI_LoadPrefs prefs.c:1230
    #4 0x10e02e0ce in fontforge_main startui.c:1109
    #5 0x10d654b11 in main main.c:33
    #6 0x7fff62d7b3d4 in start (libdyld.dylib:x86_64+0x163d4)

0x00010e2239c1 is located 63 bytes to the left of global variable 'fvhintingneededcol' defined in '../fontforgeexe/fontview.c:123:14' (0x10e223a00) of size 4
0x00010e2239c1 is located 0 bytes to the right of global variable 'warn_script_unsaved' defined in '../fontforgeexe/fontview.c:83:6' (0x10e2239c0) of size 1
SUMMARY: AddressSanitizer: global-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x27c3c) in scanf_common(void*, int, bool, char const*, __va_list_tag*)
```

`warn_script_unsaved` is declared as `bool`, but prefs.c:1230 casts its pointer to `int *`, leading the issue above. Prefs of type `pr_bool` should be int as well, FontForge is pre-C99 and does not know `bool`.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

