### PR TITLE
Call gdk_set_allowed_backends before gdk_init

### DIFF
--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1182,8 +1182,8 @@ int fontforge_main( int argc, char **argv ) {
 #endif
     }
 #ifdef FONTFORGE_CAN_USE_GDK
-    gdk_init(&argc, &argv);
     gdk_set_allowed_backends("win32,quartz,x11");
+    gdk_init(&argc, &argv);
 #endif
     ensureDotFontForgeIsSetup();
 #if defined(__MINGW32__) && !defined(_NO_LIBCAIRO)


### PR DESCRIPTION
Fixes #4247

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

@pnemade can you please confirm if this fixes it for you?
