### PR TITLE
Fix spelling mistake in 3D projection tool

### DIFF
--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -278,7 +278,7 @@ static char *popupsres[] = {
     N_("Add a corner point"),    N_("Add a tangent point"),
     N_("Scale the selection"),   N_("Rotate the selection"),
     N_("Flip the selection"),  N_("Skew the selection"),
-    N_("Rotate the selection in 3D and project back to plain"), N_("Perform a perspective transformation on the selection"),
+    N_("Rotate the selection in 3D and project back to plane"), N_("Perform a perspective transformation on the selection"),
     N_("Rectangle or Ellipse"),  N_("Polygon or Star"),
     N_("Rectangle or Ellipse"),  N_("Polygon or Star")};
 GMenuItem2 cvtoollist[] = {

--- a/po/ca.po
+++ b/po/ca.po
@@ -16568,7 +16568,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "Transforma la selecció amb perspectiva"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "Gira en 3D la selecció i projecta-la de nou al pla"
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/de.po
+++ b/po/de.po
@@ -16595,7 +16595,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/el.po
+++ b/po/el.po
@@ -16654,7 +16654,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:277
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:278 ../fontforgeexe/cvpalettes.c:279

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -16215,7 +16215,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:277
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:278 ../fontforgeexe/cvpalettes.c:279

--- a/po/es.po
+++ b/po/es.po
@@ -17258,7 +17258,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/fr.po
+++ b/po/fr.po
@@ -17526,7 +17526,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "Transformer la sélection avec mise en perspective"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "Tourner la sélection en 3D et la projeter ensuite à plat"
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/hr.po
+++ b/po/hr.po
@@ -17029,7 +17029,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "Izradi perspektivnu transformaciju na odabir"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "Rotiraj odabir u 3D i projiciraj natrag dvodimenzionalno"
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/it.po
+++ b/po/it.po
@@ -16803,7 +16803,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/ja.po
+++ b/po/ja.po
@@ -17156,7 +17156,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "選択範囲に透視変換をほどこす"
 
 #: ../fontforgeexe/cvpalettes.c:277
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "選択範囲を3次元で回転して平面に再射影する"
 
 #: ../fontforgeexe/cvpalettes.c:278 ../fontforgeexe/cvpalettes.c:279

--- a/po/ko.po
+++ b/po/ko.po
@@ -17509,7 +17509,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "선택범위에 투시변환를 적용"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "선택범위를 3차원으로 회전하여 평면에 다시 사용"
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/ml.po
+++ b/po/ml.po
@@ -16171,7 +16171,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:277
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:278 ../fontforgeexe/cvpalettes.c:279

--- a/po/pl.po
+++ b/po/pl.po
@@ -17351,7 +17351,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "Przekształca zaznaczenie perspektywicznie"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "Obraca zaznaczenie w 3D i rzutuje z powrotem na płaszczyznę"
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/pt.po
+++ b/po/pt.po
@@ -16412,7 +16412,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/ru.po
+++ b/po/ru.po
@@ -16531,7 +16531,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "Выполнить преобразование выделения в перспективе"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "Повернуть выделение в 3D и спроецировать обратно на плоскость"
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283

--- a/po/uk.po
+++ b/po/uk.po
@@ -17458,7 +17458,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "Виконати перетворення перспективи позначеного"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr ""
 "Обертати позначений фрагмент у просторі з наступним проектуванням на площину"
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -17464,7 +17464,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "Chuyển dạng phối cảnh của vùng chọn"
 
 #: ../fontforgeexe/cvpalettes.c:277
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "Xoay vùng chọn theo ba chiều và hiện hình về thô"
 
 #: ../fontforgeexe/cvpalettes.c:278 ../fontforgeexe/cvpalettes.c:279

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -18872,7 +18872,7 @@ msgstr "对选中对象作透视变换"
 
 #
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "旋转选中对象于三维空间并投影到二维"
 
 #

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -17164,7 +17164,7 @@ msgid "Perform a perspective transformation on the selection"
 msgstr "實施視角變換於所選之上"
 
 #: ../fontforgeexe/cvpalettes.c:281
-msgid "Rotate the selection in 3D and project back to plain"
+msgid "Rotate the selection in 3D and project back to plane"
 msgstr "在 3D 中旋轉所選並投射回平面"
 
 #: ../fontforgeexe/cvpalettes.c:282 ../fontforgeexe/cvpalettes.c:283


### PR DESCRIPTION
Fixing a small spelling mistake that I found here. I updated to a newer version recently and that fixed my tooltips, so I was able to find this then.

A plain is a flat, sweeping landmass that does not change much in elevation. It's a geographical term. See  also https://en.wikipedia.org/wiki/Plain
A plane is a flat, two-dimensional surface in mathematics. This is more appropriate if you're not talking about landscapes or horses or whatever. See also https://en.wikipedia.org/wiki/Plane_(geometry)

### Type of change
- **Bug fix** I'd say.
- **Non-breaking change**, technically, but really, it's a
- **janitor issue**