### PR TITLE
Potential fix for nonterminating AddExtrema loop

### DIFF
--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -3459,6 +3459,8 @@ static int ForceEndPointExtrema(Spline *s,int isto) {
 return( -1 );
     len = sqrt(len);
     if ( mylen<30*len && mylen<cplen && mylen<1 ) {
+	if ( mylen==0 )
+	    return -1;
 	if ( isto ) {
 	    s->to->noprevcp = true;
 	    s->to->prevcp = s->to->me;


### PR DESCRIPTION
This is a potential fix for the loop found by @dscorbett reported in #3991. 

Here is a zip file with his script broken into two stages. The first creates and pickles a layer using the replacement Expand Stroke code without adding extrema. The second that reads the layer and runs `AddExtrema` from python, triggering the problem. (This way testing need not be tied to the `stroke` branch.)

[et.zip](https://github.com/fontforge/fontforge/files/3853661/et.zip)

The two line fix does eliminate the problem but I'm not confident it's the right systemic answer. This PR can serve as a context to hash that out. 

I've run into other problems with the extrema code but only fleetingly -- I don't have a collection of cases to report. 