### PR TITLE
Reuse stroke arc code for SVG elliptical arcs (#2967)

### DIFF
--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -2923,6 +2923,7 @@ return( head );
     for ( layer=ly_fore; layer<sc->layer_cnt; ++layer ) {
 	if ( sc->layers[layer].dostroke ) {
 	    InitializeStrokeInfo(&si);
+	    si.extrema = false;
 	    SITranslatePSArgs(&si, sc->layers[layer].stroke_pen.linejoin,
 	                      sc->layers[layer].stroke_pen.linecap);
 	    si.width = sc->layers[layer].stroke_pen.width;
@@ -3135,6 +3136,7 @@ SplinePointList *SplinesFromEntityChar(EntityChar *ec,int *flags,int is_stroked)
 		/*  ignore the stroke. This idiom is used by MetaPost sometimes and means */
 		/*  no stroke */
 		InitializeStrokeInfo(&si);
+		si.extrema = false;
 		SITranslatePSArgs(&si, ent->u.splines.join, ent->u.splines.cap);
 		si.width = ent->u.splines.stroke_width;
 		if ( ent->u.splines.stroke_width==WIDTH_INHERITED )

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -1012,9 +1012,9 @@ static SplinePoint *AddNibPortion(NibCorner *nc, SplinePoint *tailp,
     return sp;
 }
 
-static void SSAppendArc(SplineSet *cur, bigreal major, bigreal minor, 
-                        BasePoint ang, BasePoint ut_fm, BasePoint ut_to,
-                        int bk, int limit) {
+void SSAppendArc(SplineSet *cur, bigreal major, bigreal minor, 
+                 BasePoint ang, BasePoint ut_fm, BasePoint ut_to,
+                 int bk, int limit) {
     SplineSet *ellip;
     real trans[6];
     SplinePoint *sp;
@@ -1058,7 +1058,7 @@ static void SSAppendArc(SplineSet *cur, bigreal major, bigreal minor,
     free(nc);
 }
 
-static void SplineStrokeSimpleFixup(SplinePoint *tailp, BasePoint p) {
+void SplineStrokeSimpleFixup(SplinePoint *tailp, BasePoint p) {
     BasePoint dxy = BPSub(p, tailp->me);
     tailp->prevcp = BPAdd(tailp->prevcp, dxy);
     tailp->me = p;

--- a/fontforge/splinestroke.h
+++ b/fontforge/splinestroke.h
@@ -25,6 +25,7 @@ extern int ConvexNibID(char *tok);
 extern int StrokeSetConvex(SplineSet *ss, int toknum);
 extern SplineSet *StrokeGetConvex(int toknum, int cpy);
 extern enum ShapeType NibIsValid(SplineSet *);
+extern void SplineStrokeSimpleFixup(SplinePoint *tailp, BasePoint p);
 extern const char *NibShapeTypeMsg(enum ShapeType st);
 extern SplinePoint *AppendCubicSplinePortion(Spline *s, bigreal t_start,
                                              bigreal t_end, SplinePoint *start);
@@ -32,6 +33,9 @@ extern SplinePoint *AppendCubicSplineSetPortion(Spline *s, bigreal t_start,
                                                 Spline *s_end, bigreal t_end,
                                                 SplinePoint *dst_start,
                                                 int backward);
+extern void SSAppendArc(SplineSet *cur, bigreal major, bigreal minor, 
+                        BasePoint ang, BasePoint ut_fm, BasePoint ut_to,
+                        int bk, int limit);
 extern SplineSet *SplineSetStroke(SplineSet *ss, StrokeInfo *si, int order2);
 extern SplineSet *UnitShape(int n);
 extern void FVStrokeItScript(void *_fv, StrokeInfo *si, int pointless_argument);


### PR DESCRIPTION
This PR replaces the spline-specific calculations for SVG elliptical arcs with the related function in the Expand Stroke code. It more or less guarantees that the overlapping portions of two arcs of the same ellipse will not significantly deviate because they will be sliced and copied from the same contour. 

I also removed the Add Extrema pass to the PS entity processing because (believe it or not) the extrema code is still too buggy for non-optional use.  

There are some caveats with this change:

1. You might wind up with two points quite close together, one of which would be removed by simplify. If the path containing the arc is stroked such points aren't likely to affect the output. If it is part of a closed contour it will remain unless post-processed by the user. Even so, this seems preferable to the problem of #2967 
2. Very eccentric ellipses may have less accurate (but still "matching", arc-wise) portions. This is due to the fact that the ellipse points are chosen by transforming a unit circle. However, if this is ever reported as a problem all of the ellipse code in Expand Stroke and now SVG can be made arbitrarily accurate by adding a parameter to produce a unit circle with more points.

Here are some SVGs for testing: 
[altarc.zip](https://github.com/fontforge/fontforge/files/4169208/altarc.zip). `arcs02.svg` is just a version of https://doc.4d.com/4Dv17/4D/17/SVG-PATH-ARC.301-3932329.de.html . `arc.svg` is from #2967. And `arcs.svg` is a version of a figure from https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#Arcs . By fooling with the second `A` path segment in `arc3.svg` you can verify that the start and end points of the ellipse (parameterized by tangent vector in `SSAppendArc()` are calculated correctly. (Or not, which would mean I have more to do.) 

Closes #2967 
