### PR TITLE
Make open font dialog a toplevel window

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -1108,11 +1108,6 @@ extern void GCDFillMacFeat(GGadgetCreateData *mfgcd,GTextInfo *mflabels, int wid
 	GGadgetCreateData **array);
 extern void Prefs_ReplaceMacFeatures(GGadget *list);
 
-extern unichar_t *FVOpenFont(char *title, const char *defaultfile, bool mult, bool modal);
-
-
-
-
 extern void ShowAboutScreen(void);
 extern void DelayEvent(void (*func)(void *), void *data);
 

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -721,7 +721,7 @@ extern int _FVMenuSave(FontView *fv);
 extern int _FVMenuSaveAs(FontView *fv);
 extern int _FVMenuGenerate(FontView *fv,int family);
 extern void _FVCloseWindows(FontView *fv);
-extern char *GetPostScriptFontName(char *defdir,int mult);
+extern char *GetPostScriptFontName(char *dir, bool mult, bool modal);
 extern void MergeKernInfo(SplineFont *sf,EncMap *map);
 extern int SFGenerateFont(SplineFont *sf,int layer, int family,EncMap *map);
 
@@ -1108,7 +1108,7 @@ extern void GCDFillMacFeat(GGadgetCreateData *mfgcd,GTextInfo *mflabels, int wid
 	GGadgetCreateData **array);
 extern void Prefs_ReplaceMacFeatures(GGadget *list);
 
-extern unichar_t *FVOpenFont(char *title, const char *defaultfile, int mult);
+extern unichar_t *FVOpenFont(char *title, const char *defaultfile, bool mult, bool modal);
 
 
 

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -1016,19 +1016,6 @@ void MenuExit(GWindow UNUSED(base), struct gmenuitem *UNUSED(mi), GEvent *e) {
 	DelayEvent(_MenuExit,NULL);
 }
 
