### PR TITLE
Better handling of closed self-intersecting paths in Expand Stroke

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -2319,12 +2319,8 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 	                         &closed, true);
 	    if ( !closed )
 		LogError( _("Warning: Left contour did not close\n") );
-	    else if ( c->rmov==srmov_contour ) {
-		left = SplineSetRemoveOverlap(NULL,left,over_remove);
-		SplineSetsCorrect(left, &trash);
-	    }
+
 	    cur = left;
-	    left = NULL;
 	}
 	if ( right!=NULL ) {
 	    CalcNibOffset(c, ut_ini, true, &no, -1);
@@ -2336,15 +2332,20 @@ static SplineSet *OffsetSplineSet(SplineSet *ss, StrokeContext *c) {
 		LogError( _("Warning: Right contour did not close\n") );
 	    else {
 		SplineSetReverse(right);
-		if ( c->rmov!=srmov_none )
-		    // Need to do this for either srmov_contour or srmov_layer
-		    right = SplineContourOuterCCWRemoveOverlap(right);
 	    }
 	    if ( cur != NULL ) {
 		cur->next = right;
 	    } else
 		cur = right;
 	    right = NULL;
+	}
+	if ( c->rmov==srmov_contour ) {
+	    if ( left!=NULL ) {
+		cur = SplineSetRemoveOverlap(NULL,cur,over_remove);
+		SplineSetsCorrect(cur, &trash);
+		left = NULL;
+	    } else
+		cur = SplineContourOuterCCWRemoveOverlap(cur);
 	}
     }
     return cur;


### PR DESCRIPTION
The overlap removal heuristics for closed contours were only appropriate for source contours that don't self-intersect. The output contours in such cases are kind of bizarre and processing them individually will have strange results. (For this reason it also makes little sense to use `removeinternal`/`removeexternal` with such contours, but caveat excogitator.)

This removes most of the special handling when using `removeoverlap=='layer'` and improves it when using `removeoverlap=='contour`` (by processing the left and right sides of an additional source contour together). 