### PR TITLE
Fix layer pickling

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18811,7 +18811,7 @@ return( NULL );
     self->is_quadratic = PyInt_AsLong(PyTuple_GetItem(args,0));
     if ( PyErr_Occurred()!=NULL )
 return( NULL );
-    self->cntr_cnt = self->cntr_max = len-2;
+    self->cntr_cnt = self->cntr_max = len-1;
     self->contours = PyMem_New(PyFF_Contour *,self->cntr_max);
     if ( self->contours==NULL )
 return( NULL );


### PR DESCRIPTION
This one line change fixes the read side of `fontforge.layer` pickling.

For a code example look at the contemporaneous @dscorbett discussion in #3991. However it's pretty clear what's going on here:  The code for `PyFFi_newLayer()` seems to have been copied from `PyFFi_newContour()` directly above. The latter is passed `is_quadratic`, `closed` and then the points of the contour. The former is passed `is_quadratic` and then the contours of the layer. Hence the number of contours being `len-1` rather than `len-2`. 