### PR TITLE
Clean up drag outline rendering

### DIFF
--- a/fontforge/baseviews.h
+++ b/fontforge/baseviews.h
@@ -76,7 +76,7 @@ typedef struct pressedOn {
     int spiro_index;		/* index of a clicked spiro_cp, or */
 			/* if they clicked on the spline between spiros, */
 			/* this is the spiro indexof the preceding spiro */
-    GList_Glib*      pretransform_spl; /* If we want to draw an image of the original spl while doing something
+    SplinePointList *pretransform_spl; /* If we want to draw an image of the original spl while doing something
 					* this is a copy of that original spl */
 } PressedOn;
 

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -81,6 +81,7 @@ extern SplineChar *SFSplineCharCreate(SplineFont *sf);
 extern SplineFont *SplineFontFromPSFont(FontDict *fd);
 extern SplinePointList *SPLCopyTransformedHintMasks(RefChar *r, SplineChar *basesc, BasePoint *trans,int layer);
 extern SplinePointList *SPLCopyTranslatedHintMasks(SplinePointList *base, SplineChar *basesc, SplineChar *subsc, BasePoint *trans);
+extern bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel);
 extern SplinePointList *SplinePointListCopy1(const SplinePointList *spl);
 extern SplinePointList *SplinePointListCopySelected(SplinePointList *base);
 extern SplinePointList *SplinePointListCopySpiroSelected(SplinePointList *base);

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1475,8 +1475,6 @@ extern void visitAllControlPoints( GHashTable *col, visitSelectedControlPointsVi
 extern void CVVisitAdjacentToSelectedControlPoints( CharView *cv, bool preserveState,
 						    visitSelectedControlPointsVisitor f, void* udata );
 
-extern void CVFreePreTransformSPL( CharView* cv );
-
 extern bool CVShouldInterpolateCPsOnMotion( CharView* cv );
 
 extern int CVNearRBearingLine( CharView* cv, real x, real fudge );

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -50,20 +50,7 @@ int CVAnySel(CharView *cv, int *anyp, int *anyr, int *anyi, int *anya) {
     int i;
 
     for ( spl = cv->b.layerheads[cv->b.drawmode]->splines; spl!=NULL && !anypoints; spl = spl->next ) {
-	if ( cv->b.sc->inspiro && hasspiro()) {
-	    for ( i=0; i<spl->spiro_cnt-1; ++i )
-		if ( SPIRO_SELECTED(&spl->spiros[i])) {
-		    anypoints = true;
-	    break;
-		}
-	} else {
-	    first = NULL;
-	    if ( spl->first->selected ) anypoints = true;
-	    for ( spline=spl->first->next; spline!=NULL && spline!=first && !anypoints; spline = spline->to->next ) {
-		if ( spline->to->selected ) anypoints = true;
-		if ( first == NULL ) first = spline;
-	    }
-	}
+        anypoints = SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL);
     }
     for ( rf=cv->b.layerheads[cv->b.drawmode]->refs; rf!=NULL && !anyrefs; rf=rf->next )
 	if ( rf->selected ) anyrefs = true;
@@ -150,7 +137,8 @@ int CVClearSel(CharView *cv) {
     int needsupdate = 0;
     AnchorPoint *ap;
 
-    CVFreePreTransformSPL( cv );
+    SplinePointListFree(cv->p.pretransform_spl);
+    cv->p.pretransform_spl = NULL;
     
     cv->lastselpt = NULL; cv->lastselcp = NULL;
     for ( spl = cv->b.layerheads[cv->b.drawmode]->splines; spl!=NULL; spl = spl->next )


### PR DESCRIPTION
* Don't draw splines that aren't selected
* Don't copy the whole SPL when checking for selected splines

So I was actually looking into #1115 (I thought it'd be easy), but there's just a lot of inefficiencies in how cairo mode rendering is currently done, so I'll take it one step at a time.

This one was pretty dumb, similar to #3618 - whenever points are dragged, it will render the existing outline. But the way it's implemented means that it both copies and renders a list of spline point lists (!!!). So you basically get n! complexity with the number of splines that you have, while also needlessly rerendering over what was previously drawn.

There's also no reason to use a glib list here, a list of list of splines doesn't really make much sense. 

I've also taken the opportunity to just common up some of the code where it's checked if any/all points are selected in a spline.

### Type of change
- **Bug fix**
