### PR TITLE
Protect against ceil(float) to int index overflow in splinefill.c

### DIFF
--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -276,7 +276,10 @@ return;
     }
     if ( es->interesting ) {
 	/* Mark the other end of the spline as interesting */
-	es->interesting[(int) ceil(e->mmax)]=1;
+	int idx = (int) ceil(e->mmax);
+	if (idx >= es->cnt) // Floating point madness
+	    idx = es->cnt-1;
+	es->interesting[idx]=1;
     }
 }
 

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -4090,6 +4090,9 @@ return( -1 );
 		++l_ccw_cnt;
 	    if ( (cw_cnt + l_cw_cnt)!=0 && (ccw_cnt + l_ccw_cnt)!=0 ) {
 		((SplineSet *) spl)->next = next;
+		free(el.ordered);
+		free(el.ends);
+		ElFreeEI(&el);
 		return( -1 );
 	    }
 	    winding = apt->up?1:-1;


### PR DESCRIPTION
also: Fix ELOrder() leak in _SplinePointsListIsClockwise() (from Feb 2020)

Closes 4613