### PR TITLE
Fix checkbox double toggle due to et_char and et_charup events

### DIFF
--- a/gdraw/gradio.c
+++ b/gdraw/gradio.c
@@ -454,7 +454,7 @@ return(false);
 	    event->u.chr.keysym == GK_BackTab || event->u.chr.keysym == GK_Escape )
 return( false );
 
-    if (event->u.chr.chars[0]==' ' ) {
+    if (event->type == et_char && event->u.chr.chars[0]==' ' ) {
 	GRadioChanged(gr);
 	_ggadget_redraw(g);
 return( true );


### PR DESCRIPTION
@jtanx this seems to fix #4422 under GTK and works fine under X11 (I didn't check whether the problem reproduces with the X11 backend). Does it look OK to you?

Closes #4422 