### PR TITLE
[SVG] Read large-arc and sweep as flags

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1553,9 +1553,11 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		end = skipcomma(end);
 		axisrot = strtod(end,&end)*FF_PI/180;
 		end = skipcomma(end);
+		while (isspace(*end)) ++end;
 		large_arc = *end != '0';
 		end++;
 		end = skipcomma(end);
+		while (isspace(*end)) ++end;
 		sweep = *end != '0';
 		end++;
 		end = skipcomma(end);

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1553,9 +1553,11 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		end = skipcomma(end);
 		axisrot = strtod(end,&end)*FF_PI/180;
 		end = skipcomma(end);
-		large_arc = strtol(end,&end,10);
+		large_arc = *end != '0';
+		end++;
 		end = skipcomma(end);
-		sweep = strtol(end,&end,10);
+		sweep = *end != '0';
+		end++;
 		end = skipcomma(end);
 		x = strtod(end,&end);
 		end = skipcomma(end);


### PR DESCRIPTION
Otherwise they can be considered part of one large integer.

Closes #4683.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**