### PR TITLE
Use proper offset for BitmapView scrollbar

### DIFF
--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -76,7 +76,7 @@ static void BVNewScale(BitmapView *bv) {
     GScrollBarSetBounds(bv->vsb,-2*fh*bv->scale,4*fh*bv->scale,bv->height);
     GScrollBarSetBounds(bv->hsb,-3*fh*bv->scale,6*fh*bv->scale,bv->width);
     GScrollBarSetPos(bv->vsb,bv->yoff);
-    GScrollBarSetPos(bv->hsb,bv->xoff);
+    GScrollBarSetPos(bv->hsb,-bv->xoff);
 
     GDrawRequestExpose(bv->v,NULL,false);
 }


### PR DESCRIPTION
This fixes a minor annoyance: the first time I try to drag the horizontal scrollbar, the entire view jumps to the left.

Before scrolling anything, the whole view is set up correctly, but this offset was flipped. It didn't seem to have any effect until the scrollbar is touched.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
