### PR TITLE
Correct gpos_pair output

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -1436,8 +1436,6 @@ return;					/* No support for apple "lookups" */
 			    fprintf( out, "    pos " );
 			    dump_glyphname(out,sc);
 			    putc(' ',out);
-			    dump_valuerecord(out,&pst->u.pair.vr[0]);
-			    putc(' ',out);
 			    dump_glyphnamelist(out,sf,pst->u.pair.paired );
 			    putc(' ',out);
 			    dump_valuerecord(out,&pst->u.pair.vr[0]);


### PR DESCRIPTION
This is intended to fix the first sub issue in #4005

@khaledhosny I realize I lean on you a lot for this stuff but if you have a chance could you take a look? The modified lines go back to the first introduction of the file, and therefore of Adobe feature file support, and seem to be a straightforward misreading of [section 6.b](http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6.b). (That is, format A *allows* two value records and this code is mistakenly writing the same value record twice, when it should be using format B.) 