### PR TITLE
striptcc: checksumming with filecheck() requires read+write access.

### DIFF
--- a/contrib/fonttools/stripttc.c
+++ b/contrib/fonttools/stripttc.c
@@ -81,7 +81,7 @@ static int handlefont(char *filename,int which,FILE *ttc,int offset) {
 	pt = outfile + strlen(outfile);
     sprintf( pt, "_%02d.ttf", which );
 
-    ttf = fopen( outfile,"wb");
+    ttf = fopen( outfile,"w+b");
     if ( ttf==NULL ) {
 	fprintf( stderr, "Failed to open %s for output.\n", outfile );
 	return( -3 );


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

The `stripttc` program takes a TrueType Collection font (.ttc) and splits it into separate .ttf files. Part of that process includes setting the proper `checkSumAdjustment` value in the `'head'` table, which involves checksumming the entire font. As such, the .ttf file should be opened with both read and write access to be able to complete the checksumming process.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix** not sure if this applies as there's no existing bug filed regarding this issue.
- **Non-breaking change**

