### PR TITLE
Fix CVCurEnc

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -3469,9 +3469,6 @@ return( icon );
 
 static int CVCurEnc(CharView *cv)
 {
-    if ( cv->map_of_enc == ((FontView *) (cv->b.fv))->b.map && cv->enc!=-1 )
-        return( cv->enc );
-
     return( ((FontView *) (cv->b.fv))->b.map->backmap[cv->b.sc->orig_pos] );
 }
 


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
### Bug description
Open the first or the last glyph in a font. Move to other glyphs (Next/Prev). The other Next/Prev option in the menu will remain disabled, even though you are not on the first/last glyph anymore.
### Description
Upon glyph opening, FontForge treats it as a single-glyph view. When switching to other glyphs, square brackets are added to the word list, e.g. `[a]`. From now on, the `_CVMenuChangeChar()` function treats the view as a multi-glyph view and the `cv->enc` variable is not updated (probably because `CharView` now, in theory, displays multiple glyphs, and a single index would not be a valid descriptor). At the same time, some code relies on `CVCurEnc()` to get the current glyph index, which normally uses the `cv->enc` variable. This also happens when checking the View menu for first/last glyphs in `cv_vwlistcheck()`. I commented out this part, forcing `CVCurEnc()` to always look up the index of the current `SplineChar`.