### PR TITLE
Glyph name fix for SVG

### DIFF
--- a/doc/sphinx/scripting/scripting-alpha.rst
+++ b/doc/sphinx/scripting/scripting-alpha.rst
@@ -853,6 +853,8 @@ the fourth argument you must specify the second and third arguments too.
 
    * ``%n`` -- inserts the glyph name (or the first 40 characters of it for long
      names)
+   * ``%N`` -- inserts the ligature name if present in glyph, 
+     or the glyph name if not (or the first 40 characters)
    * ``%f`` -- inserts the font name (or the first 40 characters)
    * ``%e`` -- inserts the glyph's encoding as a decimal integer
    * ``%u`` -- inserts the glyph's unicode code point in lower case hex

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -702,17 +702,24 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 	    ++format_spec;
 	    ch = *format_spec++;
 	    if ((bend = buffer+40)>end ) bend = end;
-	    if ( ch=='n' ) {
+	    if ( ch=='n' || ch=='N' ) {
+            pt=sc->name
+            if (ch=='N') {
+                char *ligature = GetLigature(sc);
+                if (ligature != NULL) {
+                    pt = ligature;
+                }
+            }
 #if defined( __CygWin ) || defined(__Mac)
 		/* Windows file systems are not case conscious */
 		/*  nor is the default mac filesystem */
-		for ( pt=sc->name; *pt!='\0' && buffer<bend; ) {
+		for ( ; *pt!='\0' && buffer<bend; ) {
 		    if ( isupper( *pt ))
 			*buffer++ = '$';
 		    *buffer++ = *pt++;
 		}
 #else
-		for ( pt=sc->name; *pt!='\0' && buffer<bend; )
+		for ( ; *pt!='\0' && buffer<bend; )
 		    *buffer++ = *pt++;
 #endif
 	    } else if ( ch=='f' ) {
@@ -726,10 +733,10 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 		for ( pt=unicode; *pt!='\0' && buffer<bend; )
 		    *buffer++ = *pt++;
 	    } else if ( ch=='e' ) {
-		sprintf( unicode,"%d", (int) map->backmap[sc->orig_pos] );
-		for ( pt=unicode; *pt!='\0' && buffer<bend; )
-		    *buffer++ = *pt++;
-	    } else
+        sprintf( unicode,"%d", (int) map->backmap[sc->orig_pos] );
+        for ( pt=unicode; *pt!='\0' && buffer<bend; )
+            *buffer++ = *pt++;
+        } else
 		*buffer++ = ch;
 	}
     }

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -703,7 +703,7 @@ static void MakeExportName(char *buffer, int blen,char *format_spec,
 	    ch = *format_spec++;
 	    if ((bend = buffer+40)>end ) bend = end;
 	    if ( ch=='n' || ch=='N' ) {
-            pt=sc->name
+            pt=sc->name;
             if (ch=='N') {
                 char *ligature = GetLigature(sc);
                 if (ligature != NULL) {

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -798,13 +798,12 @@ static void svg_scdump(FILE *file, SplineChar *sc,int defwid, int encuni, int vs
     if ( sc->comment!=NULL ) {
 		fprintf( file, "\n<!--\n%s\n-->\n",sc->comment );
     }
-    fprintf(file,"    <glyph glyph-name=\"%s\" ",sc->name );
 
     char *ligature = GetLigature(sc);
 
-    if ( ligature!=NULL ) {
-	    fprintf(file,"unicode=\"%s\" ", ligature);
-    } else if ( encuni!=-1 && encuni<0x110000 ) {
+    fprintf(file,"    <glyph glyph-name=\"%s\" ", ligature == NULL ? sc->name : ligature);
+
+    if ( encuni!=-1 && encuni<0x110000 ) {
 		if ( encuni!=0x9 &&
 			encuni!=0xa &&
 			encuni!=0xd &&

--- a/fontforge/svg.h
+++ b/fontforge/svg.h
@@ -19,5 +19,6 @@ extern SplineFont *SFReadSVGMem(char *data, int flags);
 extern SplineSet *SplinePointListInterpretSVG(char *filename, char *memory, int memlen, int em_size, int ascent, int is_stroked, ImportParams *eip);
 extern void SFLSetOrder(SplineFont *sf, int layerdest, int order2);
 extern void SFSetOrder(SplineFont *sf, int order2);
+extern char *GetLigature(SplineChar *sc);
 
 #endif /* FONTFORGE_SVG_H */


### PR DESCRIPTION
Converting font with ligatures produces following glyphs with strange names and incorrect unicode property:
```xml
<glyph glyph-name="uniE000" unicode="error" d="..." />
<glyph glyph-name="uniE001" unicode="error_outline" d="..." />
<glyph glyph-name="uniE002" unicode="warning" d="..." /> 
```
This change make things correct:
```xml
<glyph glyph-name="error" unicode="&#xe000;" d="..." />
<glyph glyph-name="error_outline" unicode="&#xe001;" d="..." />
<glyph glyph-name="warning" unicode="&#xe002;" d="..." />
```
### Type of change
- **Bug fix**
