### PR TITLE
Add second pass to the tangent solver for sloppier calculations

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -739,7 +739,7 @@ static NibOffset *_CalcNibOffset(NibCorner *nc, int n, BasePoint ut,
 	                        nc[ncni].utv[NC_IN_IDX], false) );
 	// Nib splines are locally convex and therefore have t value per slope
 	ns = nc[nci].on_nib->next;
-	no->nt = SplineSolveForUTanVec(ns, ut, 0.0);
+	no->nt = SplineSolveForUTanVec(ns, ut, 0.0, false);
 	if ( no->nt<0 ) {
 	    // At more extreme nib control point angles the solver may fail.
 	    // In such cases the tangent angle should be near one of the 
@@ -1303,7 +1303,7 @@ static bigreal SplineStrokeNextT(StrokeContext *c, Spline *s, bigreal cur_t,
 
     next_ut = SplineStrokeNextAngle(c, *cur_ut, is_ccw, &next_curved,
                                     reverse, nci_hint);
-    next_t = SplineSolveForUTanVec(s, next_ut, cur_t);
+    next_t = SplineSolveForUTanVec(s, next_ut, cur_t, false);
 
     // If there is an inflection point before next_t the spline will start
     // curving in the opposite direction, so stop and trace the next section

--- a/fontforge/utanvec.h
+++ b/fontforge/utanvec.h
@@ -114,7 +114,8 @@ extern int UTanVecsSequent(BasePoint ut1, BasePoint ut2, BasePoint ut3,
                            int ccw);
 extern int JointBendsCW(BasePoint ut_ref, BasePoint ut_vec);
 extern BasePoint SplineUTanVecAt(Spline *s, bigreal t);
-extern bigreal SplineSolveForUTanVec(Spline *spl, BasePoint ut, bigreal min_t);
+extern bigreal SplineSolveForUTanVec(Spline *spl, BasePoint ut, bigreal min_t,
+                                     bool picky);
 extern void UTanVecTests();
 
 #endif // FONTFORGE_UTANVEC_H


### PR DESCRIPTION
The very tight (10<sup>-8</sup>) epsilon on slope testing, where you recalculate the slope at the t given by the extrema solver to see if it matches, worked fine through lots of testing. However, when looking at the arcs join branch @ctrlcctrlv found some weird-acting cases (with TT's capital S) that I eventually traced to this margin. 

It appears that the quadratic calculation gets sloppier when the 1D-Spline value `a` gets close to zero because `a` is in the denominator. The code has provisions to set `a` to zero and perform an alternate calculation but doesn't do this at the problematic values and it's not clear that it should -- the t value it calculates for the extrema is still pretty accurate. 

Rather than add a big value sorting production number to the function I just added an optional second pass with a 10<sup>-5</sup> epsilon.

To see a context where it makes a difference stroke the fragment in this font at 30/30/0/bevel/bevel: 
[badexternal.sfd.txt](https://github.com/fontforge/fontforge/files/4162587/badexternal.sfd.txt)
