### PR TITLE
Add images by reference

### DIFF
--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -953,9 +953,8 @@ void SCAddScaleImage(SplineChar *sc,GImage *image,int doclear, int layer) {
     SCInsertImage(sc,image,scale,sc->parent->ascent,0,layer);
 }
 
-int FVImportImages(FontViewBase *fv,char *path,int format,int toback, int flags) {
+int FVImportImages(FontViewBase *fv,char *path,int format,int toback, bool reference, int flags) {
     GImage *image;
-    /*struct _GImage *base;*/
     int tot;
     char *start = path, *endpath=path;
     int i;
@@ -971,7 +970,7 @@ int FVImportImages(FontViewBase *fv,char *path,int format,int toback, int flags)
 	    if ( image==NULL ) {
 		ff_post_error(_("Bad image file"),_("Bad image file: %.100s"),start);
 return(false);
-	    }
+        } 
 	    ++tot;
 	    SCAddScaleImage(sc,image,true,toback?ly_back:ly_fore);
 	} else if ( format==fv_svg ) {

--- a/fontforge/cvimages.h
+++ b/fontforge/cvimages.h
@@ -7,7 +7,7 @@
 #include "splinefont.h"
 
 extern GImage *ImageAlterClut(GImage *image);
-extern int FVImportImages(FontViewBase *fv, char *path, int format, int toback, int flags);
+extern int FVImportImages(FontViewBase *fv,char *path,int format,int toback, bool reference, int flags);
 extern int FVImportImageTemplate(FontViewBase *fv, char *path, int format, int toback, int flags);
 extern void SCAddScaleImage(SplineChar *sc, GImage *image, int doclear, int layer);
 extern void SCAppendEntityLayers(SplineChar *sc, Entity *ent);

--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -43,6 +43,7 @@
 #include "ustring.h"
 
 #include <dirent.h>
+#include <langinfo.h>
 #include <locale.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -8269,6 +8269,7 @@ static struct flaglist import_ps_flags[] = {
     { "removeoverlap", 0 },			/* Obsolete */
     { "handle_eraser", sf_handle_eraser },
     { "correctdir",  sf_correctdir },
+    { "imagereferenceonly",  sf_imagereferenceonly },
     FLAGLIST_EMPTY /* Sentinel */
 };
 
@@ -8293,8 +8294,8 @@ return( NULL );
     pt = strrchr(locfilename,'.');
     if ( pt==NULL ) pt=locfilename;
 
