### PR TITLE
Add mnemonic underscores to Python registerMenuItem

### DIFF
--- a/fontforge/ffpython.h
+++ b/fontforge/ffpython.h
@@ -64,7 +64,7 @@ extern SplineChar *sc_active_in_ui;
 extern FontViewBase *fv_active_in_ui;
 extern int layer_active_in_ui;
 
-extern void FfPy_Replace_MenuItemStub(PyObject *(*func)(PyObject *,PyObject *));
+extern void FfPy_Replace_MenuItemStub(PyObject *(*func)(PyObject *,PyObject *,PyObject *));
 extern int PyFF_ConvexNibID(const char *);
 extern PyObject *PySC_From_SC(SplineChar *sc);
 extern PyObject *PyFV_From_FV(FontViewBase *fv);

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -1427,7 +1427,7 @@ void python_call_onClosingFunctions()
 /* ************************ User Interface routines ************************* */
 /* ************************************************************************** */
 
-static PyObject *PyFF_registerMenuItemStub(PyObject *UNUSED(self), PyObject *UNUSED(args)) {
+static PyObject *PyFF_registerMenuItemStub(PyObject *UNUSED(self), PyObject *UNUSED(args), PyObject *UNUSED(kwargs)) {
 //    printf("PyFF_registerMenuItemStub()\n");
     /* This is a stub which will be replaced when we've got a UI */
 Py_RETURN_NONE;
@@ -18787,7 +18787,7 @@ PyMethodDef module_fontforge_methods[] = {
     /* Access to the User Interface ... if any */
     { "hasUserInterface", PyFF_hasUserInterface, METH_NOARGS, "Returns whether this fontforge session has a user interface (True if it has opened windows) or is just running a script (False)"},
     { "registerImportExport", PyFF_registerImportExport, METH_VARARGS, "Adds an import/export spline conversion module"},
-    { "registerMenuItem", PyFF_registerMenuItemStub, METH_VARARGS, "Adds a menu item (which runs a python script) to the font or glyph (or both) windows -- in the Tools menu"},
+    { "registerMenuItem", (PyCFunction)PyFF_registerMenuItemStub, METH_VARARGS | METH_KEYWORDS, "Adds a menu item (which runs a python script) to the font or glyph (or both) windows -- in the Tools menu"},
     { "getConvexNib", PyFF_getConvexNib, METH_VARARGS, "Sets the specified 'Convex' to the layer/contour argument."},
     { "setConvexNib", PyFF_setConvexNib, METH_VARARGS, "Returns the specified 'Convex' nib as a layer."},
     { "logWarning", PyFF_logError, METH_VARARGS, "Adds a non-fatal message to the Warnings window"},
@@ -18875,12 +18875,12 @@ static module_definition module_def_fontforge = {
 /* ************************************************************************** */
 /* ************************* initializer routines *************************** */
 /* ************************************************************************** */
-void FfPy_Replace_MenuItemStub(PyObject *(*func)(PyObject *,PyObject *)) {
+void FfPy_Replace_MenuItemStub(PyObject *(*func)(PyObject *,PyObject *,PyObject *)) {
     int i;
     PyMethodDef *methods = module_fontforge_methods;
     for ( i=0; methods[i].ml_name!=NULL; ++i )
 	if ( strcmp(methods[i].ml_name,"registerMenuItem")==0 ) {
-	    methods[i].ml_meth = func;
+	    methods[i].ml_meth = (PyCFunction)func;
 return;
 	}
 }

--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -231,7 +231,9 @@ static void InsertSubMenus(PyObject *args,GMenuItem2 **mn, int is_cv, unichar_t*
     }
 
     for ( i=5; i<cnt; ++i ) {
-	unichar_t *submenuu = utf82u_copy(PyUnicode_AsUTF8(PyTuple_GetItem(args, i)));
+	// 0xFFFF means mnemonic unset
+	unichar_t t_mnemonic = mnemonic[i-5] == 0xFFFF ? 0 : mnemonic[i-5];
+	unichar_t *submenuu = utf82u_mncopy(PyUnicode_AsUTF8(PyTuple_GetItem(args, i)), &t_mnemonic);
 	for (unichar_t* p = submenuu; *p != '\0'; p++) {
 	    if (*p == '_') *p = 0x200B; // zero-width space
 	}
@@ -253,8 +255,7 @@ static void InsertSubMenus(PyObject *args,GMenuItem2 **mn, int is_cv, unichar_t*
 	if ( mmn[j].ti.text==NULL ) {
 	    mmn[j].ti.text = submenuu;
 	    mmn[j].ti.fg = mmn[j].ti.bg = COLOR_DEFAULT;
-	    // 0xFFFF means mnemonic unset
-	    mmn[j].ti.mnemonic = mnemonic[i-5] == 0xFFFF ? 0 : mnemonic[i-5];
+	    mmn[j].ti.mnemonic = t_mnemonic;
 	    // If in first or middle submenu
 	    if ( i!=cnt-1 ) {
 		mmn[j].mid = -1;


### PR DESCRIPTION
This allows Python scripts to add "mnemonics" (alt-key sequences).

Note underscored letters in example:

![image](https://user-images.githubusercontent.com/838783/98851117-a61b1e00-240a-11eb-88c1-81ff45fc4636.png)

```python
fontforge.registerMenuItem(autoNameGlyphPoints, None, None, "Glyph", None, "_Higher-Order Interpolation", "Attempt to automatically _name points")
```

In `master`, this would not work, underscores would appear in the text and <kbd>alt-T-h-n</kbd> wouldn't work.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **New feature**