### PR TITLE
cmake: Fix gcc/clang conditionals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ build_option(ENABLE_FREETYPE_DEBUGGER PATH "" "Use FreeType's internal debugger 
 build_option(REAL_TYPE ENUM "double" "Sets the floating point type used." "double" "float")
 build_option(THEME     ENUM "tango"  "Sets the GUI theme." "tango" "2012")
 
-if(CMAKE_COMPILER_IS_GNUCC)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
   list(APPEND _test_flags CFLAGS -Werror=implicit-function-declaration -Werror=int-conversion)
   if(CMAKE_GENERATOR STREQUAL "Ninja") # https://github.com/ninja-build/ninja/wiki/FAQ
     list(APPEND _test_flags BOTH -fdiagnostics-color=always)

--- a/Unicode/CMakeLists.txt
+++ b/Unicode/CMakeLists.txt
@@ -65,7 +65,7 @@ if (ENABLE_MAINTAINER_TOOLS)
   add_executable(makebuildtables makebuildtables.c)
   target_link_libraries(makebuildtables PRIVATE fontforge_common_headers)
 
-  if(CMAKE_COMPILER_IS_GNUCC)
+  if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(makeutype PRIVATE -Wall)
     target_compile_options(makebuildtables PRIVATE -Wall)
   endif()

--- a/cmake/BuildUtils.cmake
+++ b/cmake/BuildUtils.cmake
@@ -113,7 +113,7 @@ endfunction()
 function(enable_sanitizer type)
   if("${type}" STREQUAL "none")
     return()
-  elseif(NOT CMAKE_COMPILER_IS_GNUCC)
+  elseif(NOT CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     message(FATAL_ERROR "Require a GCC-like compiler to enable sanitizers.")
   endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 add_executable(systestdriver systestdriver.c)
 target_link_libraries(systestdriver PRIVATE GLIB::GLIB)
-if(CMAKE_COMPILER_IS_GNUCC)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
   target_compile_options(systestdriver PRIVATE -Wall -pedantic)
 endif()
 


### PR DESCRIPTION
I was targeting both, but it seems like CMAKE_COMPILER_IS_GNUCC only matches gcc.

### Type of change
- **Bug fix**