### PR TITLE
Fix FreeType debugger compilation with FreeType >= 2.10.3

### DIFF
--- a/fontforge/fffreetype.h
+++ b/fontforge/fffreetype.h
@@ -39,7 +39,9 @@
 #endif
 
 #if defined(FREETYPE_HAS_DEBUGGER)
-# include <internal/internal.h>
+#if FREETYPE_MAJOR == 2 && (FREETYPE_MINOR < 10 || (FREETYPE_MINOR == 10 && FREETYPE_PATCH < 3))
+#  include <internal/internal.h>
+# endif
 # include <ttdriver.h>
 # include <ttinterp.h>
 # include <ttobjs.h>

--- a/fontforgeexe/cvdebug.c
+++ b/fontforgeexe/cvdebug.c
@@ -59,7 +59,9 @@ void CVDebugPointPopup(CharView *cv) {
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
-#include <internal/internal.h>
+#if FREETYPE_MAJOR == 2 && (FREETYPE_MINOR < 10 || (FREETYPE_MINOR == 10 && FREETYPE_PATCH < 3))
+# include <internal/internal.h>
+#endif
 #include <ttinterp.h>
 
 # define PPEMX(exc)	((exc)->size->root.metrics.x_ppem)

--- a/fontforgeexe/cvdgloss.c
+++ b/fontforgeexe/cvdgloss.c
@@ -42,7 +42,9 @@ extern GBox _ggadget_Default_Box;
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
-#include <internal/internal.h>
+#if FREETYPE_MAJOR == 2 && (FREETYPE_MINOR < 10 || (FREETYPE_MINOR == 10 && FREETYPE_PATCH < 3))
+# include <internal/internal.h>
+#endif
 #include <ttinterp.h>
 
 #define PPEMX(exc)	((exc)->size->root.metrics.x_ppem)


### PR DESCRIPTION
Fixes #4477

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
