### PR TITLE
Turn on UseNewIndicScripts by default

### DIFF
--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -44,7 +44,7 @@
 #include "utype.h"
 
 int coverageformatsallowed=3;
-int use_second_indic_scripts = false;
+int use_second_indic_scripts = true;
 
 #include "ttf.h"
 


### PR DESCRIPTION
The new Indic shapers have been around since at least 2006 and are well supported by now. They should be used by default.

### Type of change
- **Non-breaking change**