### PR TITLE
Fix non-terminating AddExtrema loop

### DIFF
--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -2525,7 +2525,7 @@ return( false );
 /*    o  make the slope at the end point horizontal/vertical */
 static int ForceEndPointExtrema(Spline *s,int isto) {
     SplinePoint *end;
-    BasePoint *cp, to, unitslope, othercpunit, myslope;
+    BasePoint *cp, oldcp, to, unitslope, othercpunit, myslope;
     bigreal xdiff, ydiff, mylen, cplen, mydot, cpdot, len;
     /* To get here we know that the extremum is extremely close to the end */
     /*  point, and adjusting the slope at the end-point may be all we need */
@@ -2589,17 +2589,17 @@ return( true );	/* We changed the slope */
     if ( (xdiff = cp->x - end->me.x)<0 ) xdiff = -xdiff;
     if ( (ydiff = cp->y - end->me.y)<0 ) ydiff = -ydiff;
 
-    to = *cp;
+    oldcp = to = *cp;
     if ( xdiff<ydiff/10.0 && xdiff>0 ) {
 	to.x = end->me.x;
 	end->pointtype = pt_corner;
 	SPAdjustControl(end,cp,&to,s->order2);
-return( true );	/* We changed the slope */
+	return( (cp->x!=oldcp.x || cp->y!=oldcp.y) ? 1 : -1 );
     } else if ( ydiff<xdiff/10 && ydiff>0 ) {
 	to.y = end->me.y;
 	end->pointtype = pt_corner;
 	SPAdjustControl(end,cp,&to,s->order2);
-return( true );	/* We changed the slope */
+	return( (cp->x!=oldcp.x || cp->y!=oldcp.y) ? 1 : -1 );
     }
 
 return( -1 );		/* Didn't do anything */


### PR DESCRIPTION
This is similar to #4024 but the problem is more difficult to reproduce. @ctrlcctrlv can reproduce with 3890b4762567b84cd57b6d03fb382ad7fdb3ad50 by following the instructions in #4054 . (The commit after that modifies the output geometry of Expand Stroke in a way that dodges the problem without fixing it.) 

Anyway the idea behind the fix is pretty simple. `ForceEndPointExtrema()` is supposed to return -1 if it can't find anything to do. In some cases the control point position will converge on the on-curve point position, but `SPAdjustControl()` (in virtue of `SplineRefigureFixup()`, in virtue of `IntersectLinesClip()`) will move the cp slightly away from `to`. This creates a non-terminating loop where `ForceEndPointExtrema()` thinks it's moving the cp but isn't. 

The solution in this PR is to check to see if it's moved and adjust the return value accordingly. 

Closes #4054 .