### PR TITLE
Fix bug caused by possibly negative unienc.

### DIFF
--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -762,7 +762,7 @@ int SFFindSlot(SplineFont *sf, EncMap *map, int unienc, const char *name ) {
 			SCUniMatch(sf->glyphs[pos],unienc) )
 	break;
 	}
-    } else if ( unienc!=-1 &&
+    } else if ( unienc>=0 &&
 	    ((unienc<0x10000 && map->enc->is_unicodebmp) ||
 	     (unienc<0x110000 && map->enc->is_unicodefull))) {
 	 index = unienc;


### PR DESCRIPTION
### Type of change
- **Bug fix**
This oneliner fixes potential crash when `unienc` is a negative value other than -1. I haven't traced why such a negative value is even possible, but at least when it happens, it does not crash the whole thing.