### PR TITLE
Prevent invalid pointer access

### DIFF
--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -1942,7 +1942,7 @@ static void *GGDKDrawRequestSelection(GWindow w, enum selnames sn, char *typenam
 
     if (gw->is_notified_of_selection) {
 #endif
-        guchar *data;
+        guchar *data = NULL;
         GdkAtom received_type;
         gint received_format;
         gint rlen = gdk_selection_property_get(gw->w, &data, &received_type, &received_format);


### PR DESCRIPTION
Initialize data to NULL as gdk_selection_property_get() does not
apparently do this in case of error.

Fixes #3910 

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
