### PR TITLE
Fix for SplinePointListIsClockwise() false negative problems

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -365,7 +365,7 @@ enum ShapeType NibIsValid(SplineSet *ss) {
 	return Shape_TooFewPoints;
     if ( ss->first->prev==NULL )
 	return Shape_NotClosed;
-    if ( !SplinePointListIsClockwise(ss) )
+    if ( SplinePointListIsClockwise(ss)!=1 )
 	return Shape_CCW;
     if ( ss->first->next->order2 )
 	return Shape_Quadratic;
@@ -1728,8 +1728,18 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 	    else {
 		if ( c->rmov==srmov_contour )
 		    left = SplineSetRemoveOverlap(NULL,left,over_remove);
-		// Open paths don't always result in clockwise output
-		if ( !SplinePointListIsClockwise(left) )
+		// Open paths don't always produce clockwise output
+		is_ccw_mid = SplinePointListIsClockwise(left);
+		if ( is_ccw_mid==-1 && c->rmov!=srmov_none ) {
+		    assert( c->rmov!=srmov_contour );
+		    left = SplineSetRemoveOverlap(NULL,left,over_remove);
+		    is_ccw_mid = SplinePointListIsClockwise(left);
+		    assert( is_ccw_mid!=-1 );
+		} else {
+		    LogError( _("Warning: Can't identify contour direction, "
+		                "assuming clockwise\n") );
+		}
+		if ( is_ccw_mid==0 )
 		    SplineSetReverse(left);
 	    }
 	}

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -1735,7 +1735,7 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 		    left = SplineSetRemoveOverlap(NULL,left,over_remove);
 		    is_ccw_mid = SplinePointListIsClockwise(left);
 		    assert( is_ccw_mid!=-1 );
-		} else {
+		} else if ( is_ccw_mid==-1 ) {
 		    LogError( _("Warning: Can't identify contour direction, "
 		                "assuming clockwise\n") );
 		}

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -4041,14 +4041,14 @@ return( NULL );
 return( ret );
 }
 
