### PR TITLE
Delegate GGDK key events to GWindow directly containing element with focus

### DIFF
--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -95,6 +95,13 @@ return( NULL );
 return( td->gfocus );
 }
 
+GWindow GWindowGetFocusWindowOfWindow(GWindow gw) {
+    GGadget *gg = GWindowGetFocusGadgetOfWindow(gw);
+    if ( gg!=NULL && gg->base!=NULL )
+	return gg->base;
+    return gw;
+}
+
 int GGadgetActiveGadgetEditCmd(GWindow gw,enum editor_commands cmd) {
     GGadget *g = GWindowGetFocusGadgetOfWindow(gw);
 

--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -89,10 +89,12 @@ return;
 GGadget *GWindowGetFocusGadgetOfWindow(GWindow gw) {
     GTopLevelD *td;
     if ( gw==NULL )
-return( NULL );
+	return NULL;
     while ( gw->parent!=NULL && !gw->is_toplevel ) gw=gw->parent;
     td = (GTopLevelD *) (gw->widget_data);
-return( td->gfocus );
+    if ( td==NULL )
+	return NULL;
+    return( td->gfocus );
 }
 
 // Return the innermost GWindow of whatever gadget has focus

--- a/gdraw/gcontainer.c
+++ b/gdraw/gcontainer.c
@@ -95,6 +95,8 @@ return( NULL );
 return( td->gfocus );
 }
 
+// Return the innermost GWindow of whatever gadget has focus
+// in gw, with gw itself as the fallback
 GWindow GWindowGetFocusWindowOfWindow(GWindow gw) {
     GGadget *gg = GWindowGetFocusGadgetOfWindow(gw);
     if ( gg!=NULL && gg->base!=NULL )

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -901,7 +901,7 @@ static void _GGDKDraw_DispatchEvent(GdkEvent *event, gpointer data) {
             GdkEventKey *key = (GdkEventKey *)event;
             gevent.type = event->type == GDK_KEY_PRESS ? et_char : et_charup;
             gevent.u.chr.state = _GGDKDraw_GdkModifierToKsm(((GdkEventKey *)event)->state);
-	    gevent.w = GWindowGetFocusWindowOfWindow(gevent.w);
+	    gevent.w = GWindowGetFocusWindowOfWindow((GWindow)gw);
 	    gw = (GGDKWindow)gevent.w;
 
 #ifdef GDK_WINDOWING_QUARTZ

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -901,6 +901,8 @@ static void _GGDKDraw_DispatchEvent(GdkEvent *event, gpointer data) {
             GdkEventKey *key = (GdkEventKey *)event;
             gevent.type = event->type == GDK_KEY_PRESS ? et_char : et_charup;
             gevent.u.chr.state = _GGDKDraw_GdkModifierToKsm(((GdkEventKey *)event)->state);
+	    gevent.w = GWindowGetFocusWindowOfWindow(gevent.w);
+	    gw = (GGDKWindow)gevent.w;
 
 #ifdef GDK_WINDOWING_QUARTZ
             // On Mac, the Alt/Option key is used for alternate input.

--- a/inc/gdraw.h
+++ b/inc/gdraw.h
@@ -470,6 +470,7 @@ extern void GDrawSkipMouseMoveEvents(GWindow w,GEvent *last);
 extern void GDrawEventLoop(GDisplay *disp);
 extern void GDrawPostEvent(GEvent *e);
 extern void GDrawPostDragEvent(GWindow gw,GEvent *e,enum event_type);
+extern GWindow GWindowGetFocusWindowOfWindow(GWindow gw);
 
 extern GTimer *GDrawRequestTimer(GWindow w,int32 time_from_now,int32 frequency,
 	void *userdata);


### PR DESCRIPTION
The code in this PR fixes #4044 and so far doesn't cause any problems based on some straightforward testing. As I understand it our `GDKWindow`s are more coarse-grained than the corresponding X `Windows` because the latter can correspond to "containers". This results in key events coming in for the top-level window and being dispatched to the wrong handler. (GTK sorts out the corresponding problem above the GDK level.)

The idea here is to figure out what gadget has focus and then retarget the key events to its `GWindow` to (ultimately) get the right handler. 

I'm not sure this is the right solution but it seems likely this problem will drag on absent a PR, so I'm filing this to generate discussion and, with luck, an acceptable fix. 

Closes #4044 