### PR TITLE
Stub-out MacServiceReadFDs() on non-Mac platforms

### DIFF
--- a/gdraw/gdraw.c
+++ b/gdraw/gdraw.c
@@ -32,7 +32,7 @@
 #include "gkeysym.h"
 #include "ustring.h"
 
-#if __Mac || __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __DragonFly__
+#if __Mac
 #  include <sys/select.h>
 #endif
 
@@ -1076,7 +1076,7 @@ GDrawRemoveReadFD( GDisplay *gdisp,
 
 void MacServiceReadFDs()
 {
-#if (!defined(__MINGW32__))&&(!defined(__CYGWIN__))
+#if __Mac
     int ret = 0;
     
     GDisplay *gdisp = GDrawGetDisplayOfWindow(0);


### PR DESCRIPTION
This should fix a build failure on Linux with musl libc due to the
missing sys/select.h include.

MacServiceReadFDs seems to only be called in startui.c, also behind the
__Mac macro.

Bug: https://bugs.gentoo.org/706792

### Type of change
- **Bug fix**