### PR TITLE
Fix an off-by-one allocation bug

### DIFF
--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -3891,7 +3891,7 @@ SplineSet *SplineSetsCorrect(SplineSet *base,int *changed) {
 
 /* Give up if we are given unreasonable values (ie. if rounding errors might screw us up) */
     if ( es.mmin<1e5 && es.mmax>-1e5 && es.omin<1e5 && es.omax>-1e5 ) {
-	es.cnt = (int) (es.mmax-es.mmin) + 1;
+	es.cnt = (int)ceil(es.mmax-es.mmin) + 1;
 	es.edges = calloc(es.cnt,sizeof(Edge *));
 	es.interesting = calloc(es.cnt,sizeof(char));
 	es.sc = NULL;


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
- **Bug fix**

Assume you have an Edge Set where `mmin` = 0 and `mmax` = 1.5; the Edge Set contains an Edge with the same values for `mmin` amd `mmax`.

The bug happens as thus (all line numbers are according to this branch):

At SplineSetsCorrect (splineutils2.c)
line 3893: `es.cnt = (int) (es.mmax-es.mmin) + 1;`            // es.cnt = 2
line 3896: `es.interesting = calloc(es.cnt,sizeof(char));` // allocates an array of size 2
line 3899: `FindEdgesSplineSet(base,&es,false);`
    --> FindEdgesSplineSet
    --> AddSpline
    --> AddEdge (splinefill.c)
line 279: `es->interesting[(int) ceil(e->mmax)]=1;`          // writes into element 2, which is outside the array

Thus, the intention of Line 3893 looks like `(int)ceil(es.mmax-es.mmin) + 1`, hence the fix.