### PR TITLE
Prevent another UBSan false positive

### DIFF
--- a/fontforge/mem.c
+++ b/fontforge/mem.c
@@ -79,16 +79,21 @@ int get3byte(FILE *ttf) {
 }
 
 int32 getlong(FILE *ttf) {
-	int ch1 = getc(ttf);
-	int ch2 = getc(ttf);
-	int ch3 = getc(ttf);
-	int ch4 = getc(ttf);
+	unsigned int ch1 = getc(ttf);
+	unsigned int ch2 = getc(ttf);
+	unsigned int ch3 = getc(ttf);
+	unsigned int ch4 = getc(ttf);
 
 	if (ch4==EOF)
 		return EOF;
 
 	return (ch1<<24)|(ch2<<16)|(ch3<<8)|ch4;
 }
+
+uint32 getuint32(FILE *ttf) {
+    return (uint32)getlong(ttf);
+}
+
 
 real getfixed(FILE *ttf) {
 	int32 val = getlong(ttf);

--- a/fontforge/mem.h
+++ b/fontforge/mem.h
@@ -48,6 +48,7 @@ extern void memputshort(uint8 *data, int offset, uint16 val);
 extern int getushort(FILE *ttf);
 extern int get3byte(FILE *ttf);
 extern int32 getlong(FILE *ttf);
+extern uint32 getuint32(FILE *ttf);
 extern real getfixed(FILE *ttf);
 extern real get2dot14(FILE *ttf);
 

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -499,7 +499,7 @@ char *TTFGetFontName(FILE *ttf,int32 offset,int32 off2) {
         return( NULL );
     for ( i=0; i<num; ++i ) {
         tag = getlong(ttf);
-        /* checksum = */ getlong(ttf);
+        /* checksum = */ getuint32(ttf);
         nameoffset = off2+getlong(ttf);
         namelength = getlong(ttf);
         if ( feof(ttf) )
@@ -782,7 +782,7 @@ return;
 
     for ( i=0; i<info->numtables; ++i ) {
 	tabs[i].tag = getlong(ttf);
-	tabs[i].checksum = getlong(ttf);
+	tabs[i].checksum = getuint32(ttf);
 	tabs[i].offset = getlong(ttf);
 	tabs[i].length = getlong(ttf);
 	if ( i!=0 && tabs[i].tag<tabs[i-1].tag && !info->bad_sfnt_header ) {
@@ -1045,7 +1045,7 @@ return( 0 );			/* Not version 1 of true type, nor Open Type */
 
     for ( i=0; i<info->numtables; ++i ) {
 	tag = getlong(ttf);
-	/* checksum */ getlong(ttf);
+	/* checksum */ getuint32(ttf);
 	offset = getlong(ttf);
 	length = getlong(ttf);
         if ( offset+length > info->ttfFileSize ) {

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -546,16 +546,6 @@ static int uniranges[][3] = {
     { 0x100000, 0x10fffd, 90 },	/* Supplementary Private Use Area-B */
 };
 
-static int32 getuint32(FILE *ttf) {
-    int ch1 = getc(ttf);
-    int ch2 = getc(ttf);
-    int ch3 = getc(ttf);
-    int ch4 = getc(ttf);
-    if ( ch4==EOF )
-return( EOF );
-return( (ch1<<24)|(ch2<<16)|(ch3<<8)|ch4 );
-}
-
 static int short_too_long_warned = 0;
 
 void putshort(FILE *file,int sval) {


### PR DESCRIPTION
When parsing a TTF, this would appear:

../fontforge/mem.c:90:24: runtime error: left shift of 211 by 24 places cannot be represented in type 'int'

It's a false positive, not really a bug. I removed an unneeded function in the process of this, so it removes lines overall.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
