### PR TITLE
Reinstate fallback to compile time configured prefix if nothing else …

### DIFF
--- a/cmake/FontForgeConfigure.cmake
+++ b/cmake/FontForgeConfigure.cmake
@@ -105,7 +105,7 @@ function(fontforge_generate_config template destination)
     set(_LIBUNINAMESLIST_FUN ${Libuninameslist_FEATURE_LEVEL})
   endif()
 
-  configure_file(${template} ${destination})
+  configure_file(${template} ${destination} ESCAPE_QUOTES @ONLY)
 endfunction()
 
 function(_get_git_version)
@@ -179,5 +179,5 @@ function(fontforge_generate_version_extras template destination)
     _get_modtime()
     _get_modtime_str(${FONTFORGE_MODTIME})
 
-    configure_file(${template} ${destination})
+    configure_file(${template} ${destination} ESCAPE_QUOTES @ONLY)
 endfunction()

--- a/fontforge/start.c
+++ b/fontforge/start.c
@@ -95,9 +95,7 @@ void doinitFontForgeMain(void) {
 
     if ( inited )
 return;
-#ifdef __MINGW32__
     FindProgDir(NULL);
-#endif
     InitSimpleStuff();
     if ( default_encoding==NULL )
 	default_encoding=FindOrMakeEncoding("ISO8859-1");

--- a/fontforgeexe/encodingui.c
+++ b/fontforgeexe/encodingui.c
@@ -348,18 +348,6 @@ return;
     closedir(d);
 }
 
