### PR TITLE
Fixes #4052: Contour end did not close

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -1741,7 +1741,7 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 	    CalcNibOffset(c, ut_ini, false, &no, -1);
 	    HandleJoin(c, left, ss->first->me, &no, is_ccw_ini, ut_endlast,
 	               was_ccw, false);
-            left = SplineSetJoin(left, true, INTERSPLINE_MARGIN, &closed);
+            left = SplineSetJoin(left, true, FIXUP_MARGIN, &closed);
 	    if ( !closed )
 		LogError( _("Warning: Left contour did not close\n") );
 	    else if ( c->rmov==srmov_contour )
@@ -1753,7 +1753,7 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 	    CalcNibOffset(c, ut_ini, true, &no, -1);
 	    HandleJoin(c, right, ss->first->me, &no, is_ccw_ini, ut_endlast,
 	               was_ccw, true);
-            right = SplineSetJoin(right, true, INTERSPLINE_MARGIN, &closed);
+            right = SplineSetJoin(right, true, FIXUP_MARGIN, &closed);
 	    if ( !closed )
 		LogError( _("Warning: Right contour did not close\n") );
 	    else {

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -1586,7 +1586,7 @@ void SPLNearlyHvLines(SplineChar *sc,SplineSet *ss,bigreal err) {
 
 /* The older check below is based on an absolute distance
  * and is therefore magnification-relative. This one is
- * (more or less) hull-based with a ratio of 500 visually
+ * (more or less) hull-based with a ratio of 1000 visually
  * verified at multiple magnifications.
  */
 int SplineIsLinearish(Spline *spline) {
@@ -1612,7 +1612,7 @@ int SplineIsLinearish(Spline *spline) {
 	if (dtmp > dmax)
 	    dmax = dtmp;
     }
-    return ( ln/dmax >= 500 );
+    return ( ln/dmax >= 1000 );
 }
 
 /* Does this spline deviate from a straight line between its endpoints by more*/

--- a/fontforge/utanvec.c
+++ b/fontforge/utanvec.c
@@ -111,7 +111,7 @@ int JointBendsCW(BasePoint ut_ref, BasePoint ut_vec) {
 BasePoint SplineUTanVecAt(Spline *s, bigreal t) {
     BasePoint raw;
 
-    if ( SplineIsLinear(s) ) {
+    if ( SplineIsLinearish(s) ) {
 	raw.x = s->to->me.x - s->from->me.x;
 	raw.y = s->to->me.y - s->from->me.y;
     } else {


### PR DESCRIPTION
Problem was using two different standards for linearness for what amounts to the same check. This switches to `SplineIsLinearish()` in both cases. (The problem I'm trying to avoid with Linearish is having a spline we're treating as curved but that doesn't have a clear turning direction at one end. That may not be possible, but it's easier to just treat close-to-straight source splines as straight.) 

