### PR TITLE
Only categorize a point as a tangent when the cp vector points opposite the relevant point vector

### DIFF
--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1123,8 +1123,13 @@ static int SplinePointCategory(SplinePoint *sp) {
 	    pt = pt_curve;
 	/* Cross product of control point with unit vector normal to line in */
 	/*  opposite direction should be less than an em-unit for a tangent */
-	else if (( nclen==0 && pclen!=0 && (cross = pcdir.x*ndir.y-pcdir.y*ndir.x)<bounds && cross>-bounds ) ||
-		( pclen==0 && nclen!=0 && (cross = ncdir.x*pdir.y-ncdir.y*pdir.x)<bounds && cross>-bounds ))
+	else if (    (   nclen==0 && pclen!=0 
+	              && (cross = pcdir.x*ndir.y-pcdir.y*ndir.x)<bounds
+	              && cross>-bounds && (pcdir.x*ndir.x+pcdir.y*ndir.y)<0 )
+	          ||
+	             (   pclen==0 && nclen!=0
+	              && (cross = ncdir.x*pdir.y-ncdir.y*pdir.x)<bounds
+	              && cross>-bounds && (ncdir.x*pdir.x+ncdir.y*pdir.y)<0 ) )
 	    pt = pt_tangent;
 
 	if (pt == pt_curve &&


### PR DESCRIPTION
When a Cubic spline point has a single control point and the question is "Is this a tangent point?" the current code tests if the cross product between the vector to the CP and the vector to the cp-less point is sufficiently small. However, it does not test the dot product to see if the two vectors are in opposite directions. This adds that test. 

You can test with the contour in this by running simplify (which categorizes the points):

[tantest.sfd.txt](https://github.com/fontforge/fontforge/files/3749574/tantest.sfd.txt)

The bottom point should wind up as a tangent and the top shouldn't. Both do with the current master. 
