### PR TITLE
More SEGV protection for extreme splineoverlap cases

### DIFF
--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -313,7 +313,7 @@ static int SSRmNullSplines(SplineSet *spl) {
 		/*  and itself where the spline covers no area (the two cps */
 		/*  point in the same direction) */
 		BpSame(&s->from->me,&s->to->me)) {
-	    if ( next==s )
+	    if ( next==s || next==NULL )
 return( true );
 	    if ( next->from->selected ) s->from->selected = true;
 	    s->from->next = next;
@@ -375,14 +375,18 @@ return( start );
 	    if ( head==NULL ) head = last;
 	}
     }
-    head->prev = last;
-    last->next = head;
-    if ( start==NULL )
-	start = head;
-    else
-	(*end)->linked = head;
-    *end = last;
-    Validate(start, NULL);
+    if ( head!=NULL ) {
+	if ( last!=NULL ) {
+	    head->prev = last;
+	    last->next = head;
+	}
+	if ( start==NULL )
+	    start = head;
+	else
+	    (*end)->linked = head;
+	*end = last;
+	Validate(start, NULL);
+    }
 return( start );
 }
 


### PR DESCRIPTION
The last bits of #2832 . Note that you'll need to test with a release build or by commenting out the `NibIsValid` assertion. 

The test file is extreme in that it uses a stroke width of 0.067. Neither the Expand Stroke facility nor many other subsystems are designed to work well at such small fractions of an em-unit. So the goal in this case is not so much to produce good output as to avoid crashing. (I did try magnifying the file by 10x in Inkscape and reimporting and it looks OK. 30x would probably have worked better.)  

Closes #2832 