### PR TITLE
CID fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,8 +55,8 @@ artifacts:
     name: FontForge $(MBITS)-bit debugging symbols
   - path: fontforgebuilds\fontforge-setup\*.exe
     name: FontForge $(MBITS)-bit setup
-on_failure:
-  - cat build/CMakeCache.txt || true
-  - cat build/CMakeFiles/CMakeOutput.log || true
-  - cat build/Testing/Temporary/LastTest.log || true
-  - cat build/build.ninja || true
+#on_failure:
+#  - cat build/CMakeCache.txt || true
+#  - cat build/CMakeFiles/CMakeOutput.log || true
+#  - cat build/Testing/Temporary/LastTest.log || true
+#  - cat build/build.ninja || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,17 +112,14 @@ install:
       export PYTHON=python3.7
     else
       export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig
-      export PATH="/usr/local/opt/ruby/bin:$PATH"
+      export PATH="/usr/local/opt/ruby/bin:/usr/local/opt/gettext/bin:$PATH"
       export HOMEBREW_NO_AUTO_UPDATE=1
+      export FFCONFIG="$FFCONFIG -DCMAKE_FIND_ROOT_PATH=/usr/local/opt/gettext"
       # Disable fc-cache on fontconfig install. Because it's slow.
       sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb"
       # 10 billion years later...
       brew install autoconf automake libtool pkg-config ruby cmake ninja
       brew install cairo coreutils fontconfig gettext giflib gtk+3 jpeg libpng libspiro libtiff libtool libuninameslist python@3 wget woff2
-      # This *must* be linked or else gettext/intl will be disabled
-      brew link --force gettext
-      # Until Homebrew fixes their gtk
-      export CFLAGS="$CFLAGS -DGDK_WINDOWING_QUARTZ=1"
     fi
 
     # Don't specify the prefix in the prefix='' argument else you get different results...

--- a/doc/sphinx/glossary.rst
+++ b/doc/sphinx/glossary.rst
@@ -23,13 +23,13 @@ Typographical glossary
       Both Hebrew and Arabic have optional vowel marks and are called "impure"
       abjads. Ancient Phoenician had nothing but consonants and is a "pure" abjad.
 
-      See Also: :term:`alphabet`,
-      :term:`abugida`, :term:`syllabary` and
+      See Also: :term:`Alphabet`,
+      :term:`Abugida`, :term:`Syllabary` and
       the relevant `Wikipedia article <http://en.wikipedia.org/wiki/Abjad>`__.
 
    Abugida
-      An abugida is somewhere in between an :term:`alphabet` and
-      a :term:`syllabary`. The Indic writing systems are
+      An abugida is somewhere in between an :term:`alphabet <Alphabet>` and
+      a :term:`syllabary <Syllabary>`. The Indic writing systems are
       probably the best known abugidas.
 
       In most abugidas there are independant glyphs for the consonants, and each
@@ -45,8 +45,8 @@ Typographical glossary
       An abugida differs from an abjad in that vowels (other than the default) must
       be marked in the abugida.
 
-      See Also: :term:`alphabet`, :term:`abjad`,
-      :term:`syllabary` and the relevant
+      See Also: :term:`Alphabet`, :term:`Abjad`,
+      :term:`Syllabary` and the relevant
       `Wikipedia article <http://en.wikipedia.org/wiki/Abugida>`__.
 
    Advance Width
@@ -62,8 +62,8 @@ Typographical glossary
       vowels alike -- and (in theory anyway) all phonemes in a word will be marked
       by an appropriate glyph.
 
-      See Also: :term:`abjad`, :term:`abugida`,
-      :term:`syllabary` and the relevant
+      See Also: :term:`Abjad`, :term:`Abugida`,
+      :term:`Syllabary` and the relevant
       `Wikipedia article <http://en.wikipedia.org/wiki/Alphabet>`__.
 
    Apple Advanced Typography
@@ -83,7 +83,7 @@ Typographical glossary
 
    Ascent
       In traditional typography the ascent of a font was the distance from the top
