### PR TITLE
Fix misformatted man pages

### DIFF
--- a/fontforgeexe/fontforge.1
+++ b/fontforgeexe/fontforge.1
@@ -203,8 +203,7 @@ Optional location for online documentation.
 .TP
 /usr/share/fontforge/*.cidmap
 "Encoding" files for Adobe's cid formats, from
-http://fontforge.sourceforge.net/
-cidmaps.tgz.
+http://fontforge.sourceforge.net/cidmaps.tgz.
 .SH SEE ALSO
 \fBsfddiff\fP(1)
 .PP
@@ -224,9 +223,9 @@ FontForge is licensed under GPLv3+: GNU GPL version 3 or later
 in the FontForge distribution for details, or see
 https://github.com/fontforge/fontforge/blob/master/LICENSE.
 .PP
-FontForge is available as a whole under the terms of the [GNU GPL](http://www.gnu.org/copyleft/gpl.html), version
+FontForge is available as a whole under the terms of the GNU GPL (http://www.gnu.org/copyleft/gpl.html), version
 3 or any later version. 
-However, almost all of its parts are available under the "revised BSD license" ([pdf](http://www.law.yi.org/~sfllaw/talks/bsd.pdf)) because FontForge was mostly written by George Williams, using that license.
+However, almost all of its parts are available under the "revised BSD license" (http://www.law.yi.org/~sfllaw/talks/bsd.pdf) because FontForge was mostly written by George Williams, using that license.
 .PP
 The Revised BSD License is very permissive, and allows for code to be combined with other code under other licenses. 
 .PP

--- a/fontforgeexe/sfddiff.1
+++ b/fontforgeexe/sfddiff.1
@@ -122,11 +122,11 @@ included in the FontForge distribution for details, or see
 https://github.com/fontforge/fontforge/blob/master/LICENSE.
 .PP
 FontForge is available as a whole under the terms of the
-[GNU GPL](http://www.gnu.org/copyleft/gpl.html), version\ 3
+GNU GPL (http://www.gnu.org/copyleft/gpl.html), version\ 3
 or any later version. 
 However, almost all of its parts are available under the
 "revised BSD license"
-([pdf](http://www.law.yi.org/~sfllaw/talks/bsd.pdf))
+(http://www.law.yi.org/~sfllaw/talks/bsd.pdf)
 because FontForge was mostly written by George Williams,
 using that license.
 .PP


### PR DESCRIPTION
A URL was rendered with a space in the middle because, in the source, there was a newline in the middle.

Man pages don’t use Markdown link syntax.

### Type of change
- **Non-breaking change**
