### PR TITLE
Fix for #4095 Dies after Change Weight

### DIFF
--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -3505,7 +3505,7 @@ static SplineSet *SSRemoveTiny(SplineSet *base) {
 			else
 			    prev->next = ssnext;
 			base = NULL;
-	break;
+	goto bailout;
 		    }
 		    // We want to remove the spline following sp.
 		    // This requires that we rewrite the following spline so that it starts at sp,
@@ -3631,6 +3631,7 @@ static SplineSet *SSRemoveTiny(SplineSet *base) {
 	    if ( refigure )
 		SplineRefigure(sp->next);
 	}
+      bailout:
 	if ( base!=NULL )
 	    prev = base;
 	base = ssnext;


### PR DESCRIPTION
Closes #4095

@frank-trampe Can you look at this and modify as you see fit? In my analysis the existing `break;` was escaping to the wrong part of the loop. An alternative would be to set `sp` and `nsp` to NULL and check for their being NULL in the following top-level guards. 