### PR TITLE
Stroke: Better simplify parameters

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -1860,7 +1860,7 @@ SplineSet *SplineSetStroke(SplineSet *ss,StrokeInfo *si, int order2) {
     DBounds b;
     real trans[6];
     struct simplifyinfo smpl = { sf_forcelines | sf_mergelines |
-                                 sf_smoothcurves | sf_ignoreslopes,
+                                 sf_smoothcurves | sf_setstart2extremum,
                                  0.25, 0.1, .005, 0, 0, 0 };
 
     if ( si->stroke_type==si_centerline )


### PR DESCRIPTION
Now that my fat-fingered `&`'s have been pointed out and fixed, I've been able to experiment properly with various simplify parameters. 

I'm not entirely happy with the algorithm. `sf_ignoreslopes` is far too permissive so I've removed it. I wish there was an option to replace two existing points that are close together with a new, third, intelligently placed point. But these options seem acceptable and seem to have a good relationship to the `accuracy_target` parameter. 

Closes #4008