### PR TITLE
ustring.c: u2utf8_copyn: truncate at the first invalid utf8 char instead of returning null

### DIFF
--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -655,18 +655,19 @@ char *u2utf8_copy(const unichar_t *ubuf) {
 
 char *u2utf8_copyn(const unichar_t *ubuf,int len) {
 /* Make a utf8 string copy of unichar string ubuf[0..len] */
-    char *utf8buf, *pt;
+    char *utf8buf, *pt, *pt2;
 
     if ( ubuf==NULL || len<=0 || (utf8buf=pt=(char *)malloc(len*6+1))==NULL )
 	return( NULL );
 
-    while ( (pt=utf8_idpb(pt,*ubuf++,0)) && --len );
-    if ( pt ) {
-	*pt = '\0';
-	return( utf8buf );
-    }
-    free( utf8buf );
-    return( NULL );
+    while ( (pt2=utf8_idpb(pt,*ubuf++,0)) && --len )
+	pt = pt2;
+
+    if ( pt2 )
+	pt = pt2;
+
+    *pt = '\0';
+    return( utf8buf );
 }
 
 int32 utf8_ildb(const char **_text) {

--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -665,6 +665,8 @@ char *u2utf8_copyn(const unichar_t *ubuf,int len) {
 
     if ( pt2 )
 	pt = pt2;
+    else
+	TRACE("u2utf8_copyn: truncated on invalid char 0x%x\n", ubuf[-1]);
 
     *pt = '\0';
     return( utf8buf );

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -5870,7 +5870,7 @@ static void FVExpose(FontView *fv,GWindow pixmap, GEvent *event) {
 		    use_utf8 = true;
 			*pt = '\0'; // We terminate the string in case the appendage (?) fails.
 		    pt = utf8_idpb(pt,uni,0);
-		    if (pt) *pt = '\0'; else fprintf(stderr, "Invalid Unicode alert.\n");
+		    if (pt) *pt = '\0'; else TRACE("Invalid Unicode alert.\n");
 		} else {
 		    char *pt = strchr(sc->name,'.');
 		    buf[0] = '?';

--- a/inc/basics.h
+++ b/inc/basics.h
@@ -67,9 +67,9 @@ typedef uint32 unichar_t;
 /* A macro to print a string for debug purposes
  */
 #ifndef NDEBUG
-#define TRACE(...) printf(__VA_ARGS__)
+#define TRACE(...) fprintf(stderr, __VA_ARGS__)
 #else
-#define TRACE(...)
+#define TRACE(...) while(0)
 #endif
 
 /* assert() with an otherwise unused variable


### PR DESCRIPTION
Fixes #4294. e.g. from that case, a single surrogate is not valid utf-8

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**