-int SplinePointListIsClockwise(const SplineSet *spl) {
+static int _SplinePointListIsClockwise(const SplineSet *spl, int max_depth) {
     EIList el;
     EI *active=NULL, *apt, *pr, *e;
     int i, winding,change,waschange, cnt;
     SplineChar dummy;
     SplineSet *next;
     Layer layers[2];
-    int cw_cnt=0, ccw_cnt=0;
+    int cw_cnt=0, ccw_cnt=0, l_cw_cnt, l_ccw_cnt, lines_processed = 0;
 
     memset(&el,'\0',sizeof(el));
     memset(&dummy,'\0',sizeof(dummy));
@@ -4070,25 +4070,32 @@ return( -1 );
 
     waschange = false;
     for ( i=0; i<el.cnt ; ++i ) {
+	l_cw_cnt = l_ccw_cnt = 0;
 	active = EIActiveEdgesRefigure(&el,active,i,1,&change);
 	for ( apt=active, cnt=0; apt!=NULL; apt = apt->aenext , ++cnt );
+	// "Scan line" skip conditions:
+	//   Edge starts or ends on this line
+	//   Edge starts or ends on the following line
+	//   Odd number of edges on this line
+	//   On or immediately after a line marked "change" by EIAER
 	if ( el.ordered[i]!=NULL || el.ends[i] || cnt&1 ||
 		waschange || change ||
 		(i!=el.cnt-1 && (el.ends[i+1] || el.ordered[i+1])) ) {
 	    waschange = change;
-    continue;			/* Just too hard to get the edges sorted when we are at a start vertex */
+	    continue;
 	}
 	waschange = change;
+	++lines_processed;
 	for ( apt=active; apt!=NULL; apt = e) {
 	    if ( EISkipExtremum(apt,i+el.low,1)) {
 		e = apt->aenext->aenext;
-	continue;
+		continue;
 	    }
 	    if ( apt->up )
-		++cw_cnt;
+		++l_cw_cnt;
 	    else
-		++ccw_cnt;
-	    if ( cw_cnt!=0 && ccw_cnt!=0 ) {
+		++l_ccw_cnt;
+	    if ( (cw_cnt + l_cw_cnt)!=0 && (ccw_cnt + l_ccw_cnt)!=0 ) {
 		((SplineSet *) spl)->next = next;
 return( -1 );
 	    }
@@ -4100,36 +4107,102 @@ return( -1 );
 		}
 		if ( pr->up!=e->up ) {
 		    if ( (winding<=0 && !e->up) || (winding>0 && e->up )) {
-/* return( -1 );*/	/* This is an erroneous condition... but I don't think*/
-			/*  it can actually happen with a single contour. I */
-			/*  think it is more likely this means a rounding error*/
-			/*  and a problem in my algorithm */
-			fprintf( stderr, "SplinePointListIsClockwise: Found error\n" );
+			// This is an erroneous condition... but I don't think
+			// it can actually happen with a single contour. I
+			// think it is more likely this means a rounding error
+			// and a problem in my algorithm
+			l_cw_cnt = l_ccw_cnt = 0;
+			--lines_processed;
+			break;
 		    }
 		    winding += (e->up?1:-1);
 		} else if ( EISameLine(pr,e,i+el.low,1) )
-		    /* This just continues the line and doesn't change count */;
+		    // This just continues the line and doesn't change count
+		    ;
 		else {
 		    if ( (winding<=0 && !e->up) || (winding>0 && e->up )) {
-			fprintf( stderr, "SplinePointListIsClockwise: Found error\n" );
-/*return( -1 );*/
+			l_cw_cnt = l_ccw_cnt = 0;
+			--lines_processed;
+			break;
 		    }
 		    winding += (e->up?1:-1);
 		}
 	    }
 	}
+	cw_cnt += l_cw_cnt;
+	ccw_cnt += l_ccw_cnt;
     }
     free(el.ordered);
     free(el.ends);
     ElFreeEI(&el);
+
     ((SplineSet *) spl)->next = next;
 
-    if ( cw_cnt!=0 )
-return( true );
-    else if ( ccw_cnt!=0 )
-return( false );
+    if (    ((float) lines_processed / el.cnt) > .33 
+         || ( max_depth && lines_processed > 0 ) ) {
+	if ( cw_cnt!=0 && ccw_cnt==0 )
+	    return true;
+	else if ( cw_cnt==0 && ccw_cnt!=0 )
+	    return false;
+	else
+	    return -1;
+    }
 
-return( -1 );
+    return -2;
+}
+
+int SplinePointListIsClockwise(const SplineSet *spl) {
+    SplineSet *cpy;
+    const SplineSet *pass;
+    SplinePoint *sp;
+    int r, depth=0, mag=1, y, ymin=INT_MAX, ymax=INT_MIN, pt_cnt=0;
+
+    while ( depth<3 ) {
+	if ( mag!=1 ) {
+	    cpy = SplinePointListCopy1(spl);
+	    real trans[6] = { mag, 0.0, 0.0, mag, 0.0, 0.0 };
+	    SplinePointListTransformExtended(cpy,trans,tpt_AllPoints,
+	                                     tpmask_dontTrimValues);
+	    pass = cpy;
+	} else {
+	    cpy = NULL;
+	    pass = spl;
+	}
+	r = _SplinePointListIsClockwise(pass, depth==2);
+	if ( cpy!=NULL )
+	    SplinePointListFree(cpy);
+	if ( r>=-1 )
+	    return r;
+	// Bad run, prepare for next
+	if ( depth==0 ) {
+	    // Check for open or single-point splines and
+	    // further magnify small splines
+	    for ( sp = spl->first; ; ) {
+		if ( sp->next==NULL )
+		    return -1; // Open Spline
+		++pt_cnt;
+		y = floor(sp->me.y);
+		if ( y < ymin )
+		    ymin = y;
+		y = ceil(sp->me.y);
+		if ( y > ymax )
+		    ymax = y;
+		sp = sp->next->to;
+		if ( sp==spl->first )
+		    break;
+	    }
+	    if ( pt_cnt==1 )
+		return -1; // Single point spline
+	    y = ymax - ymin + 1;
+	    if ( y < pt_cnt + 7 )
+		mag = (int) (7 + pt_cnt)/y;
+	}
+	mag *= 3;
+	++depth;
+    }
+    mag /= 3;
+    LogError( _("Warning: SplinePointListIsClockwise found no usable line even at %dx magnification.\n"), mag );
+    return -1;
 }
 
 /* Since this function now deals with 4 arbitrarily selected points, */

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -4085,7 +4085,6 @@ return( -1 );
 	    continue;
 	}
 	waschange = change;
