### PR TITLE
Fix SSRemoveTiny crash

### DIFF
--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -3490,7 +3490,7 @@ static SplineSet *SSRemoveTiny(SplineSet *base) {
 
     while ( base!=NULL ) {
 	ssnext = base->next;
-	for ( sp=base->first; ; ) {
+	for ( sp=base->first; !( base == NULL || sp==base->first ); ) {
 	    if ( sp->next==NULL )
 	break;
 	    nsp = sp->next->to;
@@ -3587,10 +3587,10 @@ static SplineSet *SSRemoveTiny(SplineSet *base) {
 	    }
 	    // Remember that we may have deleted base and nulled nsp previously.
 	    sp = nsp; // Increment sp, possibly to NULL.
-	    // If we are at the end of the contour or have deleted it, the job is done.
-	    if ( base == NULL || sp==base->first )
-		break;
 	}
+	// If we are at the end of the contour or have deleted it, the job is done.
+	if ( base == NULL || sp==base->first )
+	    break;
 	if ( sp && sp->prev!=NULL && !sp->noprevcp ) {
 	    int refigure = false;
 	    if ( sp->me.x-sp->prevcp.x>-error && sp->me.x-sp->prevcp.x<error ) {


### PR DESCRIPTION
It wasn't properly checking base for NULL, which led to `sp` pointing at
junk.

This closes #4364.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
