### PR TITLE
Font Open flag improvements

### DIFF
--- a/doc/sphinx/scripting/python/fontforge.rst
+++ b/doc/sphinx/scripting/python/fontforge.rst
@@ -444,10 +444,23 @@ Module functions
 
 .. function:: open(filename[, flags])
 
-   Opens a filename and returns the font it contains (if any). If the flags
-   argument is 4, then ff will load all glyphs in the 'glyf' table of a ttc file
-   (rather than just the glyphs used in the font picked). This will not load all
-   'glyf' tables though.
+   Opens a filename and returns the font it contains (if any). The optional ``flags`` argument can be string tuple or integer combination of the following flags:
+
+   .. object:: fstypepermitted (1)
+
+      The user has the appropriate license to examine the font no matter what the fstype setting is.
+
+   .. object:: allglyphsinttc (4)
+
+      Load all glyphs from the 'glyf' table of a ttc font (rather than only the glyphs used in the font picked).
+
+   .. object:: fontlint (8)
+
+      Report more error conditions
+
+   .. object:: alltables (32)
+
+      Retain all recognized font tables that do not have a native format
 
 .. function:: parseTTInstrs(string)
 

--- a/doc/sphinx/scripting/scripting-alpha.rst
+++ b/doc/sphinx/scripting/scripting-alpha.rst
@@ -1813,6 +1813,8 @@ the fourth argument you must specify the second and third arguments too.
      what the fstype setting is.
    * 4 => load all glyphs from the 'glyf' table of a ttc font (rather than only
      the glyphs used in the font picked).
+   * 8 => Report more error conditions
+   * 32 => Retain all recognized font tables that do not have a native format
 
 .. function:: Ord(string[,pos])
 

--- a/fontforge/autosave.c
+++ b/fontforge/autosave.c
@@ -111,7 +111,7 @@ return( false );
 	if ( (sf = SFRecoverFile(buffer,inquire,&inquire_state)) ) {
 	    any=true;
 	    if ( sf->fv==NULL )		/* Doesn't work, cli arguments not parsed yet */
-		FontViewCreate(sf,false);
+		FontViewCreate(sf);
 	    fprintf( stderr, " Done\n" );
 	}
     }

