### PR TITLE
Fix read-after-free bug in traversing linked list

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -17884,6 +17884,7 @@ static PyObject *PyFFFont_correctDirection(PyFF_Font *self, PyObject *UNUSED(arg
     int checkrefs = true;
     RefChar *ref;
     SplineChar *sc;
+    RefChar *next;
 
     if ( CheckIfFontClosed(self) )
 return (NULL);
@@ -17893,14 +17894,18 @@ return (NULL);
     for ( i=0; i<map->enccount; ++i ) if ( (gid=map->map[i])!=-1 && (sc=sf->glyphs[gid])!=NULL && fv->selected[i] ) {
 	changed = refchanged = false;
 	if ( checkrefs ) {
-	    for ( ref=sc->layers[self->fv->active_layer].refs; ref!=NULL; ref=ref->next ) {
+	    for ( ref=sc->layers[self->fv->active_layer].refs; ref!=NULL; ) {
 		if ( ref->transform[0]*ref->transform[3]<0 ||
 			(ref->transform[0]==0 && ref->transform[1]*ref->transform[2]>0)) {
 		    if ( !refchanged ) {
 			refchanged = true;
 			SCPreserveLayer(sc,self->fv->active_layer,false);
 		    }
+		    next = ref->next;
 		    SCRefToSplines(sc,ref,self->fv->active_layer);
+		    ref = next;
+		} else {
+		    ref=ref->next;
 		}
 	    }
 	}


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

This fixes a simple read-after-free bug revealed by Address Sanitizer in `PyFFFont_correctDirection`.
Basically, in the for loop it traverses a linked list of `RefChar*`'s, passes the current pointer to `SCRefToSplines`, which then calls `SCRemoveDependent` and frees the `RefChar*`. Then, since the same pointer is used as the loop iterator, `ref = ref->next` is executed.

This fix simply stores `ref->next` to a variable before calling `SCRefToSplines`, and use the stored pointer to continue the loop.