### PR TITLE
If converting UTF-8⇔UTF-8, use existing functions

### DIFF
--- a/Unicode/ucharmap.c
+++ b/Unicode/ucharmap.c
@@ -151,42 +151,9 @@ return( encoding2u_strncpy(uto,_from,n,e_iso8859_1));
 	    ++ufrom;
 	    --n;
 	}
-    } else if ( cs==e_utf8 ) {
-	while ( *from && n>0 ) {
-	    if ( *from<=127 )
-		*upt = *from++;
-	    else if ( *from<=0xdf ) {
-		if ( from[1]>=0x80 ) {
-		    *upt = ((*from&0x1f)<<6) | (from[1]&0x3f);
-		    from += 2;
-		} else {
-		    ++from;	/* Badly formed utf */
-		    *upt = 0xfffd;
-		}
-	    } else if ( *from<=0xef ) {
-		if ( from[1]>=0x80 && from[2]>=0x80 ) {
-		    *upt = ((*from&0xf)<<12) | ((from[1]&0x3f)<<6) | (from[2]&0x3f);
-		    from += 3;
-		} else {
-		    ++from;	/* Badly formed utf */
-		    *upt = 0xfffd;
-		}
-	    } else if ( n>2 ) {
-		if ( from[1]>=0x80 && from[2]>=0x80 && from[3]>=0x80 ) {
-		    int w = ( ((*from&0x7)<<2) | ((from[1]&0x30)>>4) )-1;
-		    *upt++ = 0xd800 | (w<<6) | ((from[1]&0xf)<<2) | ((from[2]&0x30)>>4);
-		    *upt   = 0xdc00 | ((from[2]&0xf)<<6) | (from[3]&0x3f);
-		    from += 4;
-		} else {
-		    ++from;	/* Badly formed utf */
-		    *upt = 0xfffd;
-		}
-	    } else {
-		/* no space for surrogate */
-		from += 4;
-	    }
-	    ++upt;
-	}
+    } else if ( cs==e_utf8 && n > 0 ) {
+        utf82u_strncpy(uto, _from, n+1);
+        return uto;
     } else {
 	if ( !bad_enc_warn ) {
 	    bad_enc_warn = true;
@@ -343,38 +310,7 @@ return( u2encoding_strncpy(to,ufrom,n,e_iso8859_1));
 	if ( n>1 )
 	    *uto = '\0';
     } else if ( cs==e_utf8 ) {
-	while ( *ufrom ) {
-	    if ( *ufrom<0x80 ) {
-		if ( n<=1 )
-	break;
-		*pt++ = *ufrom;
-		--n;
-	    } else if ( *ufrom<0x800 ) {
-		if ( n<=2 )
-	break;
-		*pt++ = 0xc0 | (*ufrom>>6);
-		*pt++ = 0x80 | (*ufrom&0x3f);
-		n -= 2;
-	    } else if ( *ufrom>=0xd800 && *ufrom<0xdc00 && ufrom[1]>=0xdc00 && ufrom[1]<0xe000 ) {
-		int u = ((*ufrom>>6)&0xf)+1, y = ((*ufrom&3)<<4) | ((ufrom[1]>>6)&0xf);
-		if ( n<=4 )
-	    break;
-		*pt++ = 0xf0 | (u>>2);
-		*pt++ = 0x80 | ((u&3)<<4) | ((*ufrom>>2)&0xf);
-		*pt++ = 0x80 | y;
-		*pt++ = 0x80 | (ufrom[1]&0x3f);
-		n -= 4;
-	    } else {
-		if ( n<=3 )
-	    break;
-		*pt++ = 0xe0 | (*ufrom>>12);
-		*pt++ = 0x80 | ((*ufrom>>6)&0x3f);
-		*pt++ = 0x80 | (*ufrom&0x3f);
-	    }
-	    ++ufrom;
-	}
-	if ( n>1 )
-	    *pt = '\0';
+	u2utf8_strcpy(to, ufrom);
     } else {
 	if ( !bad_enc_warn ) {
 	    bad_enc_warn = true;

--- a/Unicode/ucharmap.c
+++ b/Unicode/ucharmap.c
@@ -310,7 +310,7 @@ return( u2encoding_strncpy(to,ufrom,n,e_iso8859_1));
 	if ( n>1 )
 	    *uto = '\0';
     } else if ( cs==e_utf8 ) {
-	u2utf8_strcpy(to, ufrom);
+	u2utf8_strncpy(to, ufrom, n);
     } else {
 	if ( !bad_enc_warn ) {
 	    bad_enc_warn = true;

--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -32,6 +32,7 @@
 #include "ustring.h"
 #include "utype.h"
 
+#include <assert.h>
 #include <stddef.h>
 
 long uc_strcmp(const unichar_t *str1,const char *str2) {
@@ -562,18 +563,25 @@ void utf82u_strcat(unichar_t *to,const char *from) {
     utf82u_strcpy(to+u_strlen(to),from);
 }
 
-char *u2utf8_strcpy(char *utf8buf,const unichar_t *ubuf) {
+char *u2utf8_strncpy(char *utf8buf,const unichar_t *ubuf,int len) {
 /* Copy unichar string 'ubuf' into utf8 buffer string 'utf8buf' */
     char *pt = utf8buf;
 
+    assert(utf8buf != NULL);
+
     if ( ubuf!=NULL ) {
-	while ( *ubuf && (pt=utf8_idpb(pt,*ubuf++,0)) );
-	if ( pt ) {
-	    *pt = '\0';
-	    return( utf8buf );
-	}
+        while ( *ubuf && (--len != 0) ) {
+            pt=utf8_idpb(pt,*ubuf++,0);
+        }
+        *pt = '\0';
+        return( utf8buf );
     }
+
     return( NULL );
+}
+
+char *u2utf8_strcpy(char *utf8buf,const unichar_t *ubuf) {
+    return u2utf8_strncpy(utf8buf, ubuf, -1);
 }
 
 char *utf8_strchr(const char *str, int search) {

--- a/inc/ustring.h
+++ b/inc/ustring.h
@@ -149,6 +149,7 @@ extern void       utf82u_strcat(unichar_t *ubuf,const char *utf8buf);
 extern unichar_t *utf82u_copyn(const char *utf8buf,int len);
 extern unichar_t *utf82u_copy(const char *utf8buf);
 extern char *u2utf8_strcpy(char *utf8buf,const unichar_t *ubuf);
+extern char *u2utf8_strncpy(char *utf8buf,const unichar_t *ubuf,int len);
 extern char *u2utf8_copy(const unichar_t *ubuf);
 extern char *u2utf8_copyn(const unichar_t *ubuf,int len);
 extern unichar_t *encoding2u_strncpy(unichar_t *uto, const char *from, int n, enum encoding cs);


### PR DESCRIPTION
The versions at these points were non-standard conforming, and encoded characters as surrogate pairs if possible, even though surrogate pairs are explicitly forbidden in UTF-8.

https://unicodebook.readthedocs.io/issues.html#non-strict-utf-8-decoder-overlong-byte-sequences-and-surrogates

(It took me more than three hours to come up with this solution, as I had to check basically all the code that could possibly corrupt this, and I wasted the first hour thinking that the filenames _themselves_ had the problem.)

This closes #4159, which contains a test case. But in short, the easiest way to test this now that I know the problem is to just make a file named an emoji and observe the crash.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**