### PR TITLE
Stop UniFromName from returning random-looking numbers

### DIFF
--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -142,7 +142,7 @@ int UniFromName(const char *name,enum uni_interp interp,Encoding *encname) {
 	if ( *end )
 	    i = -1;
 	_recognizePUA = true;
-    } else if ( name[0]=='u' && strlen(name)>=5 ) {
+    } else if ( name[0]=='u' && (strlen(name)==5 || strlen(name)==6)) {
 	i = strtol(name+1,&end,16);
 	if ( *end )
 	    i = -1;

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -171,6 +171,7 @@ int UniFromName(const char *name,enum uni_interp interp,Encoding *encname) {
     }
     if ( !_recognizePUA && i>=0xe000 && i<=0xf8ff )
 	i = -1;
+assert(i >= -1);
 return( i );
 }
 

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -171,7 +171,7 @@ int UniFromName(const char *name,enum uni_interp interp,Encoding *encname) {
     }
     if ( !_recognizePUA && i>=0xe000 && i<=0xf8ff )
 	i = -1;
-assert(i >= -1);
+assert( i >= -1 );
 return( i );
 }
 

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -171,7 +171,7 @@ int UniFromName(const char *name,enum uni_interp interp,Encoding *encname) {
     }
     if ( !_recognizePUA && i>=0xe000 && i<=0xf8ff )
 	i = -1;
-assert( i >= -1 );
+g_assert( i >= -1 );
 return( i );
 }
 

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -27,6 +27,7 @@
  */
 
 #include <fontforge-config.h>
+#include <assert.h>
 
 #include "namelist.h"
 
@@ -171,7 +172,7 @@ int UniFromName(const char *name,enum uni_interp interp,Encoding *encname) {
     }
     if ( !_recognizePUA && i>=0xe000 && i<=0xf8ff )
 	i = -1;
-g_assert( i >= -1 );
+    assert( i >= -1 );
 return( i );
 }
 


### PR DESCRIPTION
### Type of change
- **Bug fix**

UniFromName will return random-looking numbers for glyphs without encoding slot and named like "u10B3110B19". This oneliner fixes the problem.

This bug is the underlying problem of what I was trying to fix with #4637.