### PR TITLE
Fix Spiro hndling in SplinePointListCheckSelected1

### DIFF
--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1451,13 +1451,13 @@ static SplinePointList *SplinePointListCopySpiroSelected1(SplinePointList *spl) 
 return( head );
 }
 
-bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel, int spiro_cnt_end) {
+bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel, bool skip_spiro_end) {
     bool anysel = false;
     if (allsel) {
         *allsel = true;
     }
     if (spiro) {
-        for (int i = 0; i < (base->spiro_cnt+spiro_cnt_end); ++i) {
+        for (int i = 0; i < base->spiro_cnt-(skip_spiro_end?1:0); ++i) {
             if (SPIRO_SELECTED(&base->spiros[i])) {
                 anysel = true;
                 if (!allsel) {
@@ -1507,7 +1507,7 @@ SplinePointList *SplinePointListCopySelected(SplinePointList *base) {
     bool anysel, allsel;
 
     for ( ; base!=NULL; base = base->next ) {
-	anysel = SplinePointListCheckSelected1(base, false, &allsel, 0);
+	anysel = SplinePointListCheckSelected1(base, false, &allsel, false);
 	if ( allsel )
 	    cur = SplinePointListCopy1(base);
 	else if ( anysel )
@@ -1529,7 +1529,7 @@ SplinePointList *SplinePointListCopySpiroSelected(SplinePointList *base) {
     int i;
 
     for ( ; base!=NULL; base = base->next ) {
-	anysel = SplinePointListCheckSelected1(base, true, &allsel, -1);
+	anysel = SplinePointListCheckSelected1(base, true, &allsel, true);
 	if ( allsel )
 	    cur = SplinePointListCopy1(base);
 	else if ( anysel )
@@ -1661,7 +1661,7 @@ SplinePointList *SplinePointListRemoveSelected(SplineChar *sc,SplinePointList *b
 
     for ( ; base!=NULL; base = next ) {
 	next = base->next;
-	anysel = SplinePointListCheckSelected1(base, sc->inspiro && hasspiro(), &allsel, 0);
+	anysel = SplinePointListCheckSelected1(base, sc->inspiro && hasspiro(), &allsel, false);
 	if ( allsel ) {
 	    SplinePointListMDFree(sc,base);
     continue;
@@ -2002,7 +2002,7 @@ SplinePointList *SplinePointListSpiroTransform(SplinePointList *base, real trans
 return( SplinePointListTransform(base,transform,tpt_AllPoints));
 
     for ( spl = base; spl!=NULL; spl = spl->next ) {
-	anysel = SplinePointListCheckSelected1(spl, true, &allsel, -1);
+	anysel = SplinePointListCheckSelected1(spl, true, &allsel, true);
 	if ( !anysel )
     continue;
 	if ( allsel ) {

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1451,13 +1451,13 @@ static SplinePointList *SplinePointListCopySpiroSelected1(SplinePointList *spl) 
 return( head );
 }
 
-bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel) {
+bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel, int spiro_cnt_end) {
     bool anysel = false;
     if (allsel) {
         *allsel = true;
     }
     if (spiro) {
-        for (int i = 0; i < base->spiro_cnt; ++i) {
+        for (int i = 0; i < (base->spiro_cnt+spiro_cnt_end); ++i) {
             if (SPIRO_SELECTED(&base->spiros[i])) {
                 anysel = true;
                 if (!allsel) {
@@ -1507,7 +1507,7 @@ SplinePointList *SplinePointListCopySelected(SplinePointList *base) {
     bool anysel, allsel;
 
     for ( ; base!=NULL; base = base->next ) {
-	anysel = SplinePointListCheckSelected1(base, false, &allsel);
+	anysel = SplinePointListCheckSelected1(base, false, &allsel, 0);
 	if ( allsel )
 	    cur = SplinePointListCopy1(base);
 	else if ( anysel )
@@ -1529,7 +1529,7 @@ SplinePointList *SplinePointListCopySpiroSelected(SplinePointList *base) {
     int i;
 
     for ( ; base!=NULL; base = base->next ) {
-	anysel = SplinePointListCheckSelected1(base, true, &allsel);
+	anysel = SplinePointListCheckSelected1(base, true, &allsel, -1);
 	if ( allsel )
 	    cur = SplinePointListCopy1(base);
 	else if ( anysel )
@@ -1661,7 +1661,7 @@ SplinePointList *SplinePointListRemoveSelected(SplineChar *sc,SplinePointList *b
 
     for ( ; base!=NULL; base = next ) {
 	next = base->next;
-	anysel = SplinePointListCheckSelected1(base, sc->inspiro && hasspiro(), &allsel);
+	anysel = SplinePointListCheckSelected1(base, sc->inspiro && hasspiro(), &allsel, 0);
 	if ( allsel ) {
 	    SplinePointListMDFree(sc,base);
     continue;
@@ -2002,7 +2002,7 @@ SplinePointList *SplinePointListSpiroTransform(SplinePointList *base, real trans
 return( SplinePointListTransform(base,transform,tpt_AllPoints));
 
     for ( spl = base; spl!=NULL; spl = spl->next ) {
-	anysel = SplinePointListCheckSelected1(spl, true, &allsel);
+	anysel = SplinePointListCheckSelected1(spl, true, &allsel, -1);
 	if ( !anysel )
     continue;
 	if ( allsel ) {

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -81,7 +81,7 @@ extern SplineChar *SFSplineCharCreate(SplineFont *sf);
 extern SplineFont *SplineFontFromPSFont(FontDict *fd);
 extern SplinePointList *SPLCopyTransformedHintMasks(RefChar *r, SplineChar *basesc, BasePoint *trans,int layer);
 extern SplinePointList *SPLCopyTranslatedHintMasks(SplinePointList *base, SplineChar *basesc, SplineChar *subsc, BasePoint *trans);
-extern bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel, int spiro_cnt_end);
+extern bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel, bool skip_spiro_end);
 extern SplinePointList *SplinePointListCopy1(const SplinePointList *spl);
 extern SplinePointList *SplinePointListCopySelected(SplinePointList *base);
 extern SplinePointList *SplinePointListCopySpiroSelected(SplinePointList *base);

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -81,7 +81,7 @@ extern SplineChar *SFSplineCharCreate(SplineFont *sf);
 extern SplineFont *SplineFontFromPSFont(FontDict *fd);
 extern SplinePointList *SPLCopyTransformedHintMasks(RefChar *r, SplineChar *basesc, BasePoint *trans,int layer);
 extern SplinePointList *SPLCopyTranslatedHintMasks(SplinePointList *base, SplineChar *basesc, SplineChar *subsc, BasePoint *trans);
-extern bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel);
+extern bool SplinePointListCheckSelected1(const SplinePointList *base, bool spiro, bool *allsel, int spiro_cnt_end);
 extern SplinePointList *SplinePointListCopy1(const SplinePointList *spl);
 extern SplinePointList *SplinePointListCopySelected(SplinePointList *base);
 extern SplinePointList *SplinePointListCopySpiroSelected(SplinePointList *base);

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -4587,7 +4587,7 @@ static void CVMaybeCreateDraggingComparisonOutline( CharView* cv )
     if (cv->p.anysel) {
         SplinePointList *cur = NULL;
         for (SplinePointList *spl = l->splines; spl; spl = spl->next) {
-            if (SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL)) {
+            if (SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL, 0)) {
                 if (cur == NULL) {
                     cv->p.pretransform_spl = cur = SplinePointListCopy1(spl);
                 } else {

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -4587,7 +4587,7 @@ static void CVMaybeCreateDraggingComparisonOutline( CharView* cv )
     if (cv->p.anysel) {
         SplinePointList *cur = NULL;
         for (SplinePointList *spl = l->splines; spl; spl = spl->next) {
-            if (SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL, 0)) {
+            if (SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL, false)) {
                 if (cur == NULL) {
                     cv->p.pretransform_spl = cur = SplinePointListCopy1(spl);
                 } else {

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -51,7 +51,7 @@ int CVAnySel(CharView *cv, int *anyp, int *anyr, int *anyi, int *anya) {
     int i;
 
     for ( spl = cv->b.layerheads[cv->b.drawmode]->splines; spl!=NULL && !anypoints; spl = spl->next ) {
-        anypoints = SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL, -1);
+        anypoints = SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL, true);
     }
     for ( rf=cv->b.layerheads[cv->b.drawmode]->refs; rf!=NULL && !anyrefs; rf=rf->next )
 	if ( rf->selected ) anyrefs = true;

--- a/fontforgeexe/cvpointer.c
+++ b/fontforgeexe/cvpointer.c
@@ -51,7 +51,7 @@ int CVAnySel(CharView *cv, int *anyp, int *anyr, int *anyi, int *anya) {
     int i;
 
     for ( spl = cv->b.layerheads[cv->b.drawmode]->splines; spl!=NULL && !anypoints; spl = spl->next ) {
-        anypoints = SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL);
+        anypoints = SplinePointListCheckSelected1(spl, cv->b.sc->inspiro && hasspiro(), NULL, -1);
     }
     for ( rf=cv->b.layerheads[cv->b.drawmode]->refs; rf!=NULL && !anyrefs; rf=rf->next )
 	if ( rf->selected ) anyrefs = true;


### PR DESCRIPTION
This closes #4051. @jtanx threw away a distinction that existed in the
code before; sometimes spiros[spiro_cnt] was iterated through, sometimes
only spiros[spiro_cnt-1]. This restores that distinction, which turns
out to be necessary for proper Spiro handling.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