-static void FindMapsInNoLibsDir(struct block *block,char *dir) {
-
-    if ( dir==NULL || strstr(dir,"/.libs")==NULL )
-return;
-
-    dir = copy(dir);
-    *strstr(dir,"/.libs") = '\0';
-
-    FindMapsInDir(block,dir);
-    free(dir);
-}
-
 struct cidmap *AskUserForCIDMap(void) {
     struct block block;
     struct cidmap *map = NULL;
@@ -376,8 +364,6 @@ struct cidmap *AskUserForCIDMap(void) {
 	AddToBlock(&block,buffer,NULL);
     }
     FindMapsInDir(&block,".");
-    FindMapsInDir(&block,GResourceProgramDir);
-    FindMapsInNoLibsDir(&block,GResourceProgramDir);
     FindMapsInDir(&block,getFontForgeShareDir());
     FindMapsInDir(&block,"/usr/share/fontforge");
 

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -1267,7 +1267,6 @@ static void PrefsUI_LoadPrefs(void)
 //	if (!quiet) {
 //	    fprintf(stderr,"TESTING: getPixmapDir:%s\n", getPixmapDir() );
 //	    fprintf(stderr,"TESTING: getShareDir:%s\n", getShareDir() );
-//	    fprintf(stderr,"TESTING: GResourceProgramDir:%s\n", GResourceProgramDir );
 //	}
 	snprintf(path, PATH_MAX, "%s/%s", getPixmapDir(), "resources" );
 //	if (!quiet)

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -1180,20 +1180,6 @@ static char *SearchDirForWernerFile(char *dir,char *filename) {
     return( NULL );
 }
 
-static char *SearchNoLibsDirForWernerFile(char *dir,char *filename) {
-    char *ret;
-
-    if ( dir==NULL || strstr(dir,"/.libs")==NULL )
-return( NULL );
-
-    dir = copy(dir);
-    *strstr(dir,"/.libs") = '\0';
-
-    ret = SearchDirForWernerFile(dir,filename);
-    free(dir);
-return( ret );
-}
-
 static enum fchooserret GFileChooserFilterWernerSFDs(GGadget *g,GDirEntry *ent,
 	const unichar_t *dir) {
     enum fchooserret ret = GFileChooserDefFilter(g,ent,dir);
@@ -1248,11 +1234,7 @@ static char *GetWernerSFDFile(SplineFont *sf,EncMap *map) {
 	if ( def!=NULL ) {
 	    ret = SearchDirForWernerFile(".",def);
 	    if ( ret==NULL )
-		ret = SearchDirForWernerFile(GResourceProgramDir,def);
-	    if ( ret==NULL )
 		ret = SearchDirForWernerFile(getFontForgeShareDir(),def);
-	    if ( ret==NULL )
-		ret = SearchNoLibsDirForWernerFile(GResourceProgramDir,def);
 	    if ( ret!=NULL )
 return( ret );
 	}

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1189,14 +1189,14 @@ int fontforge_main( int argc, char **argv ) {
 #if defined(__MINGW32__) && !defined(_NO_LIBCAIRO)
     //Load any custom fonts for the user interface
     if (use_cairo) {
-        char *system_load = getGResourceProgramDir();
+        char *system_load = getShareDir();
         char *user_load = getFontForgeUserDir(Data);
         char lbuf[MAX_PATH];
         int lret;
 
         if (system_load != NULL) {
             //Follow the FontConfig APPSHAREFONTDIR location
-            lret = snprintf(lbuf, MAX_PATH, "%s/../share/fonts", system_load);
+            lret = snprintf(lbuf, MAX_PATH, "%s/../fonts", system_load);
             if (lret > 0 && lret < MAX_PATH) {
                 WinLoadUserFonts(lbuf);
             }

--- a/gdraw/gpstxtinit.c
+++ b/gdraw/gpstxtinit.c
@@ -469,8 +469,8 @@ return( true );
     if ( path==NULL )
 	path = copy(getenv("PSFONTPATH"));
     if ( path==NULL ) {
-	path = copy(GFileBuildName(GResourceProgramDir,"print",filename,sizeof(filename)));
-	/* append /print to program directory */
+	path = copy(GFileBuildName(getShareDir(),"print",filename,sizeof(filename)));
+	/* append /print to share directory */
     }
 
     for ( pp = path; *pp; pp = epp ) {

--- a/gdraw/gresource.c
+++ b/gdraw/gresource.c
@@ -168,12 +168,7 @@ return;
     else
 return;
 
-    free(GResourceProgramDir);
-    GResourceProgramDir = _GFile_find_program_dir(prog);
-    if ( GResourceProgramDir==NULL ) {
-	GFileGetAbsoluteName(".",filename,sizeof(filename));
-	GResourceProgramDir = copy(filename);
-    }
+    FindProgDir(prog);
     free(GResourceFullProgram);
     GResourceFullProgram = copy(
 	    GFileBuildName(GResourceProgramDir,GResourceProgramName,filename,sizeof(filename)));

--- a/gdraw/gresource.c
+++ b/gdraw/gresource.c
@@ -36,7 +36,7 @@
 #include "ustring.h"
 #include "utype.h"
 
-char *GResourceProgramName, *GResourceFullProgram, *GResourceProgramDir;
+char *GResourceProgramName;
 char *usercharset_names;
 /* int local_encoding = e_iso8859_1;*/
 
@@ -167,11 +167,6 @@ return;
 	GResourceProgramName = copy("gdraw");
     else
 return;
-
-    FindProgDir(prog);
-    free(GResourceFullProgram);
-    GResourceFullProgram = copy(
-	    GFileBuildName(GResourceProgramDir,GResourceProgramName,filename,sizeof(filename)));
 }
 
 void GResourceAddResourceString(char *string,char *prog) {

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -40,7 +40,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-static char dirname_[MAXPATHLEN+1];
 #if !defined(__MINGW32__)
  #include <pwd.h>
 #else
@@ -48,7 +47,8 @@ static char dirname_[MAXPATHLEN+1];
  #include <windows.h>
 #endif
 
-char *GResourceProgramDir = NULL;
+static char *program_dir = NULL;
+static char dirname_[MAXPATHLEN+1];
 
 /**
  * \brief Removes the extension from a file path, if it exists.
@@ -805,7 +805,7 @@ return(unlink(buffer));
 }
 
 void FindProgDir(char *prog) {
-    if (GResourceProgramDir != NULL) {
+    if (program_dir != NULL) {
         return;
     }
 
@@ -822,11 +822,11 @@ void FindProgDir(char *prog) {
     	}
     }
     if(tail) *tail='\0';
-    GResourceProgramDir = copy(path);
+    program_dir = copy(path);
 #else
-    GResourceProgramDir = _GFile_find_program_dir(prog);
-    if ( GResourceProgramDir==NULL ) {
-        GResourceProgramDir = smprintf("%s/%s", FONTFORGE_INSTALL_PREFIX, "bin");
+    program_dir = _GFile_find_program_dir(prog);
+    if ( program_dir==NULL ) {
+        program_dir = smprintf("%s/%s", FONTFORGE_INSTALL_PREFIX, "bin");
     }
 #endif
 }
@@ -843,14 +843,14 @@ char *getShareDir(void) {
     set = true;
 
     //Assume share folder is one directory up
-    pt = strrchr(GResourceProgramDir, '/');
+    pt = strrchr(program_dir, '/');
     if ( pt==NULL ) {
-	pt = GResourceProgramDir + strlen(GResourceProgramDir);
+	pt = program_dir + strlen(program_dir);
     }
-    len = (pt-GResourceProgramDir)+strlen("/share/fontforge")+1;
+    len = (pt-program_dir)+strlen("/share/fontforge")+1;
     sharedir = malloc(len);
-    strncpy(sharedir,GResourceProgramDir,pt-GResourceProgramDir);
-    strcpy(sharedir+(pt-GResourceProgramDir),"/share/fontforge");
+    strncpy(sharedir,program_dir,pt-program_dir);
+    strcpy(sharedir+(pt-program_dir),"/share/fontforge");
     return( sharedir );
 }
 

--- a/inc/fontforge-config.h.in
+++ b/inc/fontforge-config.h.in
@@ -33,6 +33,9 @@
 /* The tagged version of FontForge. Additional versioning information in fontforge-version-extras.h */
 #define FONTFORGE_VERSION "@PROJECT_VERSION@"
 
+/* The install prefix configured at configure/compile time, used as a last resort */
+#define FONTFORGE_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
+
 /* Platform checks */
 
 #cmakedefine WORDS_BIGENDIAN 1

--- a/inc/gfile.h
+++ b/inc/gfile.h
@@ -96,7 +96,6 @@ extern int u_GFileUnlink(unichar_t *name);
 extern off_t GFileGetSize(char *name);
 extern char *GFileReadAll(char *name);
 extern int   GFileWriteAll(char *filepath, char *data);
-extern char* getGResourceProgramDir(void);
 extern void  FindProgDir(char *prog);
 extern char *getShareDir(void);
 extern char *getLocaleDir(void);

--- a/inc/gresource.h
+++ b/inc/gresource.h
@@ -43,7 +43,7 @@ typedef struct gresstruct {
 #define GRESSTRUCT_EMPTY { NULL, 0, NULL, NULL, 0 }
 
 
-extern char *GResourceProgramName, *GResourceFullProgram, *GResourceProgramDir;
+extern char *GResourceProgramName;
 extern int local_encoding;
 #if HAVE_ICONV_H
 # include <iconv.h>


### PR DESCRIPTION
…is available

Not a big fan of this at all, but I don't have time to invest in doing something better about this. Something that's also super crap is making assumptions about where the share/libdirs are relative to the bin dir, which could all be different depending on what's done at configure/compile time.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

Fixes #4047