### PR TITLE
Stop crash under tiling WMs

### DIFF
--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -839,8 +839,8 @@ return;
     g->base = NULL;
 
     while ( gw->parent!=NULL && !gw->is_toplevel ) gw = gw->parent;
-    if (gw->is_dying) return;
     td = (GTopLevelD *) (gw->widget_data);
+    if ( td == NULL ) return; /* dying, prevents tiling WM crash */
     if ( td->gdef == g ) td->gdef = NULL;
     if ( td->gcancel == g ) td->gcancel = NULL;
     if ( td->gfocus == g ) td->gfocus = NULL;

--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -839,6 +839,7 @@ return;
     g->base = NULL;
 
     while ( gw->parent!=NULL && !gw->is_toplevel ) gw = gw->parent;
+    if (gw->is_dying) return;
     td = (GTopLevelD *) (gw->widget_data);
     if ( td->gdef == g ) td->gdef = NULL;
     if ( td->gcancel == g ) td->gcancel = NULL;

--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -840,7 +840,10 @@ return;
 
     while ( gw->parent!=NULL && !gw->is_toplevel ) gw = gw->parent;
     td = (GTopLevelD *) (gw->widget_data);
-    if ( td == NULL ) return; /* dying, prevents tiling WM crash */
+    if ( td == NULL ) { /* dying, prevents tiling WM crash */
+        assert(gw->is_dying);
+        return;
+    }
     if ( td->gdef == g ) td->gdef = NULL;
     if ( td->gcancel == g ) td->gcancel = NULL;
     if ( td->gfocus == g ) td->gfocus = NULL;

--- a/inc/gdraw.h
+++ b/inc/gdraw.h
@@ -28,6 +28,7 @@
 #ifndef FONTFORGE_GDRAW_H
 #define FONTFORGE_GDRAW_H
 
+#include "assert.h"
 #include "charset.h"
 #include "gimage.h"
 


### PR DESCRIPTION
This closes #3920.

I ran through this with `rr` and can see this change to be the correct
one. This does the same thing as the patch I offered in #3920, except is
much more readable.

When the window is dying, it has no widget_data to free; the free was
already done by `_GWidget_Container_eh`. The order of events is
different on tiling window managers

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
