### PR TITLE
parsettf.c: fix handling of invalid/0 CFF offsets

### DIFF
--- a/.github/workflows/scripts/setup_linux_deps.sh
+++ b/.github/workflows/scripts/setup_linux_deps.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 sudo add-apt-repository -y ppa:deadsnakes/ppa && sudo apt-get update -y
 sudo apt remove -y python3-pip
-sudo apt-get install -y autoconf automake libtool gcc g++ \
+sudo apt-get install -y autoconf automake libtool gcc g++ gettext \
     libjpeg-dev libtiff5-dev libpng-dev libfreetype6-dev libgif-dev \
     libx11-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev \
     libbrotli-dev ninja-build cmake lcov $PYTHON-dev $PYTHON-venv


### PR DESCRIPTION
Instead of checking against -1, check that the offset is greater
than 0; a 0 offset would imply reading the same data again which
doesn't make sense. (There are some cases which are special cased and 0 has some special meaning, I've left those alone and only changed ones which immediately fseek).

Fixes #4667

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**