-    if ( strcasecmp(pt,".eps")==0 || strcasecmp(pt,".ps")==0 || strcasecmp(pt,".art")==0 ) {
 	int psflags = FlagsFromTuple(flags,import_ps_flags,"PostScript import flag");
+    if ( strcasecmp(pt,".eps")==0 || strcasecmp(pt,".ps")==0 || strcasecmp(pt,".art")==0 ) {
 	if ( psflags==FLAG_UNKNOWN ) {
 	    free(locfilename);
 return( NULL );
@@ -8329,6 +8330,7 @@ return(NULL);
 	}
 	if ( !sc->layers[ly].background )
 	    ly = ly_back;
+    if (psflags & sf_imagereferenceonly) GImageMakeReference(image->u.image, locfilename, sc->parent->filename);
 	SCAddScaleImage(sc,image,false,ly);
     }
     free( locfilename );

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -2382,7 +2382,7 @@ static void bImport(Context *c) {
     else if ( format==fv_pk )
 	ok = FVImportBDF(c->curfv,filename,true, back);
     else if ( format==fv_image || format==fv_eps || format==fv_svg || format==fv_pdf )
-	ok = FVImportImages(c->curfv,filename,format,back,flags);
+	ok = FVImportImages(c->curfv,filename,format,back,false,flags);
     else
 	ok = FVImportImageTemplate(c->curfv,filename,format,back,flags);
     free(filename);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2411,7 +2411,7 @@ extern int BpWithin(BasePoint *first, BasePoint *mid, BasePoint *last);
     /* Colinear & between */
 
 enum psstrokeflags { /* sf_removeoverlap=2,*/ sf_handle_eraser=4,
-	sf_correctdir=8, sf_clearbeforeinput=16 };
+	sf_correctdir=8, sf_clearbeforeinput=16, sf_imagereferenceonly=32 };
 
 
 extern char *ToAbsolute(char *filename);

--- a/fontforgeexe/main.c
+++ b/fontforgeexe/main.c
@@ -28,6 +28,7 @@
 #include <fontforge-config.h>
 
 #include "fontforge.h"
+#include "gutils.h"
 
 int main( int argc, char **argv ) {
     return fontforge_main( argc, argv );

--- a/gdraw/gfilechooser.c
+++ b/gdraw/gfilechooser.c
@@ -1114,7 +1114,6 @@ void GFileChooserPopupCheck(GGadget *g,GEvent *e) {
     int inside=false;
 
     if ( e->type == et_mousemove && (e->u.mouse.state&ksm_buttons)==0 ) {
-	GGadgetEndPopup();
 	for ( g=((GContainerD *) (gfc->g.base->widget_data))->gadgets; g!=NULL; g=g->prev ) {
 	    if ( g!=(GGadget *) gfc && g!=(GGadget *) (gfc->filterb) &&
 		     g!=(GGadget *) (gfc->files) &&

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -1159,3 +1159,37 @@ char *GFileDirName(const char *path) {
     return GFileDirNameEx(path, 0);
 }
 
+char* GFileParent(char* path) {
+    GFile *gf_path = g_file_new_for_path(path);
+    GFile *gf_path_parent = g_file_get_parent(gf_path);
+
+    char* ret = g_file_get_path(gf_path_parent);
+
+    g_object_unref(gf_path);
+    g_object_unref(gf_path_parent);
+
+    return ret;
+}
+
+// If we have two files:
+// * /tmp/ex/test.sfd (file1)
+// * /tmp/ex/images/1.jpg (to_relative)
+//
+// The return is images/1.jpg
+char* GFileRelativize(char* file1, char* to_relative) {
+   GFile *gf_file1 = g_file_new_for_path(file1);
+   GFile *gf_file1_parent = g_file_get_parent(gf_file1);
+   GFile *gf_to_relative = g_file_new_for_path(to_relative);
+
+   char* ex = g_file_get_relative_path(gf_file1_parent, gf_to_relative);
+
+   g_object_unref(gf_file1);
+   g_object_unref(gf_file1_parent);
+   g_object_unref(gf_to_relative);
+
+   if (ex==NULL) {
+       // Impossible to relativize; use absolute path.
+       return to_relative;
+   }
+   return ex;
+}

--- a/gutils/gimage.c
+++ b/gutils/gimage.c
@@ -28,6 +28,7 @@
 #include <fontforge-config.h>
 
 #include "basics.h"
+#include "gfile.h"
 #include "gimage.h"
 
 GImage *GImageCreate(enum image_type type, int32 width, int32 height) {
@@ -44,6 +45,9 @@ GImage *GImageCreate(enum image_type type, int32 width, int32 height) {
 	goto errorGImageCreate;
 
     gi->u.image = base;
+    base->refdata.reference = false;
+    base->refdata.filename = NULL;
+    base->refdata.hash = "0";
     base->image_type = type;
     base->width = width;
     base->height = height;
@@ -69,6 +73,38 @@ errorGImageCreate:
     return( NULL );
 }
 
+// This makes a reference, and tries to make it relative _if possible_.
+// All functions that call this one use the SFD file path to figure out if it's relative or not, not the working directory!
+// That means that if you want relative paths in your SFD file, you should save it first (even via Python).
+extern bool GImageMakeReference(struct _GImage *base, char *to_file, char *relative_to) {
+    TRACE("Making reference to %s relative to %s\n", to_file, relative_to);
+    base->refdata.reference = true;
+    base->refdata.hash = HashFile(to_file);
+
+    char* relativized = NULL;
+
+    if (relative_to != NULL) {
+        relativized = GFileRelativize(relative_to, to_file);
+    }
+
+    if (relativized != NULL) {
+        base->refdata.filename = relativized;
+    } else {
+        char* fn = malloc(strlen(to_file));
+        strcpy(fn, to_file);
+        base->refdata.filename = fn;
+    }
+
+    return true;
+}
+
+extern bool GImageUnmakeReference(struct _GImage *base) {
+    base->refdata.reference = false;
+    base->refdata.filename = NULL;
+    free(base->refdata.filename);
+    base->refdata.hash = NULL;
+    free(base->refdata.hash);
+}
 
 GImage *_GImage_Create(enum image_type type, int32 width, int32 height) {
     GImage *gi;
@@ -112,11 +148,19 @@ void GImageDestroy(GImage *gi) {
 		free(gi->u.images[i]->clut);
 		free(gi->u.images[i]->data);
 		free(gi->u.images[i]);
+        if (gi->u.images[i]->refdata.reference) {
+            free(gi->u.images[i]->refdata.filename);
+            free(gi->u.images[i]->refdata.hash);
+        }
 	    }
 	    free(gi->u.images);
 	} else {
 	    free(gi->u.image->clut);
 	    free(gi->u.image->data);
+        if (gi->u.image->refdata.reference) {
+            free(gi->u.image->refdata.filename);
+            free(gi->u.image->refdata.hash);
+        }
 	    free(gi->u.image);
 	}
 	free(gi);
@@ -415,4 +459,61 @@ return( pixel==base->trans?~val:val );
 Color GImageGetPixelColor(GImage *image,int x, int y) {
     struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
 return( _GImageGetPixelColor(base,x,y));
+}
+
+const char* GImageHash(GImage *img) {
+    struct _GImage *base = img->list_len==0?img->u.image:img->u.images[0];
+
+    return HashData((char*)(base->data), (base->bytes_per_line * base->width));
+}
+
+// This function was moved from gimageclut.c, because libfontforge doesn't link with gdraw,
+// but GImageSame, in libfontforge, needs this function, and linking with gdraw is not 
+// acceptable for other contributors.
+int GImageSameClut(GClut *clut,GClut *nclut) {
+    static GClut dummy = { 2, true, COLOR_UNKNOWN, GCLUT_CLUT_EMPTY };
+    int i;
+    
+    dummy.clut[0] = COLOR_CREATE(0, 0, 0);
+    dummy.clut[1] = COLOR_CREATE(0xff, 0xff, 0xff);
+
+    if ( clut==nclut )
+return( true );
+    if ( clut==NULL )
+	clut = &dummy;
+    if ( nclut==NULL )
+	nclut = &dummy;
+    if ( clut->clut_len!=nclut->clut_len )
+return( false );
+    for ( i = 0; i<clut->clut_len; ++i )
+	if ( clut->clut[i]!=nclut->clut[i] )
+return( false );
+
+return( true );
+}
+
+// Is img1 the same image as img2? Used for linking references.
+bool GImageSame(GImage *img1, GImage *img2) {
+    struct _GImage *base1 = img1->list_len==0?
+	    img1->u.image:img1->u.images[0];
+
+    struct _GImage *base2 = img2->list_len==0?
+	    img2->u.image:img2->u.images[0];
+
+    int sameclut = GImageSameClut(base1->clut, base2->clut);
+    if (!sameclut) return false;
+
+    int datalen1 = base1->bytes_per_line * base1->height;
+    int datalen2 = base2->bytes_per_line * base2->height;
+
+    if (datalen1 != datalen2) return false;
+
+    // If the colors they use are the same and the number of pixels are too,
+    // check actual data.
+
+    for (int i = 0; i <= datalen1; i++) {
+        if (base1->data[i] != base2->data[i]) return false;
+    }
+
+    return true;
 }

--- a/gutils/gutils.c
+++ b/gutils/gutils.c
@@ -70,3 +70,23 @@ time_t GetST_MTime(struct stat s) {
 
 	return st_time;
 }
+
+char* HashData(unsigned char* input, int len) {
+    GChecksum* gcs = g_checksum_new(G_CHECKSUM_SHA256);
+    g_checksum_update(gcs, input, len);
+    const char* gcs_cs = g_checksum_get_string(gcs);
+    char* cs = malloc(strlen(gcs_cs)+1);
+    strcpy(cs, gcs_cs);
+    g_checksum_free(gcs);
+    return cs;
+}
+
+extern char* HashFile(char* filename) {
+    char *contents;
+    gsize length;
+    g_file_get_contents(filename, &contents, &length, NULL);
+    TRACE("Hashing %s of length %d...\n", filename, length);
+    const char* cs = HashData(contents, length);
+    g_free(contents);
+    return (char*)cs;
+}

--- a/inc/gfile.h
+++ b/inc/gfile.h
@@ -141,8 +141,7 @@ extern char *GFileDirName(const char *path);
  **/
 extern char* getLibexecDir_NonWindows(void);
 
-
-
-
+extern char* GFileParent(char* path);
+extern char* GFileRelativize(char* file1, char* to_relative);
 
 #endif /* FONTFORGE_GFILE_H */

--- a/inc/gimage.h
+++ b/inc/gimage.h
@@ -29,6 +29,7 @@
 #define FONTFORGE_GIMAGE_H
 
 #include "basics.h"
+#include "gutils.h"
 
 typedef uint32 Color;
 
@@ -86,6 +87,14 @@ typedef struct revcmap RevCMap;
 
 enum image_type { it_mono, it_bitmap=it_mono, it_index, it_true, it_rgba };
 
+// For images that are referred to by reference, not embedded in SFD.
+struct ReferenceData {
+    bool reference;
+    char* filename;
+    // This hash is a SHA256 hash in hex format
+    char* hash;
+};
+
 struct _GImage {
 /* Format: bitmaps are stored with the most significant bit first in byte units
 	    indexed    images are stored in byte units
@@ -100,6 +109,7 @@ struct _GImage {
     GClut *clut;
     Color trans;		/* PNG supports more than one transparent color, we don't */
 				/* for non-true color images this is the index, not a color */
+    struct ReferenceData refdata;
 };
 
 /* We deal with 1 bit, 8 bit and 32 bit images internal. 1 bit images may have*/
@@ -166,6 +176,9 @@ extern char *GImageNameFColour(Color col);
 extern Color GDrawColorDarken(Color col, int by);
 extern Color GDrawColorBrighten(Color col, int by);
 
+extern bool GImageMakeReference(struct _GImage *base, char *to_file, char *relative_to);
+extern bool GImageUnmakeReference(struct _GImage *base);
+
 extern int GImageWriteGImage(GImage *gi, char *filename);
 extern int GImageWrite_Bmp(GImage *gi, FILE *fp);
 extern int GImageWriteBmp(GImage *gi, char *filename);
@@ -193,6 +206,7 @@ extern GImage *GImageReadRas(char *filename);		/* Sun Raster */
 extern GImage *GImageReadRgb(char *filename);		/* SGI */
 extern GImage *GImageRead(char *filename);
 
+extern bool GImageSame(GImage *img1, GImage *img2);
 extern void GImageDrawRect(GImage *img,GRect *r,Color col);
 extern void GImageDrawImage(GImage *dest,GImage *src,GRect *junk,int x, int y);
 extern void GImageBlendOver(GImage *dest,GImage *src,GRect *from,int x, int y);

--- a/inc/gutils.h
+++ b/inc/gutils.h
@@ -36,5 +36,9 @@
 extern const char *GetAuthor(void);
 extern time_t GetTime(void);
 extern time_t GetST_MTime(struct stat s);
+// g_checksum_type_get_length(G_CHECKSUM_SHA256)
+#define SHA256_DIGEST_LEN 32
+extern char* HashData(unsigned char* input, int len);
+extern char* HashFile(char* filename);
 
 #endif /* FONTFORGE_GUTILS_H */


### PR DESCRIPTION
Images by reference! I've wanted this feature probably as long as I've used FontForge. 

Here's the first (public) SFD file containing images by reference: [ImagesByReference.zip](https://github.com/fontforge/fontforge/files/3562409/ImagesByReference.zip)

Here's the format I chose. The only difference to my proposal is I decided to quote the values so I could use `SFDReadUTF7Str`:

```sfd
StartChar: B
Encoding: 66 66 1
Width: 1000
VWidth: 0
LayerCount: 2
Back
Image2: reference 0 800 2.08333 2.08333
"a390023f572e6c79491d916e72f0444fcfa139cb84285e7dedc1e2b6b9efb158"
"B2.png"
EndImage2
```

This is ready for testing a bit more widely than on my PC, but I haven't yet tested it as much as I could have. I promised my wife I'd submit this Saturday night and take Sunday off, so I'm submitting a bit early and not using Sunday for testing. :wink: On Monday I'll deal with comments if there are any, or if not due some more robust testing. This was a ton of work as you can imagine!

UI images:

![2019-08-31-194828_1478x337_scrot](https://user-images.githubusercontent.com/838783/64063558-3024ff80-cc28-11e9-9cd4-2c76a2537327.png)
![2019-08-31-194932_2354x1408_scrot](https://user-images.githubusercontent.com/838783/64063568-521e8200-cc28-11e9-84b3-f3152c67df84.png)

Python script example:

```python
import fontforge

f = fontforge.fonts()[0]
f.save("/tmp/test.sfd") # We save here so that the imported file will be relative to /tmp.
f.createChar(ord("A"))
f["A"].right_side_bearing = 100
f["A"].importOutlines("/tmp/B.jpg", "imagereferenceonly")

f.save("/tmp/test.sfd")
```

I haven't yet added Python functions for "Link Reference" and "Unlink Reference", partially because there doesn't seem to be an API for images. I'd like @skef's input on what that should look like.

This closes #3872.
