### PR TITLE
fix memory leak in SFReplaceEncodingBDFProps

### DIFF
--- a/fontforge/bitmapchar.c
+++ b/fontforge/bitmapchar.c
@@ -372,6 +372,7 @@ void SFReplaceFontnameBDFProps(SplineFont *sf) {
 		    BDFPropReplace(bdf,"FONT",buffer2);
 		}
 	    }
+	    free(bpt);
 	}
     }
 }


### PR DESCRIPTION
since copy is implemented by strdup, we should free bpt after use.

Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**