--- a/fontforge/fontviewbase.c
+++ b/fontforge/fontviewbase.c
@@ -1350,7 +1350,7 @@ FontViewBase *ViewPostScriptFont(const char *filename,int openflags) {
 return( NULL );
     if ( sf->fv==NULL && force_names_when_opening!=NULL )
 	SFRenameGlyphsToNamelist(sf,force_names_when_opening );
-return( FontViewCreate(sf,openflags&of_hidewindow));	/* Always make a new view now */
+return( FontViewCreate(sf));	/* Always make a new view now */
 }
 
 static int tester(SplineChar *sc, struct lookup_subtable *sub) {
@@ -1947,7 +1947,7 @@ static FontViewBase *_FontViewBaseCreate(SplineFont *sf) {
 return( fv );
 }
 
-static FontViewBase *FontViewBase_Create(SplineFont *sf,int UNUSED(hide)) {
+static FontViewBase *FontViewBase_Create(SplineFont *sf) {
     FontViewBase *fv = _FontViewBaseCreate(sf);
 return( fv );
 }

--- a/fontforge/mm.c
+++ b/fontforge/mm.c
@@ -794,7 +794,7 @@ FontViewBase *MMCreateBlendedFont(MMSet *mm,FontViewBase *fv,real blends[MmMax],
 	new->weight = _MMGuessWeight(mm,axispos,new->weight);
 	new->private = BlendPrivate(PSDictCopy(hold->private),mm);
 	new->fv = NULL;
-	fv = FontViewCreate(new,false);
+	fv = FontViewCreate(new);
 	MMReblend(fv,mm);
 	new->mm = NULL;
 	mm->normal = hold;

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -1914,7 +1914,7 @@ static void bOpen(Context *c) {
 	if ( sf->fv!=NULL )
 	    /* All done */;
 	else if ( !no_windowing_ui )
-	    FontViewCreate(sf,openflags&of_hidewindow);
+	    FontViewCreate(sf);
 	else
 	    FVAppend(_FontViewCreate(sf));
 	c->curfv = sf->fv;
@@ -1942,7 +1942,7 @@ static void bSelectBitmap(Context *c) {
 
 static void bNew(Context *c) {
     if ( !no_windowing_ui )
-	c->curfv = FontViewCreate(SplineFontNew(),false);
+	c->curfv = FontViewCreate(SplineFontNew());
     else
 	c->curfv = FVAppend(_FontViewCreate(SplineFontNew()));
 }

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2047,8 +2047,8 @@ enum ttf_flags {
     ttf_flag_nomacnames        = 1 << 30  // Don't autogenerate mac name entries
 };
 enum ttc_flags { ttc_flag_trymerge=0x1, ttc_flag_cff=0x2 };
-enum openflags { of_fstypepermitted=1, of_askcmap=2, of_all_glyphs_in_ttc=4,
-	of_fontlint=8, of_hidewindow=0x10, of_all_tables=0x20 };
+enum openflags { of_fstypepermitted=1, /*of_askcmap=2,*/ of_all_glyphs_in_ttc=4,
+	of_fontlint=8, /*of_hidewindow=0x10,*/ of_all_tables=0x20 };
 enum ps_flags { ps_flag_nohintsubs = 0x10000, ps_flag_noflex=0x20000,
 		    ps_flag_nohints = 0x40000, ps_flag_restrict256=0x80000,
 		    ps_flag_afm = 0x100000, ps_flag_pfm = 0x200000,

--- a/fontforge/uiinterface.h
+++ b/fontforge/uiinterface.h
@@ -368,7 +368,7 @@ struct bdffont;
 
 struct fv_interface {
    /* Create a new font view. Whatever that may entail */
-    struct fontviewbase *(*create_view)(struct splinefont *,int hide);
+    struct fontviewbase *(*create_view)(struct splinefont *);
 
    /* Create a new font view but without attaching it to a window */
     struct fontviewbase *(*_create_view)(struct splinefont *);

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -7123,7 +7123,7 @@ static void FVCreateInnards(FontView *fv,GRect *pos) {
     FVChangeDisplayFont(fv,bdf);
 }
 
-static FontView *FontView_Create(SplineFont *sf, int hide) {
+static FontView *FontView_Create(SplineFont *sf) {
     FontView *fv = (FontView *) __FontViewCreate(sf);
     GRect pos;
     GWindow gw;
@@ -7191,10 +7191,8 @@ static FontView *FontView_Create(SplineFont *sf, int hide) {
     pos.x = 0; pos.y = fv->mbh+fv->infoh;
     FVCreateInnards(fv,&pos);
 
-    if ( !hide ) {
-	GDrawSetVisible(gw,true);
-	FontViewOpenKids(fv);
-    }
+    GDrawSetVisible(gw,true);
+    FontViewOpenKids(fv);
 return( fv );
 }
 
@@ -7212,7 +7210,7 @@ return( fv );
 }
 
 FontView *FontNew(void) {
-return( FontView_Create(SplineFontNew(),false));
+return( FontView_Create(SplineFontNew()));
 }
 
 static void FontView_Free(FontView *fv) {
@@ -7327,7 +7325,7 @@ static void FontView_Close(FontView *fv) {
 
 
 struct fv_interface gdraw_fv_interface = {
-    (FontViewBase *(*)(SplineFont *, int)) FontView_Create,
+    (FontViewBase *(*)(SplineFont *)) FontView_Create,
     (FontViewBase *(*)(SplineFont *)) __FontViewCreate,
     (void (*)(FontViewBase *)) FontView_Close,
     (void (*)(FontViewBase *)) FontView_Free,

--- a/fontforgeexe/fvfontsdlg.c
+++ b/fontforgeexe/fvfontsdlg.c
@@ -287,7 +287,7 @@ return;
     free(filename);
     if ( sf==NULL )
 return;
-    FontViewCreate(InterpolateFont(fv->b.sf,sf,amount,fv->b.map->enc),false);
+    FontViewCreate(InterpolateFont(fv->b.sf,sf,amount,fv->b.map->enc));
 }
 
 #define CID_Amount	1000
@@ -316,7 +316,7 @@ return( true );
 	if ( fv==NULL )
 	    InterAskFilename(d->fv,last_amount/100.0);
 	else
-	    FontViewCreate(InterpolateFont(d->fv->b.sf,fv->b.sf,last_amount/100.0,d->fv->b.map->enc),false);
+	    FontViewCreate(InterpolateFont(d->fv->b.sf,fv->b.sf,last_amount/100.0,d->fv->b.map->enc));
 	d->done = true;
     }
 return( true );

--- a/fontforgeexe/mmdlg.c
+++ b/fontforgeexe/mmdlg.c
@@ -345,7 +345,7 @@ static void MakeAppleBlend(FontView *fv,MMSet *mm,real *blends,real *normalized)
     sf->changed = true;
     EncMapFree(sf->map);
     sf->map = EncMapFromEncoding(sf,fv->b.map->enc);
-    FontViewCreate(sf,false);
+    FontViewCreate(sf);
 }
 
 struct mmcb {
@@ -1978,7 +1978,7 @@ continue;
     }
 
     if ( fv==NULL )
-	fv = (FontView *) FontViewCreate(setto->normal,false);
+	fv = (FontView *) FontViewCreate(setto->normal);
     if ( enc==NULL )
 	enc = default_encoding;
     FVReencode((FontViewBase *) fv,enc);


### PR DESCRIPTION
Document more Open flags
Add string tuple interface to python FontOpen API
Eliminate undocumented start-hidden flag

`of_hidewindow` was indeed undocumented, but more relevantly it doesn't currently work. Using the flag from `Execute Script...` in the UI results in an entry at the bottom of the Window menu that has no effect. 

Closes #4212 