### PR TITLE
Stroke: Misc code fixes and test coverage

### DIFF
--- a/doc/html/stroke.html
+++ b/doc/html/stroke.html
@@ -182,10 +182,15 @@ the specific rules used by the facility to verify that a contour is convex.
 These rules are slightly conservative, in that some geometrically convex
 contours fail to meet them. (Such cases are rare in practice, and can anyway
 often be "repaired" by adding some points without (visibly) changing the
-shape.) Note that the rules are defined in relation to a cubic contour.
-Although you can design a nib as a quadratic or Spiro contour, it will be
-converted to a cubic contour prior to use and any problems will be reported in
-terms of its cubic variant.
+shape.)
+
+<P> Note: These rules are defined in relation to a cubic contour.  Although you
+can design a nib as a quadratic contour, you must switch the layer to "Cubic"
+before applying Expand Stroke. (Or, in the API, you must convert the contour or
+layer prior to calling the <CODE>stroke</CODE> method or
+<CODE>ExpandStroke</CODE> function.) In contrast, when using a Spiro nib on a
+Cubic layer it is not nececessary to switch into Bezier mode. However, it can
+still be a good idea to do so to better understand any reported errors. 
 
 <P> There are actually two groups of rules.  The first group restrict the
 relative positions of <em>on-curve</em> points. The points must be arranged as

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1142,7 +1142,7 @@ static PyObject *PyFF_GetScriptPath(PyObject *UNUSED(self), PyObject *UNUSED(arg
 
 static PyObject *PyFF_GetUserConfigPath(PyObject *UNUSED(self), PyObject *UNUSED(args)) {
     PyObject *ret;
-    const char *userdir;
+    char *userdir;
 
     userdir = getFontForgeUserDir(Config);
     ret=Py_BuildValue("s",userdir);
@@ -4508,8 +4508,9 @@ static int Stroke_Parse(StrokeInfo *si, PyObject *args, PyObject *keywds) {
 	    }
 	}
     } else if (    strcmp(str, "calligraphic")==0
+                || strcmp(str, "rectangular")==0
                 || strcmp(str, "caligraphic")==0
-                || strcmp(str, "rectangular")==0 ) {
+                || strcmp(str, "square")==0 ) {
 	si->stroke_type = si_calligraphic;
 	if ( !PyArg_ParseTupleAndKeywords(args, keywds,
                 "sdd|dss" STROKE_OPTFORMAT, strokekey_rect, &type,
@@ -4527,6 +4528,7 @@ static int Stroke_Parse(StrokeInfo *si, PyObject *args, PyObject *keywds) {
 	    }
 	}
     } else if (    strcmp(str, "convex")==0
+                || strcmp(str, "poly")==0
                 || strcmp(str, "polygonal")==0 ) {
 	si->stroke_type = si_nib;
 	if ( !PyArg_ParseTupleAndKeywords(args, keywds,

--- a/fontforge/splinestroke.h
+++ b/fontforge/splinestroke.h
@@ -12,7 +12,9 @@ enum ShapeType {
 	Shape_NotClosed,
 	Shape_TinySpline,
 	Shape_HalfLinear,
-	Shape_BadCP,
+	Shape_BadCP_R1,
+	Shape_BadCP_R2,
+	Shape_BadCP_R3,
 	Shape_SelfIntersects
 };
 

--- a/fontforge/splinestroke.h
+++ b/fontforge/splinestroke.h
@@ -7,6 +7,7 @@ enum ShapeType {
 	Shape_Convex,
 	Shape_CCWTurn,
 	Shape_CCW,
+	Shape_Quadratic,
 	Shape_PointOnEdge,
 	Shape_TooFewPoints,
 	Shape_NotClosed,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,7 @@ if(ENABLE_NATIVE_SCRIPTING)
   add_ff_test(test136.pe "test136.fea"                                             "Re-using mark filtering set")
   add_ff_test(test137.pe "Ambrosia.sfd"                                            "file:// protocol")
   add_ff_test(test138.pe                                                           "Array sanity checking")
+  add_ff_test(test139.pe "StrokeTests.sfd"                                            "ExpandStroke parameters")
 endif()
 
 if(ENABLE_PYTHON_SCRIPTING_RESULT)

--- a/tests/test1003.py
+++ b/tests/test1003.py
@@ -1,38 +1,65 @@
 #Needs: fonts/StrokeTests.sfd
 
-import sys, fontforge, psMat
+import sys, fontforge, psMat, math
+from collections import OrderedDict
 
 stroketests = sys.argv[1]
+shortlist = ['D', 'Q', 'asciicircum']
+convex = fontforge.unitShape(7).transform(psMat.scale(25))
 
-print("triangle")
-font=fontforge.open(stroketests)
-font.selection.all()
-triangle=fontforge.unitShape(3).transform(psMat.scale(25))
-font.stroke("polygonal",triangle)
-font.close()
+def do_stroke_test(short, *args, **kwargs):
+    font=fontforge.open(stroketests)
+    if short:
+        font.selection.select(*shortlist)
+    else:
+        font.selection.all()
+    font.stroke(*args, **kwargs)
+    font.close()
 
-print("square")
-font=fontforge.open(stroketests)
-font.selection.all()
-square=fontforge.unitShape(4).transform(psMat.scale(25))
-font.stroke("polygonal",square)
-font.close()
+# Full font tests
+shapes = OrderedDict()
+shapes['triangle'] = fontforge.unitShape(3).transform(psMat.scale(25))
+shapes['square'] = fontforge.unitShape(4).transform(psMat.scale(25))
+shapes['pentagon'] = fontforge.unitShape(5).transform(psMat.scale(25))
+shapes['circular'] = (25,)
+shapes['calligraphic'] = (25, 2, 45)
 
-print("pentagon")
-font=fontforge.open(stroketests)
-font.selection.all()
-pent=fontforge.unitShape(5).transform(psMat.scale(25))
-font.stroke("polygonal",pent)
-font.close()
+for sn, s in shapes.items():
+    print(sn)
+    if isinstance(s, tuple):
+        do_stroke_test(False, sn, *s)
+    else:
+        do_stroke_test(False, 'polygonal', s)
 
-print("circular")
-font=fontforge.open(stroketests)
-font.selection.all()
-font.stroke("circular",25)
-font.close()
+# Argument tests
+do_stroke_test(True, 'circular', 70)
+do_stroke_test(True, 'circular', 30, "butt", "bevel")
+do_stroke_test(True, 'elliptical', 30, 40, math.radians(45), "butt", "bevel")
+do_stroke_test(True, 'elliptical', 50, 20, math.radians(25), "butt", "miter")
+do_stroke_test(True, 'elliptical', 10, 100, 0, "butt", "miterclip")
+do_stroke_test(True, 'eliptical', 40, 42, math.radians(20), "butt", "nib")
+do_stroke_test(True, 'caligraphic', 30, 40, math.radians(45), "butt", "bevel")
+do_stroke_test(True, 'rectangular', 50, 20, math.radians(25), "nib", "miter")
+do_stroke_test(True, 'rectangular', 10, 100, 0, "round", "miterclip")
+do_stroke_test(True, 'caligraphic', 40, 42, math.radians(20), "butt", "nib")
+do_stroke_test(True, 'convex', convex, math.radians(45), "butt", "bevel")
+do_stroke_test(True, 'polygonal', convex, math.radians(25), "nib", "miter")
+do_stroke_test(True, 'convex', convex, 0, "round", "miterclip")
+do_stroke_test(True, 'polygonal', convex, math.radians(20), "butt", "nib")
 
-print("caligraphic")
-font=fontforge.open(stroketests)
-font.selection.all()
-font.stroke("caligraphic",25,2,45)
-font.close()
+do_stroke_test(True, 'calligraphic', 20, 100)
+do_stroke_test(True, 'calligraphic', 20, 100, angle=math.radians(30))
+do_stroke_test(True, 'calligraphic', 20, 100, join="miterclip")
+do_stroke_test(True, 'calligraphic', 20, 100, join="bevel", cap="round")
+do_stroke_test(True, 'calligraphic', 20, 100, join="bevel", cap="round", removeinternal=True)
+do_stroke_test(True, 'calligraphic', 20, 100, join="bevel", cap="round", removeexternal=True)
+do_stroke_test(True, 'circular', 60, join="nib", cap="nib", extrema=False, angle=45)
+do_stroke_test(True, 'calligraphic', 20, 100, join="bevel", cap="round", simplify=False)
+do_stroke_test(True, 'calligraphic', 20, 100, join="bevel", cap="round", accuracy=3)
+do_stroke_test(True, 'calligraphic', 20, 100, join="bevel", cap="round", removeoverlap="contour")
+do_stroke_test(True, 'calligraphic', 20, 100, join="bevel", cap="round", removeoverlap="none")
+do_stroke_test(True, 'calligraphic', 20, 100, join="miter", cap="round", joinlimit=4)
+do_stroke_test(True, 'calligraphic', 20, 100, join="miterclip", cap="round", joinlimit=4)
+do_stroke_test(True, 'calligraphic', 20, 100, join="miterclip", cap="round", joinlimit=180, jlrelative=False)
+do_stroke_test(True, 'calligraphic', 20, 100, join="miterclip", cap="round", extendcap=3)
+do_stroke_test(True, 'calligraphic', 20, 100, join="miterclip", cap="round", extendcap=100, ecrelative=False)

--- a/tests/test139.pe
+++ b/tests/test139.pe
@@ -1,0 +1,31 @@
+#Needs: fonts/StrokeTests.sfd
+#
+Open($1);
+Select('at'); ExpandStroke(0, 70, 0, 0, -1, -1, -1, -1, -1, 0);
+Select('A'); ExpandStroke(0, 30, 0, 0, 0, 2, -1, -1, -1, 0);
+Select('B'); ExpandStroke(0, 30, 40, 45, 0, 2, -1, -1, -1, 0);
+Select('C'); ExpandStroke(0, 50, 20, 25, 0, 0, -1, -1, -1, 0);
+Select('D'); ExpandStroke(0, 10, 100, 0, 0, 4, -1, -1, -1, 0);
+Select('E'); ExpandStroke(0, 40, 42, 20, 0, 3, -1, -1, -1, 0);
+Select('F'); ExpandStroke(1, 30, 40, 45, 0, 2, -1, -1, -1, 0);
+Select('G'); ExpandStroke(1, 50, 20, 25, 3, 0, -1, -1, -1, 0);
+Select('H'); ExpandStroke(1, 10, 100, 0, 1, 4, -1, -1, -1, 0);
+Select('I'); ExpandStroke(1, 40, 42, 20, 0, 3, -1, -1, -1, 0);
+
+Select('J'); ExpandStroke(1, 20, 100, 0, -1, -1, -1, -1, -1, 0);
+Select('K'); ExpandStroke(1, 20, 100, 30, -1, -1, -1, -1, -1, 0);
+Select('L'); ExpandStroke(1, 20, 100, 0, -1, 4, -1, -1, -1, 0);
+Select('M'); ExpandStroke(1, 20, 100, 0, 1, 2, -1, -1, -1, 0);
+Select('N'); ExpandStroke(1, 20, 100, 0, 1, 2, -1, -1, -1, 1);
+Select('O'); ExpandStroke(1, 20, 100, 0, 1, 2, -1, -1, -1, 2);
+Select('P'); ExpandStroke(0, 60, 0, 45, 3, 3, -1, -1, -1, 32);
+Select('Q'); ExpandStroke(1, 20, 100, 0, 1, 2, -1, -1, -1, 16);
+Select('R'); ExpandStroke(1, 20, 100, 0, 1, 2, -1, -1, 3, 0);
+Select('S'); ExpandStroke(1, 20, 100, 0, 1, 2, -1, -1, -1, 4);
+Select('T'); ExpandStroke(1, 20, 100, 0, 1, 2, -1, -1, -1, 8);
+Select('U'); ExpandStroke(1, 20, 100, 0, 1, 0, 4, -1, -1, 0);
+Select('V'); ExpandStroke(1, 20, 100, 0, 1, 4, 4, -1, -1, 0);
+Select('W'); ExpandStroke(1, 20, 100, 0, 1, 4, 180, -1, -1, 64);
+Select('X'); ExpandStroke(1, 20, 100, 0, 1, 4, -1, 3, -1, 0);
+Select('Y'); ExpandStroke(1, 20, 100, 0, 1, 4, -1, 100, -1, 128);
+Close();


### PR DESCRIPTION
Restore "poly" and "square" options to python interface
Correct direction of output contours built from open input contours
Small edits suggested by @jtanx
Break out convex nib control point errors by (documented) "Rules"
Test breadth of options in python and native APIs