### PR TITLE
Fix MetricsView when selecting unencoded glyphs

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5282,7 +5282,6 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
             *pt = '/'; pt++;
             strcpy(pt, mv->chars[cnt]->name);
             pt += strlen(mv->chars[cnt]->name);
-            *pt = ' '; pt++;
         }
     }
     *pt = '\0';


### PR DESCRIPTION
When selecting a set of unencoded glyphs, e.g.:

![2019-12-18-110256_1502x839_scrot](https://user-images.githubusercontent.com/838783/71052276-cf451700-2185-11ea-8b69-357b2dc92d32.png)

And opening the Metrics View:

![2019-12-18-110420_2396x853_scrot](https://user-images.githubusercontent.com/838783/71052362-0d423b00-2186-11ea-984b-6fa5ff4b64ff.png)

The glyphs are all in a row. However if you go to edit the string (simply clicking the input is enough):

![2019-12-18-110525_2396x853_scrot](https://user-images.githubusercontent.com/838783/71052395-264aec00-2186-11ea-8c69-f6d423428400.png)

Spaces appear. This stops that from happening.

Example font:

[MetricsViewSpaces.zip](https://github.com/fontforge/fontforge/files/3976420/MetricsViewSpaces.zip)
