### PR TITLE
cmake: fix rpath to use CMAKE_INSTALL_LIBDIR instad of assuming <prefix>/lib

### DIFF
--- a/cmake/BuildUtils.cmake
+++ b/cmake/BuildUtils.cmake
@@ -28,7 +28,8 @@ current status.
 explicitly specified.
 
 ``set_default_rpath`` sets the default RPATH to be used on platforms
-that support it.
+that support it. Can only be called after GNUInstallDirs has been
+included.
 
 ``enable_sanitizer`` checks if the specified sanitizer is supported,
 and adds the required compiler flags to enable it if so. If unsupported,
@@ -100,11 +101,11 @@ function(set_default_build_type default_build_type)
 endfunction()
 
 function(set_default_rpath)
-  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" _present)
+  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_LIBDIR}" _present)
   if(_present LESS 0)
-    list(FIND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" _present)
+    list(FIND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}" _present)
     if(_present LESS 0)
-      list(APPEND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+      list(APPEND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
     endif()
   endif()
   if(APPLE)


### PR DESCRIPTION
Can be something else e.g. `lib64` depending on the host. See also #4394

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**