### PR TITLE
Fix crash on hiDPI while drawing closed eye

### DIFF
--- a/gdraw/gradio.c
+++ b/gdraw/gradio.c
@@ -350,7 +350,7 @@ return( false );
 
     } else if ( (!gr->ison) && gr->onbox == &visibility_on_box ) {
          /* draw closed eye */
-        GPoint pts[6];
+        GPoint pts[7];
         int c,i;
         double angle;
 	int bp = gr->onbox->border_type==bt_none ? 0 : GDrawPointsToPixels(pixmap,gr->onbox->border_width);
@@ -367,7 +367,7 @@ return( false );
             pts[i].y=.5*h*sin(angle)+y+h/4;
 
              /* draw lashes */
-            if (i>0 && i<5) GDrawDrawLine(pixmap, pts[i].x,pts[i].y, .75*w*cos(angle)+x+w/2, .75*h*sin(angle)+y+h/4, fg);
+            if (i>0 && i<6) GDrawDrawLine(pixmap, pts[i].x,pts[i].y, .75*w*cos(angle)+x+w/2, .75*h*sin(angle)+y+h/4, fg);
             ++i;
         }
         GDrawDrawPoly(pixmap, pts, i, fg);

--- a/gdraw/gradio.c
+++ b/gdraw/gradio.c
@@ -351,7 +351,6 @@ return( false );
     } else if ( (!gr->ison) && gr->onbox == &visibility_on_box ) {
          /* draw closed eye */
         GPoint pts[7];
-        int c,i;
         double angle;
 	int bp = gr->onbox->border_type==bt_none ? 0 : GDrawPointsToPixels(pixmap,gr->onbox->border_width);
         int x=gr->onoffrect.x+bp;
@@ -361,15 +360,15 @@ return( false );
         Color fg = g->state==gs_disabled?g->box->disabled_foreground:
 			g->box->main_foreground==COLOR_DEFAULT?GDrawGetDefaultForeground(GDrawGetDisplayOfWindow(pixmap)):
 			g->box->main_foreground;
-        for (c=0, i=0; c<=6; c++, i++) {
-            angle=(30+c/6.*120)*M_PI/180;
+        for (int i = 0; i <= 6; i++) {
+            angle=(30+i/6.*120)*M_PI/180;
             pts[i].x=.5*w*cos(angle)+x+w/2;
             pts[i].y=.5*h*sin(angle)+y+h/4;
 
              /* draw lashes */
             if (i>0 && i<6) GDrawDrawLine(pixmap, pts[i].x,pts[i].y, .75*w*cos(angle)+x+w/2, .75*h*sin(angle)+y+h/4, fg);
         }
-        GDrawDrawPoly(pixmap, pts, i, fg);
+        GDrawDrawPoly(pixmap, pts, sizeof(pts)/sizeof(pts[0]), fg);
     }
 
     GDrawPopClip(pixmap,&old2);

--- a/gdraw/gradio.c
+++ b/gdraw/gradio.c
@@ -361,14 +361,13 @@ return( false );
         Color fg = g->state==gs_disabled?g->box->disabled_foreground:
 			g->box->main_foreground==COLOR_DEFAULT?GDrawGetDefaultForeground(GDrawGetDisplayOfWindow(pixmap)):
 			g->box->main_foreground;
-        for (c=0, i=0; c<=6; c++) {
+        for (c=0, i=0; c<=6; c++, i++) {
             angle=(30+c/6.*120)*M_PI/180;
             pts[i].x=.5*w*cos(angle)+x+w/2;
             pts[i].y=.5*h*sin(angle)+y+h/4;
 
              /* draw lashes */
             if (i>0 && i<6) GDrawDrawLine(pixmap, pts[i].x,pts[i].y, .75*w*cos(angle)+x+w/2, .75*h*sin(angle)+y+h/4, fg);
-            ++i;
         }
         GDrawDrawPoly(pixmap, pts, i, fg);
     }


### PR DESCRIPTION
Drawing the closed eye causes a crash on hiDPI, see #3925.

This fixes the logic error found by @skef with the help of GCC's
warnings. Thanks to @dbenjaminmiller for the report.

Interestingly, this crash only happens in release builds!

This closes #3925

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
