### PR TITLE
FIX: "Create new lookup" didn't work when adding a new subtable in Glyph Info (resolves #4401)

### DIFF
--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -5258,7 +5258,7 @@ return( sub );
 	    _("Add a subtable to which lookup?"));
     if ( ans==-1 )
 	found = NULL;
-    else if ( ans==cnt )
+    else if ( ans==cnt-1 )
 	found = CreateAndSortNewLookupOfType(sf,lookup_type);
     else {
 	found = NULL;


### PR DESCRIPTION
As `choices[cnt++]` for adding the "Create new lookup" entry also increases the value of `cnt`, we have to check for `cnt-1` in order to check whether it was the selected answer of the dialogue.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix** for #4401