### PR TITLE
Fix crash in SFDTrimUndoOldToNew.

### DIFF
--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -3840,6 +3840,9 @@ char* SFDCreateUndoForLookup( SplineFont *sf, int lookup_type )
 }
 
 static SplineChar* SCFindByGlyphName( SplineFont *sf, char* n ) {
+    if (n == NULL) {
+        return 0;
+    }
     int i=0;
     for ( i=0; i<sf->glyphcnt; ++i ) {
 	if ( sf->glyphs[i]!=NULL ) {
@@ -3932,7 +3935,7 @@ static char* SFDTrimUndoOldToNew( SplineFont *sf, char* oldstr, char* newstr ) {
 	         * we have to output oglyph and read another glyph from
 	         * the old list.
 	         */
-	        while( newsc->orig_pos > oldsc->orig_pos ) {
+	        while( oglyph && newsc->orig_pos > oldsc->orig_pos ) {
 	    	    glyphsWithUndoInfoCount++;
 	    	    SFDTrimUndoOldToNew_Output( retf, oglyph, oline );
 	    	    free(oline);
@@ -3946,7 +3949,7 @@ static char* SFDTrimUndoOldToNew( SplineFont *sf, char* oldstr, char* newstr ) {
 	    	    fprintf(stderr,"failed to read new or old files during SFD diff. Returning entire new data as diff!\n");
 	    	    goto error3SFDTrimUndoOldToNew;
 	        }
-	        if( strcmp( oglyph, nglyph )) {
+	        if( !oglyph || strcmp( oglyph, nglyph )) {
 //	    	    fprintf(stderr,"mismatch between old and new SFD fragments. Skipping new glyph that is not in old...\n");
 	    	    glyphsWithUndoInfoCount++;
 	    	    SFDTrimUndoOldToNew_Output( retf, nglyph, "Kerns2: " );


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

The innermost 'while' loop advanced 'oglyph' with
'SFDMoveToNextStartChar' but did not check the return value for 0 (to
check for the last entry). As a result, 'SCFindByGlyphName' could crash
in strcmp. This changes 'SCFindByGlyphName' not to crash in this
condition and also checks for oglyph being 0 where needed. This fixes
crashes while editing font lookups.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**
