### PR TITLE
Always allow opening «Glyph Info…» in FontView

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -4218,9 +4218,7 @@ static void ellistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
 	    mi->ti.disabled = in_modal;
 	  break;
 	  case MID_CharInfo:
-	    mi->ti.disabled = anychars<0 || (gid = fv->b.map->map[anychars])==-1 ||
-		    (fv->b.cidmaster!=NULL && fv->b.sf->glyphs[gid]==NULL) ||
-		    in_modal;
+	    mi->ti.disabled = anychars<0 || in_modal;
 	  break;
 	  case MID_Transform:
 	    mi->ti.disabled = anychars==-1;


### PR DESCRIPTION
This is another one of those issues “I’d gotten so used to I forgot they were actually bugs.”

In master it is not possible to open this dialog for glyphs which don't exist…via the keyboard, or Element menu. But you can just right-click the glyph, and receive the Glyph Info option, and therefore, the dialog.

Which I do…often. The restriction seems to have no purpose, and is very annoying, so I've removed it.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
