### PR TITLE
Replace SplinePointListIsClockwise() with polygon-angle heuristic

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -1215,9 +1215,11 @@ Two contours may be compared to see if they describe similar paths.
     <TR>
       <TD><CODE><A name="#cnt-isClockwise">isClockwise</A></CODE></TD>
       <TD><CODE>()</CODE></TD>
-      <TD>Returns whether the contour is drawn in a clockwise direction. A return
-	value of -1 indicates that no consistant direction could be found (the contour
-	self-intersects).</TD>
+      <TD>Returns 1 when a non-self-intersecting contour is drawn in 
+	  a clockwise direction and 0 when such a contour is drawn in a
+	  counter-clockwise direction. When a contour intersects itself the
+	  return value may be any of 1, 0, or -1 and has no particular
+	  interpretation. 
     </TR>
     <TR>
       <TD><CODE>reverseDirection</CODE></TD>

--- a/fontforge/splineutil.h
+++ b/fontforge/splineutil.h
@@ -222,5 +222,6 @@ extern int HashKerningClassNamesFlex(SplineFont *sf, struct glif_name_index * cl
 #define SPLINE1DPTANVAL(s, t) ((3*(s)->a*(t) + 2*(s)->b)*(t) + (s)->c)
 #define SPLINEPTANVAL(s, t) (BasePoint) { SPLINE1DPTANVAL(&(s)->splines[0], t), SPLINE1DPTANVAL(&(s)->splines[1], t) }
 #define BPWITHIN(bp1, bp2, f) (RealWithin((bp1).x, (bp2).x, f) && RealWithin((bp1).y, (bp2).y, f))
+#define NORMANGLE(a) ((a)>FF_PI?(a)-2*FF_PI:(a)<-FF_PI?(a)+2*FF_PI:(a))
 
 #endif /* FONTFORGE_SPLINEUTIL_H */

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -4041,95 +4041,35 @@ return( NULL );
 return( ret );
 }
 
