### PR TITLE
Fix format overflow warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ cache:
 before_install:
   - if [ ! -z "$LINUX_FULL" ]; then pip --quiet install --user cpp-coveralls -U ; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)" -- --force; sudo rm -rf ~/.rvm; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then git config --global protocol.version 1 && /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"; fi
 
 install:
   - |

--- a/fontforgeexe/displayfonts.c
+++ b/fontforgeexe/displayfonts.c
@@ -1342,7 +1342,7 @@ static int DSP_RadioSet(GGadget *g, GEvent *e) {
 	    GTextInfo *sel = GGadgetGetListItemSelected(GWidgetGetControl(di->gw,CID_Font));
 	    SplineFont *sf;
 	    int flags;
-	    char size[12]; unichar_t usize[12];
+	    char size[14]; unichar_t usize[14];
 
 	    if ( sel!=NULL ) {
 		sf = sel->userdata;

--- a/gdraw/gchardlg.c
+++ b/gdraw/gchardlg.c
@@ -864,7 +864,7 @@ static void InsChrMouseMove(GWindow gw, GEvent *event) {
     if ( !inschr.mouse_down && event->u.mouse.y>inschr.ybase ) {
 	int uch = InsChrMapChar(16*y + x);
 	static unichar_t space[650];
-	char cspace[40];
+	char cspace[100];
 	char *uniname;
 	char *uniannot;
 


### PR DESCRIPTION
Fixes:
```
../gdraw/gchardlg.c: In function âInsChrMouseMoveâ:
../gdraw/gchardlg.c:909:59: warning: â â directive writing 1 byte into a region of size 0 [-Wformat-overflow=]
   sprintf(cspace, "Supplementary Private Use Area-A 0x%05X ", uch);
                                                           ^
../gdraw/gchardlg.c:909:3: note: âsprintfâ output between 42 and 45 bytes into a destination of size 40
   sprintf(cspace, "Supplementary Private Use Area-A 0x%05X ", uch);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../gdraw/gchardlg.c:911:55: warning: â%06Xâ directive writing between 6 and 8 bytes into a region of size 5 [-Wformat-overflow=]
   sprintf(cspace, "Supplementary Private Use Area-B 0x%06X ", uch);
                                                       ^~~~
../gdraw/gchardlg.c:911:19: note: using the range [0, 4294967295] for directive argument
   sprintf(cspace, "Supplementary Private Use Area-B 0x%06X ", uch);
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../gdraw/gchardlg.c:911:3: note: âsprintfâ output between 43 and 45 bytes into a destination of size 40
   sprintf(cspace, "Supplementary Private Use Area-B 0x%06X ", uch);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fontforgeexe/displayfonts.c: In function âDSP_RadioSetâ:
../fontforgeexe/displayfonts.c:1353:25: warning: âsprintfâ may write a terminating nul past the end of the destination [-Wformat-overflow=]
       sprintf( size, "%g",
                         ^
../fontforgeexe/displayfonts.c:1353:7: note: âsprintfâ output between 2 and 14 bytes into a destination of size 12
       sprintf( size, "%g",
       ^~~~~~~~~~~~~~~~~~~~
        rint(best->pixelsize*72.0/SFTFGetDPI(GWidgetGetControl(di->gw,CID_SampleText))) );
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Type of change
- **Bug fix**
