### PR TITLE
Correct bad comparison when building MetricsView

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -5291,7 +5291,8 @@ MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf) {
 
     for ( cnt=0; cnt<mv->clen; ++cnt ) {
         int cp = mv->chars[cnt]->unicodeenc;
-        if ( cp != -1 && strchr("#[]/\\", cp) == NULL)
+        static const unichar_t metricsview_tokens[] = {'#', '[', ']', '/', '\\', '\0'};
+        if ( cp != -1 && u_strchr(metricsview_tokens, cp) == NULL )
 	    pt = utf8_idpb(pt,cp,0);
         else {
             *pt = '/'; pt++;


### PR DESCRIPTION
Makes it so when you select Ā in the FontView and open a MetricsView it
appears correctly as Ā, not as `\uni0100`.

Close #4627

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
