### PR TITLE
Make it possible to ask user for multiple choices (Python)

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -838,7 +838,7 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
     <TR>
       <TD><CODE>askChoices</CODE></TD>
       <TD><CODE>(title,question,answers,<BR>
-	[default,multiple])</CODE></TD>
+	[default=,multiple=])</CODE></TD>
       <TD>Similar to the above allows you to ask the user a multiple choice question.
 	It popups up a dialog posing the question with a scrollable list of choices
 	-- one for each answer.
@@ -857,6 +857,9 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	<P>
 	The function returns the index in the answer array of the answer choosen
 	by the user. If the user cancels the dialog, a -1 is returned.
+	<P>
+	<CODE>default</CODE> and <CODE>multiple</CODE> may be passed by position if
+	desired.
 	<P>
 	Throws an exception if there is no user interface.</TD>
     </TR>

--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -850,9 +850,10 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	presses the [Return] key). If omitted the default answer will be the first.
 	<P>
 	The fifth argument means that multiple options can be selected. If true,
-	the fourth argument should be a tuple of boolean values. So, if there are
-	three options, it should look like <CODE>(True, False, True)</CODE>, which
-	would select the first and last option.
+	the fourth argument should be a tuple of boolean values or a single integer
+	index into the answer tuple. So, if there are three options, it should look
+	like <CODE>(True, False, True)</CODE>, which would select the first and
+	last option.
 	<P>
 	The function returns the index in the answer array of the answer choosen
 	by the user. If the user cancels the dialog, a -1 is returned.

--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -836,9 +836,9 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	Throws an exception if there is no user interface.</TD>
     </TR>
     <TR>
-      <TD><CODE>askChoice</CODE>s</TD>
+      <TD><CODE>askChoices</CODE></TD>
       <TD><CODE>(title,question,answers,<BR>
-	[def])</CODE></TD>
+	[default,multiple])</CODE></TD>
       <TD>Similar to the above allows you to ask the user a multiple choice question.
 	It popups up a dialog posing the question with a scrollable list of choices
 	-- one for each answer.