+bigreal SplinePointListPolyAngleSum(const SplineSet *ss) {
+    Spline *s;
+    bigreal anglesum = 0, angle, last_angle;
+
+    if ( ss->first==NULL || ss->first->prev==NULL )
+	return 0;
+
+    s = ss->first->prev;
+    last_angle = atan2(s->to->me.y - s->from->me.y,
+                       s->to->me.x - s->from->me.x);
+
+    s = ss->first->next;
+    while ( true ) {
+	angle = atan2(s->to->me.y - s->from->me.y, s->to->me.x - s->from->me.x);
+	anglesum += NORMANGLE(last_angle-angle);
+	last_angle = angle;
+	s=s->to->next;
+	if ( s==ss->first->next )
+	    break;
+    }
+
+    return anglesum;
+}
+
 int SplinePointListIsClockwise(const SplineSet *spl) {
-    EIList el;
-    EI *active=NULL, *apt, *pr, *e;
-    int i, winding,change,waschange, cnt;
-    SplineChar dummy;
-    SplineSet *next;
-    Layer layers[2];
-    int cw_cnt=0, ccw_cnt=0;
-
-    memset(&el,'\0',sizeof(el));
-    memset(&dummy,'\0',sizeof(dummy));
-    memset(layers,0,sizeof(layers));
-    el.layer = ly_fore;
-    dummy.layers = layers;
-    dummy.layer_cnt = 2;
-    dummy.layers[ly_fore].splines = (SplineSet *) spl;
-    dummy.name = "Clockwise Test";
-    next = spl->next; ((SplineSet *) spl)->next = NULL;
-    ELFindEdges(&dummy,&el);
-    if ( el.coordmax[1]-el.coordmin[1] > 1.e6 ) {
-	LogError( _("Warning: Unreasonably big splines. They will be ignored.\n") );
-	((SplineSet *) spl)->next = next;
-return( -1 );
-    }
-    el.major = 1;
-    ELOrder(&el,el.major);
-
-    waschange = false;
-    for ( i=0; i<el.cnt ; ++i ) {
-	active = EIActiveEdgesRefigure(&el,active,i,1,&change);
-	for ( apt=active, cnt=0; apt!=NULL; apt = apt->aenext , ++cnt );
-	if ( el.ordered[i]!=NULL || el.ends[i] || cnt&1 ||
-		waschange || change ||
-		(i!=el.cnt-1 && (el.ends[i+1] || el.ordered[i+1])) ) {
-	    waschange = change;
-    continue;			/* Just too hard to get the edges sorted when we are at a start vertex */
-	}
-	waschange = change;
-	for ( apt=active; apt!=NULL; apt = e) {
-	    if ( EISkipExtremum(apt,i+el.low,1)) {
-		e = apt->aenext->aenext;
-	continue;
-	    }
-	    if ( apt->up )
-		++cw_cnt;
-	    else
-		++ccw_cnt;
-	    if ( cw_cnt!=0 && ccw_cnt!=0 ) {
-		((SplineSet *) spl)->next = next;
-return( -1 );
-	    }
-	    winding = apt->up?1:-1;
-	    for ( pr=apt, e=apt->aenext; e!=NULL && winding!=0; pr=e, e=e->aenext ) {
-		if ( EISkipExtremum(e,i+el.low,1)) {
-		    e = e->aenext;
-	    continue;
-		}
-		if ( pr->up!=e->up ) {
-		    if ( (winding<=0 && !e->up) || (winding>0 && e->up )) {
-/* return( -1 );*/	/* This is an erroneous condition... but I don't think*/
-			/*  it can actually happen with a single contour. I */
-			/*  think it is more likely this means a rounding error*/
-			/*  and a problem in my algorithm */
-			fprintf( stderr, "SplinePointListIsClockwise: Found error\n" );
-		    }
-		    winding += (e->up?1:-1);
-		} else if ( EISameLine(pr,e,i+el.low,1) )
-		    /* This just continues the line and doesn't change count */;
-		else {
-		    if ( (winding<=0 && !e->up) || (winding>0 && e->up )) {
-			fprintf( stderr, "SplinePointListIsClockwise: Found error\n" );
-/*return( -1 );*/
-		    }
-		    winding += (e->up?1:-1);
-		}
-	    }
-	}
-    }
-    free(el.ordered);
-    free(el.ends);
-    ElFreeEI(&el);
-    ((SplineSet *) spl)->next = next;
-
-    if ( cw_cnt!=0 )
-return( true );
-    else if ( ccw_cnt!=0 )
-return( false );
-
-return( -1 );
+    bigreal as = SplinePointListPolyAngleSum(spl);
+    if ( RealWithin(as, 0, 0.1) )
+	return -1;
+    return as>0;
 }
 
 /* Since this function now deals with 4 arbitrarily selected points, */


### PR DESCRIPTION
The existing `SplinePointListIsClockwise()` sometimes returns -1 for non-intersecting contours. See #4050 and #4049 for examples. This causes problem for any code, like the new Expand Stroke code, that relies on the function in a conditional.

The python note for the wrapper around the function is "Determine if a contour is oriented in a clockwise direction. If the contour intersects itself the results are indeterminate." This implies that the function is intended to reflect the mathematical concept of [curve orientation](https://en.wikipedia.org/wiki/Curve_orientation), which is well defined only for "simple" (non-self-intersecting) closed curves. 

If a contour does not intersect itself its orientation will be the same as the orientation of the polygon formed by connecting each of its on-curve points in sequence. While the orientation of a simple *convex* polygon can be determined by examining a few sequential points, that heuristic won't always be accurate for non-convex polygons. For those, an easy way to determine the orientation is to add up the angle changes, which will be 2π for a clockwise curve (when adding a certain way) and -2π for a concave curve. 

Because the old code *sometimes* returned 0 or 1 for self-intersecting curves this code just sets the return value based on angle sum and only returns -1 for a sum of zero. This is consistent with `test1004.py`. 

While I think this assessment is accurate this change needs a close look and, with luck, some thorough testing. 

Closes #4050 
Closes #4049 