### PR TITLE
Fix a crash when pressing a key that doesn't exist in the current encoding

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -6295,7 +6295,7 @@ return;
 		    if ( sf->glyphs[i]->unicodeenc==event->u.chr.keysym )
 	    break;
 	    }
-	    if ( i!=-1 )
+	    if ( i<sf->glyphcnt )
 		enc = fv->b.map->backmap[i];
 	}
 	if ( enc<fv->b.map->enccount && enc!=-1 )


### PR DESCRIPTION
Noticed this while working on cid fonts.

Steps to repro:
* Create a new font
* Set encoding to custom, remove unused slots and add 256 (or any amount > 255)
* Fill all slots with something so they're not empty
* Press the spacebar or any key on your keyboard
* `i` is now >256 which exceeds the backmap size (backmax) --> garbage data or crash

Alternatively, open source han sans, and press the spacebar in the fontview

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
