### PR TITLE
Fix lone semicolons in FEA lookups

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -4978,7 +4978,9 @@ static int fea_LookupSwitch(struct parseState *tok) {
 	fea_TokenMustBe(tok,tk_char,';');
       break;
       case tk_char:
-	if ( tok->tokbuf[0]=='}' )
+	if ( tok->tokbuf[0]==';' ) // lone semicolon, see GitHub issue №4600
+return( 1 );
+	else if ( tok->tokbuf[0]=='}' )
 return( 2 );
 	/* Fall through */
       default:


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

Adding other random semicolons doesn't seem to matter. Tested patch on this:

```fea
;@Tlower = [a b c d e f g h i j k l m n o p q r s t u v w x y z];
;;

feature rclt {
    ;;
    lookup Routine_1 {
        ;;
        ;sub [a b c d e f g h i j k l m n o p q r s t u v w x y z] by [a.low b.low c.low d.low e.low f.low g.low h.low i.low j.low k.low l.low m.low n.low o.low p.low q.low r.low s.low t.low u.low v.low w.low x.low y.low z.low];;;;
	;;;
    } Routine_1;;;
    ;;
} rclt;;;
;
```

Closes #4600