### PR TITLE
fsys: resolve symlinks on Unix platforms

### DIFF
--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -533,6 +533,7 @@ char *_GFile_find_program_dir(char *prog) {
 	free(tmppath);
     }
 #else
+    char* buf = NULL;
     if ( (pt = strrchr(prog,'/'))!=NULL )
 	program_dir = copyn(prog,pt-prog);
     else if ( (path = getenv("PATH"))!=NULL ) {
@@ -552,6 +553,10 @@ char *_GFile_find_program_dir(char *prog) {
 		program_dir = copy(path);
 	}
     }
+	if ( (buf = realpath(program_dir, NULL)) ) {
+	   free(program_dir);
+	   program_dir = buf;
+	}
 #endif
 
     if ( program_dir==NULL )


### PR DESCRIPTION
This will make `fontforge` resolve the symbolic links on the Unix platforms when loading its assets.

This resolves the issue where if `fontforge` is invoked through symlink, it will not be able to load the resources.

### Type of change
- **Non-breaking change**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fontforge/fontforge/4626)
<!-- Reviewable:end -->
