### PR TITLE
Add image/x-inkscape-svg to accepted mime types + cleanup

### DIFF
--- a/fontforge/cvundoes.h
+++ b/fontforge/cvundoes.h
@@ -73,6 +73,7 @@ extern void PasteRemoveAnchorClass(SplineFont *sf, AnchorClass *dying);
 extern void PasteRemoveSFAnchors(SplineFont *sf);
 extern void PasteToBC(BDFChar *bc, int pixelsize, int depth);
 extern void PasteToCV(CharViewBase *cv);
+extern int  SCClipboardHasPasteableContents(void);
 extern void SCCopyLookupData(SplineChar *sc);
 extern void SCCopyWidth(SplineChar *sc, enum undotype ut);
 extern void SCDoRedo(SplineChar *sc, int layer);

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2456,8 +2456,6 @@ extern void RevertedGlyphReferenceFixup(SplineChar *sc, SplineFont *sf);
 extern void SFUntickAll(SplineFont *sf);
 
 
-extern int HasUFO(void);
-
 extern int _ExportGlif(FILE *glif,SplineChar *sc,int layer,int version);
 
 extern void SCCopyWidth(SplineChar *sc,enum undotype);

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1150,10 +1150,6 @@ return( !ferror(svg));
 #undef extended			/* used in xlink.h */
 #include <libxml/parser.h>
 
