### PR TITLE
Clear sp in SSRemoveTiny so the guards after the loop don't execute.

### DIFF
--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -3510,6 +3510,7 @@ static SplineSet *SSRemoveTiny(SplineSet *base) {
 			    prev->next = ssnext;
 			base = NULL;
 			nsp = NULL;
+			sp = NULL;
 			break;
 		    } else {
 			// We want to remove the spline following sp.


### PR DESCRIPTION
Similar/related to #4138 

Closes #4364 