### PR TITLE
Add glyph-level genericGlyphChange (same as UI "Change Glyph ...")

### DIFF
--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -1565,7 +1565,7 @@ return;
 	AlignPointPair( stem,stem->keypts[1],stem->keypts[3],hscale,vscale );
 }
 
-static void ChangeGlyph( SplineChar *sc_sc, SplineChar *orig_sc, int layer, struct genericchange *genchange ) {
+void ChangeGlyph( SplineChar *sc_sc, SplineChar *orig_sc, int layer, struct genericchange *genchange ) {
     real scale[6];
     DBounds orig_b, new_b;
     int i, dcnt = 0, removeoverlap = true;

--- a/fontforge/scstyles.h
+++ b/fontforge/scstyles.h
@@ -17,6 +17,8 @@ extern SplineSet *SSControlStems(SplineSet *ss, double stemwidthscale, double st
 extern void ChangeXHeight(FontViewBase *fv, CharViewBase *cv, struct xheightinfo *xi);
 extern void CI_Init(struct counterinfo *ci, SplineFont *sf);
 extern void CVEmbolden(CharViewBase *cv, enum embolden_type type, struct lcg_zones *zones);
+extern void ChangeGlyph(SplineChar *sc_sc, SplineChar *orig_sc, int layer,
+                        struct genericchange *genchange);
 extern void CVGenericChange(CharViewBase *cv, struct genericchange *genchange);
 extern void FVAddSmallCaps(FontViewBase *fv, struct genericchange *genchange);
 extern void FVCondenseExtend(FontViewBase *fv, struct counterinfo *ci);


### PR DESCRIPTION
The oft-requested (but already possible) "Change Glyph" Python API, but on the glyph object to avoid having to use the selection interface. Uses the same parameter parsing logic as the old command, moved to a separate function

The main annoyance with the API compared with the UI is the lack of a default `vMap`. The dialog VMap is based on the BlueValues (when those are present). However, the `font.private` object has these available in a tuple, so if that's what the user wants they're not too hard to build. 

Closes #2925 
