### PR TITLE
Fix double free crash when flattening CID fonts

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -1529,6 +1529,7 @@ return(NULL);
 	fvs->sf = new;
 	FVSetTitle(fvs);
     }
+    cidmaster->anchor = NULL;
     FontViewReformatAll(new);
     SplineFontFree(cidmaster);
 return( new );


### PR DESCRIPTION
### Type of change
- **Bug fix**
This PR fixes a crash that happens when one flattens a CID font with anchors and immediately saves it to an SFD file.

I traced the problem with Address Sanitizer and apparently it was because the anchor in the master font is freed but still referenced in the flattened fonts.

Obviously this fix introduces a memory leak of a few bytes, but I doubt it's of any concern when we still have crash bugs to deal with.

I'm bothered to create an issue for an obvious one-liner fix.

Way to reproduce (more reliably when also running with Address Sanitizer, since double freeing does not guarantee a crash on all systems):
1. open NotoSansCJK
2. flatten
3. save to an sfd file