### PR TITLE
Cygwin patches

### DIFF
--- a/cmake/FontForgeConfigure.cmake
+++ b/cmake/FontForgeConfigure.cmake
@@ -48,7 +48,6 @@ function(fontforge_generate_config template destination)
     set(__Mac 1)
   elseif(CYGWIN)
     set(__CygWin 1)
-    set(_BrokenBitmapImages 1)
     set(_ModKeysAutoRepeat 1)
   endif()
 

--- a/fontforge/CMakeLists.txt
+++ b/fontforge/CMakeLists.txt
@@ -217,8 +217,10 @@ endif()
 set_property(SOURCE splineoverlap.c APPEND PROPERTY COMPILE_OPTIONS ${FONTFORGE_EXTRA_CFLAGS})
 
 set_property(TARGET fontforge PROPERTY VERSION 4)
-if(WIN32 AND BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
+  if(WIN32 OR CYGWIN)
     target_link_options(fontforge PRIVATE -Wl,--export-all-symbols) # FIXME
+  endif()
 endif()
 
 # This is pretty bad...
@@ -271,7 +273,7 @@ endif()
 
 # No dev package -> no need to install if static
 if(BUILD_SHARED_LIBS)
-  if(WIN32)
+  if(WIN32 OR CYGWIN)
     install(TARGETS fontforge RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
   else()
     install(TARGETS fontforge RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -580,9 +580,11 @@ static void ProcessFileChooserPrefs(void) {
 	b[i++] = uc_copy("/System/Library/Fonts/");
 #endif
 #if __CygWin
-	b[i++] = uc_copy("/cygdrive/c/Windows/Fonts/");
-#endif
+	b[i++] = uc_copy("/usr/share/fonts/");
+	b[i++] = uc_copy("/usr/share/X11/fonts/");
+#else
 	b[i++] = uc_copy("/usr/X11R6/lib/X11/fonts/");
+#endif
 	b[i++] = NULL;
 	GFileChooserSetBookmarks(b);
     } else {


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

# Patches for Cygwin build

- Fix settings for a shared library for Cygwin (fontforge/CMakeLists.txt)
- Fix a building feature for Cygwin (cmake/FontForgeConfigure.cmake)
- Modify font paths for Cygwin (fontforgeexe/prefs.c)

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->

- **Non-breaking change**
