### PR TITLE
Fix destruction of the stroke dialog

### DIFF
--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -272,7 +272,12 @@ static void _GGDKDraw_InitiateWindowDestroy(GGDKWindow gw) {
     if (gw->is_pixmap) {
         _GGDKDraw_OnWindowDestroyed(gw);
     } else if (!gw->is_cleaning_up) { // Check for nested call - if we're already being destroyed.
-        g_timeout_add(10, _GGDKDraw_OnWindowDestroyed, gw);
+        // Note: This *MUST* be a 0-length timer so it always gets picked up on the next
+        //       call to GDrawProcessPendingEvents. There are assumptions made that the destroy
+        //       event will be invoked when that function is called after calling GDrawDestroyWindow.
+        //       Ideally fix wherever the GDrawSync/GDrawProcessPendingEvents pattern is used
+        //       to have a more concrete check that it's actually gone.
+        g_timeout_add(0, _GGDKDraw_OnWindowDestroyed, gw);
     }
 }
 


### PR DESCRIPTION
As it's now stack allocated, ensure that the dialog is actually gone before returning.

Prior to changing that timer in ggdkdraw.c, that pattern for doing something like

```c
    GDrawSync(NULL);
    GDrawProcessPendingEvents(NULL);
    GDrawSync(NULL);
    GDrawProcessPendingEvents(NULL);
```

Didn't actually work on Windows, because destruction was scheduled 10ms into the future. With the change to a 0 length time period, it *technically* works, but I still don't like that pattern, as it's making too many assumptions about the underlying implementation. So I've added in a specific check for the `et_destroy` event in this particular case.

I haven't bothered changing any other dialogs, I'll leave this here for now (and that 0 length timer should catch most cases)

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
