### PR TITLE
Force getAutoDirName to have no arguments.

### DIFF
--- a/fontforge/autosave.c
+++ b/fontforge/autosave.c
@@ -52,7 +52,7 @@ int AutoSaveFrequency=5;
 # include <pwd.h>
 #endif
 
-static char *getAutoDirName() {
+static char *getAutoDirName(void) {
     char *buffer, *dir=getFontForgeUserDir(Config);
 
     if ( dir!=NULL ) {
@@ -91,7 +91,7 @@ return;
 int DoAutoRecoveryExtended(int inquire)
 {
     char *buffer;
-    char *recoverdir = getAutoDirName(buffer);
+    char *recoverdir = getAutoDirName();
     DIR *dir;
     struct dirent *entry;
     int any = false;


### PR DESCRIPTION
This forces a _warning_ ("too many arguments in call to 'getAutoDirName'") encountered in Clang 12 in `DoAutoRecoveryExtended` to be an error. This also makes the  `getAutoDirName` call in said function to not pass any arguments.
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
