### PR TITLE
mathkern fixes

### DIFF
--- a/fontforgeexe/math.c
+++ b/fontforgeexe/math.c
@@ -138,7 +138,7 @@ static struct col_init mathkern[] = {
     COL_INIT_EMPTY
 };
 static struct matrixinit mi_mathkern =
-    { sizeof(mathkern)/sizeof(struct col_init)-1, mathkern, 0, NULL, NULL, NULL, extpart_finishedit, NULL, NULL, NULL };
+    { sizeof(mathkern)/sizeof(struct col_init)-1, mathkern, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
 
 
 #define CID_Exten	1000

--- a/fontforgeexe/math.c
+++ b/fontforgeexe/math.c
@@ -1546,8 +1546,8 @@ static int MKD_Parse(MathKernDlg *mkd) {
 	    }
 	    qsort(bases,cnt,sizeof(BasePoint *),bp_order_height);
 	    if ( cnt>mkv->cnt ) {
-		mkv->mkd = realloc(mkv->mkd,cnt*sizeof(struct mathkernvertex));
-		memset(mkv->mkd+mkv->cnt,0,(cnt-mkv->cnt)*sizeof(struct mathkernvertex));
+		mkv->mkd = realloc(mkv->mkd,cnt*sizeof(struct mathkerndata));
+		memset(mkv->mkd+mkv->cnt,0,(cnt-mkv->cnt)*sizeof(struct mathkerndata));
 	    }
 	    for ( j=0; j<cnt; ++j ) {
 		bases[j]->x = rint(bases[j]->x);

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -524,9 +524,11 @@ static GWindow _GGDKDraw_CreateWindow(GGDKDisplay *gdisp, GGDKWindow gw, GRect *
     }
     nw->ggc->bg = wattrs->background_color;
     GGDKDrawSetWindowBackground((GWindow)nw, wattrs->background_color);
-    _GGDKDraw_SetOpaqueRegion(nw);
 
     if (nw->is_toplevel) {
+        // Set opaque region
+        _GGDKDraw_SetOpaqueRegion(nw);
+
         // Set icon
         GGDKWindow icon = gdisp->default_icon;
         if (((wattrs->mask & wam_icon) && wattrs->icon != NULL) && ((GGDKWindow)wattrs->icon)->is_pixmap) {


### PR DESCRIPTION
This includes a few fixes:
* Fix a crash when editing in graphical mode and switching to textual mode (the first commit; fix invalid realloc size)
* Fix crash when interacting in textual mode - for #3892 (second commit). This looks like a copy-paste error from `mi_extensionpart` (line 130 in math.c). Each time you edited the matrix, it was calling the wrong callback function. As best I can tell, this matrix doesn't actually need any callback function, as there's nothing to interactively update as the fields are edited.
* Get rid of the pixman warnings seen (third commit). Somehow gtabset passes in a negative initial width when creating the window. This causes pixman to complain when we do `_GGDKDraw_SetOpaqueRegion`. But there's no reason to call this on child windows, so I've guarded against that).

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**