### PR TITLE
Fix Croatian's code and don't translate "German"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -225,11 +225,10 @@ Yi Yang (ahyangyi)
 
 Language Translations provided by:
 Rafael Ferran i Peralta - ca - Catalan
-Milo Ivir <milotype> - cr - Croatian
-Chris-je - de - Deutsch
-Ettore Atalan - de - Deutsch
-Georg A. Duffner - de - Deeutsch
-Philipp Poll - de - Deutsch
+Chris-je - de - German
+Ettore Atalan - de - German
+Georg A. Duffner - de - German
+Philipp Poll - de - German
 Apostolos Syropoulos - el - Greek
 George Williams - en_GB
 Walter Echarri - es - Spanish
@@ -238,6 +237,7 @@ Jean-René Bastien - fr - French
 Pierre Hanser - fr - French
 Thaega <Thaega> - fr - French
 Yannis Haralambous - fr - French
+Milo Ivir <milotype> - hr - Croatian
 Claudio Beccari - it - Italian
 Martino Deotto - it - Italian
 KANOU Hiroki - ja - Japanese


### PR DESCRIPTION
Croatian’s language code is hr, not cr. The only language in AUTHORS to use an endonym was “Deutsch”, so I changed it to “German”.

### Type of change
- **Non-breaking change**