### PR TITLE
Allow 0-len mult subs in UI, feature files (GSUB)

### DIFF
--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -4276,11 +4276,6 @@ return( true );
 		start = psts[cols*r+1].u.md_str;
 		if ( start==NULL ) start="";
 		while ( *start== ' ' ) ++start;
-		if ( *start=='\0' ) {
-		    ff_post_error( _("Missing glyph name"),_("You must specify a replacement glyph for %s"),
-			    psts[cols*r+0].u.md_str );
-return( true );
-		}
 		/* Replacements which aren't in the font */
 		while ( *start ) {
 		    for ( pt=start; *pt!='\0' && *pt!=' ' && *pt!='('; ++pt );


### PR DESCRIPTION
This allows glyph deletion in OpenType Layout.

Cf. MicrosoftDocs/typography-issues#673, fonttools/fonttools#2170, adobe-type-tools/afdko#1251

Close #4618

FontForge already supported this implicitly: reading an OpenType font which uses this mechanism works, as does writing it back. Adding one in the UI was broken, as were feature files in both directions. This PR fixes that.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
- **Non-breaking change**
