### PR TITLE
Extra format for exported filename

### DIFF
--- a/doc/sphinx/scripting/scripting-alpha.rst
+++ b/doc/sphinx/scripting/scripting-alpha.rst
@@ -853,6 +853,8 @@ the fourth argument you must specify the second and third arguments too.
 
    * ``%n`` -- inserts the glyph name (or the first 40 characters of it for long
      names)
+   * ``%N`` -- inserts the ligature name if present in glyph, 
+     or the glyph name if not (or the first 40 characters)
    * ``%f`` -- inserts the font name (or the first 40 characters)
    * ``%e`` -- inserts the glyph's encoding as a decimal integer
    * ``%u`` -- inserts the glyph's unicode code point in lower case hex

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -691,7 +691,7 @@ return( ret );
 static void MakeExportName(char *buffer, int blen,char *format_spec,
 	SplineChar *sc, EncMap *map) {
     char *end = buffer+blen-3;
-    char *pt, *bend;
+    char *pt, *bend, *ligature;
     char unicode[8];
     int ch;
 
@@ -705,7 +705,7 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 	    if ( ch=='n' || ch=='N' ) {
             pt=sc->name;
             if (ch=='N') {
-                char *ligature = GetLigature(sc);
+                ligature = GetLigature(sc);
                 if (ligature != NULL) {
                     pt = ligature;
                 }
@@ -722,6 +722,9 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 		for ( ; *pt!='\0' && buffer<bend; )
 		    *buffer++ = *pt++;
 #endif
+        if (ligature != NULL) {
+            free(ligature);
+        }
 	    } else if ( ch=='f' ) {
 		for ( pt=sc->parent->fontname; *pt!='\0' && buffer<bend; )
 		    *buffer++ = *pt++;

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -733,10 +733,10 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 		for ( pt=unicode; *pt!='\0' && buffer<bend; )
 		    *buffer++ = *pt++;
 	    } else if ( ch=='e' ) {
-        sprintf( unicode,"%d", (int) map->backmap[sc->orig_pos] );
-        for ( pt=unicode; *pt!='\0' && buffer<bend; )
-            *buffer++ = *pt++;
-        } else
+		sprintf( unicode,"%d", (int) map->backmap[sc->orig_pos] );
+		for ( pt=unicode; *pt!='\0' && buffer<bend; )
+		    *buffer++ = *pt++;
+	    } else
 		*buffer++ = ch;
 	}
     }

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -702,17 +702,24 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 	    ++format_spec;
 	    ch = *format_spec++;
 	    if ((bend = buffer+40)>end ) bend = end;
