### PR TITLE
Scripting: new options for glyph export

### DIFF
--- a/doc/sphinx/scripting/scripting-alpha.rst
+++ b/doc/sphinx/scripting/scripting-alpha.rst
@@ -871,6 +871,8 @@ the fourth argument you must specify the second and third arguments too.
    flags:
 
    * 1 => Flip the y-axis of exported SVGs with a transform element (instead of rewriting values)
+   * 2 => Disable fill property for path
+   * 4 => Disable viewBox adjustment (useful for icons font)
    * 256 => Use current Export dialog settings (other flags are ignored)
    * 512 => Present Export options dialog (if UI is enabled)
 

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -2499,6 +2499,8 @@ static void bExport(Context *c) {
     if ( c->a.argc==4 ) {
 	flags = c->a.vals[3].u.ival;
 	ep.use_transform = !!(flags & 1);
+	ep.no_fillcolor = !!(flags & 2);
+	ep.no_padding = !!(flags & 4);
     }
     if ( flags&256 || flags&512 ) {
 	epp = ExportParamsState();

--- a/fontforge/sd.h
+++ b/fontforge/sd.h
@@ -198,7 +198,9 @@ typedef struct exportparams {
     int initialized;
     int shown_mask, show_always;
 
-    int use_transform;		// SVG
+    int use_transform;      // SVG
+    int no_fillcolor;       // SVG
+    int no_padding;		    // SVG
 } ExportParams;
 
 extern void InitImportParams(ImportParams *ip);

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1055,11 +1055,13 @@ return( ret );
 
 int _ExportSVG(FILE *svg,SplineChar *sc,int layer,ExportParams *ep) {
     char *end;
-    int em_size, xstart, xend, ascent;
+    int em_size, xstart, xend, ascent, padding;
     real trans[6] = { 1.0, 0.0, 0.0, 1.0, 0.0, 0.0 };
     DBounds b;
     SplineChar *scc;
     SplineSet *orig;
+
+    padding = ep->no_padding ? 0 : SVGMINLRPAD;
 
     SplineCharLayerFindBounds(sc,layer,&b);
     if ( sc->parent!=NULL ) {
@@ -1079,15 +1081,15 @@ int _ExportSVG(FILE *svg,SplineChar *sc,int layer,ExportParams *ep) {
     fprintf(svg, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" >\n" );
     // Adjust horizontal ViewBox to display entire glyph
     xstart = floor(b.minx);
-    if (xstart > SVGMINLRPAD)
+    if (xstart > padding)
 	xstart = 0; // Start from origin when sufficiently past it
     else
-	xstart -= SVGMINLRPAD; // Give glyphs starting near or before the origin some extra space
+	xstart -= padding; // Give glyphs starting near or before the origin some extra space
     xend = ceil(b.maxx);
-    if (xend < ceil(sc->width) - SVGMINLRPAD)
+    if (xend < ceil(sc->width) - padding)
 	xend = ceil(sc->width); // End at the advance width when sufficiently short of it
     else
-	xend += SVGMINLRPAD; // Give glyphs ending near or past the advance width some extra space
+	xend += padding; // Give glyphs ending near or past the advance width some extra space
     fprintf(svg, "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" viewBox=\"%d 0 %d %d\">\n",
 	    xstart, xend - xstart, (int) ceil(em_size));
     if ( ep->use_transform ) {
@@ -1117,7 +1119,10 @@ int _ExportSVG(FILE *svg,SplineChar *sc,int layer,ExportParams *ep) {
 	fprintf(svg, "   <g ");
 	end = "   </g>\n";
     } else {
-	fprintf(svg, "   <path fill=\"currentColor\"\n");
+	fprintf(svg, "   <path "); 
+    if ( !ep->no_fillcolor ) {
+    	fprintf(svg, "fill=\"currentColor\"\n");
+    }
 	end = "   </path>\n";
     }
     svg_scpathdump(svg,scc,end,layer);


### PR DESCRIPTION
Exporting SVG glyph contain some hard-coded stuff like fill property (sometimes it not needed) and viewBox adjustments (it changes glyph visual dimensions, which is bad thing for icons font)

Extended scripting function Export() with two extra flags only applicable for svg-export:
```
2 => Disable fill property for path
4 => Disable viewBox adjustment (useful for icons font)
```

### Type of change
- **New feature**
