### PR TITLE
Avoid asserting on not-always-dependable output of SplinePointsListIsClockwise

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -2296,8 +2296,8 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 		    assert( c->rmov!=srmov_contour );
 		    left = SplineSetRemoveOverlap(NULL,left,over_remove);
 		    is_ccw_mid = SplinePointListIsClockwise(left);
-		    assert( is_ccw_mid!=-1 );
-		} else if ( is_ccw_mid==-1 ) {
+		}
+		if ( is_ccw_mid==-1 ) {
 		    LogError( _("Warning: Can't identify contour direction, "
 		                "assuming clockwise\n") );
 		}


### PR DESCRIPTION
What is says on the tin.

Closes #4572 