### PR TITLE
Add font.compact() to Python API

### DIFF
--- a/doc/sphinx/scripting/python/fontforge.rst
+++ b/doc/sphinx/scripting/python/fontforge.rst
@@ -3180,7 +3180,8 @@ This type may not be pickled.
 .. attribute:: font.encoding
 
    The name of the current encoding. Setting it will change the encoding used
-   for indexing
+   for indexing. To compact the encoding, first set it to your desired encoding
+   (e.g. ``UnicodeBMP``), then set it to ``compacted``.
 
 .. attribute:: font.familyname
 


### PR DESCRIPTION
Adds a function to the Python API that has the identical effect as &laquo;Encoding&rarr;Compact&raquo;.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Small new feature**