-static int libxml_init_base() {
-return( true );
-}
-
 /* Find a node with the given id */
 static xmlNodePtr XmlFindID(xmlNodePtr xml, char *name) {
     xmlChar *id;
@@ -3616,11 +3612,6 @@ SplineFont *SFReadSVG(char *filename, int flags) {
     xmlDocPtr doc;
     char *temp=filename, *pt, *lparen;
 
-    if ( !libxml_init_base()) {
-	LogError( _("Can't find libxml2.\n") );
-return( NULL );
-    }
-
     pt = strrchr(filename,'/');
     if ( pt==NULL ) pt = filename;
     if ( (lparen=strchr(pt,'('))!=NULL && strchr(lparen,')')!=NULL ) {
@@ -3641,11 +3632,6 @@ return( _SFReadSVG(doc,filename));
 SplineFont *SFReadSVGMem(char *data, int flags) {
     xmlDocPtr doc;
 
-    if ( !libxml_init_base()) {
-	LogError( _("Can't find libxml2.\n") );
-return( NULL );
-    }
-
     doc = xmlParseMemory(data,strlen(data));
     if ( doc==NULL ) {
 	/* Can I get an error message from libxml? */
@@ -3660,11 +3646,6 @@ char **NamesReadSVG(char *filename) {
     char **ret=NULL;
     int cnt;
     xmlChar *name;
-
-    if ( !libxml_init_base()) {
-	LogError( _("Can't find libxml2.\n") );
-return( NULL );
-    }
 
     doc = xmlParseFile(filename);
     if ( doc==NULL ) {
@@ -3705,10 +3686,6 @@ Entity *EntityInterpretSVG(char *filename, char *memory, int memlen,
     Entity *ret;
     int order2;
 
-    if ( !libxml_init_base()) {
-	LogError( _("Can't find libxml2.\n") );
-return( NULL );
-    }
     if ( filename!=NULL )
 	doc = xmlParseFile(filename);
     else
@@ -3751,8 +3728,4 @@ SplineSet *SplinePointListInterpretSVG(char *filename,char *memory, int memlen,i
     SplineSet *r = SplinesFromEntities(ret, ip, is_stroked);
     ip->default_joinlimit = tmpjl;
     return r;
-}
-
-int HasSVG(void) {
-return( libxml_init_base());
 }

--- a/fontforge/svg.h
+++ b/fontforge/svg.h
@@ -8,7 +8,6 @@ extern char **NamesReadSVG(char *filename);
 extern Entity *EntityInterpretSVG(char *filename, char *memory, int memlen,
                                   int em_size, int ascent, bool scale);
 extern int _ExportSVG(FILE *svg, SplineChar *sc, int layer, ExportParams *ep);
-extern int HasSVG(void);
 extern int SFFindOrder(SplineFont *sf);
 extern int SFLFindOrder(SplineFont *sf, int layerdest);
 extern int WriteSVGFont(const char *fontname, SplineFont *sf, enum fontformat format, int flags, EncMap *enc, int layer);

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -2200,10 +2200,6 @@ return( NULL );
 return( NULL );
 }
 
-static int libxml_init_base() {
-return( true );
-}
-
 static xmlNodePtr FindNode(xmlNodePtr kids,char *name) {
     while ( kids!=NULL ) {
 	if ( xmlStrcmp(kids->name,(const xmlChar *) name)== 0 )
@@ -3984,11 +3980,6 @@ SplineFont *SFReadUFO(char *basedir, int flags) {
     char *end;
     int as = -1, ds= -1, em= -1;
 
-    if ( !libxml_init_base()) {
-	LogError(_("Can't find libxml2."));
-return( NULL );
-    }
-
     sf = SplineFontEmpty();
     SFDefaultOS2Info(&sf->pfminfo, sf, ""); // We set the default pfm values.
     sf->pfminfo.pfmset = 1; // We flag the pfminfo as present since we expect the U. F. O. to set any desired values.
@@ -4551,10 +4542,6 @@ SplineSet *SplinePointListInterpretGlif(SplineFont *sf,char *filename,char *memo
     SplineChar *sc;
     SplineSet *ss;
 
-    if ( !libxml_init_base()) {
-	LogError(_("Can't find libxml2."));
-return( NULL );
-    }
     if ( filename!=NULL )
 	doc = xmlParseFile(filename);
     else
@@ -4575,8 +4562,4 @@ return( NULL );
     sc->layers[ly_fore].splines = NULL;
     SplineCharFree(sc);
 return( ss );
-}
-
-int HasUFO(void) {
-return( libxml_init_base());
 }

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -9123,16 +9123,7 @@ static void cv_edlistcheck(CharView *cv, struct gmenuitem *mi) {
 	    mi->ti.disabled = cv->b.gridfit==NULL;
 	  break;
 	  case MID_Paste:
-	    mi->ti.disabled = !CopyContainsSomething() &&
-#ifndef _NO_LIBPNG
-		    !GDrawSelectionHasType(cv->gw,sn_clipboard,"image/png") &&
-#endif
-		    !GDrawSelectionHasType(cv->gw,sn_clipboard,"image/svg+xml") &&
-		    !GDrawSelectionHasType(cv->gw,sn_clipboard,"image/svg-xml") &&
-		    !GDrawSelectionHasType(cv->gw,sn_clipboard,"image/svg") &&
-		    !GDrawSelectionHasType(cv->gw,sn_clipboard,"image/bmp") &&
-		    !GDrawSelectionHasType(cv->gw,sn_clipboard,"image/eps") &&
-		    !GDrawSelectionHasType(cv->gw,sn_clipboard,"image/ps");
+	    mi->ti.disabled = !CopyContainsSomething() && !SCClipboardHasPasteableContents();
 	  break;
 	  case MID_Undo:
 	    mi->ti.disabled = cv->b.layerheads[cv->b.drawmode]->undoes==NULL;

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -4081,16 +4081,7 @@ static void edlistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {
     FontView *fv = (FontView *) GDrawGetUserData(gw);
     int pos = FVAnyCharSelected(fv), i, gid;
     int not_pasteable = pos==-1 ||
-		    (!CopyContainsSomething() &&
-#ifndef _NO_LIBPNG
-		    !GDrawSelectionHasType(fv->gw,sn_clipboard,"image/png") &&
-#endif
-		    !GDrawSelectionHasType(fv->gw,sn_clipboard,"image/svg+xml") &&
-		    !GDrawSelectionHasType(fv->gw,sn_clipboard,"image/svg-xml") &&
-		    !GDrawSelectionHasType(fv->gw,sn_clipboard,"image/svg") &&
-		    !GDrawSelectionHasType(fv->gw,sn_clipboard,"image/bmp") &&
-		    !GDrawSelectionHasType(fv->gw,sn_clipboard,"image/eps") &&
-		    !GDrawSelectionHasType(fv->gw,sn_clipboard,"image/ps"));
+		    (!CopyContainsSomething() && !SCClipboardHasPasteableContents());
     RefChar *base = CopyContainsRef(fv->b.sf);
     int base_enc = base!=NULL ? fv->b.map->backmap[base->orig_pos] : -1;
 


### PR DESCRIPTION
So I took a further look and it seems like the problem is Inkscape is sending `image/x-inkscape-svg`, followed by image formats like png/bmp. So make FF accept that mime type. Not sure if Inkscape changed the mime type sent or something.

Fixes #4291

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
- **Non-breaking change**
