### PR TITLE
Special case İ in MakeSmallCapName to stop crash

### DIFF
--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -2061,9 +2061,15 @@ static SplineChar *MakeSmallCapName(char *buffer, int bufsize, SplineFont *sf,
 	ext = genchange->extension_for_symbols;
     }
     lc_sc = SFGetChar(sf,lower,NULL);
-    if ( lc_sc!=NULL )
-	snprintf(buffer,bufsize,"%s.%s", lc_sc->name, ext );
-    else {
+    if ( lc_sc!=NULL ) {
+	// The Turkish dotted İ must be special cased because it rightly lowercases to the regular ASCII
+	// i, however, so does I.
+	if ( sc->unicodeenc == 0x130 ) {
+	    snprintf(buffer, bufsize, "idotaccent.%s", ext);
+	} else {
+	    snprintf(buffer, bufsize, "%s.%s", lc_sc->name, ext);
+	}
+    } else {
 	const char *pt = StdGlyphName(buffer,lower,sf->uni_interp,sf->for_new_glyphs);
 	if ( pt!=buffer )
 	    strcpy(buffer,pt);


### PR DESCRIPTION
Close #4656.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
