### PR TITLE
Record unicode cmap encodings when one glyph is in multiple slots

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -4537,6 +4537,9 @@ static int PickCMap(struct cmap_encs *cmap_encs,int enccnt,int def) {
 return( ret );
 }
 
+/* This doesn't worry about putting the most appropriate encoding
+   in sc->unicodeenc because (in theory) NameConsistancyCheck()
+   will swap it in. */
 static void addttfencoding(SplineChar *sc, int unc) {
     struct altuni *alt;
     if ( unc==-1 )

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -4542,9 +4542,9 @@ return( ret );
    will swap it in. */
 static void addttfencoding(SplineChar *sc, int unc) {
     struct altuni *alt;
-    if ( unc==-1 ) {
+    if ( unc==-1 || sc->unicodeenc==unc ) {
 	return;
-    } else if (sc->unicodeenc==-1 || sc->unicodeenc==unc) {
+    } else if ( sc->unicodeenc==-1 ) {
 	sc->unicodeenc = unc;
 	return;
     } else {
@@ -4826,7 +4826,7 @@ return;
 			    } else {
 				if ( uenc!=-1 && dounicode ) used[uenc] = true;
 				if ( dounicode )
-				    addttfencoding(info->chars[(uint16) (j+delta[i])], uenc);
+				    addttfencoding(info->chars[(uint16_t) (j+delta[i])], uenc);
 			        if ( map!=NULL && lenc<map->enccount )
 				    map->map[lenc] = (uint16_t) (j+delta[i]);
 			    }

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -4542,12 +4542,16 @@ return( ret );
    will swap it in. */
 static void addttfencoding(SplineChar *sc, int unc) {
     struct altuni *alt;
-    if ( unc==-1 )
+    if ( unc==-1 ) {
 	return;
-    // This doesn't check for duplication but it easily could
-    if (sc->unicodeenc!=-1) {
+    } else if (sc->unicodeenc==-1 || sc->unicodeenc==unc) {
 	sc->unicodeenc = unc;
+	return;
     } else {
+	// Check for duplicates
+	for (alt = sc->altuni; alt!=NULL; alt = alt->next)
+	    if ( alt->unienc==unc )
+		return;
 	alt = chunkalloc(sizeof(struct altuni));
 	alt->unienc = unc;
 	alt->vs = -1;


### PR DESCRIPTION
The problem addressed by this PR is referenced in multiple bugs, including #1534, #1831, #3085 and possibly #3080. However, the scope of the problem and the complete fix is as yet unclear.