### PR TITLE
ggdkdraw.c: use the undocumented gdk_win32_selection_add_targets to fix copying on windows

### DIFF
--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -40,6 +40,10 @@
 #include <assert.h>
 #include <math.h>
 
+#ifdef GDK_WINDOWING_WIN32
+#  include <gdk/gdkwin32.h>
+#endif
+
 // Forward declarations
 static void GGDKDrawCancelTimer(GTimer *timer);
 static void GGDKDrawDestroyWindow(GWindow w);
@@ -126,6 +130,10 @@ static bool _GGDKDraw_TransmitSelection(GGDKDisplay *gdisp, GdkEventSelection *e
             targets[i++] = ((GGDKSelectionData *)ptr->data)->type_atom;
             ptr = ptr->next;
         }
+
+#ifdef GDK_WINDOWING_WIN32
+        gdk_win32_selection_add_targets(e->window, e->selection, i, targets);
+#endif
 
         gdk_property_change(requestor, e->property, gdk_atom_intern_static_string("ATOM"),
                             32, GDK_PROP_MODE_REPLACE, (const guchar *)targets, i);

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -40,8 +40,11 @@
 #include <assert.h>
 #include <math.h>
 
+// HACK HACK HACK
 #ifdef GDK_WINDOWING_WIN32
+#  define GDK_COMPILATION
 #  include <gdk/gdkwin32.h>
+#  undef GDK_COMPILATION
 #endif
 
 // Forward declarations
@@ -132,6 +135,7 @@ static bool _GGDKDraw_TransmitSelection(GGDKDisplay *gdisp, GdkEventSelection *e
         }
 
 #ifdef GDK_WINDOWING_WIN32
+        gdk_win32_selection_clear_targets(gdk_window_get_display(e->window), e->selection);
         gdk_win32_selection_add_targets(e->window, e->selection, i, targets);
 #endif
 


### PR DESCRIPTION
See also:
https://gitlab.gnome.org/GNOME/gtk/-/issues/2523


### Type of change
- **Bug fix**

Fixes #4228