### PR TITLE
Fix for #716 start MetricsView cursor in text entry box

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5372,6 +5372,7 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
     MVSetFeatures(mv);
     MVMakeLabels(mv);
     MVResize(mv);
+    GWidgetIndicateFocusGadget(mv->text);
 
     GDrawSetVisible(mv->v,true);
     GDrawSetVisible(gw,true);


### PR DESCRIPTION
This already "works" for a different reason when starting with selected chars, but doesn't when starting with an empty window. 

Closes #716