### PR TITLE
Avert askString() crash when default answer provided (Python)

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1854,7 +1854,7 @@ return( NULL );
     ret = ff_ask_string(title,def,quest);
     PyMem_Free(title);
     PyMem_Free(quest);
-    free(def);
+    PyMem_Free(def);
     if ( ret==NULL )
 Py_RETURN_NONE;
     reto = Py_BuildValue("s",ret);


### PR DESCRIPTION
This closes #4155.

This is another blocker on #703. 

It's hard to believe this bug lasted so long. Clearly script authors aren't reporting things upstream to us, and are just hacking around the problems they find. No wonder so many third party scripts are using Tkinter, etc, causing a packaging nightmare for us.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**