### PR TITLE
Fix for #4602; use the correct langID for Sanskrit

### DIFF
--- a/fontforge/macenc.c
+++ b/fontforge/macenc.c
@@ -856,7 +856,7 @@ static uint16 _WinLangFromMac[] = {
 	0x459,		/* Sindhi */
 	0xffff,		/* Tibetan */
 	0x461,		/* Nepali */
-	0x43b,		/* Sanskrit */
+	0x44f,		/* Sanskrit */
 	0x44e,		/* Marathi */
 	0x445,		/* Bengali */
 	0x44d,		/* Assamese */

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -19994,7 +19994,7 @@ static struct flaglist sfnt_name_mslangs[] = {
     { "Russian", 0x419},
     { "Russian (Moldova)", 0x819},
     { "Sami (Lappish)", 0x43b},
-    { "Sanskrit", 0x43b},
+    { "Sanskrit", 0x44f},
     { "Sepedi", 0x46c},
     { "Serbian (Cyrillic)", 0xc1a},
     { "Serbian (Latin)", 0x81a},

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3792,9 +3792,9 @@ void DefaultTTFEnglishNames(struct ttflangname *dummy, SplineFont *sf) {
 	dummy->names[ttf_fullname] = utf8_verify_copy(sf->fullname);
     if ( dummy->names[ttf_version]==NULL || *dummy->names[ttf_version]=='\0' ) {
 	if ( sf->subfontcnt!=0 )
-	    sprintf( buffer, "Version %f ", (double)sf->cidversion );
+	    sprintf( buffer, "Version %f", (double)sf->cidversion );
 	else if ( sf->version!=NULL )
-	    sprintf(buffer,"Version %.20s ", sf->version);
+	    sprintf(buffer,"Version %.20s", sf->version);
 	else
 	    strcpy(buffer,"Version 1.0" );
 	dummy->names[ttf_version] = copy(buffer);

--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -971,7 +971,7 @@ static GTextInfo mslanguages[] = {
     { (unichar_t *) N_("Russian"), NULL, 0, 0, (void *) 0x419, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},
     { (unichar_t *) N_("Russian (Moldova)"), NULL, 0, 0, (void *) 0x819, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},
     { (unichar_t *) N_("Sami (Lappish)"), NULL, 0, 0, (void *) 0x43b, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},
-    { (unichar_t *) N_("Sanskrit"), NULL, 0, 0, (void *) 0x43b, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},
+    { (unichar_t *) N_("Sanskrit"), NULL, 0, 0, (void *) 0x44f, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},
     { (unichar_t *) N_("Sepedi"), NULL, 0, 0, (void *) 0x46c, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},
     { (unichar_t *) N_("Serbian (Cyrillic)"), NULL, 0, 0, (void *) 0xc1a, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},
     { (unichar_t *) N_("Serbian (Latin)"), NULL, 0, 0, (void *) 0x81a, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0'},


### PR DESCRIPTION
- **Bug fix** for #4602.
- Issue: The Microsoft/Windows langID for `Sami (Lappish)` was also used for `Sanskrit`: possibly a copy-paste error? This led to all kinds of weird behaviour when trying to create name records in Sanskrit. See the bug for an example.
- Fix: Use the right langID for Sanskrit, per https://docs.microsoft.com/en-us/typography/opentype/spec/name
