### PR TITLE
Add a warning about our poor CID support

### DIFF
--- a/doc/html/cidmenu.html
+++ b/doc/html/cidmenu.html
@@ -224,6 +224,17 @@
     <LI>
       &lt;sub font names&gt;
   </UL>
+  <P>
+  <FONT COLOR="Red"><STRONG><BIG>Warning:</BIG></STRONG></FONT> FontForge's
+  support for CID-keyed fonts is rudimentary; especially attempting to use
+  Compact encodings and the Metrics View in CID-keyed fonts is known to cause
+  issues and crashes. At one time, the memory usage of CID-keyed fonts was seen
+  as very worrisome (&approx;250MB), however as even most modern smartphones
+  can support such usage it is no longer a concern for the majority of users.
+  Therefore, we recommend that if you will make serious edits to a CID-keyed
+  font, you <a href="cidmenu.html#CID">flatten</a> it first to prevent crashes
+  and memory corruption. Bug fixes are always welcome&mdash;to start, see 
+  <a href="https://github.com/fontforge/fontforge/issues/3946#issuecomment-534005675">issue &numero;3946</a>.
   <H2>
     Er... What is a <A NAME="CID">CID</A> keyed Font?
   </H2>

--- a/doc/html/fontview.html
+++ b/doc/html/fontview.html
@@ -518,9 +518,16 @@
   Adobe-Japan1-4.cidmap<BR>
   &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Adobe-Korea1-2.cidmap
   <P>
-  <FONT COLOR="Red"><STRONG><BIG>Warning:</BIG></STRONG></FONT> CID keyed fonts
-  (actually any CJK font) use massive amounts of memory in FontForge. I am
-  able to work on many of them on my 256M machine with 384M of swap space.
+  <FONT COLOR="Red"><STRONG><BIG>Warning:</BIG></STRONG></FONT> FontForge's
+  support for CID-keyed fonts is rudimentary; especially attempting to use
+  Compact encodings and the Metrics View in CID-keyed fonts is known to cause
+  issues and crashes. At one time, the memory usage of CID-keyed fonts was seen
+  as very worrisome (&approx;250MB), however as even most modern smartphones
+  can support such usage it is no longer a concern for the majority of users.
+  Therefore, we recommend that if you will make serious edits to a CID-keyed
+  font, you <a href="cidmenu.html#CID">flatten</a> it first to prevent crashes
+  and memory corruption. Bug fixes are always welcome&mdash;to start, see 
+  <a href="https://github.com/fontforge/fontforge/issues/3946#issuecomment-534005675">issue &numero;3946</a>.
   <P>
   The <A HREF="editmenu.html#Remove-Undoes">Remove Undoes </A>command will
   allow you to free up memory if you think you may be running short. FontForge


### PR DESCRIPTION
The memory warning really is not applicable in 2019, the numerous crashes are much more serious.

Happily, flattening CID fonts never seems to fail&mdash;I ran it on hundreds of CID fonts and have not gotten any crashes. So just recommend that instead. Fixing the actual problem would take a long time and I doubt it would have any benefit over just flattening the CID fonts&mdash;that's my opinion after experimenting with this for a week or so.

**(Note: This is a documentation-only change.)**