### PR TITLE
FindMonotonicIntersection fix and splineoverlap cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ build_option(THEME     ENUM "tango"  "Sets the GUI theme." "tango" "2012")
 
 if(CMAKE_COMPILER_IS_GNUCC)
   set_supported_c_compiler_flags(FONTFORGE_DEFAULT_CFLAGS -Werror=implicit-function-declaration -Werror=int-conversion)
+  list(APPEND FONTFORGE_EXTRA_CFLAGS -Wall -Wextra -pedantic)
+  add_compile_options(${FONTFORGE_DEFAULT_CFLAGS})
 endif()
 
 # Required and default dependencies

--- a/fontforge/CMakeLists.txt
+++ b/fontforge/CMakeLists.txt
@@ -209,6 +209,9 @@ if(ENABLE_WOFF2_RESULT)
   target_sources(fontforge PRIVATE woff2.cc)
 endif()
 
+# Turn up warnings on a few source files
+set_property(SOURCE splineoverlap.c APPEND PROPERTY COMPILE_OPTIONS ${FONTFORGE_EXTRA_CFLAGS})
+
 set_property(TARGET fontforge PROPERTY VERSION 4)
 if(WIN32 AND BUILD_SHARED_LIBS)
     target_link_options(fontforge PRIVATE -Wl,--export-all-symbols) # FIXME

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -1641,7 +1641,7 @@ return;
 }
 
 static double CalculateMinimumDiff(double from, double diff) {
-    double next = from - nextafter(from, diff);
+    double next = nextafter(from, DBL_MAX) - from;
     assert(diff >= 0 && next > 0);
     return next > diff ? next : diff;
 }


### PR DESCRIPTION
I turned up the warnings on splineoverlap.c and fixed most of them. I've `#if 0`'ed a bunch of code, but I'd prefer to just delete it.

Fix for FindMonotonicIntersection is to properly calculate the diff instead of doing that `bkp_x`/`bkp_y` logic.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**

Fixes #529. Relates to #3991.
