### PR TITLE
Misc CVE fixes

### DIFF
--- a/fontforge/sfd1.c
+++ b/fontforge/sfd1.c
@@ -674,7 +674,7 @@ void SFD_AssignLookups(SplineFont1 *sf) {
 
     /* Fix up some gunk from really old versions of the sfd format */
     SFDCleanupAnchorClasses(&sf->sf);
-    if ( sf->sf.uni_interp==ui_unset )
+    if ( sf->sf.uni_interp==ui_unset && sf->sf.map!=NULL )
 	sf->sf.uni_interp = interp_from_encoding(sf->sf.map->enc,ui_none);
 
     /* Fixup for an old bug */


### PR DESCRIPTION
Fix for #4084 Use-after-free (heap) in the SFD_GetFontMetaData() function
Fix for #4086 NULL pointer dereference in the SFDGetSpiros() function
Fix for #4088 NULL pointer dereference in the SFD_AssignLookups() function
Add empty sf->fontname string if it isn't set, fixing #4089 #4090 and many
  other potential issues (many downstream calls to strlen() on the value).

Closes #4084 
Closes #4086 
Closes #4088 
Closes #4089 
Closes #4090 

Meta-note: That I am continually annoyed at the number of open FontForge issues does not imply this is not a waste of time. 