### PR TITLE
fixes for #3209 and #3208 and #3008

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2016,7 +2016,7 @@ return( true );
 
 EncMap *EncMapFromEncoding(SplineFont *sf,Encoding *enc) {
     int i,j, extras, found, base, unmax;
-    int32 *encoded, *unencoded;
+    int32 *encoded=NULL, *unencoded=NULL;
     EncMap *map;
     struct altuni *altuni;
     SplineChar *sc;

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2111,16 +2111,14 @@ return( NULL );
 	    memcpy(map->map,encoded,base*sizeof(int32));
 	if ( extras>0 )
 	    memcpy(map->map+base,unencoded,extras*sizeof(int32));
-    } else
-	map->map = NULL;
+    }
     map->backmax = sf->glyphcnt;
     if ( sf->glyphcnt>0 ) {
 	map->backmap = malloc(sf->glyphcnt*sizeof(int32));
 	memset(map->backmap,-1,sf->glyphcnt*sizeof(int32));	/* Just in case there are some unencoded glyphs (duplicates perhaps) */
 	for ( i = map->enccount-1; i>=0; --i ) if ( map->map[i]!=-1 )
 	    map->backmap[map->map[i]] = i;
-    } else
-	map->backmap = NULL;
+    }
     map->enc = enc;
 
     free(encoded);

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2031,10 +2031,14 @@ return( NULL );
 	base = 256;
     else if ( enc->char_cnt<=0x10000 )
 	base = 0x10000;
-    encoded = malloc(base*sizeof(int32));
-    memset(encoded,-1,base*sizeof(int32));
-    unencoded = malloc(sf->glyphcnt*sizeof(int32));
-    unmax = sf->glyphcnt;
+    if ( base>0 ) {
+	encoded = malloc(base*sizeof(int32));
+	memset(encoded,-1,base*sizeof(int32));
+    }
+    if ( sf->glyphcnt>0 ) {
+	unencoded = malloc(sf->glyphcnt*sizeof(int32));
+	unmax = sf->glyphcnt;
+    }
 
     for ( i=extras=0; i<sf->glyphcnt; ++i ) if ( (sc=sf->glyphs[i])!=NULL ) {
 	found = false;
@@ -2101,14 +2105,22 @@ return( NULL );
 
     map = chunkalloc(sizeof(EncMap));
     map->enccount = map->encmax = base + extras;
-    map->map = malloc(map->enccount*sizeof(int32));
-    memcpy(map->map,encoded,base*sizeof(int32));
-    memcpy(map->map+base,unencoded,extras*sizeof(int32));
+    if ( map->enccount>0 ) {
+	map->map = malloc(map->enccount*sizeof(int32));
+	if ( base>0 )
+	    memcpy(map->map,encoded,base*sizeof(int32));
+	if ( extras>0 )
+	    memcpy(map->map+base,unencoded,extras*sizeof(int32));
+    } else
+	map->map = NULL;
     map->backmax = sf->glyphcnt;
-    map->backmap = malloc(sf->glyphcnt*sizeof(int32));
-    memset(map->backmap,-1,sf->glyphcnt*sizeof(int32));	/* Just in case there are some unencoded glyphs (duplicates perhaps) */
-    for ( i = map->enccount-1; i>=0; --i ) if ( map->map[i]!=-1 )
-	map->backmap[map->map[i]] = i;
+    if ( sf->glyphcnt>0 ) {
+	map->backmap = malloc(sf->glyphcnt*sizeof(int32));
+	memset(map->backmap,-1,sf->glyphcnt*sizeof(int32));	/* Just in case there are some unencoded glyphs (duplicates perhaps) */
+	for ( i = map->enccount-1; i>=0; --i ) if ( map->map[i]!=-1 )
+	    map->backmap[map->map[i]] = i;
+    } else
+	map->backmap = NULL;
     map->enc = enc;
 
     free(encoded);

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -4904,10 +4904,14 @@ return;
 	    else {
 		for ( i=0; i<count; ++i ) {
 		    int gid = getushort(ttf);
-		    if ( dounicode )
-			info->chars[gid]->unicodeenc = trans!=NULL ? trans[first+i] : first+i;
-		    if ( map!=NULL && first+i < map->enccount )
-			map->map[first+i] = gid;
+		    if ( dounicode ) {
+			if ( gid<info->glyph_cnt ) {
+			    info->chars[gid]->unicodeenc = trans!=NULL ? trans[first+i] : first+i;
+			    if ( map!=NULL && first+i < map->enccount )
+				map->map[first+i] = gid;
+			} else
+			    LogError( _("Warning: gid %d larger than glyph_cnt %d, skipping\n"), gid, info->glyph_cnt);
+		    }
 		}
 	    }
 	} else if ( format==2 ) {


### PR DESCRIPTION
Avoid calling malloc or memcpy with 0, sanity check a `gid` read against the glyph count.  

Closes #3209 
Closes #3208 
Closes #3008