### PR TITLE
Only adjust subdict fontmatrix for synthetic font dicts (fixes #4192)

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3351,8 +3351,13 @@ return( NULL );
 	}
 	dicts[i] = readcfftopdict(ttf,fontnames!=NULL?fontnames[i]:NULL,
 		offsets[i+1]-offsets[i], info);
-	if ( parent_dict!=NULL && parent_dict->fontmatrix_set ) {
-	    MatMultiply(parent_dict->fontmatrix,dicts[i]->fontmatrix,dicts[i]->fontmatrix);
+	if (    parent_dict!=NULL
+	     && parent_dict->fontmatrix_set
+	     && dicts[i]->synthetic_base!=-1 ) {
+	    if ( dicts[i]->fontmatrix_set )
+		MatMultiply(parent_dict->fontmatrix,dicts[i]->fontmatrix,dicts[i]->fontmatrix);
+	    else
+		memcpy(dicts[i]->fontmatrix,parent_dict->fontmatrix,6*sizeof(real));
 	}
 	dicts[i]->cff_start = cff_start;
     }


### PR DESCRIPTION
See #4192 

Closes #4192 