### PR TITLE
Adjustments for floating point corner cases (Expand stroke and SVG import)

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1301,14 +1301,18 @@ static void SVGTraceArc(SplineSet *cur,BasePoint *current,
 	y1p =-ang.y*(current->x-x)/2 + ang.x*(current->y-y)/2;
 	/* Correct for bad radii */
 	lambda = x1p*x1p/(rx*rx) + y1p*y1p/(ry*ry);
-	if ( lambda>1 ) {
+	if ( lambda>=1 ) {
 	   lambda = sqrt(lambda);
 	   rx *= lambda;
 	   ry *= lambda;
 	   cxp = cyp = 0;
 	} else {
 	    factor = rx*rx*ry*ry - rx*rx*y1p*y1p - ry*ry*x1p*x1p;
-	    factor = sqrt(factor/(rx*rx*y1p*y1p+ry*ry*x1p*x1p));
+	    factor = factor/(rx*rx*y1p*y1p+ry*ry*x1p*x1p);
+	    if (factor < 0) // Ideally the lambda check will prevent this, but ...
+		factor = 0;
+	    else
+		factor = sqrt(factor);
 	    // This part of the center calculation deals with large_arc
 	    // leaving sweep as a parameter to SSAppendArc
 	    if ( large_arc==sweep )

--- a/fontforge/utanvec.c
+++ b/fontforge/utanvec.c
@@ -34,10 +34,12 @@
 #include <math.h>
 #include <assert.h>
 
-#define UTMARGIN (1e-8)
-#define UTSOFTMARGIN (1e-5)
+#define UTMARGIN (1e-7)     // Arrived at through testing
+#define UTSOFTMARGIN (1e-5) // Fallback margin for some cases
 #define BPNEAR(bp1, bp2) BPWithin(bp1, bp2, UTMARGIN)
-#define UTRETRY (UTMARGIN/10.0)
+#define UTRETRY (1e-9)      // Amount of "t" to walk back from the 
+                            // ends of degenerate splines to find
+                            // a slope.
 
 BasePoint MakeUTanVec(bigreal x, bigreal y) {
     BasePoint ret = { 0.0, 0.0 };


### PR DESCRIPTION
Adjust UTMARGIN for case just outside unit vector accuracy
Protect against bad calculations of circular SVG args that
slip through the SVG 1.1 standard test

closes #4406