### PR TITLE
Corrected: Unify PI to FF_PI and fix cp deselect function

### DIFF
--- a/fontforge/autowidth.c
+++ b/fontforge/autowidth.c
@@ -750,7 +750,7 @@ return( 0 );
     if ( topx==bottomx )
 return( 0 );
 
-    angle = atan2(as/3,topx-bottomx)*180/3.1415926535897932-90;
+    angle = atan2(as/3,topx-bottomx)*180/FF_PI-90;
     if ( angle<1 && angle>-1 ) angle = 0;
 return( angle );
 }

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -418,7 +418,7 @@ static SplinePoint *ArcSpline(SplinePoint *sp,float sa,SplinePoint *ep,float ea,
     ss = sin(sa); sc = cos(sa); es = sin(ea); ec = cos(ea);
     if ( ep==NULL )
 	ep = SplinePointCreate((double)(cx+r)*ec, (double)(cy+r)*es);
-    len = ((double)(ea-sa)/(3.1415926535897932/2)) * (double)r * .552;
+    len = ((double)(ea-sa)/(FF_PI/2)) * (double)r * .552;
 
     sp->nextcp.x = sp->me.x - len*ss; sp->nextcp.y = sp->me.y + len*sc;
     ep->prevcp.x = ep->me.x + len*es; ep->prevcp.y = ep->me.y - len*ec;
@@ -457,23 +457,23 @@ static SplineSet * slurparc(FILE *fig,SplineChar *sc, SplineSet *sofar) {
     spl->last = ep = SplinePointCreate(ex,ey);
 
     if ( dir==0 ) {	/* clockwise */
-	if ( ea>sa ) ea = (double)ea - 2*3.1415926535897932;
-	ma=ceil((double)sa/(3.1415926535897932/2)-1)*(3.1415926535897932/2);
-	if ( RealNearish( sa,ma )) ma = (double)ma - (3.1415926535897932/2);
+	if ( ea>sa ) ea = (double)ea - 2*FF_PI;
+	ma=ceil((double)sa/(FF_PI/2)-1)*(FF_PI/2);
+	if ( RealNearish( sa,ma )) ma = (double)ma - (FF_PI/2);
 	while ( ma > ea ) {
 	    sp = ArcSpline(sp,sa,NULL,ma,cx,cy,r);
 	    sa = ma;
-	    ma = (double)ma - (3.1415926535897932/2);
+	    ma = (double)ma - (FF_PI/2);
 	}
 	sp = ArcSpline(sp,sa,ep,ea,cx,cy,r);
     } else {		/* counterclockwise */
-	if ( ea<sa ) ea = (double)ea + 2*3.1415926535897932;
-	ma=floor((double)sa/(3.1415926535897932/2)+1)*(3.1415926535897932/2);
-	if ( RealNearish( sa,ma )) ma = (double)ma + (3.1415926535897932/2);
+	if ( ea<sa ) ea = (double)ea + 2*FF_PI;
+	ma=floor((double)sa/(FF_PI/2)+1)*(FF_PI/2);
+	if ( RealNearish( sa,ma )) ma = (double)ma + (FF_PI/2);
 	while ( ma < ea ) {
 	    sp = ArcSpline(sp,sa,NULL,ma,cx,cy,r);
 	    sa = ma;
-	    ma = (double)ma + (3.1415926535897932/2);
+	    ma = (double)ma + (FF_PI/2);
 	}
 	sp = ArcSpline(sp,sa,ep,ea,cx,cy,r);
     }

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -1605,7 +1605,7 @@ void FVMetricsCenter(FontViewBase *fv,int docenter) {
     memset(itransform,0,sizeof(itransform));
     transform[0] = transform[3] = 1.0;
     itransform[0] = itransform[3] = 1.0;
-    itransform[2] = tan( fv->sf->italicangle * 3.1415926535897932/180.0 );
+    itransform[2] = tan( fv->sf->italicangle * FF_PI/180.0 );
     bvts[1].func = bvt_none;
     bvts[0].func = bvt_transmove; bvts[0].y = 0;
     if ( !fv->sf->onlybitmaps ) {

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -2848,7 +2848,7 @@ return;
 
     if (( ia = sf->italicangle )==0 )
 	ia = SFGuessItalicAngle(sf);
-    ia *= 3.1415926535897932/180;	/* convert degrees to radians */
+    ia *= FF_PI/180;	/* convert degrees to radians */
 
     dot = strchr(sc->name,'.');
 
@@ -2927,7 +2927,7 @@ return( 1 );				/* No base character reference found */
 
     if (( ia = sf->italicangle )==0 )
 	ia = SFGuessItalicAngle(sf);
-    ia *= 3.1415926535897932/180;	/* convert degrees to radians */
+    ia *= FF_PI/180;	/* convert degrees to radians */
 
     SCPreserveLayer(sc,layer,true);
 

--- a/fontforge/ikarus.c
+++ b/fontforge/ikarus.c
@@ -658,7 +658,7 @@ return( NULL );
     /* descender? = */ getushort(file);
     /* line thickness = */ getushort(file);
     /* stroke thickness = */ getushort(file);
-    italic_angle = getushort(file)/10.0 * 3.1415926535897932/180.0;
+    italic_angle = getushort(file)/10.0 * FF_PI/180.0;
     opt_pt_size = getushort(file);
     /* average char width = */ getushort(file);
 

--- a/fontforge/nowakowskittfinstr.c
+++ b/fontforge/nowakowskittfinstr.c
@@ -2162,13 +2162,13 @@ static int __same_angle(int *contourends, BasePoint *bp, int p, double angle) {
     /* true. 'Close' means about 5 deg, i.e. about 0.087 rad. */
     PrevTangent = fabs(PrevTangent-angle);
     NextTangent = fabs(NextTangent-angle);
-    while (PrevTangent > M_PI) PrevTangent -= 2*M_PI;
-    while (NextTangent > M_PI) NextTangent -= 2*M_PI;
+    while (PrevTangent > FF_PI) PrevTangent -= 2*FF_PI;
+    while (NextTangent > FF_PI) NextTangent -= 2*FF_PI;
 return (fabs(PrevTangent) <= 0.087) || (fabs(NextTangent) <= 0.087);
 }
 
 static int same_angle(int *contourends, BasePoint *bp, int p, double angle) {
-return __same_angle(contourends, bp, p, angle) || __same_angle(contourends, bp, p, angle+M_PI);
+return __same_angle(contourends, bp, p, angle) || __same_angle(contourends, bp, p, angle+FF_PI);
 }
 
 /* I found it needed to write some simple functions to classify points snapped
@@ -2364,7 +2364,7 @@ static int value_point(InstrCt *ct, int p, SplinePoint *sp, real fudge) {
         IsExtremum(ct->xdir, p, sp))
             score+=4;
 
-    if (same_angle(ct->contourends, ct->bp, p, ct->xdir?0.5*M_PI:0.0))
+    if (same_angle(ct->contourends, ct->bp, p, ct->xdir?0.5*FF_PI:0.0))
         score++;
 
     if (p == sp->ttfindex && IsAnglePoint(ct->contourends, ct->bp, sp))

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -734,7 +734,7 @@ static void circlearcto(real a1, real a2, real cx, real cy, real r,
 return;
 
     cplen = (a2-a1)/90 * r * .552;
-    a1 *= 3.1415926535897932/180; a2 *= 3.1415926535897932/180;
+    a1 *= FF_PI/180; a2 *= FF_PI/180;
     s1 = sin(a1); s2 = sin(a2); c1 = cos(a1); c2 = cos(a2);
     temp.x = cx+r*c2; temp.y = cy+r*s2;
     base.x = cx+r*c1; base.y = cy+r*s1;
@@ -1745,18 +1745,18 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 	  case pt_atan:
 	    if ( sp>=2 && stack[sp-1].type==ps_num && stack[sp-2].type==ps_num ) {
 		stack[sp-2].u.val = atan2(stack[sp-2].u.val,stack[sp-1].u.val)*
-			180/3.1415926535897932;
+			180/FF_PI;
 		--sp;
 	    }
 	  break;
 	  case pt_sin:
 	    if ( sp>=1 && stack[sp-1].type==ps_num ) {
-		stack[sp-1].u.val = sin(stack[sp-1].u.val*3.1415926535897932/180);
+		stack[sp-1].u.val = sin(stack[sp-1].u.val*FF_PI/180);
 	    }
 	  break;
 	  case pt_cos:
 	    if ( sp>=1 && stack[sp-1].type==ps_num ) {
-		stack[sp-1].u.val = cos(stack[sp-1].u.val*3.1415926535897932/180);
+		stack[sp-1].u.val = cos(stack[sp-1].u.val*FF_PI/180);
 	    }
 	  break;
 	  case pt_if:
@@ -2092,8 +2092,8 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		a1 = stack[sp-2].u.val;
 		a2 = stack[sp-1].u.val;
 		sp -= 5;
-		temp.x = cx+r*cos(a1/180 * 3.1415926535897932);
-		temp.y = cy+r*sin(a1/180 * 3.1415926535897932);
+		temp.x = cx+r*cos(a1/180 * FF_PI);
+		temp.y = cy+r*sin(a1/180 * FF_PI);
 		if ( temp.x!=current.x || temp.y!=current.y ||
 			!( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) )) {
 		    pt = chunkalloc(sizeof(SplinePoint));
@@ -2114,8 +2114,8 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		    }
 		}
 		circlearcsto(a1,a2,cx,cy,r,cur,transform,tok==pt_arcn);
-		current.x = cx+r*cos(a2/180 * 3.1415926535897932);
-		current.y = cy+r*sin(a2/180 * 3.1415926535897932);
+		current.x = cx+r*cos(a2/180 * FF_PI);
+		current.y = cy+r*sin(a2/180 * FF_PI);
 	    } else
 		sp = 0;
 	  break;
@@ -2179,13 +2179,13 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 			SplineMake3(cur->last,pt);
 			cur->last = pt;
 		    }
-		    a1 = 3*3.1415926535897932/2+a1;
-		    a2 = 3.1415926535897932/2+a2;
+		    a1 = 3*FF_PI/2+a1;
+		    a2 = FF_PI/2+a2;
 		    if ( !clockwise ) {
-			a1 += 3.1415926535897932;
-			a2 += 3.1415926535897932;
+			a1 += FF_PI;
+			a2 += FF_PI;
 		    }
-		    circlearcsto(a1*180/3.1415926535897932,a2*180/3.1415926535897932,
+		    circlearcsto(a1*180/FF_PI,a2*180/FF_PI,
 			    cx,cy,r,cur,transform,clockwise);
 		}
 		if ( tok==pt_arcto ) {

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -4492,7 +4492,7 @@ static void bRotate(Context *c) {
 	a = c->a.vals[1].u.fval;
     a = fmod(a,360.0);
     if ( a<0 ) a += 360;
-    a *= 3.1415926535897932/180.;
+    a *= FF_PI/180.;
     trans[0] = trans[3] = cos(a);
     trans[2] = -(trans[1] = sin(a));
     trans[4] = trans[5] = 0;
@@ -4602,7 +4602,7 @@ static void bSkew(Context *c) {
 	a = args[1];
     a = fmod(a,360.0);
     if ( a<0 ) a+=360;
-    a = a *3.1415926535897932/180.;
+    a = a *FF_PI/180.;
     trans[0] = trans[3] = 1;
     trans[1] = 0; trans[2] = tan(a);
     trans[4] = trans[5] = 0;
@@ -5145,11 +5145,11 @@ static void bExpandStroke(Context *c) {
 	    bESFlags(c, 5, &si);
     } else if ( c->a.argc==5 ) {
 	si.stroke_type = si_calligraphic;
-	si.penangle = 3.1415926535897932*args[2]/180;
+	si.penangle = FF_PI*args[2]/180;
 	si.minorradius = si.radius * args[3] / (double) args[4];
     } else if ( c->a.argc==7 ) {
         si.stroke_type = si_calligraphic;
-	si.penangle = 3.1415926535897932*args[2]/180;
+	si.penangle = FF_PI*args[2]/180;
 	si.minorradius = si.radius * args[3] / (double) args[4];
 	if ( c->a.vals[5].type!=v_int || c->a.vals[5].u.ival!=0 )
             ScriptError(c,"If 6 arguments are given, the fifth must be zero");
@@ -5173,7 +5173,7 @@ static void bExpandStroke(Context *c) {
 		ScriptError(c,"Convex nib unknown or not defined");
 	} else
 	    si.minorradius = args[3]/2.0;
-	si.penangle = 3.1415926535897932*args[4]/180;
+	si.penangle = FF_PI*args[4]/180;
 	bESJoinCap(c, 5, 6, &si);
 	if ( args[7]>0 )
 	    si.joinlimit = args[7];
@@ -5203,7 +5203,7 @@ static void bShadow(Context *c) {
 	ScriptError(c,"Bad argument type");
     if ( c->a.vals[1].type == v_int ) a = c->a.vals[1].u.ival;
     else a = c->a.vals[1].u.fval;
-    FVShadow(c->curfv,a*3.1415926535897932/180.,
+    FVShadow(c->curfv,a*FF_PI/180.,
 	    c->a.vals[2].u.ival, c->a.vals[3].u.ival,false);
 }
 
@@ -5216,7 +5216,7 @@ static void bWireframe(Context *c) {
 	ScriptError(c,"Bad argument type");
     if ( c->a.vals[1].type == v_int ) a = c->a.vals[1].u.ival;
     else a = c->a.vals[1].u.fval;
-    FVShadow(c->curfv,a*3.1415926535897932/360.,
+    FVShadow(c->curfv,a*FF_PI/360.,
 	    c->a.vals[2].u.ival, c->a.vals[3].u.ival,true);
 }
 

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -1894,7 +1894,7 @@ void SmallCapsFindConstants(struct smallcaps *small, SplineFont *sf,
     memset(small,0,sizeof(*small));
 
     small->sf = sf; small->layer = layer;
-    small->italic_angle = sf->italicangle * 3.1415926535897932/180.0;
+    small->italic_angle = sf->italicangle * FF_PI/180.0;
     small->tan_ia = tan( small->italic_angle );
 
     small->lc_stem_width = CaseMajorVerticalStemWidth(sf, layer,lc_stem_str, small->tan_ia );
@@ -3410,7 +3410,7 @@ void SCCondenseExtend(struct counterinfo *ci,SplineChar *sc, int layer,
     if ( ci->correct_italic && sc->parent->italicangle!=0 ) {
 	memset(transform,0,sizeof(transform));
 	transform[0] = transform[3] = 1;
-	transform[2] = tan( sc->parent->italicangle * 3.1415926535897932/180.0 );
+	transform[2] = tan( sc->parent->italicangle * FF_PI/180.0 );
 	SplinePointListTransform(sc->layers[layer].splines,transform,tpt_AllPoints);
 	StemInfosFree(sc->vstem); sc->vstem=NULL;
     }
@@ -3460,7 +3460,7 @@ void SCCondenseExtend(struct counterinfo *ci,SplineChar *sc, int layer,
 	/* If we unskewed it, we want to skew it now */
 	memset(transform,0,sizeof(transform));
 	transform[0] = transform[3] = 1;
-	transform[2] = -tan( sc->parent->italicangle * 3.1415926535897932/180.0 );
+	transform[2] = -tan( sc->parent->italicangle * FF_PI/180.0 );
 	SplinePointListTransform(sc->layers[layer].splines,transform,tpt_AllPoints);
     }
 
@@ -6781,7 +6781,7 @@ static void InitItalicConstants(SplineFont *sf, int layer, ItalicInfo *ii) {
     int i,cnt;
     double val;
 
-    ii->tan_ia = tan(ii->italic_angle * 3.1415926535897932/180.0 );
+    ii->tan_ia = tan(ii->italic_angle * FF_PI/180.0 );
 
     ii->x_height	  = SFXHeight  (sf,layer,false);
     ii->ascender_height   = SFAscender (sf,layer,false);

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -1924,8 +1924,6 @@ static SplineSet *UnitCircle(int clockwise) {
 return( spl );
 }
 
-#define PI	3.1415926535897932
-
 static int CutCircle(SplineSet *spl,BasePoint *me,int first) {
     Spline *s, *firsts;
     SplinePoint *end;
@@ -2223,7 +2221,7 @@ static int EllipseSomewhere(CharViewBase *cv,SplinePoint *sp1,SplinePoint *sp2,
 	BasePoint slope1, slope2;
     } centered, rot;
     bigreal bestrot=9999, bestrtest = 1e50, e1sq, e2sq, r1, r2, rtest;
-    bigreal low, high, offset=PI/128., rotation;
+    bigreal low, high, offset=FF_PI/128., rotation;
     int i;
     int clockwise;
     /* First figure out a center. There will be one: */
@@ -2272,7 +2270,7 @@ return( false );
     r1 = r2 = 1;
     for ( i=0; i<ITER; ++i ) {
 	if ( i==0 ) {
-	    low = 0; high = PI; offset = PI/1024;
+	    low = 0; high = FF_PI; offset = FF_PI/1024;
 	} else {
 	    low = bestrot-offset; high = bestrot+offset; offset /= 64.;
 	}

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -44,7 +44,6 @@
 #include <math.h>
 
 #define CIRCOFF 0.551915
-#define PI      3.1415926535897932
 
 // Rounding makes even slope-continuous splines only approximately so.
 #define INTERSPLINE_MARGIN (1e-1)
@@ -55,7 +54,7 @@
 #define COS_MARGIN (1e-5)
 #define MIN_ACCURACY (1e-5)
 
-#define NORMANGLE(a) ((a)>PI?(a)-2*PI:(a)<-PI?(a)+2*PI:(a))
+#define NORMANGLE(a) ((a)>FF_PI?(a)-2*FF_PI:(a)<-FF_PI?(a)+2*FF_PI:(a))
 #define SIGNOF(a) ((0 < (a)) - ((a) < 0))
 #define BPNEAR(bp1, bp2) BPWITHIN(bp1, bp2, INTRASPLINE_MARGIN)
 #define BP_DIST(bp1, bp2) sqrt(pow((bp1).x-(bp2).x,2)+pow((bp1).y-(bp2).y,2))
@@ -248,7 +247,7 @@ StrokeInfo *CVStrokeInfo() {
     if ( cv_si==NULL ) {
 	cv_si = InitializeStrokeInfo(NULL);
 	cv_si->minorradius = cv_si->radius;
-	cv_si->penangle = PI/4;
+	cv_si->penangle = FF_PI/4;
     }
     return cv_si;
 }
@@ -261,7 +260,7 @@ StrokeInfo *CVFreeHandInfo() {
 	fv_si->cap = lc_butt;
 	fv_si->stroke_type = si_centerline;
 	fv_si->minorradius = fv_si->radius;
-	fv_si->penangle = PI/4;
+	fv_si->penangle = FF_PI/4;
     }
     return fv_si;
 }
@@ -389,7 +388,7 @@ enum ShapeType NibIsValid(SplineSet *ss) {
     }
     if ( n<3 )
 	return Shape_TooFewPoints;
-    if ( !RealWithin(anglesum, 2*PI, 1e-1) )
+    if ( !RealWithin(anglesum, 2*FF_PI, 1e-1) )
 	return Shape_SelfIntersects;
 
     assert( s==ss->first->next );
@@ -1348,7 +1347,7 @@ static void RoundJoin(JoinParams *jpp) {
     ut1 = BP_ROT(BP_REV(jpp->ut_fm), UT_NEG(cut));
     ut2 = BP_ROT(jpp->no_to->utanvec, UT_NEG(cut));
     BasePoint pp1 = BP_ROT(jpp->cur->last->me, UT_NEG(cut)), pp2 = BP_ROT(jpp->oxy, UT_NEG(cut));
-    // printf("p1: %lf,%lf p2: %lf,%lf pp1: %lf,%lf: pp2: %lf,%lf, c: %lf,%lf cut: %lf, alpha: %lf\n", jpp->cur->last->me.x, jpp->cur->last->me.y, jpp->oxy.x, jpp->oxy.y, pp1.x, pp1.y, pp2.x, pp2.y, c.x, c.y, atan2(cut.y, cut.x) * 180 / PI, alpha);
+    // printf("p1: %lf,%lf p2: %lf,%lf pp1: %lf,%lf: pp2: %lf,%lf, c: %lf,%lf cut: %lf, alpha: %lf\n", jpp->cur->last->me.x, jpp->cur->last->me.y, jpp->oxy.x, jpp->oxy.y, pp1.x, pp1.y, pp2.x, pp2.y, c.x, c.y, atan2(cut.y, cut.x) * 180 / FF_PI, alpha);
     mu = -ut1.x/ut1.y;
     nu = -ut2.x/ut2.y;
     B = 1 + pow(mu + nu, 2)/2;
@@ -1360,7 +1359,7 @@ static void RoundJoin(JoinParams *jpp) {
     // printf("mu: %lf, nu:%lf, B: %lf, C: %lf, E: %lf, B2AC: %lf, tmp: %lf, tmp2: %lf\n", mu, nu, B, C, E, B2AC, tmp, tmp2);
     maj = sqrt(tmp * (1 + C + tmp2))/B2AC;
     min = sqrt(tmp * (1 + C - tmp2))/B2AC;
-    // printf("maj: %lf, min: %lf, angle: %lf\n", maj, min, atan2(cut.y, cut.x) * 180 / PI);
+    // printf("maj: %lf, min: %lf, angle: %lf\n", maj, min, atan2(cut.y, cut.x) * 180 / FF_PI);
     BevelJoin(jpp);
 }
 
@@ -1724,18 +1723,18 @@ SplineSet *UnitShape(int n) {
     if ( n>=3 || n<=-3 ) {
 	/* Regular n-gon with n sides */
 	/* Inscribed in a unit circle, if n<0 then circumscribed around */
-	bigreal angle = 2*PI/(2*n);
+	bigreal angle = 2*FF_PI/(2*n);
 	bigreal factor=1;
 	if ( n<0 ) {
 	    angle = -angle;
 	    n = -n;
 	    factor = 1/cos(angle);
 	}
-	angle -= PI/2;
+	angle -= FF_PI/2;
 	ret->first = sp1 = SplinePointCreate(factor*cos(angle), factor*sin(angle));
 	sp1->pointtype = pt_corner;
 	for ( i=1; i<n; ++i ) {
-	    angle = 2*PI/(2*n) + i*2*PI/n - PI/2;
+	    angle = 2*FF_PI/(2*n) + i*2*FF_PI/n - FF_PI/2;
 	    sp2 = SplinePointCreate(factor*cos(angle),factor*sin(angle));
 	    sp2->pointtype = pt_corner;
 	    SplineMake3(sp1,sp2);

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -2219,8 +2219,8 @@ void SplinePointListClearCPSel(SplinePointList *spl) {
 	spl->first->nextcpselected = false;
 	spl->first->prevcpselected = false;
 	for ( spline = spl->first->next; spline!=NULL && spline!=first; spline=spline->to->next ) {
-	     spl->first->nextcpselected = false;
-	     spl->first->prevcpselected = false;
+	     spline->to->nextcpselected = false;
+	     spline->to->prevcpselected = false;
 	    if ( first==NULL ) first = spline;
 	}
     }

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -3049,10 +3049,10 @@ void SPWeightedAverageCps(SplinePoint *sp) {
 	    sp->prev && sp->next ) {
 	pangle = atan2(sp->me.y-sp->prevcp.y,sp->me.x-sp->prevcp.x);
 	nangle = atan2(sp->nextcp.y-sp->me.y,sp->nextcp.x-sp->me.x);
-	if ( pangle<0 && nangle>0 && nangle-pangle>=3.1415926 )
-	    pangle += 2*3.1415926535897932;
-	else if ( pangle>0 && nangle<0 && pangle-nangle>=3.1415926 )
-	    nangle += 2*3.1415926535897932;
+	if ( pangle<0 && nangle>0 && nangle-pangle>=(FF_PI-6e-8) )
+	    pangle += 2*FF_PI;
+	else if ( pangle>0 && nangle<0 && pangle-nangle>=(FF_PI-6e-8) )
+	    nangle += 2*FF_PI;
 	plen = sqrt((sp->me.y-sp->prevcp.y)*(sp->me.y-sp->prevcp.y) +
 		(sp->me.x-sp->prevcp.x)*(sp->me.x-sp->prevcp.x));
 	nlen = sqrt((sp->nextcp.y-sp->me.y)*(sp->nextcp.y-sp->me.y) +
@@ -3085,10 +3085,10 @@ void SPAverageCps(SplinePoint *sp) {
 	    nangle = atan2(sp->next->to->me.y-sp->me.y,sp->next->to->me.x-sp->me.x);
 	else
 	    nangle = atan2(sp->nextcp.y-sp->me.y,sp->nextcp.x-sp->me.x);
-	if ( pangle<0 && nangle>0 && nangle-pangle>=3.1415926 )
-	    pangle += 2*3.1415926535897932;
-	else if ( pangle>0 && nangle<0 && pangle-nangle>=3.1415926 )
-	    nangle += 2*3.1415926535897932;
+	if ( pangle<0 && nangle>0 && nangle-pangle>=(FF_PI-6e-8) )
+	    pangle += 2*FF_PI;
+	else if ( pangle>0 && nangle<0 && pangle-nangle>=(FF_PI-6e-8) )
+	    nangle += 2*FF_PI;
 	angle = (nangle+pangle)/2;
 	plen = -sqrt((sp->me.y-sp->prevcp.y)*(sp->me.y-sp->prevcp.y) +
 		(sp->me.x-sp->prevcp.x)*(sp->me.x-sp->prevcp.x));

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -41,7 +41,6 @@
 #include <math.h>
 
 #define GLYPH_DATA_DEBUG 0
-#define PI 3.14159265358979323846264338327
 
 /* A diagonal end is like the top or bottom of a slash. Should we add a vertical stem at the end? */
 /* A diagonal corner is like the bottom of circumflex. Should we add a horizontal stem? */
@@ -80,9 +79,9 @@ static int IsUnitHV( BasePoint *unit,int strict ) {
     double angle = atan2( unit->y,unit->x );
     double deviation = ( strict ) ? stem_slope_error : stub_slope_error;
     
-    if ( fabs( angle ) >= PI/2 - deviation && fabs( angle ) <= PI/2 + deviation )
+    if ( fabs( angle ) >= FF_PI/2 - deviation && fabs( angle ) <= FF_PI/2 + deviation )
 return( 2 );
-    else if ( fabs( angle ) <= deviation || fabs( angle ) >= PI - deviation )
+    else if ( fabs( angle ) <= deviation || fabs( angle ) >= FF_PI - deviation )
 return( 1 );
 
 return( 0 );
@@ -94,15 +93,15 @@ static int UnitCloserToHV( BasePoint *u1,BasePoint *u2 ) {
     adiff1 = fabs( atan2( u1->y,u1->x ));
     adiff2 = fabs( atan2( u2->y,u2->x ));
     
-    if ( adiff1 > PI*.25 && adiff1 < PI*.75 )
-	adiff1 = fabs( adiff1 - PI*.5 );
-    else if ( adiff1 >= PI*.75 )
-	adiff1 = PI - adiff1;
+    if ( adiff1 > FF_PI*.25 && adiff1 < FF_PI*.75 )
+	adiff1 = fabs( adiff1 - FF_PI*.5 );
+    else if ( adiff1 >= FF_PI*.75 )
+	adiff1 = FF_PI - adiff1;
 
-    if ( adiff2 > PI*.25 && adiff2 < PI*.75 )
-	adiff2 = fabs( adiff2 - PI*.5 );
-    else if ( adiff2 >= PI*.75 )
-	adiff2 = PI - adiff2;
+    if ( adiff2 > FF_PI*.25 && adiff2 < FF_PI*.75 )
+	adiff2 = fabs( adiff2 - FF_PI*.5 );
+    else if ( adiff2 >= FF_PI*.75 )
+	adiff2 = FF_PI - adiff2;
 
     if ( adiff1 < adiff2 )
 return( 1 );
@@ -125,7 +124,7 @@ static int UnitsOrthogonal( BasePoint *u1,BasePoint *u2,int strict ) {
     
     angle = GetUnitAngle( u1,u2 );
     
-return( fabs( angle ) >= PI/2 - deviation && fabs( angle ) <= PI/2 + deviation );
+return( fabs( angle ) >= FF_PI/2 - deviation && fabs( angle ) <= FF_PI/2 + deviation );
 }
 
 int UnitsParallel( BasePoint *u1,BasePoint *u2,int strict ) {
@@ -133,7 +132,7 @@ int UnitsParallel( BasePoint *u1,BasePoint *u2,int strict ) {
     
     angle = GetUnitAngle( u1,u2 );
     
-return( fabs( angle ) <= deviation || fabs( angle ) >= PI - deviation );
+return( fabs( angle ) <= deviation || fabs( angle ) >= FF_PI - deviation );
 }
 
 static int IsInflectionPoint( struct glyphdata *gd,struct pointdata *pd ) {
@@ -1218,7 +1217,7 @@ static uint8 IsStubOrIntersection( struct glyphdata *gd, BasePoint *dir1,
     odir2 = ( is_next2 ) ? &pd2->prevunit : &pd2->nextunit;
     
     angle = fabs( GetUnitAngle( dir1,dir2 ));
-    if ( angle > (double)stub_slope_error*1.5 && angle < PI - (double)stub_slope_error*1.5 )
+    if ( angle > (double)stub_slope_error*1.5 && angle < FF_PI - (double)stub_slope_error*1.5 )
 return( 0 );
 
     /* First check if it is a slightly slanted line or a curve which joins */
@@ -1235,11 +1234,11 @@ return( 0 );
     /* of out going-to-be stem should point in the same direction. So */
     /* the following value should be positive */
     opp = dir1->x * dir2->x + dir1->y * dir2->y;
-    if (( angle <= mid_err || angle >= PI - mid_err ) && 
+    if (( angle <= mid_err || angle >= FF_PI - mid_err ) && 
 	opp > 0 && norm1 < 0 && norm2 < 0 && UnitsParallel( odir1,odir2,true ) && 
 	( UnitsOrthogonal( dir1,odir1,false ) || UnitsOrthogonal( dir2,odir1,false )))
 return( 2 );
-    if (( angle <= mid_err || angle >= PI - mid_err ) &&
+    if (( angle <= mid_err || angle >= FF_PI - mid_err ) &&
 	opp > 0 && (( norm1 < 0 && pd1->colinear &&
 	IsUnitHV( dir1,true ) && UnitsOrthogonal( dir1,odir2,false )) ||
 	( norm2 < 0 && pd2->colinear &&
@@ -1830,9 +1829,9 @@ static int ParallelToDir( struct pointdata *pd,int checknext,BasePoint *dir,
     n = ( checknext ) ? pd->nextunit : pd->prevunit;
 
     angle = fabs( GetUnitAngle( dir,&n ));
-    if (( !is_stub && angle > stem_slope_error && angle < PI - stem_slope_error ) ||
-	( is_stub & 1 && angle > stub_slope_error*1.5 && angle < PI - stub_slope_error*1.5 ) ||
-	( is_stub & 6 && angle > mid_err && angle < PI - mid_err ))
+    if (( !is_stub && angle > stem_slope_error && angle < FF_PI - stem_slope_error ) ||
+	( is_stub & 1 && angle > stub_slope_error*1.5 && angle < FF_PI - stub_slope_error*1.5 ) ||
+	( is_stub & 6 && angle > mid_err && angle < FF_PI - mid_err ))
 return( false );
 
     /* Now sp must be on the same side of the spline as opposite */
@@ -5782,8 +5781,8 @@ return( NULL );
     if ( sc->parent != NULL && sc->parent->italicangle ) {
 	iangle = ( 90 + sc->parent->italicangle );
 	gd->has_slant = true;
-	gd->slant_unit.x = cos( iangle * ( PI/180 ));
-	gd->slant_unit.y = sin( iangle * ( PI/180 ));
+	gd->slant_unit.x = cos( iangle * ( FF_PI/180 ));
+	gd->slant_unit.y = sin( iangle * ( FF_PI/180 ));
     } else {
 	gd->has_slant = false;
 	gd->slant_unit.x = 0; gd->slant_unit.y = 1;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1236,8 +1236,6 @@ return( fonts[choice] );
 return( NULL );
 }
 
-#define PI	3.1415926535897932
-
 /* I don't see where the spec says that the seperator between numbers is */
 /*  comma or whitespace (both is ok too) */
 /* But the style sheet spec says it, so I probably just missed it */
@@ -1298,7 +1296,7 @@ static void SVGTraceArc(SplineSet *cur,BasePoint *current,
 		  sqrt((tmpx*tmpx+tmpy*tmpy)*(t2x*t2x+t2y*t2y));
 	/* We occasionally got rounding errors near -1 */
 	if ( delta<=-1 )
-	    delta = 3.1415926535897932;
+	    delta = FF_PI;
 	else if ( delta>=1 )
 	    delta = 0;
 	else
@@ -1306,14 +1304,14 @@ static void SVGTraceArc(SplineSet *cur,BasePoint *current,
 	if ( tmpx*t2y-tmpy*t2x<0 )
 	    delta = -delta;
 	if ( sweep==0 && delta>0 )
-	    delta -= 2*PI;
+	    delta -= 2*FF_PI;
 	if ( sweep && delta<0 )
-	    delta += 2*PI;
+	    delta += 2*FF_PI;
 
 	if ( delta>0 ) {
 	    i = 0;
-	    ia = firstia = floor(startangle/(PI/2))+1;
-	    for ( a=ia*(PI/2), ia+=4; a<startangle+delta && !RealNear(a,startangle+delta); a += PI/2, ++i, ++ia ) {
+	    ia = firstia = floor(startangle/(FF_PI/2))+1;
+	    for ( a=ia*(FF_PI/2), ia+=4; a<startangle+delta && !RealNear(a,startangle+delta); a += FF_PI/2, ++i, ++ia ) {
 		t2x = rx*cosines[ia]; t2y = ry*sines[ia];
 		arcp[i].x = cosr*t2x - sinr*t2y + cx;
 		arcp[i].y = sinr*t2x + cosr*t2y + cy;
@@ -1329,8 +1327,8 @@ static void SVGTraceArc(SplineSet *cur,BasePoint *current,
 	    }
 	} else {
 	    i = 0;
-	    ia = firstia = ceil(startangle/(PI/2))-1;
-	    for ( a=ia*(PI/2), ia += 8; a>startangle+delta && !RealNear(a,startangle+delta); a -= PI/2, ++i, --ia ) {
+	    ia = firstia = ceil(startangle/(FF_PI/2))-1;
+	    for ( a=ia*(FF_PI/2), ia += 8; a>startangle+delta && !RealNear(a,startangle+delta); a -= FF_PI/2, ++i, --ia ) {
 		t2x = rx*cosines[ia]; t2y = ry*sines[ia];
 		arcp[i].x = cosr*t2x - sinr*t2y + cx;
 		arcp[i].y = sinr*t2x + cosr*t2y + cy;
@@ -1346,7 +1344,7 @@ static void SVGTraceArc(SplineSet *cur,BasePoint *current,
 	    }
 	}
 	if ( i!=0 ) {
-	    double firsta=firstia*PI/2;
+	    double firsta=firstia*FF_PI/2;
 	    double d = (firsta-startangle)/2;
 	    double th = startangle+d;
 	    double hypot = 1/cos(d);
@@ -1379,7 +1377,7 @@ static void SVGTraceArc(SplineSet *cur,BasePoint *current,
 	    hypot = 1.0/cos(delta/2);
 	    c = cos(th); s=sin(th);
 	} else {
-	    double lasta = delta<0 ? a+PI/2 : a-PI/2;
+	    double lasta = delta<0 ? a+FF_PI/2 : a-FF_PI/2;
 	    double d = (startangle+delta-lasta);
 	    double th = lasta+d/2;
 	    hypot = 1.0/cos(d/2);
@@ -1598,7 +1596,7 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		end = skipcomma(end);
 		ry = strtod(end,&end);
 		end = skipcomma(end);
-		axisrot = strtod(end,&end)*3.1415926535897932/180;
+		axisrot = strtod(end,&end)*FF_PI/180;
 		end = skipcomma(end);
 		large_arc = strtol(end,&end,10);
 		end = skipcomma(end);
@@ -1951,7 +1949,7 @@ static void SVGFigureTransform(struct svg_state *st,char *name) {
 	    trans[5] = strtod(skipcomma(end),&end);
 	} else if ( strncmp(pt,"rotate",paren-pt)==0 ) {
 	    trans[4] = trans[5] = 0;
-	    a = strtod(paren+1,&end)*3.1415926535897932/180;
+	    a = strtod(paren+1,&end)*FF_PI/180;
 	    trans[0] = trans[3] = cos(a);
 	    trans[1] = sin(a);
 	    trans[2] = -trans[1];
@@ -1985,11 +1983,11 @@ static void SVGFigureTransform(struct svg_state *st,char *name) {
 	} else if ( strncmp(pt,"skewX",paren-pt)==0 ) {
 	    trans[0] = trans[3] = 1;
 	    trans[1] = trans[2] = trans[4] = trans[5] = 0;
-	    trans[2] = tan(strtod(paren+1,&end)*3.1415926535897932/180);
+	    trans[2] = tan(strtod(paren+1,&end)*FF_PI/180);
 	} else if ( strncmp(pt,"skewY",paren-pt)==0 ) {
 	    trans[0] = trans[3] = 1;
 	    trans[1] = trans[2] = trans[4] = trans[5] = 0;
-	    trans[1] = tan(strtod(paren+1,&end)*3.1415926535897932/180);
+	    trans[1] = tan(strtod(paren+1,&end)*FF_PI/180);
 	} else
     break;
 	while ( isspace(*end)) ++end;

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -2969,7 +2969,7 @@ static void sethhead(struct hhead *hhead,struct hhead *vhead,struct alltabs *at,
 	hhead->caretSlopeRise = 1;
     else {
 	hhead->caretSlopeRise = 100;
-	hhead->caretSlopeRun = (int) rint(100*tan(-sf->italicangle*3.1415926535897/180.));
+	hhead->caretSlopeRun = (int) rint(100*tan(-sf->italicangle*FF_PI/180.));
     }
 
     vhead->maxwidth = height;
@@ -3041,7 +3041,7 @@ void SFDefaultOS2Simple(struct pfminfo *pfminfo,SplineFont *sf) {
 }
 
 void SFDefaultOS2SubSuper(struct pfminfo *pfminfo,int emsize,double italic_angle) {
-    double s = sin(italic_angle*3.1415926535897932/180.0);
+    double s = sin(italic_angle*FF_PI/180.0);
     pfminfo->os2_supysize = pfminfo->os2_subysize = .7*emsize;
     pfminfo->os2_supxsize = pfminfo->os2_subxsize = .65*emsize;
     pfminfo->os2_subyoff = .14*emsize;

--- a/fontforge/utanvec.c
+++ b/fontforge/utanvec.c
@@ -34,8 +34,6 @@
 #include <math.h>
 #include <assert.h>
 
-#define PI      3.1415926535897932 // For tests
-
 #define UTMARGIN (1e-8)
 #define BPNEAR(bp1, bp2) BPWITHIN(bp1, bp2, UTMARGIN)
 #define UTRETRY (UTMARGIN/10.0)
@@ -187,7 +185,7 @@ void UTanVecTests() {
     BasePoint ut[361], utmax = { -1, 0 }, utmin = UTMIN;
 
     for (i = 0; i<=360; i++) {
-	r = ((180-i) * PI / 180);
+	r = ((180-i) * FF_PI / 180);
 	ut[i] = MakeUTanVec(cos(r), sin(r));
 	// printf("i:%d, i.x:%lf, i.y:%lf\n", i, ut[i].x, ut[i].y);
     }
@@ -207,7 +205,7 @@ void UTanVecTests() {
 	    y = atan2(ut[j].x, ut[j].y);
 	    z = x-y;
 	    z = atan2(sin(z), cos(z));
-	    if ( RealNear(z, PI) || RealNear(z, -PI) )
+	    if ( RealNear(z, FF_PI) || RealNear(z, -FF_PI) )
 		continue;
 	    assert( (z>0) == JointBendsCW(ut[i], ut[j]) );
 	}
@@ -228,8 +226,8 @@ void UTanVecTests() {
 		    x = atan2(ut[i].x, ut[i].y);
 		    y = atan2(ut[j].x, ut[j].y);
 		    z = atan2(ut[k].x, ut[k].y);
-		    y = fmod(4*PI+y-x,2*PI);
-		    z = fmod(4*PI+z-x,2*PI);
+		    y = fmod(4*FF_PI+y-x,2*FF_PI);
+		    z = fmod(4*FF_PI+z-x,2*FF_PI);
 		    if ( y<z )
 			assert( a && !b );
 		    else

--- a/fontforgeexe/autowidth2dlg.c
+++ b/fontforgeexe/autowidth2dlg.c
@@ -199,11 +199,10 @@ void FVAutoWidth2(FontView *fv) {
     gcd[i++].creator = GLabelCreate;
     harray2[0] = &gcd[i-1];
 
-#define PI	3.1415926535897932
     if ( sf->italicangle<0 )
-	sprintf( minbuf, "%d", (int) rint( sf->descent*tan(sf->italicangle*PI/180 )) );
+	sprintf( minbuf, "%d", (int) rint( sf->descent*tan(sf->italicangle*FF_PI/180 )) );
     else if ( sf->italicangle>0 )
-	sprintf( minbuf, "%d", (int) -rint( sf->ascent*tan(sf->italicangle*PI/180 )) );
+	sprintf( minbuf, "%d", (int) -rint( sf->ascent*tan(sf->italicangle*FF_PI/180 )) );
     else
 	sprintf( minbuf, "%d", (int) rint( width_min_side_bearing * emsize / width_last_em_size ));
     label[i].text = (unichar_t *) minbuf;

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -2388,7 +2388,7 @@ static void DrawVLine(CharView *cv,GWindow pixmap,real pos,Color fg, int flags,
 	    GDrawDrawText8(pixmap,x+5,cv->sas+cv->sfh*(1+lock!=NULL)+3,name,-1,metricslabelcol);
     }
     if ( ItalicConstrained && cv->b.sc->parent->italicangle!=0 ) {
-	double t = tan(-cv->b.sc->parent->italicangle*3.1415926535897932/180.);
+	double t = tan(-cv->b.sc->parent->italicangle*FF_PI/180.);
 	int xoff = rint(8096*t);
 	DrawLine(cv,pixmap,pos-xoff,-8096,pos+xoff,8096,italiccoordcol);
     }
@@ -2722,7 +2722,7 @@ return;				/* no points. no side bearings */
 	    GDrawDrawText8(pixmap,x,y-4,buf,-1,metricslabelcol);
 	}
 	if ( ItalicConstrained && cv->b.sc->parent->italicangle!=0 ) {
-	    double t = tan(-cv->b.sc->parent->italicangle*3.1415926535897932/180.);
+	    double t = tan(-cv->b.sc->parent->italicangle*FF_PI/180.);
 	    if ( t!=0 ) {
 		SplinePoint *leftmost=NULL, *rightmost=NULL;
 		for ( layer=first; layer<=last; ++layer ) {
@@ -4151,7 +4151,7 @@ return;
     GDrawDrawText8(pixmap,SDS_DATA,ybase,buffer,-1,fg);
 
 	/* Utf-8 for degree sign */
-    sprintf( buffer, "%d\302\260", (int) rint(180*atan2(ydiff,xdiff)/3.1415926535897932));
+    sprintf( buffer, "%d\302\260", (int) rint(180*atan2(ydiff,xdiff)/FF_PI));
     GDrawDrawText8(pixmap,SAN_DATA,ybase,buffer,-1,fg);
 }
 
@@ -4457,7 +4457,7 @@ return( event );
 	cv->p.cx = basetruex ;
 	if ( !(event->u.mouse.state&ksm_meta) &&
 		ItalicConstrained && cv->b.sc->parent->italicangle!=0 ) {
-	    double off = tan(cv->b.sc->parent->italicangle*3.1415926535897932/180)*
+	    double off = tan(cv->b.sc->parent->italicangle*FF_PI/180)*
 		    (cv->p.cy-basetruey);
 	    double aoff = off<0 ? -off : off;
 	    if ( dx>=aoff*tab->scale/2 && (event->u.mouse.x-basex<0)!=(off<0) ) {
@@ -5319,7 +5319,7 @@ return;
 		p.x = fake.u.mouse.x = basex;
 		p.cx = cv->p.constrain.x;
 		if ( ItalicConstrained && cv->b.sc->parent->italicangle!=0 ) {
-		    double off = tan(cv->b.sc->parent->italicangle*3.1415926535897932/180)*
+		    double off = tan(cv->b.sc->parent->italicangle*FF_PI/180)*
 			    (p.cy-cv->p.constrain.y);
 		    double aoff = off<0 ? -off : off;
 		    if ( dx>=aoff*tab->scale/2 && (event->u.mouse.x-basex<0)!=(off<0) ) {
@@ -8117,7 +8117,7 @@ return;
 		d.keyboarddx = 1;
 	    }
 	    /* if ( event->u.chr.state & (ksm_shift) ) */
-	    /* 	dx -= dy*tan((cv->b.sc->parent->italicangle)*(3.1415926535897932/180) ); */
+	    /* 	dx -= dy*tan((cv->b.sc->parent->italicangle)*(FF_PI/180) ); */
 	    if ( event->u.chr.state & (ksm_shift) )
 	    {
 		dx *= arrowAccelFactor; dy *= arrowAccelFactor;
@@ -11613,7 +11613,7 @@ static void CVMenuCenter(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     else {
 	SplineSet *base, *temp;
 	base = LayerAllSplines(cv->b.layerheads[cv->b.drawmode]);
-	transform[2] = tan( cv->b.sc->parent->italicangle * 3.1415926535897932/180.0 );
+	transform[2] = tan( cv->b.sc->parent->italicangle * FF_PI/180.0 );
 	temp = SplinePointListTransform(SplinePointListCopy(base),transform,tpt_AllPoints);
 	transform[2] = 0;
 	LayerUnAllSplines(cv->b.layerheads[cv->b.drawmode]);

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -372,10 +372,10 @@ static void TraceMassage(TraceData *head, TraceData *end) {
 		/* We've got tangent corner tangent */
 		pangle = atan2(npt->y-pt->y,npt->x-pt->x);
 		nangle = atan2(nnpt->y-npt->y,nnpt->x-npt->x);
-		if ( pangle<0 && nangle>0 && nangle-pangle>=3.1415926 )
-		    pangle += 2*3.1415926535897932;
-		else if ( pangle>0 && nangle<0 && pangle-nangle>=3.1415926 )
-		    nangle += 2*3.1415926535897932;
+		if ( pangle<0 && nangle>0 && nangle-pangle>=FF_PI )
+		    pangle += 2*FF_PI;
+		else if ( pangle>0 && nangle<0 && pangle-nangle>=FF_PI )
+		    nangle += 2*FF_PI;
 		if ( nangle-pangle<1 && nangle-pangle>-1 ) {
 		    for (;;) {
 			pt->online = pt->use_as_pt = false;
@@ -689,10 +689,10 @@ return;
 		sin(langle)*hlen;
 	trace->first->prevcp = oldp;
     } else {
-	if ( hangle>3.1415926535897932/2 && langle<-3.1415926535897932/2 )
-	    langle += 2*3.1415926535897932;
-	if ( hangle<-3.1415926535897932/2 && langle>3.1415926535897932/2 )
-	    hangle += 2*3.1415926535897932;
+	if ( hangle>FF_PI/2 && langle<-FF_PI/2 )
+	    langle += 2*FF_PI;
+	if ( hangle<-FF_PI/2 && langle>FF_PI/2 )
+	    hangle += 2*FF_PI;
 	hangle = (hangle+langle)/2;
 	dx = cos(hangle);
 	dy = sin(hangle);

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -43,7 +43,7 @@
 
 #include <math.h>
 
-#define RAD2DEG	(180/3.1415926535897932)
+#define RAD2DEG	(180/FF_PI)
 #define TCnt	3
 
 typedef struct gidata {

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -366,7 +366,7 @@ return( ps_pointcnt );
 
 real CVStarRatio(void) {
     if ( regular_star )
-return( sin(3.1415926535897932/ps_pointcnt)*tan(2*3.1415926535897932/ps_pointcnt)+cos(3.1415926535897932/ps_pointcnt) );
+return( sin(FF_PI/ps_pointcnt)*tan(2*FF_PI/ps_pointcnt)+cos(FF_PI/ps_pointcnt) );
 	
 return( star_percent );
 }
@@ -417,8 +417,8 @@ static void FakeShapeEvents(CharView *cv) {
     CVMouseMoveShape(cv);
     CVMouseUpShape(cv);
     if ( raddiam_x!=0 && raddiam_y!=0 && rotate_by!=0 ) {
-	trans[0] = trans[3] = cos ( rotate_by*3.1415926535897932/180. );
-	trans[1] = sin( rotate_by*3.1415926535897932/180. );
+	trans[0] = trans[3] = cos ( rotate_by*FF_PI/180. );
+	trans[1] = sin( rotate_by*FF_PI/180. );
 	trans[2] = -trans[1];
 	trans[4] = -cv->p.x*trans[0] - cv->p.y*trans[2] + cv->p.x;
 	trans[5] = -cv->p.x*trans[1] - cv->p.y*trans[3] + cv->p.y;

--- a/fontforgeexe/cvruler.c
+++ b/fontforgeexe/cvruler.c
@@ -51,9 +51,9 @@ static void SlopeToBuf(char *buf,char *label,double dx, double dy) {
     if ( dx==0 && dy==0 )
 	sprintf( buf, _("%s No Slope"), label );
     else if ( dx==0 )
-	sprintf( buf, "%s dy/dx= ∞, %4g°", label, atan2(dy,dx)*180/3.1415926535897932);
+	sprintf( buf, "%s dy/dx= ∞, %4g°", label, atan2(dy,dx)*180/FF_PI);
     else
-	sprintf( buf, "%s dy/dx= %4g, %4g°", label, dy/dx, atan2(dy,dx)*180/3.1415926535897932);
+	sprintf( buf, "%s dy/dx= %4g, %4g°", label, dy/dx, atan2(dy,dx)*180/FF_PI);
 }
 
 static void CurveToBuf(char *buf,CharView *cv,Spline *s, double t) {
@@ -95,7 +95,7 @@ static int RulerText(CharView *cv, unichar_t *ubuf, int line) {
 	    sprintf( buf, "%f,%f", (double) cv->info.x, (double) cv->info.y);
 	else
 	    sprintf( buf, "%f %.0f° (%f,%f)", (double) len,
-		    atan2(yoff,xoff)*180/3.1415926535897932,
+		    atan2(yoff,xoff)*180/FF_PI,
 		    (double) xoff,(double) yoff);
       break; }
       case 1:
@@ -767,7 +767,7 @@ return( buffer );
       break;
       case 4:
 	dx = cp->x - sp->me.x; dy = cp->y - sp->me.y;
-	snprintf( buffer, blen, "∠ %g°", atan2(dy,dx)*180/3.1415926535897932 );
+	snprintf( buffer, blen, "∠ %g°", atan2(dy,dx)*180/FF_PI );
       break;
       case 5:
 	if ( s==NULL )

--- a/fontforgeexe/cvshapes.c
+++ b/fontforgeexe/cvshapes.c
@@ -273,19 +273,19 @@ return;
 	base = atan2(cv->p.cy-cv->info.y,cv->p.cx-cv->info.x);
 	radius = sqrt((cv->p.cy-cv->info.y)*(cv->p.cy-cv->info.y) +
 		(cv->p.cx-cv->info.x)*(cv->p.cx-cv->info.x));
-	off = -2*3.1415926535897932/points;
+	off = -2*FF_PI/points;
 	sp = cv->active_shape->last->prev->from;
 	for ( i=0; i<points; ++i )
 	    SetCorner(sp=sp->next->to, cv->p.cx+radius*cos(base+i*off),
 		    cv->p.cy+radius*sin(base+i*off));
       break;
       case cvt_star:
-	base = atan2(cv->p.cy-cv->info.y,cv->p.cx-cv->info.x)-3.1415926535897932;
-	if ( base<-3.1416 )
-	    base += 2*3.1415926535897932;
+	base = atan2(cv->p.cy-cv->info.y,cv->p.cx-cv->info.x)-FF_PI;
+	if ( base<(-FF_PI-0.00001) )
+	    base += 2*FF_PI;
 	radius = sqrt((cv->p.cy-cv->info.y)*(cv->p.cy-cv->info.y) +
 		(cv->p.cx-cv->info.x)*(cv->p.cx-cv->info.x));
-	off = -2*3.1415926535897932/(2*points);
+	off = -2*FF_PI/(2*points);
 	sp = cv->active_shape->last->prev->from;
 	r2 = radius/CVStarRatio();
 	for ( i=0; i<2*points; ++i ) {

--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -40,7 +40,6 @@
 
 #include <assert.h>
 #include <math.h>
-#define PI      3.1415926535897932
 
 extern GDevEventMask input_em[];
 extern const int input_em_cnt;
@@ -229,7 +228,7 @@ static int _Stroke_OK(StrokeDlg *sd,int isapply) {
     else if ( si->penangle<-180 )
 	si->penangle += 360;
     }
-    si->penangle *= 3.1415926535897932/180;
+    si->penangle *= FF_PI/180;
     si->cap = GGadgetIsChecked( GWidgetGetControl(sw,CID_ButtCap))?lc_butt:
               GGadgetIsChecked( GWidgetGetControl(sw,CID_BevelCap))?lc_bevel:
               GGadgetIsChecked( GWidgetGetControl(sw,CID_RoundCap))?lc_round:
@@ -317,7 +316,7 @@ static void Stroke_ShowNib(StrokeDlg *sd) {
 	memset(transform,0,sizeof(transform));
 	width = GetCalmReal8(sd->gw,CID_Width,"",&err)/2;
 	height = GetCalmReal8(sd->gw,CID_MinorAxis,"",&err)/2;
-	angle = GetCalmReal8(sd->gw,CID_PenAngle,"",&err)*PI/180;
+	angle = GetCalmReal8(sd->gw,CID_PenAngle,"",&err)*FF_PI/180;
 	c = cos(angle); s=sin(angle);
 	transform[0] = transform[3] = c;
 	transform[1] = s; transform[2] = -s;
@@ -756,7 +755,7 @@ static void MakeStrokeDlg(void *cv, void (*strokeit)(void *,StrokeInfo *,int),
 	gcd[gcdoff++].creator = GLabelCreate;
 	swarray[swpos][0] = &gcd[gcdoff-1];
 
-	sprintf( anglebuf, "%g", (double) (si->penangle*180/3.1415926535897932) );
+	sprintf( anglebuf, "%g", (double) (si->penangle*180/FF_PI) );
 	label[gcdoff].text = (unichar_t *) anglebuf;
 	label[gcdoff].text_is_1byte = true;
 	gcd[gcdoff].gd.pos.width = 50;
@@ -2044,8 +2043,8 @@ return( true );
 	else
 	    t = 9999;
 	if ( RealWithin(c*c+s*s,1,.005) && RealWithin(t*c-s,trans[2],.01) && RealWithin(t*s+c,trans[3],.01)) {
-	    double skew = atan(t)*180/3.1415926535897932;
-	    double rot  = atan2(s,c)*180/3.1415926535897932;
+	    double skew = atan(t)*180/FF_PI;
+	    double rot  = atan2(s,c)*180/FF_PI;
 	    sprintf( buffer, "%g", skew );
 	    GGadgetSetTitle8(GWidgetGetControl(gw,CID_Skew), buffer);
 	    sprintf( buffer, "%g", rot );
@@ -2074,8 +2073,8 @@ static int Pat_AnglesChanged(GGadget *g, GEvent *e) {
 	char buffer[340];
 	int err=false;
 
-	skew   = GetCalmReal8(gw,CID_Skew,_("Skew"),&err)*3.1415926535897932/180;
-	rotate = GetCalmReal8(gw,CID_Rotate,_("Rotate"),&err)*3.1415926535897932/180;
+	skew   = GetCalmReal8(gw,CID_Skew,_("Skew"),&err)*FF_PI/180;
+	rotate = GetCalmReal8(gw,CID_Rotate,_("Rotate"),&err)*FF_PI/180;
 	x      = GetCalmReal8(gw,CID_TransX,_("Translation in X"),&err);
 	y      = GetCalmReal8(gw,CID_TransY,_("Translation in Y"),&err);
 	if ( err )

--- a/fontforgeexe/cvtranstools.c
+++ b/fontforgeexe/cvtranstools.c
@@ -80,7 +80,7 @@ void CVMouseMoveTransform(CharView *cv) {
 /* Allow one pixel per degree */
 	    real zangle = sqrt( (cv->info.x-cv->p.cx)*(cv->info.x-cv->p.cx) +
 		    (cv->info.y-cv->p.cy)*(cv->info.y-cv->p.cy) ) * tab->scale *
-		    3.1415926535897932/180;
+		    FF_PI/180;
 	    real s = sin(angle), c = cos(angle);
 	    real cz = cos(zangle);
 	    transform[0] = c*c + s*s*cz;

--- a/fontforgeexe/effectsui.c
+++ b/fontforgeexe/effectsui.c
@@ -376,8 +376,8 @@ return(true);
 	def_outline_width = width;
 	def_shadow_len = len;
 	def_sun_angle = angle;
-	angle *= -3.1415926535897932/180;
-	angle -= 3.1415926535897932/2;
+	angle *= -FF_PI/180;
+	angle -= FF_PI/2;
 	if ( od->fv!=NULL )
 	    FVShadow((FontViewBase *) od->fv,angle,width,len,od->wireframe);
 	else if ( od->cv!=NULL )

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -347,7 +347,7 @@ static void MVSubExpose(MetricsView *mv, GWindow pixmap, GEvent *event) {
     GClut clut;
     int si;
     double iscale = mv->pixelsize_set_by_window ? 1.0 : mv_scales[mv->scale_index];
-    double s = sin(-mv->sf->italicangle*3.1415926535897932/180.);
+    double s = sin(-mv->sf->italicangle*FF_PI/180.);
     int x_iaoffh = 0, x_iaoffl = 0;
 
     clip = &event->u.expose.rect;

--- a/fontforgeexe/nonlineartransui.c
+++ b/fontforgeexe/nonlineartransui.c
@@ -258,8 +258,8 @@ extern char *coord_sep;
     y = GetQuietReal(d->gw,CID_YValue,&err);
     /*z = GetQuietReal(d->gw,CID_ZValue,&err);*/
     dv = GetQuietReal(d->gw,CID_DValue,&err);
-    tilt = GetQuietReal(d->gw,CID_Tilt,&err)*3.1415926535897932/180;
-    dir = GetQuietReal(d->gw,CID_GazeDirection,&err)*3.1415926535897932/180;
+    tilt = GetQuietReal(d->gw,CID_Tilt,&err)*FF_PI/180;
+    dir = GetQuietReal(d->gw,CID_GazeDirection,&err)*FF_PI/180;
     if ( err )
 return;
     if ( GGadgetGetFirstListSelectedItem( GWidgetGetControl(d->gw,CID_XType))!=3 )
@@ -289,7 +289,7 @@ return( true );
 
 int PointOfViewDlg(struct pov_data *pov, SplineFont *sf, int flags) {
     static struct pov_data def = { or_center, or_value, 0, 0, .1,
-	    0, 3.1415926535897932/16, .2, 0 };
+	    0, FF_PI/16, .2, 0 };
     double emsize = (sf->ascent + sf->descent);
     struct nldlg d;
     GRect pos;
@@ -464,7 +464,7 @@ int PointOfViewDlg(struct pov_data *pov, SplineFont *sf, int flags) {
     gcd[k++].creator = GLabelCreate;
     varray[l][0] = &gcd[k-1];
 
-    sprintf( tval, "%g", rint(pov->tilt*180/3.1415926535897932));
+    sprintf( tval, "%g", rint(pov->tilt*180/FF_PI));
     label[k].text = (unichar_t *) tval;
     label[k].text_is_1byte = true;
     gcd[k].gd.label = &label[k];
@@ -496,7 +496,7 @@ int PointOfViewDlg(struct pov_data *pov, SplineFont *sf, int flags) {
     gcd[k++].creator = GLabelCreate;
     varray[l][0] = &gcd[k-1];
 
-    sprintf( dirval, "%g", rint(pov->direction*180/3.1415926535897932));
+    sprintf( dirval, "%g", rint(pov->direction*180/FF_PI));
     label[k].text = (unichar_t *) dirval;
     label[k].text_is_1byte = true;
     gcd[k].gd.label = &label[k];
@@ -595,8 +595,8 @@ return( -1 );
     continue;
 	    }
 	    pov->x = x; pov->y = y; pov->z = z; pov->d = dv;
-	    pov->tilt = tilt*3.1415926535897932/180;
-	    pov->direction = dir*3.1415926535897932/180;
+	    pov->tilt = tilt*FF_PI/180;
+	    pov->direction = dir*FF_PI/180;
 	    pov->xorigin = GGadgetGetFirstListSelectedItem( GWidgetGetControl(d.gw,CID_XType));
 	    pov->yorigin = GGadgetGetFirstListSelectedItem( GWidgetGetControl(d.gw,CID_YType));
 	}

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -58,7 +58,7 @@
 # include <langinfo.h>
 #endif
 
-#define RAD2DEG	(180/3.1415926535897932)
+#define RAD2DEG	(180/FF_PI)
 
 static void change_res_filename(const char *newname);
 

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -781,8 +781,8 @@ static int HVITest(struct problems *p,BasePoint *to, BasePoint *from,
     xoff = to->x-from->x;
     angle = atan2(yoff,xoff);
     if ( angle<0 )
-	angle += 3.1415926535897932;
-    if ( angle<.1 || angle>3.1415926535897932-.1 ) {
+	angle += FF_PI;
+    if ( angle<.1 || angle>FF_PI-.1 ) {
 	if ( yoff!=0 )
 	    ishor = true;
     } else if ( angle>1.5707963-.1 && angle<1.5707963+.1 ) {
@@ -1297,7 +1297,7 @@ static int SCProblems(CharView *cv,SplineChar *sc,struct problems *p) {
     }
 
     if ( p->linenearstd && !p->finish ) {
-	real ia = (90-p->fv->b.sf->italicangle)*(3.1415926535897932/180);
+	real ia = (90-p->fv->b.sf->italicangle)*(FF_PI/180);
 	int hasia = p->fv->b.sf->italicangle!=0;
 	for ( test=spl; test!=NULL && !p->finish && p->linenearstd; test = test->next ) {
 	    first = NULL;
@@ -1322,7 +1322,7 @@ static int SCProblems(CharView *cv,SplineChar *sc,struct problems *p) {
     }
 
     if ( p->cpnearstd && !p->finish ) {
-	real ia = (90-p->fv->b.sf->italicangle)*(3.1415926535897932/180);
+	real ia = (90-p->fv->b.sf->italicangle)*(FF_PI/180);
 	int hasia = p->fv->b.sf->italicangle!=0;
 	for ( test=spl; test!=NULL && !p->finish && p->linenearstd; test = test->next ) {
 	    first = NULL;

--- a/fontforgeexe/scstylesui.c
+++ b/fontforgeexe/scstylesui.c
@@ -2313,7 +2313,7 @@ return;
     last_ii.italic_angle = temp;
     memset(transform,0,sizeof(transform));
     transform[0] = transform[3] = 1;
-    transform[2] = -tan( last_ii.italic_angle * 3.1415926535897932/180.0 );
+    transform[2] = -tan( last_ii.italic_angle * FF_PI/180.0 );
     if ( cv!=NULL ) {
 	CVPreserveState((CharViewBase *) cv);
 	CVTransFunc(cv,transform,fvt_dontmovewidth);

--- a/fontforgeexe/tilepath.c
+++ b/fontforgeexe/tilepath.c
@@ -155,7 +155,7 @@ return( false );
 		sx = spline->to->me.x - spline->from->me.x;
 		sy = spline->to->me.y - spline->from->me.y;
 	    }
-	    angle = atan2(sy,sx) - 3.1415926535897932/2;
+	    angle = atan2(sy,sx) - FF_PI/2;
 	    td->samples[i].c = cos(angle);
 	    td->samples[i].s = sin(angle);
 	    if ( td->samples[i].s>-.00001 && td->samples[i].s<.00001 ) { td->samples[i].s=0; td->samples[i].c = ( td->samples[i].c>0 )? 1 : -1; }
@@ -176,7 +176,7 @@ return( false );
 	    /* there are two normals at a join, one for each spline */
 	    /*  it should bisect the normal vectors of the two splines */
 	    sx = next->splines[0].c; sy = next->splines[1].c;
-	    angle = atan2(sy,sx) - 3.1415926535897932/2;
+	    angle = atan2(sy,sx) - FF_PI/2;
 	    td->joins[pcnt].c1 = cos(angle);
 	    td->joins[pcnt].s1 = sin(angle);
 	    if ( td->joins[pcnt].s1>-.00001 && td->joins[pcnt].s1<.00001 ) { td->joins[pcnt].s1=0; td->joins[pcnt].c1 = ( td->joins[pcnt].c1>0 )? 1 : -1; }
@@ -184,7 +184,7 @@ return( false );
 
 	    sx = (3*spline->splines[0].a+2*spline->splines[0].b)+spline->splines[0].c;
 	    sy = (3*spline->splines[1].a+2*spline->splines[1].b)+spline->splines[1].c;
-	    angle = atan2(sy,sx) - 3.1415926535897932/2;
+	    angle = atan2(sy,sx) - FF_PI/2;
 	    td->joins[pcnt].c2 = cos(angle);
 	    td->joins[pcnt].s2 = sin(angle);
 	    if ( td->joins[pcnt].s2>-.00001 && td->joins[pcnt].s2<.00001 ) { td->joins[pcnt].s2=0; td->joins[pcnt].c2 = ( td->joins[pcnt].c2>0 )? 1 : -1; }

--- a/fontforgeexe/transform.c
+++ b/fontforgeexe/transform.c
@@ -180,7 +180,7 @@ static int Trans_OK(GGadget *g, GEvent *e) {
 		    else if ( angle==180 ) bvts[bvpos++].func = bvt_rotate180;
 		    else if ( angle==270 ) bvts[bvpos++].func = bvt_rotate90cw;
 		}
-		angle *= 3.1415926535897932/180;
+		angle *= FF_PI/180;
 		trans[0] = trans[3] = cos(angle);
 		trans[2] = -(trans[1] = sin(angle));
 	      break;
@@ -206,13 +206,13 @@ static int Trans_OK(GGadget *g, GEvent *e) {
 		angle = GetReal8(td->gw,CID_SkewAng+i*TBlock_CIDOffset,_("Skew Angle"),&err);
 		if ( GGadgetIsChecked( GWidgetGetControl(td->gw,CID_CounterClockwise+i*TBlock_CIDOffset)) )
 		    angle = -angle;
-		angle *= 3.1415926535897932/180;
+		angle *= FF_PI/180;
 		trans[2] = tan(angle);
 		skewselect(&bvts[bvpos],trans[2]); ++bvpos;
 	      break;
 	      case 7:		/* 3D rotate */
-		angle =  GetReal8(td->gw,CID_XAxis+i*TBlock_CIDOffset,_("Rotation about X Axis"),&err) * 3.1415926535897932/180;
-		angle2 = GetReal8(td->gw,CID_YAxis+i*TBlock_CIDOffset,_("Rotation about Y Axis"),&err) * 3.1415926535897932/180;
+		angle =  GetReal8(td->gw,CID_XAxis+i*TBlock_CIDOffset,_("Rotation about X Axis"),&err) * FF_PI/180;
+		angle2 = GetReal8(td->gw,CID_YAxis+i*TBlock_CIDOffset,_("Rotation about Y Axis"),&err) * FF_PI/180;
 		trans[0] = cos(angle2);
 		trans[3] = cos(angle );
 		bvts[0].func = bvt_none;		/* Bad trans=> No trans */
@@ -300,7 +300,7 @@ static int Trans_TypeChange(GGadget *g, GEvent *e) {
 		uc_strcpy(ubuf,buf);
 		GGadgetSetTitle(GWidgetGetControl(bw,CID_YMove+offset), ubuf );
 	    } else {
-		sprintf( buf, "%.0f", atan2(yoff,xoff)*180/3.1415926535897932 );
+		sprintf( buf, "%.0f", atan2(yoff,xoff)*180/FF_PI );
 		uc_strcpy(ubuf,buf);
 		GGadgetSetTitle(GWidgetGetControl(bw,((mask&0x2)?CID_Angle:CID_SkewAng)+offset), ubuf );
 		GGadgetSetChecked(GWidgetGetControl(bw,CID_Clockwise+offset), false );

--- a/gdraw/gcolor.c
+++ b/gdraw/gcolor.c
@@ -58,7 +58,7 @@ static GImage *ColorWheel(int width,int height) {
 	    if ( col.s>1.0 ) {
 		*row++ = 0xffffff;
 	    } else {
-		col.h = atan2(y,x)*180/3.1415926535897932;
+		col.h = atan2(y,x)*180/FF_PI;
 		if ( col.h < 0 ) col.h += 360;
 		gHSV2RGB(&col);
 		*row++ = COLOR_CREATE( (int) rint(255*col.r), (int) rint(255*col.g), (int) rint(255*col.b));
@@ -308,8 +308,8 @@ static int wheel_e_h(GWindow gw, GEvent *event) {
 	}
 	GDrawDrawImage(gw,d->wheel,NULL,0,0);
 	if ( d->col.hsv ) {
-	    double s = sin(d->col.h*3.1415926535897932/180.);
-	    double c = cos(d->col.h*3.1415926535897932/180.);
+	    double s = sin(d->col.h*FF_PI/180.);
+	    double c = cos(d->col.h*FF_PI/180.);
 	    int y = (int) rint(d->col.s*(size.height-1)*s/2.0) + size.height/2;
 	    int x = (int) rint(d->col.s*(size.width-1)*c/2.0) + size.width/2;
 	    circle.x = x-3; circle.y = y-3;

--- a/gdraw/ggdkcdraw.c
+++ b/gdraw/ggdkcdraw.c
@@ -778,7 +778,7 @@ void GGDKDrawDrawArrow(GWindow w, int32 x, int32 y, int32 xend, int32 yend, int1
     }
 
     const double head_angle = 0.5;
-    double angle = atan2(yend - y, xend - x) + M_PI;
+    double angle = atan2(yend - y, xend - x) + FF_PI;
     double length = sqrt((x - xend) * (x - xend) + (y - yend) * (y - yend));
 
     cairo_new_path(gw->cc);
@@ -845,7 +845,7 @@ void GGDKDrawFillRoundRect(GWindow w, GRect *rect, int radius, Color col) {
 
     GGDKDrawSetcolfunc(gw, gw->ggc);
 
-    double degrees = M_PI / 180.0;
+    double degrees = FF_PI / 180.0;
     int rr = (radius <= (rect->height + 1) / 2) ? (radius > 0 ? radius : 0) : (rect->height + 1) / 2;
     cairo_new_path(gw->cc);
     cairo_arc(gw->cc, rect->x + rect->width - rr, rect->y + rr, rr, -90 * degrees, 0 * degrees);
@@ -924,7 +924,7 @@ void GGDKDrawDrawArc(GWindow w, GRect *rect, int32 sangle, int32 eangle, Color c
     gw->ggc->fg = col;
 
     // Leftover from XDrawArc: sangle/eangle in degrees*64.
-    double start = -(sangle + eangle) * M_PI / 11520., end = -sangle * M_PI / 11520.;
+    double start = -(sangle + eangle) * FF_PI / 11520., end = -sangle * FF_PI / 11520.;
     int width = GGDKDrawSetline(gw, gw->ggc);
 
     cairo_new_path(gw->cc);

--- a/gdraw/gpsdraw.c
+++ b/gdraw/gpsdraw.c
@@ -439,7 +439,7 @@ static void PSDoArc(GPSWindow ps, double cx, double cy, double radx, double rady
 
     lenx = ((ea-sa)/90.0) * radx * .552;
     leny = ((ea-sa)/90.0) * rady * .552;
-    sa *= 3.1415926535897932/180; ea *= 3.1415926535897932/180;
+    sa *= FF_PI/180; ea *= FF_PI/180;
     ss = -sin(sa); sc = cos(sa); es = -sin(ea); ec = cos(ea);
     sx = cx+sc*radx; sy = cy+ss*rady;
     PSMoveTo(ps,sx,sy);
@@ -670,9 +670,9 @@ return;
     if ( line_width!=0 ) {
 	points[0].x += line_width*1.3*cos(a); points[0].y += line_width*1.3*sin(a);
     }
-    off1 = len*sin(a+3.1415926535897932/8)+.5; off2 = len*cos(a+3.1415926535897932/8)+.5;
+    off1 = len*sin(a+FF_PI/8)+.5; off2 = len*cos(a+FF_PI/8)+.5;
     points[1].x = x-off2; points[1].y = y-off1;
-    off1 = len*sin(a-3.1415926535897932/8)+.5; off2 = len*cos(a-3.1415926535897932/8)+.5;
+    off1 = len*sin(a-FF_PI/8)+.5; off2 = len*cos(a-FF_PI/8)+.5;
     points[2].x = x-off2; points[2].y = y-off1;
     PSDrawDoPoly(ps,points,3,"fill");
 }

--- a/gdraw/gradio.c
+++ b/gdraw/gradio.c
@@ -319,13 +319,13 @@ return( false );
         int h=gr->onoffrect.height-1-2*bp;
         GRect rect;
         for (c=0, i=0; c<7; c++) {
-            angle=(30+c/6.*120)*M_PI/180;
+            angle=(30+c/6.*120)*FF_PI/180;
             pts[i].x=.5*w*cos(angle)+x+w/2;
             pts[i].y=.5*h*sin(angle)+y+h/4;
             ++i;
         }
         for (c=1; c<6; c++) {
-            angle=(180+30+c/6.*120)*M_PI/180;
+            angle=(180+30+c/6.*120)*FF_PI/180;
             pts[i].x=.5*w*cos(angle)+x+w/2;
             pts[i].y=.5*h*sin(angle)+y+h*3/4;
             ++i;
@@ -361,7 +361,7 @@ return( false );
 			g->box->main_foreground==COLOR_DEFAULT?GDrawGetDefaultForeground(GDrawGetDisplayOfWindow(pixmap)):
 			g->box->main_foreground;
         for (int i = 0; i <= 6; i++) {
-            angle=(30+i/6.*120)*M_PI/180;
+            angle=(30+i/6.*120)*FF_PI/180;
             pts[i].x=.5*w*cos(angle)+x+w/2;
             pts[i].y=.5*h*sin(angle)+y+h/4;
 

--- a/gdraw/gxcdraw.c
+++ b/gdraw/gxcdraw.c
@@ -298,7 +298,7 @@ void _GXCDraw_FillRect(GXWindow gw, GRect *rect) {
 }
 
 void _GXCDraw_FillRoundRect(GXWindow gw, GRect *rect, int radius) {
-    double degrees = M_PI / 180.0;
+    double degrees = FF_PI / 180.0;
 
     GXCDrawSetcolfunc(gw,gw->ggc);
 

--- a/gdraw/gxdraw.c
+++ b/gdraw/gxdraw.c
@@ -1873,9 +1873,9 @@ return;
 return;
 
     points[0].x = x; points[0].y = y;
-    off1 = len*sin(a+3.1415926535897932/8)+.5; off2 = len*cos(a+3.1415926535897932/8)+.5;
+    off1 = len*sin(a+FF_PI/8)+.5; off2 = len*cos(a+FF_PI/8)+.5;
     points[1].x = x-off2; points[1].y = y-off1;
-    off1 = len*sin(a-3.1415926535897932/8)+.5; off2 = len*cos(a-3.1415926535897932/8)+.5;
+    off1 = len*sin(a-FF_PI/8)+.5; off2 = len*cos(a-FF_PI/8)+.5;
     points[2].x = x-off2; points[2].y = y-off1;
     XFillPolygon(display->display,gxw->w,display->gcstate[gxw->ggc->bitmap_col].gc,points,3,Complex,CoordModeOrigin);
     XDrawLines(display->display,gxw->w,display->gcstate[gxw->ggc->bitmap_col].gc,points,3,CoordModeOrigin);
@@ -1985,7 +1985,7 @@ static void GXDrawDrawArc(GWindow gw, GRect *rect, int32 sangle, int32 tangle, C
 #ifndef _NO_LIBCAIRO
     if (gxw->usecairo) {
         // Leftover from XDrawArc: sangle/tangle in degrees*64.
-        _GXCDraw_DrawArc(gxw, rect, -(sangle+tangle)*M_PI/11520., -sangle*M_PI/11520.);
+        _GXCDraw_DrawArc(gxw, rect, -(sangle+tangle)*FF_PI/11520., -sangle*FF_PI/11520.);
     } else
 #endif
     {

--- a/inc/basics.h
+++ b/inc/basics.h
@@ -50,6 +50,8 @@ typedef intptr_t	intpt;
 
 typedef uint32 unichar_t;
 
+#define FF_PI 3.1415926535897932
+
 /* A macro to mark unused function parameters with. We often
  * have such parameters, because of extensive use of callbacks.
  */


### PR DESCRIPTION
Requested by @jtanx . 

I used FF_PI because PI alone would be hard to search for after the change, and M_PI would require math.h which might cause issues/be controversial. 