### PR TITLE
Fix appveyor [skip travis]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
 # These steps will update msys2 to the latest version
 # Run unconditionally if builds fail because of pacman not installing dependencies due to version conflicts
   - >-
-    if "%APPVEYOR_REPO_BRANCH:~0,8%"=="release/"
+    if "%APPVEYOR_REPO_BRANCH:~0,8%"=="release/" (
     move C:\msys64 C:\msys64_old &&
     curl -ko msys2.tar.xz http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz &&
     7z x -so msys2.tar.xz | 7z x -si -ttar &&
@@ -41,7 +41,8 @@ install:
     call %MBASH% "ls" &&
     call %MBASH% "pacman -Syuu --noconfirm" &&
     call %MBASH% "pacman -Suu --noconfirm" &&
-    call %MBASH% "pacman -Suu --noconfirm"
+    call %MBASH% "pacman -Suu --noconfirm" )
+    else call %MBASH% "pacman -Syuu --noconfirm"
   - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER/fontforgebuilds; exec 0</dev/null; ./ffbuild.sh --appveyor --depsonly"
 build_script:
   - call %MBASH% "cd $APPVEYOR_BUILD_FOLDER/fontforgebuilds; exec 0</dev/null; ./ffbuild.sh --appveyor"


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->
The msys2 environment supplied by appveyor is too old, so update it.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
