### PR TITLE
Export PYTHONPATH and PYTHONHOME, closes #3959

### DIFF
--- a/Packaging/AppDir/AppRun
+++ b/Packaging/AppDir/AppRun
@@ -1,4 +1,6 @@
 #!/bin/bash
 HERE="$(dirname "$(readlink -f "${0}")")"
+export PYTHONPATH="$HERE/usr/lib/python3.7"
+export PYTHONHOME="$HERE/usr"
 cd "${HERE}/usr/"
 exec ./bin/fontforge "$@"


### PR DESCRIPTION
Export `PYTHONPATH` and `PYTHONHOME`, closes #3959