### PR TITLE
Don't crash if encoding is negative

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -4843,7 +4843,7 @@ return;
     }
     if ( enc>=map->enccount )
 	map->enccount = enc+1;
-    if ( enc!=-1 )
+    if ( enc>-1 )
 	map->map[enc] = orig_pos;
 }
 


### PR DESCRIPTION
Apparently this can happen sometimes, perhaps only on old versions, when
using the "Merge Fonts" feature.

Close #4427

Cf. https://github.com/ctrlcctrlv/some-time-later/commit/82f80d03cb947d53eab08df2d3e854695dad4897

If you encounter this issue, you'll need to manually edit your SFD like
that to see your glyphs in FontView; this only prevents crash.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
