### PR TITLE
Extend glyph.clear() in Python to clear layers

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -2518,9 +2518,8 @@ must be created through the font.
           With no arguments, clears the contents of the glyph (and marks it as
           not <A href="#g-isWorthOutputting">worth outputting</A>).
 
-          If a layer is provided it must be an integer index, e.g. 0 for Back
-          and 1 for Fore; it is not possible to clear the guide layer with this
-          function.
+          It is not possible to clear the guide layer with this function.
+          <CODE>layer</CODE> may be either an integer index or a string.
       </TD>
     </TR>
     <TR>

--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -2513,9 +2513,15 @@ must be created through the font.
     </TR>
     <TR>
       <TD><CODE>clear</CODE></TD>
-      <TD><CODE>()</CODE></TD>
-      <TD>Clears the contents of the glyph (and marks it as not
-	<A href="#g-isWorthOutputting">worth outputting</A>).</TD>
+      <TD><CODE>([layer])</CODE></TD>
+      <TD>
+          With no arguments, clears the contents of the glyph (and marks it as
+          not <A href="#g-isWorthOutputting">worth outputting</A>).
+
+          If a layer is provided it must be an integer index, e.g. 0 for Back
+          and 1 for Fore; it is not possible to clear the guide layer with this
+          function.
+      </TD>
     </TR>
     <TR>
       <TD><CODE><A name="g-cluster">cluster</A></CODE></TD>

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -9384,11 +9384,22 @@ static PyObject *PyFFGlyph_clear(PyFF_Glyph *self, PyObject *args) {
         return NULL;
     } else { /* arglen == 1 */
         PyObject *layerp = PySequence_GetItem(args,0);
-        if (!PyInt_Check(layerp)) {
-            PyErr_Format(PyExc_ValueError, "First argument must be layer index (int)");
+        if ( STRING_CHECK(layerp)) {
+            char *name;
+            PYGETSTR(layerp, name, NULL);
+            layeri = SFFindLayerIndexByName(self->sc->parent,name);
+            if ( layeri<0 ) {
+                PyErr_Format(PyExc_ValueError, "Requested layer '%s' not found", name);
+                ENDPYGETSTR();
+                return NULL;
+            }
+            ENDPYGETSTR();
+        } else if (!PyInt_Check(layerp)) {
+            PyErr_Format(PyExc_ValueError, "First argument must be string or layer index");
             return NULL;
+        } else {
+            layeri = PyInt_AsLong(layerp);
         }
-        layeri = PyInt_AsLong(layerp);
         // ly_grid not clearable with this function. In any event, it makes no
         // sense to put it here; clearing ly_grid should quite rightly go at
         // the font level since ly_grid is per-font not per-glyph so this is


### PR DESCRIPTION
At least since 2010, people have noted that it's not possible to clear a single layer from Python.

This fixes that by extending `clear()`, the function of `glyph`, to take an optional integer argument, which, if provided, is a positive layer index.

I use this function to build my TT2020 font so kind of need it. Without it, background images would take up all available memory and FontForge would crash. There are messy hacks I could do to avoid the problem but this is the best solution.

Closes #4041

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **New feature** (sort of)
