### PR TITLE
Integrate relevant parts of vertical metrics patch

### DIFF
--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -468,7 +468,7 @@ return;
 		(!sc->parent->layers[layer].background && SCWasEmpty(sc,layer)))) {
 	sc->widthset = false;
 	if ( sc->parent!=NULL && sc->width!=0 )
-	    sc->width = sc->parent->ascent+sc->parent->descent;
+	    sc->vwidth = sc->width = sc->parent->ascent+sc->parent->descent;
 	AnchorPointsFree(sc->anchor);
 	sc->anchor = NULL;
 	StemInfosFree(sc->hstem); sc->hstem = NULL;

--- a/fontforge/splinefont.c
+++ b/fontforge/splinefont.c
@@ -216,6 +216,7 @@ return( sc );
 	sc->unicodeenc = dummy.unicodeenc;
 	sc->name = copy(dummy.name);
 	sc->width = dummy.width;
+	sc->vwidth = dummy.vwidth;
 	sc->orig_pos = 0xffff;
 	if ( sf->cidmaster!=NULL )
 	    sc->altuni = CIDSetAltUnis(FindCidMap(sf->cidmaster->cidregistry,sf->cidmaster->ordering,sf->cidmaster->supplement,sf->cidmaster),enc);

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -2501,7 +2501,7 @@ static int dumpcffhmtx(struct alltabs *at,SplineFont *sf,int bitmaps) {
 	putshort(at->gi.hmtx,b.minx);
 	if ( dovmetrics ) {
 	    putshort(at->gi.vmtx,sf->glyphs[at->gi.bygid[0]]->vwidth);
-	    putshort(at->gi.vmtx,sc->parent->ascent - b.miny);
+	    putshort(at->gi.vmtx,sf->ascent - b.miny);
 	}
     } else {
 	putshort(at->gi.hmtx,width<=0?(sf->ascent+sf->descent)/2:width);

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -1065,7 +1065,7 @@ static void dumpmissingglyph(SplineFont *sf,struct glyphinfo *gi,int fixedwidth)
     putshort(gi->hmtx,stem);
     if ( sf->hasvmetrics ) {
 	putshort(gi->vmtx,sf->ascent+sf->descent);
-	putshort(gi->vmtx,/*sf->vertical_origin-*/gh.ymax);
+	putshort(gi->vmtx,sf->ascent - gh.ymax);
     }
 }
 
@@ -2501,7 +2501,7 @@ static int dumpcffhmtx(struct alltabs *at,SplineFont *sf,int bitmaps) {
 	putshort(at->gi.hmtx,b.minx);
 	if ( dovmetrics ) {
 	    putshort(at->gi.vmtx,sf->glyphs[at->gi.bygid[0]]->vwidth);
-	    putshort(at->gi.vmtx,/*sf->vertical_origin-*/b.miny);
+	    putshort(at->gi.vmtx,sc->parent->ascent - b.miny);
 	}
     } else {
 	putshort(at->gi.hmtx,width<=0?(sf->ascent+sf->descent)/2:width);
@@ -2539,7 +2539,7 @@ static int dumpcffhmtx(struct alltabs *at,SplineFont *sf,int bitmaps) {
 	    if ( dovmetrics ) {
 		if ( i<=at->gi.lastvwidth )
 		    putshort(at->gi.vmtx,sc->vwidth);
-		putshort(at->gi.vmtx,/*sf->vertical_origin-*/b.maxy);
+		putshort(at->gi.vmtx,sc->parent->ascent - b.maxy);
 	    }
 	    ++cnt;
 	    if ( i==at->gi.lasthwidth )
@@ -2590,7 +2590,7 @@ static void dumpcffcidhmtx(struct alltabs *at,SplineFont *_sf) {
 	    if ( dovmetrics ) {
 		if ( sc->ttf_glyph<=at->gi.lastvwidth )
 		    putshort(at->gi.vmtx,sc->vwidth);
-		putshort(at->gi.vmtx,/*sf->vertical_origin-*/b.maxy);
+		putshort(at->gi.vmtx,sc->parent->ascent - b.maxy);
 	    }
 	    ++cnt;
 	    if ( sc->ttf_glyph==at->gi.lasthwidth )

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -123,7 +123,7 @@ struct cvshows CVShows = {
 	1,		/* show x minimum distances */
 	1,		/* show y minimum distances */
 	1,		/* show horizontal metrics */
-	0,		/* show vertical metrics */
+	1,		/* show vertical metrics */
 	0,		/* mark extrema */
 	0,		/* show points of inflection */
 	1,		/* show blue values */
@@ -2769,12 +2769,12 @@ return;				/* no points. no side bearings */
 	y2 = cv->height-tab->yoff-rint(-sc->parent->descent*tab->scale);
 	DrawPLine(cv,pixmap,x,y,x,y2,metricslabelcol);
 	 /* arrow heads */
-	 DrawPLine(cv,pixmap,x,y,x-4,y-4,metricslabelcol);
-	 DrawPLine(cv,pixmap,x,y,x+4,y-4,metricslabelcol);
-	 DrawPLine(cv,pixmap,x,y2,x+4,y2+4,metricslabelcol);
-	 DrawPLine(cv,pixmap,x,y2,x-4,y2+4,metricslabelcol);
-	dtos( buf, bounds[2]->y-sc->parent->descent);
-	y = y + (y-y2-cv->sfh)/2;
+	 DrawPLine(cv,pixmap,x,y,x-4,y+4,metricslabelcol);
+	 DrawPLine(cv,pixmap,x,y,x+4,y+4,metricslabelcol);
+	 DrawPLine(cv,pixmap,x,y2,x+4,y2-4,metricslabelcol);
+	 DrawPLine(cv,pixmap,x,y2,x-4,y2-4,metricslabelcol);
+	dtos( buf, bounds[2]->y+sc->parent->descent);
+	y = y - (y-y2-cv->sfh)/2;
 	GDrawDrawText8(pixmap,x+4,y,buf,-1,metricslabelcol);
 
 	x = rint(bounds[3]->x*tab->scale) + tab->xoff;
@@ -2786,7 +2786,7 @@ return;				/* no points. no side bearings */
 	 DrawPLine(cv,pixmap,x,y,x+4,y-4,metricslabelcol);
 	 DrawPLine(cv,pixmap,x,y2,x+4,y2+4,metricslabelcol);
 	 DrawPLine(cv,pixmap,x,y2,x-4,y2+4,metricslabelcol);
-	dtos( buf, sc->vwidth-bounds[3]->y);
+	dtos( buf, sc->parent->ascent-bounds[3]->y);
 	x = x + (x2-x-GDrawGetText8Width(pixmap,buf,-1))/2;
 	GDrawDrawText8(pixmap,x,y-4,buf,-1,metricslabelcol);
     }
@@ -2921,8 +2921,8 @@ static void CVExpose(CharView *cv, GWindow pixmap, GEvent *event ) {
 	    DrawLine(cv,pixmap,-8096,-sf->descent,8096,-sf->descent,coordcol);
 	}
 	if ( cv->showvmetrics ) {
-	    DrawLine(cv,pixmap,(sf->ascent+sf->descent)/2,-8096,(sf->ascent+sf->descent)/2,8096,coordcol);
-	    /*DrawLine(cv,pixmap,-8096,sf->vertical_origin,8096,sf->vertical_origin,coordcol);*/
+	    /*DrawLine(cv,pixmap,(sf->ascent+sf->descent)/2,-8096,(sf->ascent+sf->descent)/2,8096,coordcol);
+	    DrawLine(cv,pixmap,-8096,sf->vertical_origin,8096,sf->vertical_origin,coordcol);*/
 	}
 
 	DrawSelImageList(cv,pixmap,cv->b.layerheads[cv->b.drawmode]->images);
@@ -3121,9 +3121,9 @@ static void CVExpose(CharView *cv, GWindow pixmap, GEvent *event ) {
 		    NULL,_("TopAccent"));
     }
     if ( cv->showvmetrics ) {
-	int len, y = -tab->yoff + cv->height - rint((/*sf->vertical_origin*/-cv->b.sc->vwidth)*tab->scale);
-	DrawLine(cv,pixmap,-32768,/*sf->vertical_origin*/-cv->b.sc->vwidth,
-			    32767,/*sf->vertical_origin*/-cv->b.sc->vwidth,
+	int vertical_height = -cv->b.sc->vwidth + cv->b.sc->parent->ascent;
+	int len, y = -tab->yoff + cv->height - rint(vertical_height*tab->scale);
+	DrawLine(cv,pixmap,-32768,vertical_height,32767,vertical_height,
 		(!cv->inactive && cv->vwidthsel)?widthselcol:widthcol);
 	if ( y>-40 && y<cv->height+40 ) {
 	    dtos( buf, cv->b.sc->vwidth);
@@ -12542,7 +12542,7 @@ static void _CharViewCreate(CharView *cv, SplineChar *sc, FontView *fv,int enc,i
     cv->showmdx = CVShows.showmdx;
     cv->showmdy = CVShows.showmdy;
     cv->showhmetrics = CVShows.showhmetrics;
-    cv->showvmetrics = CVShows.showvmetrics;
+    cv->showvmetrics = sc->parent->hasvmetrics ? CVShows.showvmetrics : 0;
     cv->markextrema = CVShows.markextrema;
     cv->showsidebearings = CVShows.showsidebearings;
     cv->showrefnames = CVShows.showrefnames;

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -516,8 +516,8 @@ void CVCheckResizeCursors(CharView *cv) {
 	    else if( CVNearLBearingLine( cv, cv->info.x, fudge ))
 		cv->expandedge = ee_left;
 	    if ( cv->showvmetrics && cv->b.sc->parent->hasvmetrics && cv->b.container==NULL &&
-		    cv->info.y > /*cv->b.sc->parent->vertical_origin*/-cv->b.sc->vwidth-fudge &&
-		    cv->info.y < /*cv->b.sc->parent->vertical_origin*/-cv->b.sc->vwidth+fudge )
+		    cv->info.y > -cv->b.sc->vwidth - fudge + cv->b.sc->parent->ascent &&
+		    cv->info.y < -cv->b.sc->vwidth + fudge + cv->b.sc->parent->ascent)
 		cv->expandedge = ee_down;
 	}
     }
@@ -639,8 +639,8 @@ return;
 		cv->p.cx<cv->b.sc->top_accent_horiz+fs->fudge &&
 		cv->b.container==NULL );
     dovwidth = ( cv->showvmetrics && cv->b.sc->parent->hasvmetrics && cv->b.container == NULL &&
-		cv->p.cy>/*cv->b.sc->parent->vertical_origin*/-cv->b.sc->vwidth-fs->fudge &&
-		cv->p.cy</*cv->b.sc->parent->vertical_origin*/-cv->b.sc->vwidth+fs->fudge &&
+		cv->p.cy > -cv->b.sc->vwidth + cv->b.sc->parent->ascent - fs->fudge &&
+		cv->p.cy < -cv->b.sc->vwidth + cv->b.sc->parent->ascent + fs->fudge &&
 		usemymetrics==NULL );
     cv->nearcaret = nearcaret = -1;
     if ( cv->showhmetrics ) nearcaret = NearCaret(cv->b.sc,cv->p.cx,fs->fudge);


### PR DESCRIPTION
I sidetracked discussion of #3929 with additional code suggestions that weren't convenient to discuss, so I'm proposing those ideas here. These changes include @jackhumbert's code from that PR. 

As I noted there, it seems that there has been a widely referenced [patch](http://www.akenotsuki.com/eyeben/fonts/ffpatch20120731b.txt) for vertical metrics discussed here: http://www.akenotsuki.com/eyeben/fonts/kanren.html . Over time bits of this patch have been integrated through individual PRs, but as far as I can tell the FontForge devs have not evaluated (or been aware of) the bulk of it. This PR represents my attempt to. 

What the changes do, following the `eyeben` doc:

1. Turns on vertical metrics by default when there are vertical metrics in the font (tested, works)
2. Fix the display location of the advance line (tested, seems to work)
3. Apply @jackhumbert's fixes, and additional fixes in `tottf.c:dumpmissingglyph()` for `gh.ymax`  and `dumpccfhtmx()` for `b.miny` (the former seems right based on the other fixes, the latter I'm less sure of -- could just be wrong).
4. Initialize the `vwidth` to ascent+descent, just like `width`
5. Copy the vwidth from the dummy in `splinefont.c`.
6. Fix the direction of some arrows when displaying vertical metrics (in `charview.c`)

What I've tested works well, but I'm far from an expert on this subject. 