### PR TITLE
Keep GContainerD in sync with GTopLevelD

### DIFF
--- a/gdraw/gwidgetP.h
+++ b/gdraw/gwidgetP.h
@@ -68,6 +68,8 @@ typedef struct gwidgetcontainerdata /* : GWidgetD */{
     unsigned int ispalette: 1;			/* only for top level widgets */
     unsigned int positioned_yet: 1;		/* only for top level palettes*/
     unsigned int isdocked: 1;			/* only for top level palettes*/
+    unsigned int isnestedkey: 1;		/* is this a nested key event*/
+    unsigned int programmove: 10;
     /* ******************* */
     struct ggadget *gadgets;
     struct gwidgetdata *widgets;		/* children */


### PR DESCRIPTION
On review of GTopLevelD, it's meant to inherit from GContainerD, so this aligns the definition of the latter to match the former.

Note this wasn't actually breaking anything, as the different fields were falling into the struct padding between the fields (4/8 byte alignment for 32/64 bits). 

### Type of change
- **Bug fix**
- **Non-breaking change**