@@ -848,6 +848,11 @@ fontforge.registerImportExport(importGlyph,exportGlyph,None,"foosball","foo","fo
 	the fourth and fifth arguments are option, the fourth is the index in the
 	answer array that will be the default answer (the one invoked if the user
 	presses the [Return] key). If omitted the default answer will be the first.
+	<P>
+	The fifth argument means that multiple options can be selected. If true,
+	the fourth argument should be a tuple of boolean values. So, if there are
+	three options, it should look like <CODE>(True, False, True)</CODE>, which
+	would select the first and last option.
 	<P>
 	The function returns the index in the answer array of the answer choosen
 	by the user. If the user cancels the dialog, a -1 is returned.

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1788,9 +1788,19 @@ static PyObject *PyFF_askChoices(PyObject *UNUSED(self), PyObject *args, PyObjec
                 PyMem_Free(title); PyMem_Free(quest); PyMem_Free(sel);
                 return( NULL );
             }
+            bool def_set = false;
             for (int i = 0; i < cnt; i++) {
                 PyObject* temp = PyTuple_GetItem(defo, i);
                 sel[i] = PyObject_IsTrue(temp);
+                if (!multiple && PyObject_IsTrue(temp)) {
+                    if (def_set) {
+                        PyErr_Format(PyExc_ValueError, "`multiple` False, only expected 1 True in `default`" );
+                        PyMem_Free(title); PyMem_Free(quest); PyMem_Free(sel);
+                        return( NULL );
+                    }
+                    def = i;
+                    def_set = true;
+                }
             }
         } else {
             PyErr_Format(PyExc_TypeError, "4th argument must be a tuple or integer" );

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1735,50 +1735,100 @@ return( Py_BuildValue("i",ret));
 }
 
 static PyObject *PyFF_askChoices(PyObject *UNUSED(self), PyObject *args) {
-    char *title=NULL,*quest=NULL, **answers;
-    int def=0, cnt;
-    PyObject *answero;
-    int i, ret;
+    char *title=NULL, *quest=NULL;
+    char **answers; // receives answers written into `answero`
+    PyObject* defo = NULL; // default answer index, or tuple of len cnt
+    int def = 0; // default index, only used if not multianswer
+    int cnt; // number of answers
+    PyObject *multipleo; // expected to be boolean
+    bool multiple = false;
+    PyObject *answero; // expected to be tuple
+    int ret;
 
     if ( no_windowing_ui ) {
-	PyErr_Format(PyExc_EnvironmentError, "No user interface");
-return( NULL );
+        PyErr_Format(PyExc_EnvironmentError, "No user interface");
+        return( NULL );
     }
 
-    if ( !PyArg_ParseTuple(args,"esesO|i","UTF-8", &title, "UTF-8", &quest, &answero, &def) )
-return( NULL );
+    if ( !PyArg_ParseTuple(args,"ssO|OO", &title, &quest, &answero, &defo, &multipleo) )
+        return( NULL );
+
+    multiple = multipleo == Py_True;
+
     if ( !PySequence_Check(answero) || STRING_CHECK(answero)) {
-	PyErr_Format(PyExc_TypeError, "Expected a tuple of strings for the third argument");
-	PyMem_Free(title);
-	PyMem_Free(quest);
-return( NULL );
+        PyErr_Format(PyExc_TypeError, "Expected a tuple of strings for the third argument");
+        PyMem_Free(title);
+        PyMem_Free(quest);
+        return( NULL );
     }
+
     cnt = PySequence_Size(answero);
-    answers = calloc(cnt+1, sizeof(char *));
-    if ( def<0 || def>=cnt ) {
-	PyErr_Format(PyExc_ValueError, "Value out of bounds for 4th argument");
-	PyMem_Free(title);
-	PyMem_Free(quest);
-return( NULL );
+    char* sel = calloc(cnt, sizeof(char));
+
+    if (defo != NULL && defo != Py_None)
+    if (multiple) {
+        if ( !PyTuple_Check(defo) ) {
+            PyErr_Format(PyExc_TypeError, "4th argument must be a tuple" );
+            PyMem_Free(title); PyMem_Free(quest); free(sel);
+            return( NULL );
+        }
+        int dcnt = PySequence_Size(defo);
+        if (dcnt != cnt) {
+            PyErr_Format(PyExc_ValueError, "Expected tuple/list of %d items, got %d items", cnt, dcnt );
+            PyMem_Free(title); PyMem_Free(quest); free(sel);
+            return( NULL );
+        }
+        for (int i = 0; i < cnt; i++) {
+            PyObject* temp = PyTuple_GetItem(defo, i);
+            sel[i] = temp == Py_True ? (char)1 : (char)0;
+        }
+    } else {
+        if (!PyInt_Check(defo) && !PyLong_Check(defo)) {
+            PyErr_Format(PyExc_TypeError, "Expected an integer for 4th argument");
+            PyMem_Free(title); PyMem_Free(quest); free(sel);
+            return( NULL );
+        }
+        def = (int)PyLong_AsLong(defo);
+        if ( def<0 || def>=cnt ) {
+            PyErr_Format(PyExc_ValueError, "Value out of bounds for 4th argument");
+            PyMem_Free(title); PyMem_Free(quest); free(sel);
+            return( NULL );
+        }
     }
-    for ( i=0; i<cnt; ++i ) {
+
+    answers = calloc(cnt+1, sizeof(char *));
+    for ( int i=0; i<cnt; ++i ) {
         PyObject *utf8_name = PYBYTES_UTF8(PySequence_GetItem(answero,i));
         if ( utf8_name==NULL ) {
-	    PyMem_Free(title);
-	    PyMem_Free(quest);
-	    FreeStringArray( i, answers );
-return( NULL );
-	}
+            PyMem_Free(title); PyMem_Free(quest); free(sel);
+            FreeStringArray( i, answers );
+            return( NULL );
+        }
         answers[i] = copy(PyBytes_AsString(utf8_name));
         Py_DECREF(utf8_name);
     }
     answers[cnt] = NULL;
 
-    ret = ff_choose(title,(const char **) answers,cnt,def,quest);
-    PyMem_Free(title);
-    PyMem_Free(quest);
+    PyObject* reto;
+    if (multiple) {
+        char* buts2[2] = {_("OK"), _("Cancel")};
+        reto = PyTuple_New(cnt);
+        ret = ff_choose_multiple(title,(const char **) answers,sel,cnt,buts2,quest);
+        for (int i = 0; i < cnt; i++) {
+            char o = sel[i];
+            PyTuple_SetItem(reto, i, o == 1 ? Py_True : Py_False);
+            Py_INCREF(o == 1 ? Py_True : Py_False); // prevents crash on finalize
+        }
+    } else {
+        ret = ff_choose(title,(const char **) answers,cnt,def,quest);
+    }
+
+    PyMem_Free(title); PyMem_Free(quest); free(sel);
     FreeStringArray( cnt, answers );
-return( Py_BuildValue("i",ret));
+    if (multiple) {
+        return ( reto );
+    }
+    return( Py_BuildValue("i",ret));
 }
 
 static PyObject *PyFF_askString(PyObject *UNUSED(self), PyObject *args) {

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1790,7 +1790,7 @@ static PyObject *PyFF_askChoices(PyObject *UNUSED(self), PyObject *args, PyObjec
             }
             for (int i = 0; i < cnt; i++) {
                 PyObject* temp = PyTuple_GetItem(defo, i);
-                sel[i] = temp == Py_True ? (char)1 : (char)0;
+                sel[i] = PyObject_IsTrue(temp);
             }
         } else {
             PyErr_Format(PyExc_TypeError, "4th argument must be a tuple or integer" );


### PR DESCRIPTION
Multiple of which can be selected.

This is needed for #703, which I'm implementing as a Python script.

This is the first of two new needed APIs. The second will add a new
function that works on `fontforge.glyph` objects, similar to `build`,
but will instead take a combining class type and place an anchor.

For easier testing, the script below may be used:

```python3
import fontforge

AnchorLocations = (
    ["Above", 0x100],
    ["Below", 0x200],
    ["Overstrike", 0x400],
    ["Left", 0x800],
    ["Right", 0x1000],
    ["Joins2", 0x2000],
    ["Center-left", 0x4000],
    ["Center-right", 0x8000],
    ["Centered outside", 0x10000],
    ["Outside", 0x20000],
    ["Left edge", 0x80000],
    ["Right edge", 0x40000],
    ["Touching", 0x100000]
)


def guess_anchors(data, font):
    al_strings = tuple([x[0] for x in AnchorLocations])
    print(al_strings)
    r=fontforge.askChoices("Anchor types", "What anchor type?", al_strings)
                         #tuple([True for i in range(len(al_strings))]), True)
    print(r)
    print(data, font)


pr = {}

fontforge.registerMenuItem(guess_anchors, None, pr, "Font", None,
                           "Guess Appropriate Anchors")
```

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **New feature**
