### PR TITLE
Fix GDrawDrawImageMagnififed and add bounds checking to GDrawDrawImage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,11 @@ build_option(REAL_TYPE ENUM "double" "Sets the floating point type used." "doubl
 build_option(THEME     ENUM "tango"  "Sets the GUI theme." "tango" "2012")
 
 if(CMAKE_COMPILER_IS_GNUCC)
-  set_supported_c_compiler_flags(FONTFORGE_DEFAULT_CFLAGS -Werror=implicit-function-declaration -Werror=int-conversion)
+  list(APPEND _test_flags -Werror=implicit-function-declaration -Werror=int-conversion)
+  if(CMAKE_GENERATOR STREQUAL "Ninja") # https://github.com/ninja-build/ninja/wiki/FAQ
+    list(APPEND _test_flags -fdiagnostics-color=always)
+  endif()
+  set_supported_c_compiler_flags(FONTFORGE_DEFAULT_CFLAGS ${_test_flags})
   list(APPEND FONTFORGE_EXTRA_CFLAGS -Wall -Wextra -pedantic)
   add_compile_options(${FONTFORGE_DEFAULT_CFLAGS})
 endif()

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -2302,23 +2302,14 @@ return;
 
 static void DrawImageList(CharView *cv,GWindow pixmap,ImageList *backimages) {
     CharViewTab* tab = CVGetActiveTab(cv);
-    GRect size, temp;
-    int x,y;
-
-    GDrawGetSize(pixmap,&size);
 
     while ( backimages!=NULL ) {
 	struct _GImage *base = backimages->image->list_len==0?
 		backimages->image->u.image:backimages->image->u.images[0];
 
-	temp = size;
-	x = (int) (tab->xoff + rint(backimages->xoff * tab->scale));
-	y = (int) (-tab->yoff + cv->height - rint(backimages->yoff*tab->scale));
-	temp.x -= x; temp.y -= y;
-	temp.width += x; temp.height += y;
-
-	GDrawDrawImageMagnified(pixmap, backimages->image, &temp,
-		x,y,
+	GDrawDrawImageMagnified(pixmap, backimages->image, NULL,
+		(int) (tab->xoff + rint(backimages->xoff * tab->scale)),
+		(int) (-tab->yoff + cv->height - rint(backimages->yoff*tab->scale)),
 		(int) rint((base->width*backimages->xscale*tab->scale)),
 		(int) rint((base->height*backimages->yscale*tab->scale)));
 	backimages = backimages->next;

--- a/gdraw/ggdkcdraw.c
+++ b/gdraw/ggdkcdraw.c
@@ -285,7 +285,7 @@ static cairo_surface_t *_GGDKDraw_GImage2Surface(GImage *image, GRect *src) {
     /*  premultiply each channel by alpha. We can reuse it for non-transparent*/
     /*  rgb images */
     if (base->image_type == it_true && type == CAIRO_FORMAT_RGB24) {
-        idata = ((uint32 *)(base->data)) + src->y * base->bytes_per_line + src->x;
+        idata = ((uint32 *)(base->data + src->y * base->bytes_per_line)) + src->x;
         return cairo_image_surface_create_for_data((uint8 *) idata, type,
                 src->width, src->height,
                 base->bytes_per_line);

--- a/gdraw/gxcdraw.c
+++ b/gdraw/gxcdraw.c
@@ -491,7 +491,7 @@ static cairo_surface_t *GImage2Surface(GImage *image, GRect *src, uint8 **_data)
     /*  premultiply each channel by alpha. We can reuse it for non-transparent*/
     /*  rgb images */
     if ( base->image_type == it_true && type == CAIRO_FORMAT_RGB24 ) {
-	idata = ((uint32 *) (base->data)) + src->y*base->bytes_per_line + src->x;
+	idata = ((uint32 *)(base->data + src->y * base->bytes_per_line)) + src->x;
 	*_data = NULL;		/* We can reuse the image's own data, don't need a copy */
 return( cairo_image_surface_create_for_data((uint8 *) idata,type,
 		src->width, src->height,


### PR DESCRIPTION
Fixes the crash/oob memory access by fixing the casting of the pointer.

Also fixes the display of the image when at that zoom level.

### Type of change
- **Bug fix** Fixes #3919

