### PR TITLE
Remove trailing space from Version string in TTF output

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3792,9 +3792,9 @@ void DefaultTTFEnglishNames(struct ttflangname *dummy, SplineFont *sf) {
 	dummy->names[ttf_fullname] = utf8_verify_copy(sf->fullname);
     if ( dummy->names[ttf_version]==NULL || *dummy->names[ttf_version]=='\0' ) {
 	if ( sf->subfontcnt!=0 )
-	    sprintf( buffer, "Version %f ", (double)sf->cidversion );
+	    sprintf( buffer, "Version %f", (double)sf->cidversion );
 	else if ( sf->version!=NULL )
-	    sprintf(buffer,"Version %.20s ", sf->version);
+	    sprintf(buffer,"Version %.20s", sf->version);
 	else
 	    strcpy(buffer,"Version 1.0" );
 	dummy->names[ttf_version] = copy(buffer);


### PR DESCRIPTION
- **Bug fix** for #4595
- Trivial change to not generate trailing spaces in TTF Version strings. [According to Fontbakery](https://font-bakery.readthedocs.io/en/latest/fontbakery/profiles/universal.html#com.google.fonts/check/name/trailing_spaces), trailing spaces are verboten in TTF name records, and this change removes them. Trailing spaces were only being generated for a user-specified string and not for the default `Version 1.0` string, so this change also brings in consistency.