### PR TITLE
Bump the travis image to High Sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 compiler: gcc
 sudo: false
 dist: xenial
-osx_image: xcode9.2
+osx_image: xcode10.1
 
 branches:
   only:


### PR DESCRIPTION
Sierra support is dropped with https://github.com/Homebrew/brew/releases/tag/2.1.13

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
- **Breaking change**
