### PR TITLE
Write out note as normal text element rather than dictionary

### DIFF
--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -923,7 +923,8 @@ xmlNodePtr _GlifToXML(const SplineChar *sc, int layer, int version) {
 			    // "<anchor x=\"%g\" y=\"%g\" name=\"%s%s\"/>" ap->me.x ap->me.y ap->anchor->name
 			}
 	}
-    if (sc->comment) PListAddString(topglyphxml, "note", sc->comment);
+    if (sc->comment)
+	xmlNewChild(topglyphxml, NULL, BAD_CAST "note", BAD_CAST sc->comment);
     if ( sc->layers[layer].refs!=NULL || sc->layers[layer].splines!=NULL ) {
       xmlNodePtr outlinexml = xmlNewChild(topglyphxml, NULL, BAD_CAST "outline", NULL);
 	// "<outline>"


### PR DESCRIPTION
The code to read a UFO 3 "note" element into the SplineChar comment field seems to be correct. The old code to write it out was using a key/value pair format rather than a simple text element. It appears that the glif `note` field is the latter. 

Closes #3964 