### PR TITLE
parsepdf.c: fix parsing of FontFile3 entries based on the Subtype

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1970,6 +1970,8 @@ return( NULL );
     ff = strtol(pt,NULL,10);
     if ( !pdf_findobject(pc,ff) || !pdf_readdict(pc) )
   goto fail;
+    if ( type==3 && (pt=PSDictHasEntry(&pc->pdfdict, "Subtype"))!=NULL && strcmp(pt, "/OpenType")==0 )
+	type = 2;
     file = pdf_defilterstream(pc);
     if ( file==NULL )
 return( NULL );
@@ -1992,6 +1994,8 @@ return( NULL );
 	sf = _CFFParse(file,len,pc->fontnames[font_num]);
     }
     fclose(file);
+    if (sf == NULL)
+	goto fail;
     /* Don't attempt to parse CMaps for Type 1 fonts: they already have glyph names */
     /* which are usually more meaningful */
     if (pc->cmapobjs[font_num] != -1 && type > 1)


### PR DESCRIPTION
If the subtype is `/CIDFontType0` it's CFF, otherwise if `/OpenType` it's a sfnt. (See also https://github.com/felipeochoa/minecart/wiki/%5BPDF-spec%5D-Fonts, for easy reading, otherwise you can pull the same info out of the reference) 

Also fix a crash if sf ends up being null.

Fixes #4299.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
