### PR TITLE
Fix for #4494 Crash when pressing Tab or Right in glyph info dialog

### DIFF
--- a/gdraw/gmatrixedit.c
+++ b/gdraw/gmatrixedit.c
@@ -1392,7 +1392,7 @@ static void GMatrixEdit_StartSubGadgets(GMatrixEdit *gme,int r, int c,GEvent *ev
 	gme->wasnew = true;
     }
 
-    if ( c==gme->cols || r>=gme->rows || gme->col_data[c].disabled )
+    if ( c<0 || r<0 || c==gme->cols || r>=gme->rows || gme->col_data[c].disabled )
 return;
     oldr = gme->active_row;
     gme->active_col = c; gme->active_row = r;


### PR DESCRIPTION
Closes #4491 

This code was suggested by @jtanx and I've tested it to confirm it resolves the crash. It doesn't leave the dialog in a perfect accelerator state (tab works to advance the left menu position if you fiddle with it but not to start with). However, we have a lot of that sort of thing across the code base and I don't think its worth having individual open issues for them. 