### PR TITLE
Fix contextual chaining lookups rules modification (#2796)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build/
-out/
 
 .vscode/
 .vs/

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1748,7 +1748,8 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
 	}
     } else {
 	for ( i=0; i<rows; ++i ) {
-	    char* end_back = NULL, * end_match = NULL;
+	    char *end_back = NULL;
+	    char *end_match = NULL;
 	    char *oldrule = classrules[cols*i+0].u.md_str;
 	    char *newrule;
 	    for ( pt=last_name=oldrule; *pt; ) {

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1748,10 +1748,10 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
 	}
     } else {
 	for ( i=0; i<rows; ++i ) {
-	    char* end_back = NULL, * end_match = NULL;
-	    char *oldrule = classrules[cols*i+0].u.md_str;
-	    char *newrule;
-	    for ( pt=last_name=oldrule; *pt; ) {
+		char* end_back = NULL, * end_match = NULL;
+		char *oldrule = classrules[cols*i+0].u.md_str;
+		char *newrule;
+		for ( pt=last_name=oldrule; *pt; ) {
 		while ( isspace(*pt)) ++pt;
 		if ( *pt=='|' ) {
 		    if ( end_back == NULL )

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1748,7 +1748,7 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
 	}
     } else {
 	for ( i=0; i<rows; ++i ) {
-        char* end_back = NULL, * end_match = NULL;
+		char* end_back = NULL, * end_match = NULL;
 	    char *oldrule = classrules[cols*i+0].u.md_str;
 	    char *newrule;
 	    for ( pt=last_name=oldrule; *pt; ) {

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1748,7 +1748,7 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
 	}
     } else {
 	for ( i=0; i<rows; ++i ) {
-		char* end_back = NULL, * end_match = NULL;
+        char* end_back = NULL, * end_match = NULL;
 	    char *oldrule = classrules[cols*i+0].u.md_str;
 	    char *newrule;
 	    for ( pt=last_name=oldrule; *pt; ) {

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1735,7 +1735,7 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
     GGadget *gclassrules = GWidgetGetControl(ccd->classes_simple,CID_CList_Simple);
     struct matrix_data *classrules = GMatrixEditGet(gclassrules,&rows);
     int cols = GMatrixEditGetColCnt(gclassrules);
-    char *end_back=NULL, *end_match=NULL, *pt, *last_name, *temp;
+    char *pt, *last_name, *temp;
     int ch;
 
     if ( sections==0x7 ) {
@@ -1748,6 +1748,7 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
 	}
     } else {
 	for ( i=0; i<rows; ++i ) {
+		char* end_back = NULL, * end_match = NULL;
 	    char *oldrule = classrules[cols*i+0].u.md_str;
 	    char *newrule;
 	    for ( pt=last_name=oldrule; *pt; ) {

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1748,7 +1748,7 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
 	}
     } else {
 	for ( i=0; i<rows; ++i ) {
-		char* end_back = NULL, * end_match = NULL;
+	    char* end_back = NULL, * end_match = NULL;
 	    char *oldrule = classrules[cols*i+0].u.md_str;
 	    char *newrule;
 	    for ( pt=last_name=oldrule; *pt; ) {

--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1748,10 +1748,10 @@ static void RenameClass(struct contextchaindlg *ccd,char *old,char *new,int sect
 	}
     } else {
 	for ( i=0; i<rows; ++i ) {
-		char* end_back = NULL, * end_match = NULL;
-		char *oldrule = classrules[cols*i+0].u.md_str;
-		char *newrule;
-		for ( pt=last_name=oldrule; *pt; ) {
+	    char* end_back = NULL, * end_match = NULL;
+	    char *oldrule = classrules[cols*i+0].u.md_str;
+	    char *newrule;
+	    for ( pt=last_name=oldrule; *pt; ) {
 		while ( isspace(*pt)) ++pt;
 		if ( *pt=='|' ) {
 		    if ( end_back == NULL )


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

### Fix contextual chaining lookups rules modification (#2796)
Rule section markers are not zeroed in the next iterations.

### Specify untracked files that Git should ignore when using Visual Studio 2019
Add exceptions in .gitignore for Visual Studio 2019.