-	    if ( ch=='n' ) {
+	    if ( ch=='n' || ch=='N' ) {
+            pt=sc->name
+            if (ch=='N') {
+                char *ligature = GetLigature(sc);
+                if (ligature != NULL) {
+                    pt = ligature;
+                }
+            }
 #if defined( __CygWin ) || defined(__Mac)
 		/* Windows file systems are not case conscious */
 		/*  nor is the default mac filesystem */
-		for ( pt=sc->name; *pt!='\0' && buffer<bend; ) {
+		for ( ; *pt!='\0' && buffer<bend; ) {
 		    if ( isupper( *pt ))
 			*buffer++ = '$';
 		    *buffer++ = *pt++;
 		}
 #else
-		for ( pt=sc->name; *pt!='\0' && buffer<bend; )
+		for ( ; *pt!='\0' && buffer<bend; )
 		    *buffer++ = *pt++;
 #endif
 	    } else if ( ch=='f' ) {
@@ -726,10 +733,10 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 		for ( pt=unicode; *pt!='\0' && buffer<bend; )
 		    *buffer++ = *pt++;
 	    } else if ( ch=='e' ) {
-		sprintf( unicode,"%d", (int) map->backmap[sc->orig_pos] );
-		for ( pt=unicode; *pt!='\0' && buffer<bend; )
-		    *buffer++ = *pt++;
-	    } else
+        sprintf( unicode,"%d", (int) map->backmap[sc->orig_pos] );
+        for ( pt=unicode; *pt!='\0' && buffer<bend; )
+            *buffer++ = *pt++;
+        } else
 		*buffer++ = ch;
 	}
     }

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -703,7 +703,7 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 	    ch = *format_spec++;
 	    if ((bend = buffer+40)>end ) bend = end;
 	    if ( ch=='n' || ch=='N' ) {
-            pt=sc->name
+            pt=sc->name;
             if (ch=='N') {
                 char *ligature = GetLigature(sc);
                 if (ligature != NULL) {

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -770,18 +770,29 @@ return( SFGetChar(sc->parent,-1,pst->u.subs.variant));
 return( NULL );
 }
 
+#define LIGATURE_MAXLEN 150
+
 char *GetLigature(SplineChar *sc) {
     PST *best = HasLigature(sc);
     if ( best != NULL ) {
     	int32 univals[50];
-        char *buf = "";
-        int i, c;
+        char buf[LIGATURE_MAXLEN] = "";
+        char buf2[15];
+        int i, c, r, n = 0;
+
 		c = LigCnt(sc->parent,best,univals,sizeof(univals)/sizeof(univals[0]));
 		for ( i=0; i<c; ++i ) {
-		    if ( (univals[i]>='A' && univals[i]<='Z') ||  (univals[i]>='a' && univals[i]<='z') || (univals[i] >= '0' && univals[i] <= '9') || univals[i] == '_' || univals[i] == '-')
-		    	asprintf(&buf,"%s%c", buf, univals[i]);
-		    else
-		    	asprintf(&buf, "%s&#x%x;", buf, (unsigned int) univals[i]);
+		    if ( (univals[i]>='A' && univals[i]<='Z') || (univals[i]>='a' && univals[i]<='z') || (univals[i] >= '0' && univals[i] <= '9') || univals[i] == '_' || univals[i] == '-') {
+		    	r = sprintf(buf2, "%c", univals[i]);
+		    } else {
+		    	r = sprintf(buf2, "&#x%x;", (unsigned int) univals[i]);
+		    }
+		    n = LIGATURE_MAXLEN - strlen(buf) - 1;
+		    if (r > 0 && n >= r) {
+		        strncat(buf, buf2, n);
+		    } else {
+		        break;
+		    }
 		}
         return (  copy(buf)  );
     }

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -766,7 +766,6 @@ SplineChar *SCHasSubs(SplineChar *sc, uint32 tag) {
 	if ( pst->type==pst_substitution &&
 		FeatureTagInFeatureScriptList(tag,pst->subtable->lookup->features) )
 return( SFGetChar(sc->parent,-1,pst->u.subs.variant));
-
     }
 return( NULL );
 }
@@ -805,36 +804,35 @@ static void svg_scdump(FILE *file, SplineChar *sc,int defwid, int encuni, int vs
     if ( ligature!=NULL ) {
 	    fprintf(file,"unicode=\"%s\" ", ligature);
     } else if ( encuni!=-1 && encuni<0x110000 ) {
-		if ( encuni!=0x9 &&
-			encuni!=0xa &&
-			encuni!=0xd &&
-			!(encuni>=0x20 && encuni<=0xd7ff) &&
-			!(encuni>=0xe000 && encuni<=0xfffd) &&
-			!(encuni>=0x10000 && encuni<=0x10ffff) )
-		    /* Not allowed in XML */;
-		else if ( (encuni>=0x7f && encuni<=0x84) ||
-			  (encuni>=0x86 && encuni<=0x9f) ||
-			  (encuni>=0xfdd0 && encuni<=0xfddf) ||
-			  (encuni&0xffff)==0xfffe ||
-			  (encuni&0xffff)==0xffff )
-		    /* Not recommended in XML */;
-		else if ( encuni>=32 && encuni<127 &&
-			encuni!='"' && encuni!='&' &&
-			encuni!='<' && encuni!='>' )
-		    fprintf( file, "unicode=\"%c\" ", encuni);
-		else if ( encuni<0x10000 &&
-			( isarabisolated(encuni) || isarabinitial(encuni) || isarabmedial(encuni) || isarabfinal(encuni) ) &&
-			unicode_alternates[encuni>>8]!=NULL &&
-			(alt = unicode_alternates[encuni>>8][encuni&0xff])!=NULL &&
-			alt[1]=='\0' )
-		    /* For arabic forms use the base representation in the 0600 block */
-		    fprintf( file, "unicode=\"&#x%x;\" ", alt[0]);
-		else if ( vs!=-1 )
-		    fprintf( file, "unicode=\"&#x%x;\" ", vs);
-		else
-		    fprintf( file, "unicode=\"&#x%x;\" ", encuni);
+	if ( encuni!=0x9 &&
+		encuni!=0xa &&
+		encuni!=0xd &&
+		!(encuni>=0x20 && encuni<=0xd7ff) &&
+		!(encuni>=0xe000 && encuni<=0xfffd) &&
+		!(encuni>=0x10000 && encuni<=0x10ffff) )
+	    /* Not allowed in XML */;
+	else if ( (encuni>=0x7f && encuni<=0x84) ||
+		  (encuni>=0x86 && encuni<=0x9f) ||
+		  (encuni>=0xfdd0 && encuni<=0xfddf) ||
+		  (encuni&0xffff)==0xfffe ||
+		  (encuni&0xffff)==0xffff )
+	    /* Not recommended in XML */;
+	else if ( encuni>=32 && encuni<127 &&
+		encuni!='"' && encuni!='&' &&
+		encuni!='<' && encuni!='>' )
+	    fprintf( file, "unicode=\"%c\" ", encuni);
+	else if ( encuni<0x10000 &&
+		( isarabisolated(encuni) || isarabinitial(encuni) || isarabmedial(encuni) || isarabfinal(encuni) ) &&
+		unicode_alternates[encuni>>8]!=NULL &&
+		(alt = unicode_alternates[encuni>>8][encuni&0xff])!=NULL &&
+		alt[1]=='\0' )
+	    /* For arabic forms use the base representation in the 0600 block */
+	    fprintf( file, "unicode=\"&#x%x;\" ", alt[0]);
+	else if ( vs!=-1 )
+	    fprintf( file, "unicode=\"&#x%x;\" ", vs);
+	else
+	    fprintf( file, "unicode=\"&#x%x;\" ", encuni);
     }
-
     if ( sc->width!=defwid )
 	fprintf( file, "horiz-adv-x=\"%d\" ", sc->width );
     if ( sc->parent->hasvmetrics && sc->vwidth!=sc->parent->ascent+sc->parent->descent )

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -814,6 +814,7 @@ static void svg_scdump(FILE *file, SplineChar *sc,int defwid, int encuni, int vs
 
     if ( ligature!=NULL ) {
 	    fprintf(file,"unicode=\"%s\" ", ligature);
+	    free(ligature);
     } else if ( encuni!=-1 && encuni<0x110000 ) {
 	if ( encuni!=0x9 &&
 		encuni!=0xa &&

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -795,7 +795,7 @@ static void svg_scdump(FILE *file, SplineChar *sc,int defwid, int encuni, int vs
     int i, c;
 
     if ( sc->comment!=NULL ) {
-		fprintf( file, "\n<!--\n%s\n-->\n",sc->comment );
+	fprintf( file, "\n<!--\n%s\n-->\n",sc->comment );
     }
     fprintf(file,"    <glyph glyph-name=\"%s\" ",sc->name );
 

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -777,24 +777,28 @@ char *GetLigature(SplineChar *sc) {
     if ( best != NULL ) {
     	int32 univals[50];
         char buf[LIGATURE_MAXLEN] = "";
-        char buf2[15];
-        int i, c, r, n = 0;
-
+        int i, c, r, stored, remain;
+        stored = 0;
 		c = LigCnt(sc->parent,best,univals,sizeof(univals)/sizeof(univals[0]));
+
 		for ( i=0; i<c; ++i ) {
+		    remain = LIGATURE_MAXLEN - stored;
 		    if ( (univals[i]>='A' && univals[i]<='Z') || (univals[i]>='a' && univals[i]<='z') || (univals[i] >= '0' && univals[i] <= '9') || univals[i] == '_' || univals[i] == '-') {
-		    	r = sprintf(buf2, "%c", univals[i]);
+		        r = snprintf( buf + stored, remain, "%c", univals[i] );
 		    } else {
-		    	r = sprintf(buf2, "&#x%x;", (unsigned int) univals[i]);
+                r = snprintf( buf + stored, remain, "&#x%x;", (unsigned int) univals[i] );
 		    }
-		    n = LIGATURE_MAXLEN - strlen(buf) - 1;
-		    if (r > 0 && n >= r) {
-		        strncat(buf, buf2, n);
-		    } else {
-		        break;
-		    }
+
+            if ( r < 0 || r >= remain) {
+               if ((r - remain) > 0) {
+       		       snprintf( buf + stored, remain, "");
+               }
+       		   break;
+            }
+
+            stored += r;
 		}
-        return (  copy(buf)  );
+        return ( copy(buf) );
     }
     return ( NULL );
 }

--- a/fontforge/svg.h
+++ b/fontforge/svg.h
@@ -19,5 +19,6 @@ extern SplineFont *SFReadSVGMem(char *data, int flags);
 extern SplineSet *SplinePointListInterpretSVG(char *filename, char *memory, int memlen, int em_size, int ascent, int is_stroked, ImportParams *eip);
 extern void SFLSetOrder(SplineFont *sf, int layerdest, int order2);
 extern void SFSetOrder(SplineFont *sf, int order2);
+extern char *GetLigature(SplineChar *sc);
 
 #endif /* FONTFORGE_SVG_H */


### PR DESCRIPTION
Ability to set filename for exporting glyph with char ligature if present.
```
``%N`` -- inserts the ligature name if present in glyph, or the glyph name if not (or the first 40 characters)
```

### Type of change
- **New feature**
