### PR TITLE
ggdkdraw.c: re-set transient status for restricted windows when un-hiding

### DIFF
--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -1481,6 +1481,9 @@ static void GGDKDrawSetVisible(GWindow w, int show) {
         _GGDKDraw_OnFakedConfigure(gw);
 #endif
         gdk_window_show(gw->w);
+        if (gw->restrict_input_to_me && gw->transient_owner == NULL && gw->display->mru_windows->length > 0) {
+            GGDKDrawSetTransientFor((GWindow)gw, (GWindow) - 1);
+        }
     } else {
         GGDKDrawSetTransientFor((GWindow)gw, NULL);
         gdk_window_hide(gw->w);


### PR DESCRIPTION
The transient state was only being set on window creation. But sometimes windows
are held around and only hidden/shown. While the transient state was being
cleared on hide events, it was not reinstated when the window was shown again.

Fixes #4328

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**