### PR TITLE
Expand stroke: cleanup, disable round and arcs joins, restore square cap

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -4601,10 +4601,27 @@ static int Stroke_Parse(StrokeInfo *si, PyObject *args, PyObject *keywds) {
     c = FlagsFromString(cap,linecap,"linecap type");
     if ( c==FLAG_UNKNOWN )
 	return( -1 );
+    if ( c==lc_square ) {
+	c = lc_butt;
+	if ( si->extendcap!=0 )
+	    si->extendcap=1.0;
+    }
     si->cap = c;
     j = FlagsFromString(join,linejoin,"linejoin type");
     if ( j==FLAG_UNKNOWN )
 	return( -1 );
+    if ( j==lj_round ) {
+	if (    si->stroke_type==si_round
+	     && ( si->radius==si->minorradius || si->minorradius==0 ) )
+	    j=lj_nib;
+	else {
+            PyErr_Format(PyExc_ValueError, "Round join requires circular nib" );
+	    return -1;
+	}
+    } else if ( j==lj_arcs ) {
+	PyErr_Format(PyExc_ValueError, "Arcs join not yet supported" );
+	return -1;
+    }
     si->join = j;
     r = FlagsFromString(rostring,rmov,"removeoverlap type");
     if ( r==FLAG_UNKNOWN )

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -543,7 +543,6 @@ static NibOffset *_CalcNibOffset(NibCorner *nc, int n, BasePoint ut,
                                  int reverse, NibOffset *no, int nci_hint) {
     int nci, ncni, ncpi;
     Spline *ns;
-    BasePoint tmp;
 
     if ( no==NULL )
 	no = malloc(sizeof(NibOffset));
@@ -857,7 +856,6 @@ static void SSAppendSemiCircle(SplineSet *cur, bigreal radius, BasePoint ut,
                                int bk) {
     SplineSet *circ;
     real trans[6];
-    BasePoint cxy = cur->last->me;
     SplinePoint *sp;
     NibOffset no_fm, no_to;
     NibCorner *nc = NULL;
@@ -998,9 +996,9 @@ int GenStrokeTracePoints(void *vinfo, bigreal t_fm, bigreal t_to,
     StrokeTraceInfo *stip = (StrokeTraceInfo *)vinfo;
     int i, nib_ccw, on_cusp;
     NibOffset no;
-    FitPoint *fp, tmp_fp;
-    bigreal nidiff, t, csd;
-    BasePoint xy, rel_ut;
+    FitPoint *fp;
+    bigreal nidiff, t;
+    BasePoint xy;
 
     fp = calloc(stip->num_points, sizeof(FitPoint));
     nidiff = (t_to - t_fm) / (stip->num_points-1);
@@ -1105,9 +1103,9 @@ SplinePoint *TraceAndFitSpline(StrokeContext *c, Spline *s, bigreal t_fm,
 static bigreal SplineStrokeNextT(StrokeContext *c, Spline *s, bigreal cur_t,
 		                 int is_ccw, BasePoint *cur_ut,
 				 int *curved, int reverse, int nci_hint) {
-    int next_curved, nci, inout, at_line, icnt, i;
+    int next_curved, icnt, i;
     bigreal next_t;
-    extended poi[2], tp;
+    extended poi[2];
     BasePoint next_ut;
 
     assert( cur_ut!=NULL && curved!=NULL );
@@ -1130,7 +1128,7 @@ static bigreal SplineStrokeNextT(StrokeContext *c, Spline *s, bigreal cur_t,
     // to but not at the inflection point. The disadvantage is that we would
     // need to track how many times the direction changes to feed the right
     // value to SplineStrokeAppendFixup, leading to more code complexity.
-    if ( icnt = Spline2DFindPointsOfInflection(s, poi) ) {
+    if ( (icnt = Spline2DFindPointsOfInflection(s, poi)) ) {
 	assert ( icnt < 2 || poi[0] <= poi[1] );
 	for ( i=0; i<2; ++i )
 	    if (    poi[i] > cur_t
@@ -1163,7 +1161,6 @@ static void SplineSetLineTo(SplineSet *cur, BasePoint xy) {
 static void HandleFlat(SplineSet *cur, BasePoint sxy, NibOffset *noi,
                        int is_ccw) {
     BasePoint oxy;
-    SplinePoint *sp;
 
     oxy = BP_ADD(sxy, noi->off[is_ccw]);
     if ( !BPNEAR(cur->last->me, oxy) ) {
@@ -1289,9 +1286,9 @@ static void CalcExtend(BasePoint refp, BasePoint ut, BasePoint op1,
 	clip2 = BP_ADD(clip1, UT_90CW(ut));
     }
     intersects = IntersectLines(np1, &op1, &cop1, &clip1, &clip2);
-    assert(intersects);
+    VASSERT(intersects);
     intersects = IntersectLines(np2, &op2, &cop2, &clip1, &clip2);
-    assert(intersects);
+    VASSERT(intersects);
 }
 
 typedef struct joinparams {
@@ -1321,7 +1318,7 @@ static void NibJoin(JoinParams *jpp) {
 
 static void DoubleBackJoin(JoinParams *jpp) {
     BasePoint refp, p1, p2;
-    bigreal fsw, jlim, d1 = 0, d2 = 0;
+    bigreal fsw, jlim;
 
     assert( jpp->c->join==lj_miterclip || jpp->c->join==lj_arcs );
     assert( RealWithin( BP_DOT(jpp->ut_fm, jpp->no_to->utanvec),
@@ -1336,6 +1333,7 @@ static void DoubleBackJoin(JoinParams *jpp) {
     SplineSetLineTo(jpp->cur, jpp->oxy);
 }
 
+/*
 static void RoundJoin(JoinParams *jpp) {
     BasePoint c, cut, ut1, ut2;
     bigreal alpha, B, C, E, mu, nu, B2AC, maj, min, tmp, tmp2;
@@ -1361,12 +1359,11 @@ static void RoundJoin(JoinParams *jpp) {
     min = sqrt(tmp * (1 + C - tmp2))/B2AC;
     // printf("maj: %lf, min: %lf, angle: %lf\n", maj, min, atan2(cut.y, cut.x) * 180 / FF_PI);
     BevelJoin(jpp);
-}
+} */
 
 static void MiterJoin(JoinParams *jpp) {
     BasePoint ixy, refp, cow, coi, clip1, clip2, ut;
     int intersects;
-    SplinePoint *sp;
     SplineSet *cur = jpp->cur;
     bigreal fsw, jlen, jlim;
 
@@ -1406,10 +1403,10 @@ static void MiterJoin(JoinParams *jpp) {
 	}
 	// Clipped miter join
 	intersects = IntersectLines(&ixy, &cur->last->me, &cow, &clip1, &clip2);
-	assert(intersects);
+	VASSERT(intersects);
 	SplineSetLineTo(cur, ixy);
 	intersects = IntersectLines(&ixy, &jpp->oxy, &coi, &clip1, &clip2);
-	assert(intersects);
+	VASSERT(intersects);
 	SplineSetLineTo(cur, ixy);
 	SplineSetLineTo(cur, jpp->oxy);
     }
@@ -1438,11 +1435,11 @@ static int _HandleJoin(JoinParams *jpp) {
 	BevelJoin(jpp);
     } else if ( c->join==lj_bevel ) {
 	BevelJoin(jpp);
-    } else if ( c->join==lj_round ) {
+/*    } else if ( c->join==lj_round ) {
 	if ( RealWithin(costheta, -1, COS_MARGIN) )
 	    BevelJoin(jpp);
 	else
-	    RoundJoin(jpp);
+	    RoundJoin(jpp); */
     } else if ( c->join==lj_miter || c->join==lj_miterclip ) {
 	if ( RealWithin(costheta, -1, COS_MARGIN) ) {
 	    if ( c->join==lj_miter )
@@ -1520,7 +1517,7 @@ static void HandleCap(StrokeContext *c, SplineSet *cur, BasePoint sxy,
 /******************************************************************************/
 
 static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
-    NibOffset no, no_last;
+    NibOffset no;
     Spline *s, *first=NULL;
     SplineSet *left=NULL, *right=NULL, *cur;
     SplinePoint *sp;
@@ -1528,7 +1525,7 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
     BasePoint sxy;
     bigreal last_t, t;
     int is_right, linear, curved, on_cusp;
-    int is_ccw_ini, is_ccw_start, is_ccw_mid, was_ccw;
+    int is_ccw_ini = false, is_ccw_start, is_ccw_mid, was_ccw = false;
     int closed = ss->first->prev!=NULL;
 
     if ( (c->contour_was_ccw ? !c->remove_inner : !c->remove_outer) || !closed )
@@ -1849,7 +1846,7 @@ return( first );
 SplineSet *SplineSetStroke(SplineSet *ss,StrokeInfo *si, int order2) {
     int max_pc;
     StrokeContext c;
-    SplineSet *nibs, *nib, *bnext, *first, *last, *cur;
+    SplineSet *nibs, *nib, *first, *last, *cur;
     bigreal sn = 0.0, co = 1.0, mr;
     DBounds b;
     real trans[6];

--- a/inc/basics.h
+++ b/inc/basics.h
@@ -72,6 +72,15 @@ typedef uint32 unichar_t;
 #define TRACE(...)
 #endif
 
+/* assert() with an otherwise unused variable
+ * to get around "unused" compiler warnings
+ */
+#ifndef NDEBUG
+#define VASSERT(v) assert(v)
+#else
+#define VASSERT(v) ((void)(v))
+#endif
+
 extern void NoMoreMemMessage(void);
 
 static inline int imin(int a, int b)


### PR DESCRIPTION
This restores square cap support in the python and native APIs, disables arcs joins (for now), and limits round joins to circular nibs. 

Other than that it makes `splinestroke.c` compile cleanly with -Wall, mostly by removing unused variables and partly by way of a new debug macro in `inc/basics.h`. 
