### PR TITLE
Use glyph names for #[]/\ when MetricsView opened

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5276,8 +5276,9 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
     mv->chars[mv->clen] = NULL;
 
     for ( cnt=0; cnt<mv->clen; ++cnt ) {
-        if ( mv->chars[cnt]->unicodeenc != -1 )
-	    pt = utf8_idpb(pt,mv->chars[cnt]->unicodeenc,0);
+        int cp = mv->chars[cnt]->unicodeenc;
+        if ( cp != -1 && strchr("#[]/\\", cp) == NULL)
+	    pt = utf8_idpb(pt,cp,0);
         else {
             *pt = '/'; pt++;
             strcpy(pt, mv->chars[cnt]->name);


### PR DESCRIPTION
When a MetricsView is opened from a FontView, these characters cause
weird effects in the string.

For example, if you select slash (/) and C, and hit Ctrl+K to open a
MetricsView from the selected characters, you'll get two glyphs. But
when you click the MetricsView text input, those become one glyph, as /C
is interpreted as  "the glyph named C" and not "a slash and a C."

The glyph # is used also to mean "ignore rest of glyphs", but once
again, MetricsView is not respecting this if opened from FontView.

This bug is very similar to #4070, and deals with the same code path.

This closes #3982.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**