-      of a block of type to the :term:`baseline`.
+      of a block of type to the :term:`baseline <Baseline>`.
 
       Its precise meaning in modern typography seems to vary with different
       definers.
@@ -127,7 +127,7 @@ Typographical glossary
    Black letter
       Any of various type families based on medieval handwriting.
 
-      See also :term:`gothic`.
+      See also :term:`Gothic`.
 
    BMP
    Basic Multilingual Plane
@@ -142,13 +142,13 @@ Typographical glossary
         (0xE0000-0xEFFFF)
 
    Bold
-      A common font :term:`style`. The stems of the glyphs are
+      A common font :term:`style <Style>`. The stems of the glyphs are
       wider than in the normal font, giving the letters a darker impression. Bold
       is one of the few :term:`LGC` styles that translate readily to
       other scripts.
 
    Bopomofo
-      A (modern~1911) Chinese (Mandarin) :term:`alphabet` used
+      A (modern~1911) Chinese (Mandarin) :term:`alphabet <Alphabet>` used
       to provide phonetic transliteration of Han ideographs in dictionaries.
 
    Boustrophedon
@@ -158,7 +158,7 @@ Typographical glossary
       Writing "as the ox plows", that is alternating between left to right and
       right to left writing directions. Early alphabets (Old Canaanite, and the
       very early greek writings (and, surprisingly,
-      :term:`fuþark`)) used this. Often the right to left glyphs
+      :term:`Fuþark`)) used this. Often the right to left glyphs
       would be mirrors of the left to right ones. As far as I know, no modern
       writing system uses this method (nor does OpenType have any support for it).
       See Also :term:`Bidi`.
@@ -181,7 +181,7 @@ Typographical glossary
 
    Character
       A character is a Platonic ideal reified into at least one
-      :term:`glyph`. For example the letter "s" is a character
+      :term:`glyph <Glyph>`. For example the letter "s" is a character
       which is reified into several different glyphs: "S", "s", "*s*", long-s, etc.
       Note that these glyphs can look fairly different from each other, however
       although the glyph for an integral sign might be the same as the long-s
@@ -232,7 +232,7 @@ Typographical glossary
 
    Descent
       In traditional typography the descent of a font was the distance from the
-      bottom of a block of type to the :term:`baseline`.
+      bottom of a block of type to the :term:`baseline <Baseline>`.
 
       Its precise meaning in modern typography seems to vary with different
       definers.
@@ -248,7 +248,7 @@ Typographical glossary
       :ref:`anchored marks <anchorcontrol.DeviceTable>`.
 
    Didot point
-      The European :term:`point`. 62 :sup:`2`/:small:`3` points per
+      The European :term:`point <Point>`. 62 :sup:`2`/:small:`3` points per
       23.566mm ( 2.66pt/mm or 67.55pt/inch ). There is also a "metric" didiot
       point: .4mm.
 
@@ -275,7 +275,7 @@ Typographical glossary
 
    Encoding
       An encoding is a mapping from a set of bytes onto a
-      :term:`character set`. It is what determines which
+      :term:`character set <Character set>`. It is what determines which
       byte sequence represents which character. The words "encoding" and "character
       set" are often used synonymously. The specification for ASCII specifies both
       a character set and an encoding. But CJK character sets often have multiple
@@ -293,7 +293,7 @@ Typographical glossary
       two sounds associated with it, but it does, see also
       :term:`Thorn`)
 
-   Even-Odd Fill rule
+   Even-Odd Fill Rule
       To determine if a pixel should be
       :ref:`filled using this rule <editexample2.even-odd-non-zero>`, draw a line from the
       pixel to infinity (in any direction) then count the number of times contours
@@ -332,7 +332,7 @@ Typographical glossary
    Font
       A collection of :term:`glyphs <Glyph>`, generally with at least one
       glyph associated with each character in the font's
-      :term:`character set`, often with an encoding.
+      :term:`character set <Character set>`, often with an encoding.
 
       A font contains much of the information needed to turn a sequence of bytes
       into a set of pictures representing the characters specified by those bytes.
