### PR TITLE
Better heuristics for correction of direction in Expand Stroke

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -2288,6 +2288,10 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 		    left = SplineSetRemoveOverlap(NULL,left,over_remove);
 		// Open paths don't always produce clockwise output
 		is_ccw_mid = SplinePointListIsClockwise(left);
+		if ( is_ccw_mid==0 && left->next==NULL ) {
+		    SplineSetReverse(left);
+		    is_ccw_mid=1;
+		}
 		if ( is_ccw_mid==-1 && c->rmov!=srmov_none ) {
 		    assert( c->rmov!=srmov_contour );
 		    left = SplineSetRemoveOverlap(NULL,left,over_remove);
@@ -2297,8 +2301,6 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 		    LogError( _("Warning: Can't identify contour direction, "
 		                "assuming clockwise\n") );
 		}
-		if ( is_ccw_mid==0 )
-		    SplineSetReverse(left);
 	    }
 	}
 	cur = left;


### PR DESCRIPTION
Closes #4492 

I'm unhappy with the heuristics I have available at this stage of the processing but this is an improvement. 

This issue was caused by my forgetting that `RemoveOverlap` can return multiple contours in any order, and I was futzing with the direction of the first one. I shouldn't touch its output as it knows more about direction than I do, hence the ordering change for the counter-clockwise case.