### PR TITLE
Add selection status to reference get/set routines

### DIFF
--- a/doc/sphinx/scripting/python/fontforge.rst
+++ b/doc/sphinx/scripting/python/fontforge.rst
@@ -1517,10 +1517,12 @@ This type may not be pickled.
    Ends the contour without closing it. This is only relevant if you are
    stroking contours.
 
-.. method:: glyphPen.addComponent(glyph_name, transform)
+.. method:: glyphPen.addComponent(glyph_name[, transform, selected])
 
    Adds a reference (a component) to the glyph. The PostScript transformation
-   matrix is a 6 element tuple.
+   matrix is a 6 element tuple (with a default of the identity transformation).
+   When ``selected`` is true the reference will be marked as selected in the
+   UI and related API calls.
 
 
 Glyph
@@ -1776,8 +1778,10 @@ must be created through the font.
 
 .. attribute:: glyph.references
 
-   A tuple of tuples containing glyph-name and a transformation matrix for each
-   reference in the foreground. See also :attr:`glyph.foreground` and :attr:`glyph.layerrefs`.
+   A tuple of tuples containing, for each reference in the foreground, a
+   glyph-name, a transformation matrix, and whether the reference is currently
+   selected. When assigning to the object the matrix and ``selected`` values
+   are optional. See also :attr:`glyph.foreground` and :attr:`glyph.layerrefs`.
 
 .. attribute:: glyph.right_side_bearing
 
@@ -2041,10 +2045,11 @@ must be created through the font.
       As above but also merge away on-curve points which are very close to,
       but not on, an added extremum
 
-.. method:: glyph.addReference(glyph_name[, transform])
+.. method:: glyph.addReference(glyph_name[, transform, selected])
 
    Adds a reference to the specified glyph into the current glyph. Optionally
-   specifying a transformation matrix
+   specifying a transformation matrix and whether the reference is to be
+   marked selected in the UI and related API calls.
 
 .. method:: glyph.addHint(is_vertical, start, width)
 

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -1619,13 +1619,15 @@ return(( lbx + rbx )/2 - ( rbb->maxx - rbb->minx )/2 - rbb->minx );
 return( 0x70000000 );
 }
 
-void _SCAddRef(SplineChar *sc,SplineChar *rsc,int layer,real transform[6]) {
+void _SCAddRef(SplineChar *sc,SplineChar *rsc,int layer,real transform[6],
+        int selected) {
     RefChar *ref = RefCharCreate();
 
     ref->sc = rsc;
     ref->unicode_enc = rsc->unicodeenc;
     ref->orig_pos = rsc->orig_pos;
     ref->adobe_enc = getAdobeEnc(rsc->name);
+    ref->selected = selected;
     ref->next = sc->layers[layer].refs;
     sc->layers[layer].refs = ref;
     memcpy(ref->transform,transform,sizeof(real [6]));
@@ -1638,7 +1640,7 @@ void SCAddRef(SplineChar *sc,SplineChar *rsc,int layer, real xoff, real yoff) {
     transform[0] = transform[3] = 1;
     transform[1] = transform[2] = 0;
     transform[4] = xoff; transform[5] = yoff;
-    _SCAddRef(sc,rsc,layer,transform);
+    _SCAddRef(sc,rsc,layer,transform,false);
 }
 
 static void BCClearAndCopyBelow(BDFFont *bdf,int togid,int fromgid, int ymax) {
@@ -2243,7 +2245,7 @@ return;
     /*if ( invert ) transform[5] -= yoff; else */transform[5] += yoff;
 
     if ( bdf == NULL || !disp_only ) {
-	_SCAddRef(sc,rsc,layer,transform);
+	_SCAddRef(sc,rsc,layer,transform,false);
 	if ( pos != FF_UNICODE_NOPOSDATAGIVEN && (pos & FF_UNICODE_RIGHT) )
 	    SCSynchronizeWidth(sc,sc->width + rbb.maxx-rbb.minx+spacing,sc->width,NULL);
 	if ( pos != FF_UNICODE_NOPOSDATAGIVEN && (pos & (FF_UNICODE_LEFT|FF_UNICODE_RIGHT|FF_UNICODE_CENTERLEFT|FF_UNICODE_LEFTEDGE|FF_UNICODE_CENTERRIGHT|FF_UNICODE_RIGHTEDGE)) )

--- a/fontforge/fvcomposite.h
+++ b/fontforge/fvcomposite.h
@@ -14,7 +14,7 @@ extern int SCAppendAccent(SplineChar *sc, int layer, char *glyph_name, int uni, 
 extern int SFIsCompositBuildable(SplineFont *sf, int unicodeenc, SplineChar *sc, int layer);
 extern int SFIsRotatable(SplineFont *sf, SplineChar *sc);
 extern int SFIsSomethingBuildable(SplineFont *sf, SplineChar *sc, int layer, int onlyaccents);
-extern void _SCAddRef(SplineChar *sc, SplineChar *rsc, int layer, real transform[6]);
+extern void _SCAddRef(SplineChar *sc, SplineChar *rsc, int layer, real transform[6], int selected);
 extern void SCBuildComposit(SplineFont *sf, SplineChar *sc, int layer, BDFFont *bdf, int disp_only, int accent_hint);
 
 #endif /* FONTFORGE_FVCOMPOSITE_H */


### PR DESCRIPTION
Closes #4303 

I first wrote this up on the model of `glyph.anchorPointsWithSel` by copying the `PyFF_RefArray` object and its related functions. But then after realizing that the `selected` element could and should be optional adding it didn't seem likely to cause problems. Consumers of the output of `glyph.references` and `glyph.layerrefs` will see an extra element at the end of the tuple, and that could break particularly sensitive scripts, but for the most part this won't create new issues.

@frank-trampe If you want me to do the more conservative thing instead I can. Still, this seems like a candidate for mailing a warning to the email list and calling it a day.