### PR TITLE
Fix crash on exit introduced in previous commit

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -7998,9 +7998,9 @@ bool SFD_GetFontMetaData( FILE *sfd,
 	int layer_cnt_tmp;
 	getint(sfd,&layer_cnt_tmp);
 	if ( layer_cnt_tmp>2 ) {
+	    sf->layer_cnt = layer_cnt_tmp;
 	    sf->layers = realloc(sf->layers,sf->layer_cnt*sizeof(LayerInfo));
 	    memset(sf->layers+2,0,(sf->layer_cnt-2)*sizeof(LayerInfo));
-	    sf->layer_cnt = layer_cnt_tmp;
 	}
     }
     else if ( strmatch(tok,"Layer:")==0 )


### PR DESCRIPTION
When the number of layers is greater than 2, as in Chomsky.sfd and most of my other fonts, FontForge will crash on exiting.

This is just a simple mistake @skef made. I'd say merging this fix is quite urgent. This closes #4099.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**