### PR TITLE
Fix loading ascent/descent from SbitLineMetrics and make FV glyph centering consistent

### DIFF
--- a/fontforge/parsettfbmf.c
+++ b/fontforge/parsettfbmf.c
@@ -521,8 +521,8 @@ void TTFLoadBitmaps(FILE *ttf,struct ttfinfo *info,int onlyone) {
 	sizes[j].numIndexSubTables = getlong(ttf);
 	if ( /* colorRef = */ getlong(ttf)!=0 )
 	    good = false;
-	sizes[j].ascent = getc(ttf);
-	sizes[j].descent = getc(ttf);
+	sizes[j].ascent = (int8)getc(ttf);
+	sizes[j].descent = (int8)getc(ttf);
 	for ( k=0; k<12-2; ++k ) getc(ttf);	/* Horizontal Line Metrics */
 	for ( k=0; k<12; ++k ) getc(ttf);	/* Vertical   Line Metrics */
 	sizes[j].firstglyph = getushort(ttf);

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -333,24 +333,31 @@ static void FVDrawGlyph(GWindow pixmap, FontView *fv, int index, int forcebg ) {
 		++b.x; ++b.y; b.width -= 2; b.height -= 2;
 		GDrawDrawRect(pixmap,&b,0x008000);
 	    }
+
+	    // Keep centering consistent to bdfc->width. If base.width!=bdfc->width,
+	    // the bitmap has likely been run through BCCompressBitmap. In this
+	    // case, bdfc->xmin should represent the true offset from the origin
+	    // to the first used column.
+	    int xwidth = (bdfc->width != base.width) ? bdfc->width - bdfc->xmin*2 : base.width;
+
 	    /* I assume that the bitmap image matches the bounding*/
 	    /*  box. In some bitmap fonts the bitmap has white space on the*/
 	    /*  right. This can throw off the centering algorithem */
 	    if ( fv->magnify>1 ) {
 		GDrawDrawImageMagnified(pixmap,&gi,NULL,
-			j*fv->cbw+(fv->cbw-1-fv->magnify*base.width)/2,
+			j*fv->cbw+(fv->cbw-1-fv->magnify*xwidth)/2,
 			i*fv->cbh+fv->lab_height+1+fv->magnify*(fv->show->ascent-bdfc->ymax),
 			fv->magnify*base.width,fv->magnify*base.height);
 	    } else if ( (GDrawHasCairo(pixmap)&gc_alpha) && base.image_type==it_index ) {
 		GDrawDrawGlyph(pixmap,&gi,NULL,
-			j*fv->cbw+(fv->cbw-1-base.width)/2,
+			j*fv->cbw+(fv->cbw-1-xwidth)/2,
 			i*fv->cbh+fv->lab_height+1+fv->show->ascent-bdfc->ymax);
 	    } else
 		GDrawDrawImage(pixmap,&gi,NULL,
-			j*fv->cbw+(fv->cbw-1-base.width)/2,
+			j*fv->cbw+(fv->cbw-1-xwidth)/2,
 			i*fv->cbh+fv->lab_height+1+fv->show->ascent-bdfc->ymax);
 	    if ( fv->showhmetrics ) {
-		int x1, x0 = j*fv->cbw+(fv->cbw-1-fv->magnify*base.width)/2- bdfc->xmin*fv->magnify;
+		int x1, x0 = j*fv->cbw+(fv->cbw-1-fv->magnify*xwidth)/2- bdfc->xmin*fv->magnify;
 		/* Draw advance width & horizontal origin */
 		if ( fv->showhmetrics&fvm_origin )
 		    GDrawDrawLine(pixmap,x0,i*fv->cbh+fv->lab_height+yorg-3,x0,
@@ -364,7 +371,7 @@ static void FVDrawGlyph(GWindow pixmap, FontView *fv, int index, int forcebg ) {
 			    (i+1)*fv->cbh-2,METRICS_ADVANCE);
 	    }
 	    if ( fv->showvmetrics ) {
-		int x0 = j*fv->cbw+(fv->cbw-1-fv->magnify*base.width)/2- bdfc->xmin*fv->magnify
+		int x0 = j*fv->cbw+(fv->cbw-1-fv->magnify*xwidth)/2- bdfc->xmin*fv->magnify
 			+ fv->magnify*fv->show->pixelsize/2;
 		int y0 = i*fv->cbh+fv->lab_height+yorg;
 		int yvw = y0 + fv->magnify*sc->vwidth*fv->show->pixelsize/em;


### PR DESCRIPTION
The first change is fairly straightforward, the [ascent/descent are signed](https://docs.microsoft.com/en-us/typography/opentype/spec/eblc#sbitlinemetrics) but they were being read unsigned.

The second fix is a bit harder to explain. Basically it's fixing the discrepancy in what was rendered in the fontview between opening the PCF and the converted OTB from #4262:
![image](https://user-images.githubusercontent.com/5137410/80857521-33c8c480-8c96-11ea-9c69-996613917a1f.png)
vs
![image](https://user-images.githubusercontent.com/5137410/80857523-375c4b80-8c96-11ea-9b13-1c4328359a4b.png)

(It's easier to see the discrepancy when flipping between the two)

The commit message should hopefully explain it, but in the context of the above example:
* Glyphs are fixed width, 6 pixels wide (with a 10 pixel ascent, 2 pixel descent, but this doesn't matter).
* When the PCF is read, FontForge does *not* run it through BCCompressBitmap. So all bitmap data has the same dimensions, equal to the actual glyph width (6 pixels wide x 13 pixels tall)
* When the OTB is read, FontForge *does* run it through BCCompressBitmap. This strips the padding from all the bitmaps, so a glyph may have bitmap data that's only say 5 pixels wide x 10 pixels tall (with appropriately fixed x/y offsets).
* When you open and close a charview, it also runs BCCompressBitmap on those, so you'll also see the discrepancy with the PCF on the glyphs where you do this.

In the FontView, it tries to center the bitmap data within the given glyph box, but it does so against bdfc->xmax-bdfc->xmin, i.e. the 5 pixels in the above example vs. 6 pixels. This leads to the visual discrepancy shown above, even though there's no actual difference. 

e.g. bounds: Uncompressed, xmin=0, xmax=5, ymin=-2, ymax=10. Compressed, xmin=1, xmax=3, ymin=-1,ymax=9
![image](https://user-images.githubusercontent.com/5137410/80857831-7b505000-8c98-11ea-9684-6844dd890cbb.png)



### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
