### PR TITLE
Fix out of bounds access

### DIFF
--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -304,11 +304,9 @@ u_WordlistEscapedInputStringToRealString_readGlyphName(
 		tmp_gn = malloc((gn_len+1)*sizeof(unichar_t));
 		u_strncpy(tmp_gn, glyphname, gn_len);
 		for (int i = gn_len; i>0; i--) {
-		    c = tmp_gn[i+1];
-		    tmp_gn[i+1] = 0;
+		    tmp_gn[i] = 0;
 		    tmp = SFGetChar( sf, -1, u_to_c(tmp_gn) );
 		    TRACE("looking for subst. char: %s\n", u_to_c(tmp_gn));
-		    tmp_gn[i+1] = c;
 		    if (tmp != NULL) {
 			TRACE("have subst. char: %s\n", tmp->name ); break;
 		    }


### PR DESCRIPTION
The i variable is initialized to the string length, so adding 1 to it
causes out of bounds access in the first run of the loop. Furthermore
reading the current char and then setting it back is pointless since the
code it iterating backwards and trimming the string anyway and anything
after the terminating NULL is ignored.

Fixes #3909 and #3877 

### Type of change
- **Bug fix**
