### PR TITLE
Correct wrong script tag: tagl→tglg

### DIFF
--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -221,7 +221,7 @@ static uint32 scripts[][61] = {
 /* Syloti Nagri */
 		{ CHR('s','y','l','o'), 0xa800, 0xa82f },
 /* Syriac */	{ CHR('s','y','r','c'), 0x0700, 0x074f, 0x0860, 0x086f },
-/* Tagalog */	{ CHR('t','a','g','l'), 0x1700, 0x171f },
+/* Tagalog */	{ CHR('t','g','l','g'), 0x1700, 0x171f },
 /* Tagbanwa */	{ CHR('t','a','g','b'), 0x1760, 0x177f },
 /* Tai Le */	{ CHR('t','a','l','e'), 0x1950, 0x197f },
 /* Tai Tham */	{ CHR('l','a','n','a'), 0x1a20, 0x1aaf },

--- a/tests/test0004.py
+++ b/tests/test0004.py
@@ -2,7 +2,7 @@
 
 import sys, fontforge
 
-assert fontforge.scriptFromUnicode(ord('ᜈ')) == "tagl"
+assert fontforge.scriptFromUnicode(ord('ᜈ')) == "tglg"
 assert fontforge.scriptFromUnicode(ord('Q')) == "latn"
 assert fontforge.scriptFromUnicode(ord('θ')) == "grek"
 assert fontforge.scriptFromUnicode(ord('Щ')) == "cyrl"


### PR DESCRIPTION
Cf. https://docs.microsoft.com/en-us/typography/opentype/spec/scripttags

This bug is in the same vein as #4603. Fixes a fontmake error in Noto Sans/Serif Tagalog.
