### PR TITLE
Avoid integer size conflict when setting stylemap

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -8104,7 +8104,9 @@ bool SFD_GetFontMetaData( FILE *sfd,
     }
     else if ( strmatch(tok,"StyleMap:")==0 )
     {
-    gethex(sfd,(uint32 *)&sf->pfminfo.stylemap);
+	uint32 u;
+	gethex(sfd,&u);
+	sf->pfminfo.stylemap = u;
     }
     /* Legacy attribute for StyleMap. Deprecated. */
     else if ( strmatch(tok,"OS2StyleName:")==0 )


### PR DESCRIPTION
stylemap is a 16-bit integer, but gethex writes 32-bits.

Bug: https://bugs.gentoo.org/642756

### Type of change
- **Bug fix**

Possibly obsoletes #4244.