### PR TITLE
Make «Glyph Info…→Unicode→Glyph Name» mnemonic `y`

### DIFF
--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -4388,13 +4388,13 @@ return;
 	ugcd[0].gd.label = &ulabel[0];
 	ugcd[0].gd.pos.x = 5; ugcd[0].gd.pos.y = 5+4; 
 	ugcd[0].gd.flags = gg_enabled|gg_visible;
-	ugcd[0].gd.mnemonic = 'N';
+	ugcd[0].gd.mnemonic = 'y';
 	ugcd[0].creator = GLabelCreate;
 	uhvarray[0] = &ugcd[0];
 
 	ugcd[1].gd.pos.x = 85; ugcd[1].gd.pos.y = 5;
 	ugcd[1].gd.flags = gg_enabled|gg_visible;
-	ugcd[1].gd.mnemonic = 'N';
+	ugcd[1].gd.mnemonic = 'y';
 	ugcd[1].gd.cid = CID_UName;
 	ugcd[1].creator = GListFieldCreate;
 	ugcd[1].data = (void *) (-2);


### PR DESCRIPTION
`N` is already taken by `Next >`.

Also, `y` is what we're telling users works, when it doesn't.

Close #4532

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
