### PR TITLE
Bitmap view colors

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1308,6 +1308,7 @@ extern struct hslrgb *SFFontCols(SplineFont *sf,struct hslrgb fontcols[6]);
 extern Color view_bgcol;	/* Background color for views */
 extern void MVColInit(void);
 extern void CVColInit( void );
+extern void BVColInit( void );
 
 extern void FontViewRemove(FontView *fv);
 extern void FontViewFinishNonStatic();

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -2121,6 +2121,16 @@ GResInfo bitmapview_ri = {
     NULL
 };
 
+void BVColInit(void) {
+    static bool cinit = false;
+
+    if (cinit)
+	return;
+
+    cinit = true;
+    GResEditFind(bitmapview_re, "BitmapView.");
+}
+
 static GMenuItem2 wnmenu[] = {
     { { (unichar_t *) N_("New O_utline Window"), NULL, COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 0, 1, 0, 0, 0, 0, 1, 1, 0, 'u' }, H_("New Outline Window|Ctl+H"), NULL, NULL, BVMenuOpenOutline, 0 },
     { { (unichar_t *) N_("New _Bitmap Window"), NULL, COLOR_DEFAULT, COLOR_DEFAULT, NULL, NULL, 1, 0, 0, 0, 0, 0, 1, 1, 0, 'B' }, H_("New Bitmap Window|Ctl+J"), NULL, NULL, /* No function, never avail */NULL, 0 },
@@ -2298,6 +2308,7 @@ return;
     mb2DoGetText(mblist);
     for ( i=0; BVFlipNames[i]!=NULL ; ++i )
 	BVFlipNames[i] = S_(BVFlipNames[i]);
+    BVColInit();
     atexit(&BitmapViewFinishNonStatic);
 }
 

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -13433,9 +13433,9 @@ struct cv_interface gdraw_cv_interface = {
     CV_LayerPaletteCheck
 };
 
-extern GResInfo metricsview_ri;
+extern GResInfo bitmapview_ri;
 GResInfo charview2_ri = {
-    &metricsview_ri, NULL,NULL, NULL,
+    &bitmapview_ri, NULL,NULL, NULL,
     NULL,
     NULL,
     NULL,

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -2637,6 +2637,7 @@ void DoXRes(void) {
 
     MVColInit();
     CVColInit();
+    BVColInit();
     GResEdit(&fontview_ri,xdefs_filename,change_res_filename);
 }
 


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

I've been working on a bitmap font, and found myself really wanting a darker view for nighttime work. This exposes the color options for a nicer dark theme:
![bitmap_dark](https://user-images.githubusercontent.com/1683303/66247725-38bc9a00-e6ee-11e9-8e48-b02834dc0f28.png)

If this is acceptable so far, I'll keep going and include the rest of the hard-coded colors in `bitmapview.c`, which are mostly for references and selections.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **New feature**
- **Non-breaking change**
