### PR TITLE
gmenu.c: prevent the menu key from creating a menu if one is already present

### DIFF
--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -2026,7 +2026,7 @@ int GMenuBarCheckKey(GWindow top, GGadget *g, GEvent *event) {
     }
 
 //    TRACE("menubarcheckkey(e2)\n");
-    if ( event->u.chr.keysym==GK_Menu )
+    if ( event->u.chr.keysym==GK_Menu && most_recent_popup_menu==NULL )
 	GMenuCreatePopupMenu(event->w,event, mb->mi);
 
     return( false );


### PR DESCRIPTION
Fixes #4462

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**