-	++lines_processed;
 	for ( apt=active; apt!=NULL; apt = e) {
 	    if ( EISkipExtremum(apt,i+el.low,1)) {
 		e = apt->aenext->aenext;
@@ -4097,7 +4096,7 @@ return( -1 );
 		++l_ccw_cnt;
 	    if ( (cw_cnt + l_cw_cnt)!=0 && (ccw_cnt + l_ccw_cnt)!=0 ) {
 		((SplineSet *) spl)->next = next;
-return( -1 );
+		return( -1 );
 	    }
 	    winding = apt->up?1:-1;
 	    for ( pr=apt, e=apt->aenext; e!=NULL && winding!=0; pr=e, e=e->aenext ) {
@@ -4112,7 +4111,6 @@ return( -1 );
 			// think it is more likely this means a rounding error
 			// and a problem in my algorithm
 			l_cw_cnt = l_ccw_cnt = 0;
-			--lines_processed;
 			break;
 		    }
 		    winding += (e->up?1:-1);
@@ -4122,7 +4120,6 @@ return( -1 );
 		else {
 		    if ( (winding<=0 && !e->up) || (winding>0 && e->up )) {
 			l_cw_cnt = l_ccw_cnt = 0;
-			--lines_processed;
 			break;
 		    }
 		    winding += (e->up?1:-1);
@@ -4131,6 +4128,8 @@ return( -1 );
 	}
 	cw_cnt += l_cw_cnt;
 	ccw_cnt += l_ccw_cnt;
+	if ( l_cw_cnt!=0 || l_ccw_cnt!=0 )
+	    ++lines_processed;
     }
     free(el.ordered);
     free(el.ends);
@@ -4138,7 +4137,7 @@ return( -1 );
 
     ((SplineSet *) spl)->next = next;
 
-    if (    ((float) lines_processed / el.cnt) > .33 
+    if (    ( lines_processed > 4 && ((float) lines_processed / el.cnt) > .33 )
          || ( max_depth && lines_processed > 0 ) ) {
 	if ( cw_cnt!=0 && ccw_cnt==0 )
 	    return true;


### PR DESCRIPTION
Suppose you want to know whether a closed, non-intersecting contour is clockwise or counterclockwise. You can do this by finding a single point in the inside, following a line to the outside, and looking at the direction of the spline you cross. As long as by "non-intersecting" we exclude both crosses and "shared" edges, this will work. 

However, perhaps it is a pain to determine a point conclusively inside the contour. In that case you can start a line definitively outside of the contour and look at the direction of the first spline crossed. This will also work. 

In practice, however, you may not know whether a spline is self-intersecting and may not want to run a separate algorithm to determine that. Or you may want to classify "degrees" of clockwise- or counterclockwise-ness. For such purposes you need to analyze more of the glyph. 

The existing `SplinePointListIsClockwise()` code uses the autohint toolset to build a structure of spline fragments (broken at extrema points) and organized by the vertical em-unit each starts on. This allows the contour to be "scanned" across at a given height looking for regions enclosed clockwise or counter-clockwise based on the directions of the splines that are crossed. The more heights that are examined the higher the probability of finding regions enclosed multiple times, and therefore of self-intersections. I don't entirely understand what the algorithm is determining because I didn't look at the winding-related code all that closely. (It wasn't necessary.) However, it rarely marks a self-intersecting glyph as definitively clockwise or counterclockwise. 

The mystery of this function was that it was sometimes failing for non-intersecting contours, and this was causing problems in Expand Stroke code that depends on its output. It turns out that there are a moderate number of conditions that cause the algorithm to skip a given line. If these line up just right no line will be processed and therefore no data is available. 

My basic fix for this problem is simple: When the algorithm fails make a copy of the contour, enlarge it, and try again. In addition to that idea I add:

1. If the spline is particularly small (in em-units) relative to the number of points it has (lines that include a point are skipped), enlarge it more.
2. When hitting the conditions that used to result in printing "SplinePointListIsClockwise: Found error", just skip that line. 
3. Until the spline is being processed at maximum magnification, discard the result unless one third of the lines are usable and try again. 

Closes #4049
Closes #4050
Closes #3571