### PR TITLE
Make kern in MetricsView toggleable with `-`

### DIFF
--- a/doc/html/metricsview.html
+++ b/doc/html/metricsview.html
@@ -279,7 +279,9 @@
   <P>
   Underneath the display area are a set of text fields. You may type in new
   numbers for any of these fields to change the corresponding metrics of the
-  glyph.
+  glyph. If you wish to type a negative number, it is best to type the positive
+  portion first, then an ASCII minus (`-`). So, to type, -300, type 300, then
+  press -.
   <P>
   The up and down arrow keys will increase and decrease the field's value by 
   a single unit. Holding Shift-up or -down will accelerate this by 10 and 

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -1542,16 +1542,26 @@ static int MV_KernChanged(GGadget *g, GEvent *e) {
 return( true );
     if ( which>mv->glyphcnt-1 || which==0 )
 return( true );
-    if ( e->u.control.subtype == et_textchanged ) {
-	unichar_t *end;
-	int val = u_strtol(_GGadgetGetTitle(g),&end,10);
 
-	if ( *end && !(*end=='-' && end[1]=='\0'))
-	    GDrawBeep(NULL);
-	else {
-	    MV_ChangeKerning(mv,which,val, false);
-	    MVRemetric(mv);
-	}
+    if ( e->u.control.subtype == et_textchanged ) {
+        char* title = GGadgetGetTitle8(g);
+
+        int negatives = 0;
+        for (char* p = title; *p != '\0'; p++) {
+            if (*p == '-') negatives++;
+        }
+
+        char* new = str_replace_all(title, "-", "", true); // frees title
+        int val = strtol(new,NULL,10);
+        free(new);
+
+        while (negatives) {
+            val *= -1;
+            negatives--;
+        }
+
+        MV_ChangeKerning(mv,which,val, false);
+        MVRemetric(mv);
     } else if ( e->u.control.subtype == et_textfocuschanged &&
 	    e->u.control.u.tf_focus.gained_focus ) {
 	for ( i=0 ; i<mv->glyphcnt; ++i )

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -1555,9 +1555,8 @@ return( true );
         int val = strtol(new,NULL,10);
         free(new);
 
-        while (negatives) {
+        if (negatives%2==1) {
             val *= -1;
-            negatives--;
         }
 
         MV_ChangeKerning(mv,which,val, false);


### PR DESCRIPTION
This, in my opinion, solves #3983.

It is still not possible to type a negative integer in LTR order. I
think that making that possible will cause needless disruption to this
file and is also a waste of time. Instead, first type the number, then a
minus sign, which will "toggle" the value negative.

I've documented this as the right way to do it, as well. I understand
why some people might not like this compromise, but it has been broken
for over ten years. If you have a better way to fix it, feel free :-)

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

