### PR TITLE
Remove (most) zero-adjacent distortion from RealNear()

### DIFF
--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2134,7 +2134,7 @@ extern const unichar_t *_uGetModifiers(const unichar_t *fontname, const unichar_
 extern void ttfdumpbitmap(SplineFont *sf,struct alltabs *at,int32 *sizes);
 extern void SplineFontSetUnChanged(SplineFont *sf);
 
-extern int RealNear(real a,real b);
+extern bool RealNear(real a,real b);
 
 
 extern void UndoesFree(Undoes *undo);

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -163,28 +163,19 @@ return( v2-v1 > re );
 }
 
 int RealNear(real a,real b) {
-    real d;
-
+    real d = a-b;
 #ifdef FONTFORGE_CONFIG_USE_DOUBLE
+    // These tighter equals-zero tests are retained for code tuned when
+    // passing zero as a constant
     if ( a==0 )
-return( b>-1e-8 && b<1e-8 );
+	return b>-1e-8 && b<1e-8;
     if ( b==0 )
-return( a>-1e-8 && a<1e-8 );
+	return a>-1e-8 && a<1e-8;
 
-    d = a/(1024*1024.);
+    return d>-1e-6 && d<1e-6;
 #else		/* For floats */
-    if ( a==0 )
-return( b>-1e-5 && b<1e-5 );
-    if ( b==0 )
-return( a>-1e-5 && a<1e-5 );
-
-    d = a/(1024*64.);
+    return d>-1e-5 && d<1e-5
 #endif
-    a-=b;
-    if ( d<0 )
-return( a>d && a<-d );
-    else
-return( a>-d && a<d );
 }
 
 int RealNearish(real a,real b) {

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -162,7 +162,7 @@ return( v2-v1 > re );
     }
 }
 
-int RealNear(real a,real b) {
+bool RealNear(real a,real b) {
     real d = a-b;
 #ifdef FONTFORGE_CONFIG_USE_DOUBLE
     // These tighter equals-zero tests are retained for code tuned when


### PR DESCRIPTION
This PR is a response to #3848. The reasons are discussed towards the top and this particular choice of implementation is discussed in my comment towards the bottom. https://github.com/fontforge/fontforge/issues/3848#issuecomment-517515359 is my short explanation of why eliminating the severe zero-adjacent distortion in `RealNear()` should be a high priority.

The main reason I didn't submit something like this earlier -- always better to test this sort of thing abundantly pre-release -- is because I was considering @jtanx's suggestion and link. What finally decided is that we do need something along those lines, but not here. `RealNear()` is, more or less, "`RealWithin()` except I don't care much about the particulars". More importantly, one is usually saved from having to worry about ULPs by the problem domain itself. FontForge generally stays within x<sup>4</sup> of em-unit values, maybe occasionally stretching up into x<sup>5</sup> land, and so variable values typically stay under 10<sup>18</sup> (being *very* generous about the em scale). That would be too high except that it rarely compares/tests intermediate calculations, especially casually as with `RealNear()`. Generally you're playing around with em-units, unit slopes, radians, or maybe multiples or squares of these. Those spaces are going to be fine with a 10<sup>-6</sup> epsilon at double precision.

In short, I'm much more worried when it comes to uses of `RealWithin()`. I looked at my own code and the main bullshitty thing I found was in a later addition to `utanvec.c`:

```
        // If one control point is colocated with its on-curve point the 
        // slope will be undefined at that end, so walk back a bit for
        // consistency
        if (   RealWithin(t, 0, UTRETRY)
            && BPWithin(s->from->me, s->from->nextcp, 1e-13) )
            t = UTRETRY;
        else if (   RealWithin(t, 1, UTRETRY)
            && BPWithin(s->to->me, s->to->prevcp, 1e-13) )
            t = 1-UTRETRY;
```
`UTRETRY` is 10<sup>-9</sup>, which for a t value is fine, but 10<sup>-13</sup> for comparing em-unit values is more than pushing it: I didn't think enough about this. As it happens I don't think it winds up mattering in this particular case; if `me.x` and `nextcp.x` (for example) are both around 30,000 or whatever, all that's needed is that they be unequal at all so that walking `t` back a bit gives you a slope. But that's luck (or maybe wrong).

Therefore I think we should consider some ULP-based thinking (beyond whatever is in the more specific `WithinXXRoundingErrors()` functions, assuming those work) but applied to `RealWithin()` or some alternative.  

Closes #3848 