### PR TITLE
Make number of chars openable in MetricsView from CharView configurable

### DIFF
--- a/fontforge/noprefs.c
+++ b/fontforge/noprefs.c
@@ -154,6 +154,7 @@ static int cv_width;			/* in charview.c */
 static int cv_height;			/* in charview.c */
 static int mv_width;				/* in metricsview.c */
 static int mv_height;				/* in metricsview.c */
+static int fvmv_selectmax;			/* in metricsview.c */
 static int bv_width;				/* in bitmapview.c */
 static int bv_height;				/* in bitmapview.c */
 static int mvshowgrid;				/* in metricsview.c */
@@ -251,6 +252,7 @@ extras[] = {
     { N_("SplashScreen"), pr_bool, &splash, NULL, NULL, 'S', NULL, 0, N_("Show splash screen on start-up") },
     { N_("GlyphAutoGoto"), pr_bool, &cv_auto_goto, NULL, NULL, '\0', NULL, 0, N_("Typing a normal character in the glyph view window changes the window to look at that character") },
     { N_("OpenCharsInNewWindow"), pr_bool, &OpenCharsInNewWindow, NULL, NULL, '\0', NULL, 0, N_("When double clicking on a character in the font view\nopen that character in a new window, otherwise\nreuse an existing one.") },
+    { N_("FontViewMetricsViewSelectMax"), pr_int, &fvmv_selectmax, NULL, NULL, '\0', NULL, 0, N_("When characters are selected in the FontView, how many should be put into the MetricsView if you open one? Negative values mean there's no limit, which should be used sparingly.") },
     { N_("ArrowMoveSize"), pr_real, &arrowAmount, NULL, NULL, '\0', NULL, 0, N_("The number of em-units by which an arrow key will move a selected point") },
     { N_("ArrowAccelFactor"), pr_real, &arrowAccelFactor, NULL, NULL, '\0', NULL, 0, N_("Holding down the Shift key will speed up arrow key motion by this factor") },
     { N_("SnapDistance"), pr_real, &snapdistance, NULL, NULL, '\0', NULL, 0, N_("When the mouse pointer is within this many pixels\nof one of the various interesting features (baseline,\nwidth, grid splines, etc.) the pointer will snap\nto that feature.") },

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5186,7 +5186,8 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
     // The maximum length of a glyph's name is 31 chars.
 #define MAXGLYPHNAME_LEN 31
     unsigned int selectmax = fvmv_selectmax < 0 ? fv->b.sf->glyphcnt : fvmv_selectmax;
-    char buf[selectmax * MAXGLYPHNAME_LEN], *pt;
+    char *buf = malloc(selectmax * MAXGLYPHNAME_LEN);
+    char *pt;
     char titlebuf[50+strlen(fv->b.sf->fontname)+1];
     GTextInfo label;
     int i,j,cnt;
@@ -5376,6 +5377,7 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
     GDrawSetVisible(mv->v,true);
     GDrawSetVisible(gw,true);
     /*GWidgetHidePalettes();*/
+    free(buf);
 return( mv );
 }
 

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5180,10 +5180,11 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
     FontRequest rq;
     static GWindow icon = NULL;
     extern int _GScrollBar_Width;
-    // The maximum length of a glyph's name is 31 chars.
+    // The maximum length of a glyph's name is 31 chars:
+    // https://docs.microsoft.com/en-us/typography/opentype/spec/recom#post-table
 #define MAXGLYPHNAME_LEN 31
     unsigned int selectmax = fvmv_selectmax < 0 ? fv->b.sf->glyphcnt : fvmv_selectmax;
-    char *buf = malloc(selectmax * MAXGLYPHNAME_LEN);
+    char *buf = malloc(selectmax * (MAXGLYPHNAME_LEN + 1) + 1);
     char *pt;
     GTextInfo label;
     int i,j,cnt;

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5263,6 +5263,7 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
     mv->fh = as+ds; mv->as = as;
 
     pt = buf;
+    // +1 because mv->chars is 0 terminated
     mv->chars = calloc(mv->cmax=selectmax+1,sizeof(SplineChar *));
     if ( sc!=NULL ) {
 	mv->chars[mv->clen++] = sc;

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -169,6 +169,7 @@ extern float prefs_cvEditHandleSize;            /* in charview.c */
 extern int prefs_cvInactiveHandleAlpha;         /* in charview.c */
 extern int mv_width;				/* in metricsview.c */
 extern int mv_height;				/* in metricsview.c */
+extern int fvmv_selectmax;			/* in metricsview.c */
 extern int bv_width;				/* in bitmapview.c */
 extern int bv_height;				/* in bitmapview.c */
 extern int ask_user_for_cmap;			/* in parsettf.c */
@@ -335,6 +336,7 @@ static struct prefs_list {
   navigation_list[] = {
 	{ N_("GlyphAutoGoto"), pr_bool, &cv_auto_goto, NULL, NULL, '\0', NULL, 0, N_("Typing a normal character in the glyph view window changes the window to look at that character.\nEnabling GlyphAutoGoto will disable the shortcut where holding just the ` key will enable Preview mode as long as the key is held.") },
 	{ N_("OpenCharsInNewWindow"), pr_bool, &OpenCharsInNewWindow, NULL, NULL, '\0', NULL, 0, N_("When double clicking on a character in the font view\nopen that character in a new window, otherwise\nreuse an existing one.") },
+	{ N_("FontViewMetricsViewSelectMax"), pr_int, &fvmv_selectmax, NULL, NULL, '\0', NULL, 0, N_("When characters are selected in the FontView, how many should be put into the MetricsView if you open one? Negative values mean there's no limit, which should be used sparingly.") },
 	PREFS_LIST_EMPTY
 },
   editing_list[] = {

--- a/fontforgeexe/wordlistparser.c
+++ b/fontforgeexe/wordlistparser.c
@@ -401,8 +401,6 @@ void WordlistTrimTrailingSingleSlash( unichar_t* txt )
 /************************************************************/
 /************************************************************/
 
-static int WordListLineSz = 1024;
-
 int WordListLine_countSelected( WordListLine wll )
 {
     int ret = 0;
@@ -436,10 +434,11 @@ WordListLine WordlistEscapedInputStringToParsedDataComplex(
     void* udata )
 {
     unichar_t* input = u_copy( input_const );
-    WordListChar* ret = calloc( WordListLineSz, sizeof(WordListChar));
+    int input_len = u_strlen(input);
+    WordListChar* ret = calloc( input_len+1, sizeof(WordListChar));
     WordListChar* out = ret;
     unichar_t* in     = input;
-    unichar_t* in_end = input + u_strlen(input);
+    unichar_t* in_end = input + input_len;
     // trim comment and beyond from input
     {
 	unichar_t* p = input;


### PR DESCRIPTION
Close #4114. More useful than it sounds. Fifteen characters is far too few.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