@@ -342,8 +342,8 @@ Typographical glossary
       different font for each point-size.
 
    Font Family, or just Family
-      A collection of related :term:`font`\ s. Often including plain,
-      italic and bold :term:`style`\ s.
+      A collection of related :term:`font <Font>`\ s. Often including plain,
+      italic and bold :term:`style <Style>`\ s.
 
    FontForge
       This.
@@ -356,7 +356,7 @@ Typographical glossary
    Fractur
       The old black letter writing style used in Germany up until world war II.
 
-      See also :term:`gothic`.
+      See also :term:`Gothic`.
 
    Fuþark
    Futhark
@@ -430,7 +430,7 @@ Typographical glossary
       China.
 
    Hangul
-      The Korean :term:`syllabary`. The only syllabary (that
+      The Korean :term:`Syllabary`. The only syllabary (that
       I'm aware of anway) based on an alphabet -- the letters of the alphabet never
       appear alone, but only as groups of two or three making up a syllable.
 
@@ -439,11 +439,11 @@ Typographical glossary
 
    Hints
       These are described in detail in :ref:`the main manual <overview.Hints>`.
-      They help the rasterizer to draw a :term:`glyph` well at
+      They help the rasterizer to draw a :term:`glyph <Glyph>` well at
       small pointsizes.
 
    Hint Masks
-      At any given point on a contour :term:`hints` may not
+      At any given point on a contour :term:`hints <Hints>` may not
       :term:`conflict <Conflicting hints>`. However different points in a
       glyph may need conflicting hints. So every now and then a contour will change
       which hints are active. Each list of active hints is called a hint mask.
@@ -457,7 +457,7 @@ Typographical glossary
       Generally used to mean Han (Chinese) characters.
 
    Italic
-      A slanted :term:`style` of a font, generally used for
+      A slanted :term:`style <Style>` of a font, generally used for
       emphasis.
 
       Italic differs from :term:`Oblique` in that the
@@ -498,7 +498,7 @@ Typographical glossary
       to it.
 
    Kern pair
-      A pair of glyphs for which :term:`kerning` information has
+      A pair of glyphs for which :term:`kerning <Kerning>` information has
       been specified.
 
    Kerning by classes
@@ -541,9 +541,9 @@ Typographical glossary
 
    Manyogana
       An early Japanese script, ancestral to both
-      :term:`hiragana` and :term:`katakana`.
+      :term:`Hiragana` and :term:`Katakana`.
       `Manyogana <http://en.wikipedia.org/wiki/Manyogana>`__ used
-      :term:`kanji` for their phontic sounds, and over the years
+      :term:`Kanji` for their phontic sounds, and over the years
       these kanji were simplified into hiragana and katahana.
 
    Metal Type
@@ -622,7 +622,7 @@ Typographical glossary
       :doc:`here for the tables used by FontForge </techref/TrueOpenTables>`.
 
    Oblique
-      A slanted :term:`style` of a font, generally used for
+      A slanted :term:`style <Style>` of a font, generally used for
       emphasis.
 
       Oblique differs from :term:`Italic` in that the
@@ -695,7 +695,7 @@ Typographical glossary
       `See Caslon's type specimen sheet on Wikipedia. <http://en.wikipedia.org/wiki/Alphabet>`__
 
    Pica point
-      The Anglo-American :term:`point`. With 72.27 points per inch
+      The Anglo-American :term:`point <Point>`. With 72.27 points per inch
       ( 2.85pt /mm ).
 
    Point
@@ -708,7 +708,7 @@ Typographical glossary
       points per inch, 2.86pt/mm).
 
       The didiot and pica points were so arranged that text at a given point-size
-      would have approximately the same :term:`cap-height` in
+      would have approximately the same :term:`cap-height <Cap-height>` in
       both systems, the didot point would have extra white-space above the capitals
       to contain the accents present in most non-English Latin based scripts.
 
@@ -757,7 +757,7 @@ Typographical glossary
         again only allows a 1 byte encoding, but the OpenType wrapper extends this to
         provide more complex encoding types.
       * Type 3 -- This format allows full postscript within the font, but it means
-        that no :term:`hints` are allowed, so these fonts will not
+        that no :term:`hints <Hints>` are allowed, so these fonts will not
         look as nice at small point-sizes. Also most (screen) rasterizers are
         incapable of dealing with them. A type 3 font is limited to a one byte
         encoding (ie. only 256 glyphs may be encoded).
@@ -922,13 +922,13 @@ Typographical glossary
    Style
       There are various conventional variants of a font. In probably any writing
       system the thickness of the stems of the glyphs may be varied, this is called
-      the :term:`weight` of a font. Common weights are normal and
+      the :term:`weight <Weight>` of a font. Common weights are normal and
       bold.
 
-      In :term:`LGC` alphabets an :term:`italic` (or
-      :term:`oblique`) style has arisen and is used for emphasis.
+      In :term:`LGC` alphabets an :term:`italic <Italic>` (or
+      :term:`oblique <Oblique>`) style has arisen and is used for emphasis.
 
-      Fonts are often compressed into a :term:`condensed`
+      Fonts are often compressed into a :term:`condensed <Condensed>`
       style, or expanded out into an :term:`extended style <Extended>`.
 
       Various other styles are in occasional use: underline, overstrike, outline,
@@ -945,7 +945,7 @@ Typographical glossary
       tend to be bigger than alphabets (Japanese KataKana requires about 60
       different characters, while the Korean Hangul requires tens of thousands).
 
-      See Also: :term:`abjad`, :term:`abugida`, :term:`alphabet` and the relevant
+      See Also: :term:`Abjad`, :term:`Abugida`, :term:`Alphabet` and the relevant
       `Wikipedia article <http://en.wikipedia.org/wiki/S%20yllabary>`__.
 
    TeX
@@ -1061,7 +1061,7 @@ Typographical glossary
 
    Width
       This is a slightly ambiguous term and is sometimes used to mean the
-      :term:`advance width` (the distance from the start of
+      :term:`advance width <Advance Width>` (the distance from the start of
       this glyph to the start of the next glyph), and sometimes used to mean the
       distance from the left side bearing to the right side bearing.
 

--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2414,18 +2414,18 @@ void SFAddGlyphAndEncode(SplineFont *sf,SplineChar *sc,EncMap *basemap, int base
 	    map->backmap[gid] = -1;
 	}
     } else {
-	gid = baseenc;
-	if ( baseenc+1>=sf->glyphmax )
-	    sf->glyphs = realloc(sf->glyphs,(sf->glyphmax = baseenc+10)*sizeof(SplineChar *));
-	if ( baseenc>=sf->glyphcnt ) {
-	    memset(sf->glyphs+sf->glyphcnt,0,(baseenc+1-sf->glyphcnt)*sizeof(SplineChar *));
-	    sf->glyphcnt = baseenc+1;
+	gid = baseenc < 0 ? sf->glyphcnt : baseenc;
+	if ( gid+1>=sf->glyphmax )
+	    sf->glyphs = realloc(sf->glyphs,(sf->glyphmax = gid+10)*sizeof(SplineChar *));
+	if ( gid>=sf->glyphcnt ) {
+	    memset(sf->glyphs+sf->glyphcnt,0,(gid+1-sf->glyphcnt)*sizeof(SplineChar *));
+	    sf->glyphcnt = gid+1;
 	    for ( bdf = sf->cidmaster->bitmaps; bdf!=NULL; bdf=bdf->next ) {
-		if ( baseenc+1>=bdf->glyphmax )
-		    bdf->glyphs = realloc(bdf->glyphs,(bdf->glyphmax=baseenc+10)*sizeof(BDFChar *));
-		if ( baseenc+1>bdf->glyphcnt ) {
-		    memset(bdf->glyphs+bdf->glyphcnt,0,(baseenc+1-bdf->glyphcnt)*sizeof(BDFChar *));
-		    bdf->glyphcnt = baseenc+1;
+		if ( gid+1>=bdf->glyphmax )
+		    bdf->glyphs = realloc(bdf->glyphs,(bdf->glyphmax=gid+10)*sizeof(BDFChar *));
+		if ( gid+1>bdf->glyphcnt ) {
+		    memset(bdf->glyphs+bdf->glyphcnt,0,(gid+1-bdf->glyphcnt)*sizeof(BDFChar *));
+		    bdf->glyphcnt = gid+1;
 		}
 	    }
 	    for ( fv=sf->fv; fv!=NULL; fv = fv->nextsame ) if ( fv->sf==sf ) {

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -14750,28 +14750,28 @@ Py_RETURN( self );
 }
 
 static PyObject *PyFFFont_cidFlatten(PyFF_Font *self, PyObject *UNUSED(args)) {
-    SplineFont *sf;
+    SplineFont *cidmaster;
 
     if ( CheckIfFontClosed(self) )
 return (NULL);
-    sf = self->fv->sf;
-    if ( sf->cidmaster==NULL ) {
+    cidmaster = self->fv->cidmaster;
+    if ( cidmaster==NULL ) {
 	PyErr_Format(PyExc_EnvironmentError,"This font is not a CID keyed font." );
 return( NULL );
     }
 
-    SFFlatten(&(sf->cidmaster));
+    SFFlatten(&cidmaster);
 Py_RETURN( self );
 }
 
 static PyObject *PyFFFont_cidFlattenByCMap(PyFF_Font *self,PyObject *args) {
-    SplineFont *sf;
+    SplineFont *cidmaster;
     char *locfilename;
 
     if ( CheckIfFontClosed(self) )
 return (NULL);
-    sf = self->fv->sf;
-    if ( sf->cidmaster==NULL ) {
+    cidmaster = self->fv->cidmaster;
+    if ( cidmaster==NULL ) {
 	PyErr_Format(PyExc_EnvironmentError,"This font is not a CID keyed font." );
 return( NULL );
     }
@@ -14779,7 +14779,7 @@ return( NULL );
     if ( !PyArg_ParseTuple(args,"s", &locfilename ))
 return( NULL );
 
-    if ( !SFFlattenByCMap(&sf,locfilename)) {
+    if ( !SFFlattenByCMap(&cidmaster,locfilename)) {
 	PyErr_Format(PyExc_EnvironmentError,"Can't find (or can't parse) cmap file: %s", locfilename);
 return( NULL );
     }

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -6722,24 +6722,24 @@ static void bCIDSetFontNames(Context *c) {
 }
 
 static void bCIDFlatten(Context *c) {
-    SplineFont *sf = c->curfv->sf;
+    SplineFont *cidmaster = c->curfv->cidmaster;
 
-    if ( sf->cidmaster==NULL )
-	ScriptErrorString( c, "Not a cid-keyed font", sf->fontname );
+    if ( cidmaster==NULL )
+	ScriptErrorString( c, "Not a cid-keyed font", c->curfv->sf->fontname );
 
-    SFFlatten(&(sf->cidmaster));
+    SFFlatten(&cidmaster);
 }
 
 static void bCIDFlattenByCMap(Context *c) {
-    SplineFont *sf = c->curfv->sf;
+    SplineFont *cidmaster = c->curfv->cidmaster;
     char *t; char *locfilename;
 
-    if ( sf->cidmaster==NULL )
-	ScriptErrorString( c, "Not a cid-keyed font", sf->fontname );
+    if ( cidmaster==NULL )
+	ScriptErrorString( c, "Not a cid-keyed font", c->curfv->sf->fontname );
 
     t = script2utf8_copy(c->a.vals[1].u.sval);
     locfilename = utf82def_copy(t);
-    if ( !SFFlattenByCMap(&sf,locfilename))
+    if ( !SFFlattenByCMap(&cidmaster,locfilename))
 	ScriptErrorString( c, "Can't find (or can't parse) cmap file",c->a.vals[1].u.sval);
     free(t); free(locfilename);
 }

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -90,7 +90,7 @@ static int comparespline(Spline *ps, Spline *ttf, real tmin, real tmax, real err
     else if ( ps->to->me.x<bb.minx ) bb.minx = ps->to->me.x;
     if ( ps->to->me.y>bb.maxy ) bb.maxy = ps->to->me.y;
     else if ( ps->to->me.y<bb.miny ) bb.miny = ps->to->me.y;
-    for ( t=.1; t<1; t+= .1 ) {
+    for ( t=.1; t<0.99; t+= .1 ) {
 	d = (ttf->splines[0].b*t+ttf->splines[0].c)*t+ttf->splines[0].d;
 	o = (ttf->splines[1].b*t+ttf->splines[1].c)*t+ttf->splines[1].d;
 	if ( d<bb.minx || d>bb.maxx || o<bb.miny || o>bb.maxy )

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -6784,7 +6784,7 @@ static void FontView_ReformatAll(SplineFont *sf) {
     MetricsView *mvs;
     extern int use_freetype_to_rasterize_fv;
 
-    if ( sf->fv==NULL || ((FontView *) (sf->fv))->v==NULL || ((FontView *) (sf->fv))->colcnt==0 )			/* Can happen in scripts */
+    if ( sf->fv==NULL || ((FontView *) (sf->fv))->v==NULL )			/* Can happen in scripts */
 return;
 
     for ( fv=(FontView *) (sf->fv); fv!=NULL; fv=(FontView *) (fv->b.nextsame) ) {
@@ -6805,14 +6805,16 @@ return;
 	    else fv->show = new;
 	}
 	BDFFontFree(old);
-	fv->rowltot = (fv->b.map->enccount+fv->colcnt-1)/fv->colcnt;
-	GScrollBarSetBounds(fv->vsb,0,fv->rowltot,fv->rowcnt);
-	if ( fv->rowoff>fv->rowltot-fv->rowcnt ) {
-	    fv->rowoff = fv->rowltot-fv->rowcnt;
-	    if ( fv->rowoff<0 ) fv->rowoff =0;
-	    GScrollBarSetPos(fv->vsb,fv->rowoff);
+	if ( ((FontView *) (sf->fv))->colcnt!=0 ) {
+	    fv->rowltot = (fv->b.map->enccount+fv->colcnt-1)/fv->colcnt;
+	    GScrollBarSetBounds(fv->vsb,0,fv->rowltot,fv->rowcnt);
+	    if ( fv->rowoff>fv->rowltot-fv->rowcnt ) {
+		    fv->rowoff = fv->rowltot-fv->rowcnt;
+		    if ( fv->rowoff<0 ) fv->rowoff =0;
+		    GScrollBarSetPos(fv->vsb,fv->rowoff);
+	    }
+	    GDrawRequestExpose(fv->v,NULL,false);
 	}
-	GDrawRequestExpose(fv->v,NULL,false);
 	GDrawSetCursor(fv->v,ct_pointer);
     }
     for ( mvs=sf->metrics; mvs!=NULL; mvs=mvs->next ) if ( mvs->bdf==NULL ) {

--- a/gutils/CMakeLists.txt
+++ b/gutils/CMakeLists.txt
@@ -37,6 +37,7 @@ if(BUILD_SHARED_LIBS)
   set_property(TARGET gutils PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
+list(APPEND gutils_LIBRARIES Intl::Intl)
 if(ENABLE_LIBGIF_RESULT)
   list(APPEND gutils_LIBRARIES GIF::GIF)
 endif()


### PR DESCRIPTION
* Fix use after free on the call to SFFlatten (it frees the sf
  that the cidmaster belongs to). Matches behaviour to what
  FVMenuFlatten does
* Ensure that the FontViewReformatAll call actually runs if
  executing the script from the GUI, prevents another use after
  free on stale FV show/filled BDFFonts
* Fix GID allocation on cid keyed fonts in SFAddGlyphAndEncode

<details>
<summary>Asan error for second case</summary>

```
=================================================================
==7233==ERROR: AddressSanitizer: heap-use-after-free on address 0x61a0000924f0 at pc 0x7f2213311a27 bp 0x7fff662193f0 sp 0x7fff662193e0
READ of size 4 at 0x61a0000924f0 thread T0
    #0 0x7f2213311a26 in BDFPieceMeal ../fontforge/splinefill.c:1677
    #1 0x557fe410ac1e in FVDrawGlyph ../fontforgeexe/fontview.c:262
    #2 0x557fe4114da0 in FVExpose ../fontforgeexe/fontview.c:6014
    #3 0x557fe4125f47 in v_e_h ../fontforgeexe/fontview.c:6733
    #4 0x557fe435a90d in _GWidget_Container_eh ../gdraw/gcontainer.c:281
    #5 0x557fe4383c0e in _GGDKDraw_CallEHChecked ../gdraw/ggdkdraw.c:346
    #6 0x557fe4385c44 in _GGDKDraw_DispatchEvent ../gdraw/ggdkdraw.c:1249
    #7 0x7f2211e2f764  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x37764)
    #8 0x7f2211e3f7f4  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x477f4)
    #9 0x7f2211e3f897  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x47897)
    #10 0x7f2211e409f5  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x489f5)
    #11 0x7f2211e40bef  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x48bef)
    #12 0x7f221143d10c in g_closure_invoke (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x1010c)
    #13 0x7f221145005d  (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x2305d)
    #14 0x7f2211458714 in g_signal_emit_valist (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x2b714)
    #15 0x7f221145912e in g_signal_emit (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x2c12e)
    #16 0x7f2211e38ac8  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x40ac8)
    #17 0x7f2211e2407f  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x2c07f)
    #18 0x7f2211162d02  (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4cd02)
    #19 0x7f2211162284 in g_main_context_dispatch (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c284)
    #20 0x7f221116264f  (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c64f)
    #21 0x7f22111626db in g_main_context_iteration (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c6db)
    #22 0x557fe4380539 in GGDKDrawProcessPendingEvents ../gdraw/ggdkdraw.c:2188
    #23 0x557fe43cb483 in GProgressProcess ../gdraw/gprogress.c:154
    #24 0x7f22132ad5e8 in SFD_Dump ../fontforge/sfd.c:2938
    #25 0x7f22132af25a in SFDDump ../fontforge/sfd.c:3087
    #26 0x7f22132af898 in SFDWrite ../fontforge/sfd.c:3192
    #27 0x7f22132afcb2 in SFDWriteBak ../fontforge/sfd.c:3317
    #28 0x7f22132b0252 in SFDWriteBakExtended ../fontforge/sfd.c:3255
    #29 0x7f221319aa85 in PyFFFont_Save ../fontforge/python.c:16545
    #30 0x7f221230177a in _PyCFunction_FastCallDict (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21377a)
    #31 0x7f221226a44b  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x17c44b)
    #32 0x7f2212270562 in _PyEval_EvalFrameDefault (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x182562)
    #33 0x7f2212269c6e  (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x17bc6e)
    #34 0x7f221226a72d in PyEval_EvalCodeEx (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x17c72d)
    #35 0x7f221226b4aa in PyEval_EvalCode (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x17d4aa)
    #36 0x7f221223cb0a in PyRun_StringFlags (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x14eb0a)
    #37 0x7f221223db0a in PyRun_SimpleStringFlags (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x14fb0a)
    #38 0x557fe42906d1 in ExecPython ../fontforgeexe/scriptingdlg.c:134
    #39 0x557fe42906d1 in SD_OK ../fontforgeexe/scriptingdlg.c:160
    #40 0x557fe4341958 in GButtonInvoked ../gdraw/gbuttons.c:257
    #41 0x557fe4342a2e in gbutton_mouse ../gdraw/gbuttons.c:485
    #42 0x557fe435b1a9 in _GWidget_Container_eh ../gdraw/gcontainer.c:304
    #43 0x557fe435c4cd in _GWidget_TopLevel_eh ../gdraw/gcontainer.c:743
    #44 0x557fe4383c0e in _GGDKDraw_CallEHChecked ../gdraw/ggdkdraw.c:346
    #45 0x557fe4385c44 in _GGDKDraw_DispatchEvent ../gdraw/ggdkdraw.c:1249
    #46 0x7f2211e2f764  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x37764)
    #47 0x7f2211e5ff91  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x67f91)
    #48 0x7f2211162416 in g_main_context_dispatch (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c416)
    #49 0x7f221116264f  (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c64f)
    #50 0x7f22111626db in g_main_context_iteration (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c6db)
    #51 0x557fe4290a46 in ScriptDlg ../fontforgeexe/scriptingdlg.c:364
    #52 0x557fe43c47b0 in gmenu_mouse ../gdraw/gmenu.c:948
    #53 0x557fe43c5d92 in gmenu_eh ../gdraw/gmenu.c:1389
    #54 0x557fe4383c0e in _GGDKDraw_CallEHChecked ../gdraw/ggdkdraw.c:346
    #55 0x557fe4385c44 in _GGDKDraw_DispatchEvent ../gdraw/ggdkdraw.c:1249
    #56 0x7f2211e2f764  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x37764)
    #57 0x7f2211e5ff91  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x67f91)
    #58 0x7f2211162416 in g_main_context_dispatch (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c416)
    #59 0x7f221116264f  (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c64f)
    #60 0x7f22111626db in g_main_context_iteration (/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4c6db)
    #61 0x557fe4380aec in GGDKDrawEventLoop ../gdraw/ggdkdraw.c:2216
    #62 0x557fe42f6e2d in fontforge_main ../fontforgeexe/startui.c:1414
    #63 0x7f2210d46b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #64 0x557fe3e99bf9 in _start (/home/jeremy/ffstaging/build/bin/fontforge+0x160bf9)

0x61a0000924f0 is located 112 bytes inside of 1160-byte region [0x61a000092480,0x61a000092908)
freed by thread T0 here:
    #0 0x7f2213ef47b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
    #1 0x7f22133f470f in SplineFontFree ../fontforge/splineutil.c:6596
    #2 0x7f2212f333b7 in CIDFlatten ../fontforge/encoding.c:1533
    #3 0x7f2212f33a8f in SFFlatten ../fontforge/encoding.c:1565
    #4 0x7f221319909b in PyFFFont_cidFlatten ../fontforge/python.c:14763
    #5 0x7f2212301736 in _PyCFunction_FastCallDict (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x213736)

previously allocated by thread T0 here:
    #0 0x7f2213ef4d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7f2213413109 in SplineFontEmpty ../fontforge/splineutil2.c:2907
    #2 0x7f22130b48ea in cffsffillup ../fontforge/parsettf.c:3711
    #3 0x7f22130b48ea in cidfigure ../fontforge/parsettf.c:3874
    #4 0x7f22130b48ea in readcffglyphs ../fontforge/parsettf.c:4001
    #5 0x7f22130c5dc0 in readttf ../fontforge/parsettf.c:5593
    #6 0x7f22130c5dc0 in _SFReadTTF ../fontforge/parsettf.c:6336
    #7 0x7f22133245f0 in _ReadSplineFont ../fontforge/splinefont.c:1142
    #8 0x7f2213325fdc in LoadSplineFont ../fontforge/splinefont.c:1380
    #9 0x7f22131d0a60 in PyFF_OpenFont ../fontforge/python.c:1228
    #10 0x7f221230177a in _PyCFunction_FastCallDict (/usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0+0x21377a)

SUMMARY: AddressSanitizer: heap-use-after-free ../fontforge/splinefill.c:1677 in BDFPieceMeal
Shadow bytes around the buggy address:
  0x0c348000a440: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c348000a450: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c348000a460: fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa
  0x0c348000a470: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c348000a480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c348000a490: fd fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd
  0x0c348000a4a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c348000a4b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c348000a4c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c348000a4d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c348000a4e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==7233==ABORTING
```
</details>

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
