### PR TITLE
Don't change to custom encoding on setting altuni

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -241,6 +241,10 @@ static int TryEscape( Encoding *enc, const char *escape_sequence ) {
 return( enc->has_2byte );
 }
 
+int IsUnicodeEncoding(Encoding *enc, int bmp_compatible) {
+    return enc == &unicodefull || (bmp_compatible && enc == &unicodebmp );
+}
+
 Encoding *_FindOrMakeEncoding(const char *name,int make_it) {
     Encoding *enc;
     char buffer[20];

--- a/fontforge/encoding.h
+++ b/fontforge/encoding.h
@@ -81,5 +81,6 @@ extern void SFEncodeToMap(SplineFont *sf, struct cidmap *map);
 extern void SFExpandGlyphCount(SplineFont *sf, int newcnt);
 extern void SFMatchGlyphs(SplineFont *sf, SplineFont *target, int addempties);
 extern void SFRemoveGlyph(SplineFont *sf, SplineChar *sc);
+extern int IsUnicodeEncoding(Encoding *, int bmp_compatible);
 
 #endif /* FONTFORGE_ENCODING_H */

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -6728,7 +6728,7 @@ return( ret );
 static int PyFF_Glyph_set_altuni(PyFF_Glyph *self,PyObject *value, void *UNUSED(closure)) {
     int cnt, i;
     struct altuni *head, *last=NULL, *cur;
-    int uni, vs, fid;
+    int uni, vs, fid, bmp_compat=true;
     PyObject *obj;
     FontViewBase *fvs;
 
@@ -6754,6 +6754,8 @@ return( -1 );
 	    else
 		last->next = cur;
 	    last = cur;
+	    if (uni > 0xFFFF)
+		bmp_compat = false;
 	}
     }
 
@@ -6761,8 +6763,10 @@ return( -1 );
     self->sc->altuni = head;
 
     for ( fvs=self->sc->parent->fv; fvs!=NULL; fvs=fvs->nextsame ) {
-	fvs->map->enc = &custom;
-	FVSetTitle(fvs);
+	if ( !IsUnicodeEncoding(fvs->map->enc, bmp_compat) ) {
+	    fvs->map->enc = &custom;
+	    FVSetTitle(fvs);
+	} // XXX else rebuild map? 
     }
 
     return( 0 );

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -31,6 +31,7 @@
 #include "autowidth2.h"
 #include "chardata.h"
 #include "cvundoes.h"
+#include "encoding.h"
 #include "fontforgeui.h"
 #include "fvcomposite.h"
 #include "fvfonts.h"
@@ -1149,7 +1150,7 @@ static void CI_ParseAltUnis(CharInfo *ci) {
     GGadget *au = GWidgetGetControl(ci->gw,CID_AltUni);
     int rows, cols = GMatrixEditGetColCnt(au);
     struct matrix_data *stuff = GMatrixEditGet(au,&rows);
-    int i;
+    int i, bmp_compat=true;
     struct altuni *altuni, *last = NULL;
     SplineChar *sc = ci->cachedsc;
     int deenc = false;
@@ -1177,17 +1178,13 @@ static void CI_ParseAltUnis(CharInfo *ci) {
     break;
 	}
     }
-    if ( oldcnt!=newcnt || deenc ) {
-	for ( fvs=(FontView *) sc->parent->fv; fvs!=NULL; fvs=(FontView *) fvs->b.nextsame ) {
-	    fvs->b.map->enc = &custom;
-	    FVSetTitle((FontViewBase *) fvs);
-	}
-    }
     AltUniFree(sc->altuni); sc->altuni = NULL;
     for ( i=0; i<rows; ++i ) {
 	int uni = stuff[i*cols+0].u.md_ival, vs = stuff[i*cols+1].u.md_ival;
 	altuni = chunkalloc(sizeof(struct altuni));
 	altuni->unienc = uni;
+	if ( uni > 0xFFFF )
+	    bmp_compat = false;
 	altuni->vs = vs==0 ? -1 : vs;
 	altuni->fid = 0;
 	if ( last == NULL )
@@ -1195,6 +1192,14 @@ static void CI_ParseAltUnis(CharInfo *ci) {
 	else
 	    last->next = altuni;
 	last = altuni;
+    }
+    if ( oldcnt!=newcnt || deenc ) {
+	for ( fvs=(FontView *) sc->parent->fv; fvs!=NULL; fvs=(FontView *) fvs->b.nextsame ) {
+	    if ( !IsUnicodeEncoding(fvs->b.map->enc, bmp_compat) ) {
+		fvs->b.map->enc = &custom;
+		FVSetTitle((FontViewBase *) fvs);
+	    } // XXX else rebuild map?
+	}
     }
 }
 


### PR DESCRIPTION
... when the encoding is already unicode compatible.

`PyFF_Glyph_set_altuni()` currently ends with:

```
    for ( fvs=self->sc->parent->fv; fvs!=NULL; fvs=fvs->nextsame ) {
        fvs->map->enc = &custom;
        FVSetTitle(fvs);
    }
```

This is always executed no matter what the existing encoding. As far as I can see:

1. There's no reason to ever do this when the current encoding is UnicodeFull
2. There's no reason to do this when the current encoding is UnicodeBMP and none of the altuni values for the glyph are outside of the BMP range. 

Anyway this is super-annoying when working with a script because (for example) `createMappedChar()` stops working right after you add an altuni unless you set the encoding back to UnicodeBMP (for example) after every addition.
