### PR TITLE
Fix «Layer Info» dialog

### DIFF
--- a/fontforgeexe/cvstroke.c
+++ b/fontforgeexe/cvstroke.c
@@ -2553,7 +2553,7 @@ return( true );
 	}
 	temp.stroke_pen.linecap =
 		GGadgetIsChecked(GWidgetGetControl(gw,CID_ButtCap))?lc_butt:
-		GGadgetIsChecked(GWidgetGetControl(gw,CID_BevelCap))?lc_round:
+		GGadgetIsChecked(GWidgetGetControl(gw,CID_RoundCap))?lc_round:
 		GGadgetIsChecked(GWidgetGetControl(gw,CID_SquareCap))?lc_square:
 			lc_inherited;
 	temp.stroke_pen.linejoin =


### PR DESCRIPTION
The &laquo;Layer Info&raquo; dialog doesn't work at all in `master` due to a typo that Git is blaming on @skef. (d2c34ab283) I doubt anyone will ever actually _use_ multi-layered "Type 3" fonts without COLR/CPAL output support, but it _is_ a regression, so I opened #4076 anyway.

(Foregoing copied from https://github.com/fontforge/fontforge/issues/677#issuecomment-568240793)

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
