### PR TITLE
Require some movement before snapping non-point objects

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -5385,7 +5385,9 @@ return;
 	p.cx = p.spiro->x;
 	p.cy = p.spiro->y;
     } else {
-	CVDoSnaps(cv,&fs);
+	// Require some movement before snapping objects with the pointer tool
+	if ( !RealNear(cv->info.x,cv->p.cx) || !RealNear(cv->info.y,cv->p.cy) )
+	    CVDoSnaps(cv,&fs);
     }
     cx = (p.cx -cv->p.cx) / tab->scale;
     cy = (p.cy - cv->p.cy) / tab->scale;


### PR DESCRIPTION
... "non-point objects" being references and anchor points. 

When editing LibertinusSerif-Regular and selecting an anchor point or reference with the pointer tool it often moves. This is more likely the more zoomed out you are. Therefore when you just want to select one of these things you often have to click on it and then Ctrl-Z to reverse the move (leaving it selected, for whatever reason). 

This turns out to be because the code is trying to snap the points to grid lines (of which there are many in LibertinusSerif-Regular. There's already code in `CVMouseMovePointer()` to take care of the case of zero movement. This PR puts an analogous check into `CVMouseMove()` before the call to `CVDoSnaps()` to avoid moving the selection target if the mouse pointer location doesn't change. 