### PR TITLE
Do not document nonexistent -library-status option

### DIFF
--- a/doc/sphinx/techref/cliargs.rst
+++ b/doc/sphinx/techref/cliargs.rst
@@ -117,12 +117,6 @@ FontForge recognizes the following options:
    Opens the last sfd file closed. If used more than once will open the last
    several sfd files.
 
-.. option:: -library-status
-
-   Writes info about the status of optional libraries to stderr. Including:
-   Whether the library exists on this system, whether ff can use it, and an URL
-   from which the library can be found.
-
 .. option:: -new
 
    Creates a new font.

--- a/fontforgeexe/fontforge.1
+++ b/fontforgeexe/fontforge.1
@@ -15,7 +15,6 @@ fontforge \- create, modify, and view font files
 [\fB\-display\fP\ \fIstr\fP]
 [\fB\-lang\fP=ff]
 [\fB\-lang\fP=py]
-[\fB\-library-status\fP]
 [\fB\-help\fP]
 [\fB\-keyboard\fP\ \fIktype\fP]
 [\fB\-new\fP]
@@ -132,9 +131,6 @@ using the \fBBROWSER\fP environment variable.
 .TP
 .B \-version
 Prints the version of fontforge and exits.
-.TP
-.B \-library-status
-Prints information about optional libraries and exits.
 .TP
 \fB\-lang\fP=py
 Use Python for scripts (may precede \fB\-script\fP).

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -149,7 +149,6 @@ static void _dousage(void) {
     printf( "\t-help\t\t\t (displays this message, and exits)\n" );
     printf( "\t-docs\t\t\t (displays this message, invokes a browser)\n\t\t\t\t (Using the BROWSER environment variable)\n" );
     printf( "\t-version\t\t (prints the version of fontforge and exits)\n" );
-    printf( "\t-library-status\t (prints information about optional libraries\n\t\t\t\t and exits)\n" );
 #ifndef _NO_PYTHON
     printf( "\t-lang=py\t\t use python for scripts (may precede -script)\n" );
 #endif


### PR DESCRIPTION
The `-library-status` option was removed in 23147e533ab666c9430ba7739f1d71f800995fa1 but the documentation was never updated.

### Type of change
- **Bug fix**