### PR TITLE
Allow flags tuple to be None in font.addLookup (Python)

### DIFF
--- a/doc/html/python.html
+++ b/doc/html/python.html
@@ -4201,8 +4201,8 @@ This type may not be pickled.
 	    kern_statemachine
 	</UL>
 	<P>
-	The flags argument is a tuple of strings. At most one of these strings may
-	be the name of a mark class. The others are:
+	The flags argument is a tuple of strings, or <CODE>None</CODE>. At most one
+	of these strings may be the name of a mark class. The others are:
 	<UL>
 	  <LI>
 	    right_to_left

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -15710,7 +15710,7 @@ static PyObject *PyFFFont_addLookup(PyFF_Font *self, PyObject *args) {
     OTLookup *otl, *after = NULL;
     int itype;
     char *lookup_str, *type, *after_str=NULL;
-    PyObject *flagtuple, *featlist;
+    PyObject *flagtuple=NULL, *featlist;
     int flags;
     FeatureScriptLangList *fl;
 
@@ -15737,6 +15737,9 @@ return( NULL );
     if ( itype==FLAG_UNKNOWN )
 return( NULL );
 
+    if (flagtuple == Py_None || flagtuple == NULL)
+    flags = 0;
+    else
     flags = ParseLookupFlags(sf,flagtuple);
     if ( flags==-1 )
 return( NULL );


### PR DESCRIPTION
Not much to say, just looks a lot better than an empty tuple, and is easier to remember. If it's not required it should be allowed to be `None`, API-wide.

Required for #703.