-char *GetPostScriptFontName(char *dir, bool mult, bool modal) {
-    unichar_t *ret;
-    char *u_dir;
-    char *temp;
-
-    u_dir = def2utf8_copy(dir);
-    ret = FVOpenFont(_("Open Font"), u_dir, mult, modal);
-    temp = u2def_copy(ret);
-
-    free(ret);
-return( temp );
-}
-
 void MergeKernInfo(SplineFont *sf,EncMap *map) {
 #ifndef __Mac
     static char wild[] = "*.{afm,tfm,ofm,pfm,bin,hqx,dfont,feature,feat,fea}";

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -1016,13 +1016,13 @@ void MenuExit(GWindow UNUSED(base), struct gmenuitem *UNUSED(mi), GEvent *e) {
 	DelayEvent(_MenuExit,NULL);
 }
 
-char *GetPostScriptFontName(char *dir, int mult) {
+char *GetPostScriptFontName(char *dir, bool mult, bool modal) {
     unichar_t *ret;
     char *u_dir;
     char *temp;
 
     u_dir = def2utf8_copy(dir);
-    ret = FVOpenFont(_("Open Font"), u_dir,mult);
+    ret = FVOpenFont(_("Open Font"), u_dir, mult, modal);
     temp = u2def_copy(ret);
 
     free(ret);
@@ -1083,7 +1083,7 @@ void _FVMenuOpen(FontView *fv) {
             OpenDir = DefaultDir;
         }
         
-        temp = GetPostScriptFontName(OpenDir,true);
+        temp = GetPostScriptFontName(OpenDir,true,fv != NULL);
         if ( temp==NULL )
             return;
 
@@ -3726,7 +3726,7 @@ static void FVMenuInsertFont(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *U
     if ( cidmaster==NULL || cidmaster->subfontcnt>=255 )	/* Open type allows 1 byte to specify the fdselect */
 return;
 
-    filename = GetPostScriptFontName(NULL,false);
+    filename = GetPostScriptFontName(NULL,false,true);
     if ( filename==NULL )
 return;
     new = LoadSplineFont(filename,0);

--- a/fontforgeexe/fvfontsdlg.c
+++ b/fontforgeexe/fvfontsdlg.c
@@ -36,7 +36,7 @@
 #include "utype.h"
 
 static void MergeAskFilename(FontView *fv,int preserveCrossFontKerning) {
-    char *filename = GetPostScriptFontName(NULL,true);
+    char *filename = GetPostScriptFontName(NULL,true,true);
     SplineFont *sf;
     char *eod, *fpt, *file, *full;
 
@@ -276,7 +276,7 @@ void FVMergeFonts(FontView *fv) {
 /******************************************************************************/
 
 static void InterAskFilename(FontView *fv, real amount) {
-    char *filename = GetPostScriptFontName(NULL,false);
+    char *filename = GetPostScriptFontName(NULL,false,true);
     SplineFont *sf;
 
     if ( filename==NULL )

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -2375,7 +2375,7 @@ static int MMW_CheckBrowse(GGadget *g, GEvent *e) {
 	unichar_t *ut;
 
 	if ( ti!=NULL && ti->userdata == (void *) -1 ) {
-	    temp = GetPostScriptFontName(NULL,false);
+	    temp = GetPostScriptFontName(NULL,false,true);
 	    if ( temp==NULL )
 return(true);
 	    sf = LoadSplineFont(temp,0);

--- a/fontforgeexe/openfontdlg.c
+++ b/fontforgeexe/openfontdlg.c
@@ -612,7 +612,7 @@ return( GGadgetDispatchEvent((GGadget *) (d->gfc),event));
 return( event->type!=et_char );
 }
 
-unichar_t *FVOpenFont(char *title, const char *defaultfile, bool mult, bool modal) {
+static unichar_t *FVOpenFont(char *title, const char *defaultfile, bool mult, bool modal) {
     GRect pos;
     int i, filter, renamei;
     GWindow gw;
@@ -833,3 +833,17 @@ unichar_t *FVOpenFont(char *title, const char *defaultfile, bool mult, bool moda
     free(nlnames);
 return(d.ret);
 }
+
+char *GetPostScriptFontName(char *dir, bool mult, bool modal) {
+    unichar_t *ret;
+    char *u_dir;
+    char *temp;
+
+    u_dir = def2utf8_copy(dir);
+    ret = FVOpenFont(_("Open Font"), u_dir, mult, modal);
+    temp = u2def_copy(ret);
+
+    free(ret);
+return( temp );
+}
+

--- a/fontforgeexe/openfontdlg.c
+++ b/fontforgeexe/openfontdlg.c
@@ -612,7 +612,7 @@ return( GGadgetDispatchEvent((GGadget *) (d->gfc),event));
 return( event->type!=et_char );
 }
 
-unichar_t *FVOpenFont(char *title, const char *defaultfile, int mult) {
+unichar_t *FVOpenFont(char *title, const char *defaultfile, bool mult, bool modal) {
     GRect pos;
     int i, filter, renamei;
     GWindow gw;
@@ -630,13 +630,18 @@ unichar_t *FVOpenFont(char *title, const char *defaultfile, int mult) {
     memset(&d,'\0',sizeof(d));
 
     memset(&wattrs,0,sizeof(wattrs));
-    wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_undercursor|wam_isdlg|wam_restrict;
+    if (modal) {
+        wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle|wam_undercursor|wam_isdlg|wam_restrict;
+        wattrs.restrict_input_to_me = 1;
+        wattrs.is_dlg = true;
+        wattrs.undercursor = 1;
+    } else {
+        wattrs.mask = wam_events|wam_cursor|wam_utf8_wtitle;
+    }
     wattrs.event_masks = ~(1<<et_charup);
-    wattrs.restrict_input_to_me = 1;
-    wattrs.is_dlg = true;
-    wattrs.undercursor = 1;
     wattrs.cursor = ct_pointer;
     wattrs.utf8_window_title = title;
+
     pos.x = pos.y = 0;
 
     totwid = GGadgetScale(295);

--- a/fontforgeexe/showatt.c
+++ b/fontforgeexe/showatt.c
@@ -2995,7 +2995,7 @@ static void FontCmpDlg(FontView *fv1, FontView *fv2,int flags) {
 }
 
 static void FCAskFilename(FontView *fv,int flags) {
-    char *filename = GetPostScriptFontName(NULL,false);
+    char *filename = GetPostScriptFontName(NULL,false,true);
     FontView *otherfv;
 
     if ( filename==NULL )

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1381,7 +1381,7 @@ exit( 0 );
 			    buffer[strlen(buffer)+1]='\0';
 			    buffer[strlen(buffer)] = '/';
 			}
-			fname = GetPostScriptFontName(buffer,false);
+			fname = GetPostScriptFontName(buffer,false,false);
 			if ( fname!=NULL )
 			    ViewPostScriptFont(fname,openflags);
 			any = 1;	/* Even if we didn't get a font, don't bring up dlg again */


### PR DESCRIPTION
If the splash screen window is worthy of this, surely the open font
dialog is. This closes #4145.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
