### PR TITLE
Set noprevcp and nonextcp only in SplineRefigure* and SplinePointCreate

### DIFF
--- a/contrib/fonttools/acorn2sfd.c
+++ b/contrib/fonttools/acorn2sfd.c
@@ -220,22 +220,18 @@ static SplineSet *ReadSplineSets(FILE *file,int flags,SplineSet *old,int closed)
 		fprintf( stderr, "No initial point, assuming 0,0\n" );
 		active = calloc(1,sizeof(SplineSet));
 		active->first = active->last = calloc(1,sizeof(SplinePoint));
-		active->first->nonextcp = active->first->noprevcp = true;
 	    }
 	    next = calloc(1,sizeof(SplinePoint));
 	    if ( (verb&3)==2 ) {		/* Line to */
 		next->me.x = x1; next->me.y = y1;
 		next->nextcp = next->prevcp = next->me;
-		next->nonextcp = next->noprevcp = true;
 	    } else {				/* Curve to */
 		readcoords(file,flags&1,&x2,&y2);
 		readcoords(file,flags&1,&x3,&y3);
 		active->last->nextcp.x = x1; active->last->nextcp.y = y1;
-		active->last->nonextcp = false;
 		next->prevcp.x = x2; next->prevcp.y = y2;
 		next->me.x = x3; next->me.y = y3;
 		next->nextcp = next->me;
-		next->nonextcp = true;
 	    }
 	    SplineMake3(active->last,next);
 	    active->last = next;

--- a/fontforge/bezctx_ff.c
+++ b/fontforge/bezctx_ff.c
@@ -112,10 +112,8 @@ bezctx_ff_quadto(bezctx *z, double xm, double ym, double x3, double y3) {
 	y2 = ym + (1./3) * (y3 - ym);
 	bc->ss->last->nextcp.x = x1;
 	bc->ss->last->nextcp.y = y1;
-	bc->ss->last->nonextcp = false;
 	sp->prevcp.x = x2;
 	sp->prevcp.y = y2;
-	sp->noprevcp = false;
 	if ( SplineMake3(bc->ss->last,sp)!=NULL )
 	    bc->ss->last = sp;
     }
@@ -135,10 +133,8 @@ bezctx_ff_curveto(bezctx *z, double x1, double y1, double x2, double y2,
     if ( (sp=SplinePointCreate(x3,y3))!=NULL ) {
 	bc->ss->last->nextcp.x = x1;
 	bc->ss->last->nextcp.y = y1;
-	bc->ss->last->nonextcp = false;
 	sp->prevcp.x = x2;
 	sp->prevcp.y = y2;
-	sp->noprevcp = false;
 	if ( SplineMake3(bc->ss->last,sp)!=NULL )
 	    bc->ss->last = sp;
     }

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -464,7 +464,6 @@ static SplinePoint *ArcSpline(SplinePoint *sp,float sa,SplinePoint *ep,float ea,
 
     sp->nextcp.x = sp->me.x - len*ss; sp->nextcp.y = sp->me.y + len*sc;
     ep->prevcp.x = ep->me.x + len*es; ep->prevcp.y = ep->me.y - len*ec;
-    sp->nonextcp = ep->noprevcp = false;
     SplineMake3(sp,ep);
 return( ep );
 }
@@ -611,33 +610,32 @@ static SplineSet * slurppolyline(FILE *fig,SplineChar *sc, SplineSet *sofar) {
 		bottomright.y = bps[2].y;
 	    }
 	    spl->first = SplinePointCreate(topleft.x,topleft.y-r); spl->first->pointtype = pt_tangent;
-	    spl->first->nextcp.y += .552*r; spl->first->nonextcp = false;
+	    spl->first->nextcp.y += .552*r;
 	    spl->last = sp = SplinePointCreate(topleft.x+r,topleft.y); sp->pointtype = pt_tangent;
-	    sp->prevcp.x -= .552*r; sp->noprevcp = false;
+	    sp->prevcp.x -= .552*r;
 	    SplineMake3(spl->first,sp);
 	    sp = SplinePointCreate(bottomright.x-r,topleft.y); sp->pointtype = pt_tangent;
-	    sp->nextcp.x += .552*r; sp->nonextcp = false;
+	    sp->nextcp.x += .552*r;
 	    SplineMake3(spl->last,sp); spl->last = sp;
 	    sp = SplinePointCreate(bottomright.x,topleft.y-r); sp->pointtype = pt_tangent;
-	    sp->prevcp.y += .552*r; sp->noprevcp = false;
+	    sp->prevcp.y += .552*r;
 	    SplineMake3(spl->last,sp); spl->last = sp;
 	    sp = SplinePointCreate(bottomright.x,bottomright.y+r); sp->pointtype = pt_tangent;
-	    sp->nextcp.y -= .552*r; sp->nonextcp = false;
+	    sp->nextcp.y -= .552*r;
 	    SplineMake3(spl->last,sp); spl->last = sp;
 	    sp = SplinePointCreate(bottomright.x-r,bottomright.y); sp->pointtype = pt_tangent;
-	    sp->prevcp.x += .552*r; sp->noprevcp = false;
+	    sp->prevcp.x += .552*r;
 	    SplineMake3(spl->last,sp); spl->last = sp;
 	    sp = SplinePointCreate(topleft.x+r,bottomright.y); sp->pointtype = pt_tangent;
-	    sp->nextcp.x -= .552*r; sp->nonextcp = false;
+	    sp->nextcp.x -= .552*r;
 	    SplineMake3(spl->last,sp); spl->last = sp;
 	    sp = SplinePointCreate(topleft.x,bottomright.y+r); sp->pointtype = pt_tangent;
-	    sp->prevcp.y -= .552*r; sp->noprevcp = false;
+	    sp->prevcp.y -= .552*r;
 	    SplineMake3(spl->last,sp); spl->last = sp;
 	} else {
 	    for ( i=0; i<cnt; ++i ) {
 		sp = chunkalloc(sizeof(SplinePoint));
 		sp->me = sp->nextcp = sp->prevcp = bps[i];
-		sp->nonextcp = sp->noprevcp = true;
 		sp->pointtype = pt_corner;
 		if ( spl->first==NULL )
 		    spl->first = sp;
@@ -784,7 +782,6 @@ static SplineSet *ApproximateXSpline(struct xspline *xs,int order2) {
 	spl->last = sp;
     }
     if ( !xs->closed ) {
-	spl->first->noprevcp = spl->last->nonextcp = true;
 	spl->first->prevcp = spl->first->me;
 	spl->last->nextcp = spl->last->me;
     } else

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -777,10 +777,7 @@ static SplineSet *ApproximateXSpline(struct xspline *xs,int order2) {
 	SPAverageCps(spl->last);
 	spl->last = sp;
     }
-    if ( !xs->closed ) {
-	spl->first->prevcp = spl->first->me;
-	spl->last->nextcp = spl->last->me;
-    } else
+    if ( xs->closed )
 	SPAverageCps(spl->first);
 return( spl );
 }

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -542,23 +542,19 @@ static SplineSet * slurpelipse(FILE *fig,SplineChar *sc, SplineSet *sofar) {
 
     spl = chunkalloc(sizeof(SplinePointList));
     spl->next = sofar;
-    spl->first = sp = chunkalloc(sizeof(SplinePoint));
-    sp->me.x = dcx; sp->me.y = dcy+dry;
+    spl->first = sp = SplinePointCreate(dcx, dcy+dry);
 	sp->nextcp.x = sp->me.x + .552*drx; sp->nextcp.y = sp->me.y;
 	sp->prevcp.x = sp->me.x - .552*drx; sp->prevcp.y = sp->me.y;
-    spl->last = sp = chunkalloc(sizeof(SplinePoint));
-    sp->me.x = dcx+drx; sp->me.y = dcy;
+    spl->last = sp = SplinePointCreate(dcx+drx, dcy);
 	sp->nextcp.x = sp->me.x; sp->nextcp.y = sp->me.y - .552*dry;
 	sp->prevcp.x = sp->me.x; sp->prevcp.y = sp->me.y + .552*dry;
     SplineMake3(spl->first,sp);
-    sp = chunkalloc(sizeof(SplinePoint));
-    sp->me.x = dcx; sp->me.y = dcy-dry;
+    sp = SplinePointCreate(dcx, dcy-dry);
 	sp->nextcp.x = sp->me.x - .552*drx; sp->nextcp.y = sp->me.y;
 	sp->prevcp.x = sp->me.x + .552*drx; sp->prevcp.y = sp->me.y;
     SplineMake3(spl->last,sp);
     spl->last = sp;
-    sp = chunkalloc(sizeof(SplinePoint));
-    sp->me.x = dcx-drx; sp->me.y = dcy;
+    sp = SplinePointCreate(dcx-drx, dcy);
 	sp->nextcp.x = sp->me.x; sp->nextcp.y = sp->me.y + .552*dry;
 	sp->prevcp.x = sp->me.x; sp->prevcp.y = sp->me.y - .552*dry;
     SplineMake3(spl->last,sp);
@@ -634,8 +630,7 @@ static SplineSet * slurppolyline(FILE *fig,SplineChar *sc, SplineSet *sofar) {
 	    SplineMake3(spl->last,sp); spl->last = sp;
 	} else {
 	    for ( i=0; i<cnt; ++i ) {
-		sp = chunkalloc(sizeof(SplinePoint));
-		sp->me = sp->nextcp = sp->prevcp = bps[i];
+		sp = SplinePointCreate(bps[i].x, bps[i].y);
 		sp->pointtype = pt_corner;
 		if ( spl->first==NULL )
 		    spl->first = sp;
@@ -760,17 +755,18 @@ static SplineSet *ApproximateXSpline(struct xspline *xs,int order2) {
     FitPoint mids[7];
     SplineSet *spl = chunkalloc(sizeof(SplineSet));
     SplinePoint *sp;
+    BasePoint tbp;
 
-    spl->first = spl->last = chunkalloc(sizeof(SplinePoint));
-    xsplineeval(&spl->first->me,0,xs);
+    xsplineeval(&tbp,0,xs);
+    spl->first = spl->last = SplinePointCreate(tbp.x, tbp.y);
     spl->first->pointtype = ( xs->s[0]==0 )?pt_corner:pt_curve;
     for ( i=0; i<(size_t)(xs->n-1); ++i ) {
 	if ( i==(size_t)(xs->n-2) && xs->closed )
 	    sp = spl->first;
 	else {
-	    sp = chunkalloc(sizeof(SplinePoint));
 	    sp->pointtype = ( xs->s[i+1]==0 )?pt_corner:pt_curve;
-	    xsplineeval(&sp->me,i+1,xs);
+	    xsplineeval(&tbp,i+1,xs);
+	    sp = SplinePointCreate(tbp.x, tbp.y);
 	}
 	for ( j=0, t=1./8; j<sizeof(mids)/sizeof(mids[0]); ++j, t+=1./8 ) {
 	    xsplineeval((BasePoint *) &mids[j].p,i+t,xs);

--- a/fontforge/effects.c
+++ b/fontforge/effects.c
@@ -278,21 +278,17 @@ return(NULL);
 		    new->ticked = false; sp->ticked = false;
 		    if ( sp->next->rightedge ) {
 			sp->next->from = new;
-			sp->nonextcp = true;
 			sp->nextcp = sp->me;
 			new->me.x += shadow_length;
 			new->nextcp.x += shadow_length;
-			new->noprevcp = true;
 			new->prevcp = new->me;
 			SplineMake(sp,new,sp->prev->order2);
 			sp = new;
 		    } else {
 			sp->prev->to = new;
-			sp->noprevcp = true;
 			sp->prevcp = sp->me;
 			new->me.x += shadow_length;
 			new->prevcp.x += shadow_length;
-			new->nonextcp = true;
 			new->nextcp = new->me;
 			SplineMake(new,sp,sp->next->order2);
 			SplineRefigure(new->prev);
@@ -392,14 +388,12 @@ static void SSCleanup(SplineSet *spl) {
 	    if ( x==s->from->nextcp.x && x==s->to->prevcp.x && x==s->to->me.x &&
 		    ((y<s->to->me.y && s->from->nextcp.y>=y && s->from->nextcp.y<=s->to->prevcp.y && s->to->prevcp.y<=s->to->me.y) ||
 		     (y>=s->to->me.y && s->from->nextcp.y<=y && s->from->nextcp.y>=s->to->prevcp.y && s->to->prevcp.y>=s->to->me.y))) {
-		s->from->nonextcp = true; s->to->noprevcp = true;
 		s->from->nextcp = s->from->me;
 		s->to->prevcp = s->to->me;
 	    }
 	    if ( y==s->from->nextcp.y && y==s->to->prevcp.y && y==s->to->me.y &&
 		    ((x<s->to->me.x && s->from->nextcp.x>=x && s->from->nextcp.x<=s->to->prevcp.x && s->to->prevcp.x<=s->to->me.x) ||
 		     (x>=s->to->me.x && s->from->nextcp.x<=x && s->from->nextcp.x>=s->to->prevcp.x && s->to->prevcp.x>=s->to->me.x))) {
-		s->from->nonextcp = true; s->to->noprevcp = true;
 		s->from->nextcp = s->from->me;
 		s->to->prevcp = s->to->me;
 	    }
@@ -572,7 +566,6 @@ static void SplineComplete(SplineSet *cur,Spline *s,bigreal t_of_from,bigreal t_
     y.a = dt*dt*dt*s->splines[1].a;
     cur->last->nextcp.y = y.c/3 + y.d;
     to->prevcp.y = cur->last->nextcp.y + (y.b+y.c)/3;
-    to->noprevcp = cur->last->nonextcp = false;
 
     SplineMake(cur->last,to,s->order2);
     cur->last = to;

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -553,9 +553,7 @@ static int FT_MoveTo(const FT_Vector *to,void *user) {
     if ( context->orig_cpl!=NULL )
 	context->orig_sp = context->orig_cpl->first;
 
-    context->last = context->cpl->first = chunkalloc(sizeof(SplinePoint));
-    context->last->me.x = to->x*context->scalex;
-    context->last->me.y = to->y*context->scaley;
+    context->last = context->cpl->first = SplinePointCreate(to->x*context->scalex, to->y*context->scaley);
     if ( context->orig_sp==NULL )
 	context->last->ttfindex = -2;
     else {

--- a/fontforge/freetype.c
+++ b/fontforge/freetype.c
@@ -589,11 +589,9 @@ static int FT_ConicTo(const FT_Vector *_cp, const FT_Vector *to,void *user) {
     SplinePoint *sp;
 
     sp = SplinePointCreate( to->x*context->scalex, to->y*context->scaley );
-    sp->noprevcp = false;
     sp->prevcp.x = _cp->x*context->scalex;
     sp->prevcp.y = _cp->y*context->scaley;
     context->last->nextcp = sp->prevcp;
-    context->last->nonextcp = false;
     SplineMake2(context->last,sp);
     context->last = sp;
 
@@ -614,7 +612,6 @@ static int FT_CubicTo(const FT_Vector *cp1, const FT_Vector *cp2,
     SplinePoint *sp;
 
     sp = SplinePointCreate( to->x*context->scalex, to->y*context->scaley );
-    sp->noprevcp = false;
     sp->prevcp.x = cp2->x*context->scalex;
     sp->prevcp.y = cp2->y*context->scaley;
     context->last->nextcp.x = cp1->x*context->scalex;

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -2430,10 +2430,7 @@ static void DoSpaces(SplineFont *sf,SplineChar *sc,int layer,BDFFont *bdf,int di
 }
 
 static SplinePoint *MakeSP(real x, real y, SplinePoint *last,int order2) {
-    SplinePoint *new = chunkalloc(sizeof(SplinePoint));
-
-    new->me.x = x; new->me.y = y;
-    new->prevcp = new->nextcp = new->me;
+    SplinePoint *new = SplinePointCreate(x, y);
     new->pointtype = pt_corner;
     if ( last!=NULL )
 	SplineMake(last,new,order2);

--- a/fontforge/fvcomposite.c
+++ b/fontforge/fvcomposite.c
@@ -2434,7 +2434,6 @@ static SplinePoint *MakeSP(real x, real y, SplinePoint *last,int order2) {
 
     new->me.x = x; new->me.y = y;
     new->prevcp = new->nextcp = new->me;
-    new->noprevcp = new->nonextcp = true;
     new->pointtype = pt_corner;
     if ( last!=NULL )
 	SplineMake(last,new,order2);

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -1310,14 +1310,11 @@ return( head );
 }
 
 static void InterpPoint(SplineSet *cur, SplinePoint *base, SplinePoint *other, real amount ) {
-    SplinePoint *p = chunkalloc(sizeof(SplinePoint));
+    SplinePoint *p = SplinePointCreate(base->me.x + amount*(other->me.x-base->me.x),
+                                       base->me.y + amount*(other->me.y-base->me.y));
     int order2 = base->prev!=NULL ? base->prev->order2 : base->next!=NULL ? base->next->order2 : false;
 
-    p->me.x = base->me.x + amount*(other->me.x-base->me.x);
-    p->me.y = base->me.y + amount*(other->me.y-base->me.y);
-    if ( order2 && base->prev!=NULL && (base->prev->islinear || other->prev->islinear ))
-	p->prevcp = p->me;
-    else {
+    if ( !( order2 && base->prev!=NULL && (base->prev->islinear || other->prev->islinear) ) ) {
 	p->prevcp.x = base->prevcp.x + amount*(other->prevcp.x-base->prevcp.x);
 	p->prevcp.y = base->prevcp.y + amount*(other->prevcp.y-base->prevcp.y);
 	if ( order2 && cur->first!=NULL ) {
@@ -1328,9 +1325,7 @@ static void InterpPoint(SplineSet *cur, SplinePoint *base, SplinePoint *other, r
 	    cur->last->nextcp.y = p->prevcp.y = (cur->last->nextcp.y+p->prevcp.y)/2;
 	}
     }
-    if ( order2 && base->next!=NULL && (base->next->islinear || other->next->islinear ))
-	p->nextcp = p->me;
-    else {
+    if ( ! ( order2 && base->next!=NULL && (base->next->islinear || other->next->islinear ) ) ) {
 	p->nextcp.x = base->nextcp.x + amount*(other->nextcp.x-base->nextcp.x);
 	p->nextcp.y = base->nextcp.y + amount*(other->nextcp.y-base->nextcp.y);
     }

--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -1334,8 +1334,6 @@ static void InterpPoint(SplineSet *cur, SplinePoint *base, SplinePoint *other, r
 	p->nextcp.x = base->nextcp.x + amount*(other->nextcp.x-base->nextcp.x);
 	p->nextcp.y = base->nextcp.y + amount*(other->nextcp.y-base->nextcp.y);
     }
-    p->nonextcp = ( p->nextcp.x==p->me.x && p->nextcp.y==p->me.y );
-    p->noprevcp = ( p->prevcp.x==p->me.x && p->prevcp.y==p->me.y );
     p->prevcpdef = base->prevcpdef && other->prevcpdef;
     p->nextcpdef = base->nextcpdef && other->nextcpdef;
     p->selected = false;

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1447,7 +1447,7 @@ static void _InterpretPdf(FILE *in, struct pdfcontext *pc, EntityChar *ec) {
 		sp -= 2;
 		pt = chunkalloc(sizeof(SplinePoint));
 		Transform(&pt->me,&current,transform);
-		pt->noprevcp = true; pt->nonextcp = true;
+		pt->prevcp = pt->me; pt->nextcp = pt->me;
 		if ( tok==pt_moveto ) {
 		    SplinePointList *spl = chunkalloc(sizeof(SplinePointList));
 		    spl->first = spl->last = pt;
@@ -1487,11 +1487,10 @@ static void _InterpretPdf(FILE *in, struct pdfcontext *pc, EntityChar *ec) {
 		current = to;
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    Transform(&cur->last->nextcp,&ncp,transform);
-		    cur->last->nonextcp = false;
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    Transform(&pt->prevcp,&pcp,transform);
 		    Transform(&pt->me,&current,transform);
-		    pt->nonextcp = true;
+		    pt->nextcp = pt->me;
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
 		}
@@ -1540,7 +1539,6 @@ static void _InterpretPdf(FILE *in, struct pdfcontext *pc, EntityChar *ec) {
 		    if ( cur->first->me.x==cur->last->me.x && cur->first->me.y==cur->last->me.y ) {
 			SplinePoint *oldlast = cur->last;
 			cur->first->prevcp = oldlast->prevcp;
-			cur->first->noprevcp = false;
 			oldlast->prev->from->next = NULL;
 			cur->last = oldlast->prev->from;
 			SplineFree(oldlast->prev);

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1445,9 +1445,9 @@ static void _InterpretPdf(FILE *in, struct pdfcontext *pc, EntityChar *ec) {
 		current.x = stack[sp-2].u.val;
 		current.y = stack[sp-1].u.val;
 		sp -= 2;
-		pt = chunkalloc(sizeof(SplinePoint));
-		Transform(&pt->me,&current,transform);
-		pt->prevcp = pt->me; pt->nextcp = pt->me;
+		BasePoint ini_me;
+		Transform(&ini_me,&current,transform);
+		pt = SplinePointCreate(ini_me.x, ini_me.y);
 		if ( tok==pt_moveto ) {
 		    SplinePointList *spl = chunkalloc(sizeof(SplinePointList));
 		    spl->first = spl->last = pt;
@@ -1487,10 +1487,10 @@ static void _InterpretPdf(FILE *in, struct pdfcontext *pc, EntityChar *ec) {
 		current = to;
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    Transform(&cur->last->nextcp,&ncp,transform);
-		    pt = chunkalloc(sizeof(SplinePoint));
+		    BasePoint ini_me;
+		    Transform(&ini_me,&current,transform);
+		    pt = SplinePointCreate(ini_me.x, ini_me.y);
 		    Transform(&pt->prevcp,&pcp,transform);
-		    Transform(&pt->me,&current,transform);
-		    pt->nextcp = pt->me;
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
 		}

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -1872,8 +1872,7 @@ static SplineSet *ttfbuildcontours(int path_cnt,uint16 *endpt, char *flags,
 	sp = NULL;
 	while ( i<=endpt[path] ) {
 	    if ( flags[i]&_On_Curve ) {
-		sp = chunkalloc(sizeof(SplinePoint));
-		sp->me = sp->nextcp = sp->prevcp = pts[i];
+		sp = SplinePointCreate(pts[i].x, pts[i].y);
 		sp->ttfindex = i;
 		sp->nextcpindex = 0xffff;
 		if ( last_off && cur->last!=NULL ) {
@@ -1883,10 +1882,7 @@ static SplineSet *ttfbuildcontours(int path_cnt,uint16 *endpt, char *flags,
 	    } else if ( last_off ) {
 		/* two off curve points get a third on curve point created */
 		/* half-way between them. Now isn't that special */
-		sp = chunkalloc(sizeof(SplinePoint));
-		sp->me.x = (pts[i].x+pts[i-1].x)/2;
-		sp->me.y = (pts[i].y+pts[i-1].y)/2;
-		sp->nextcp = sp->prevcp = sp->me;
+		sp = SplinePointCreate((pts[i].x+pts[i-1].x)/2, (pts[i].y+pts[i-1].y)/2);
 		sp->ttfindex = 0xffff;
 		sp->nextcpindex = i;
 		if ( last_off && cur->last!=NULL )
@@ -1912,19 +1908,13 @@ static SplineSet *ttfbuildcontours(int path_cnt,uint16 *endpt, char *flags,
 	    /*  point. What on earth do they think that means? */
 	    /* Oh. I see. It's used to possition marks and such */
 	    if ( cur->first==NULL ) {
-		sp = chunkalloc(sizeof(SplinePoint));
-		sp->me.x = pts[start].x;
-		sp->me.y = pts[start].y;
-		sp->nextcp = sp->prevcp = sp->me;
+		sp = SplinePointCreate(pts[start].x, pts[start].y);
 		sp->ttfindex = i-1;
 		sp->nextcpindex = 0xffff;
 		cur->first = cur->last = sp;
 	    }
 	} else if ( !(flags[start]&_On_Curve) && !(flags[i-1]&_On_Curve) ) {
-	    sp = chunkalloc(sizeof(SplinePoint));
-	    sp->me.x = (pts[start].x+pts[i-1].x)/2;
-	    sp->me.y = (pts[start].y+pts[i-1].y)/2;
-	    sp->nextcp = sp->prevcp = sp->me;
+	    sp = SplinePointCreate((pts[start].x+pts[i-1].x)/2, (pts[start].y+pts[i-1].y)/2);
 	    sp->ttfindex = 0xffff;
 	    sp->nextcpindex = start;
 	    FigureControls(cur->last,sp,&pts[i-1],is_order2);

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -754,10 +754,9 @@ return;
 	cp.x = temp.x+cplen*s2; cp.y = temp.y - cplen*c2;
     }
     Transform(&pt->prevcp,&cp,transform);
-    pt->nonextcp = true;
+    pt->nextcp = pt->me;
     cp.x = base.x + sign*cplen*s1; cp.y = base.y - sign*cplen*c1;
     Transform(&cur->last->nextcp,&cp,transform);
-    cur->last->nonextcp = false;
     CheckMake(cur->last,pt);
     SplineMake3(cur->last,pt);
     cur->last = pt;
@@ -2044,7 +2043,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		}
 		pt = chunkalloc(sizeof(SplinePoint));
 		Transform(&pt->me,&current,transform);
-		pt->noprevcp = true; pt->nonextcp = true;
+		pt->prevcp = pt->nextcp = pt->me;
 		if ( tok==pt_moveto || tok==pt_rmoveto ) {
 		    SplinePointList *spl = chunkalloc(sizeof(SplinePointList));
 		    spl->first = spl->last = pt;
@@ -2078,12 +2077,11 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    temp.x = stack[sp-6].u.val; temp.y = stack[sp-5].u.val;
 		    Transform(&cur->last->nextcp,&temp,transform);
-		    cur->last->nonextcp = false;
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    temp.x = stack[sp-4].u.val; temp.y = stack[sp-3].u.val;
 		    Transform(&pt->prevcp,&temp,transform);
 		    Transform(&pt->me,&current,transform);
-		    pt->nonextcp = true;
+		    pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -2107,7 +2105,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 			!( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) )) {
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    Transform(&pt->me,&temp,transform);
-		    pt->noprevcp = true; pt->nonextcp = true;
+		    pt->prevcp = pt->nextcp = pt->me;
 		    if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 			CheckMake(cur->last,pt);
 			SplineMake3(cur->last,pt);
@@ -2150,7 +2148,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		    current.x = x1; current.y = y1;
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    Transform(&pt->me,&current,transform);
-		    pt->noprevcp = true; pt->nonextcp = true;
+		    pt->prevcp = pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -2183,7 +2181,7 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 			temp.x = xt1; temp.y = yt1;
 			pt = chunkalloc(sizeof(SplinePoint));
 			Transform(&pt->me,&temp,transform);
-			pt->noprevcp = true; pt->nonextcp = true;
+			pt->prevcp = pt->me; pt->nextcp = pt->me;
 			CheckMake(cur->last,pt);
 			SplineMake3(cur->last,pt);
 			cur->last = pt;
@@ -3966,7 +3964,6 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 			    cur = oldcur;
 			    if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 				cur->last->nextcp = old_nextcp;
-				cur->last->nonextcp = false;
 				pt = chunkalloc(sizeof(SplinePoint));
 			        pt->hintmask = pending_hm; pending_hm = NULL;
 				pt->prevcp = mid_prevcp;
@@ -3979,7 +3976,7 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 				pt = chunkalloc(sizeof(SplinePoint));
 				pt->prevcp = end_prevcp;
 				pt->me = end;
-				pt->nonextcp = true;
+				pt->nextcp = pt->me;
 			        CheckMake(cur->last,pt);
 				SplineMake3(cur->last,pt);
 				cur->last = pt;
@@ -3991,7 +3988,7 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 			    /*  the appropriate line */
 			    pt = chunkalloc(sizeof(SplinePoint));
 			    pt->me.x = pops[1]; pt->me.y = pops[0];
-			    pt->noprevcp = true; pt->nonextcp = true;
+			    pt->prevcp = pt->nextcp = pt->me;
 			    SplinePointListFree(oldcur->next); oldcur->next = NULL; spl = NULL;
 			    cur = oldcur;
 			    if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
@@ -4186,27 +4183,25 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    current.x = rint((current.x+dx)*1024)/1024; current.y = rint((current.y+dy)*1024)/1024;
 		    cur->last->nextcp.x = current.x; cur->last->nextcp.y = current.y;
-		    cur->last->nonextcp = false;
 		    current.x = rint((current.x+dx2)*1024)/1024; current.y = rint((current.y+dy2)*1024)/1024;
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    pt->hintmask = pending_hm; pending_hm = NULL;
 		    pt->prevcp.x = current.x; pt->prevcp.y = current.y;
 		    current.x = rint((current.x+dx3)*1024)/1024; current.y = rint((current.y+dy3)*1024)/1024;
 		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->nonextcp = true;
+		    pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
 
 		    current.x = rint((current.x+dx4)*1024)/1024; current.y = rint((current.y+dy4)*1024)/1024;
 		    cur->last->nextcp.x = current.x; cur->last->nextcp.y = current.y;
-		    cur->last->nonextcp = false;
 		    current.x = rint((current.x+dx5)*1024)/1024; current.y = rint((current.y+dy5)*1024)/1024;
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    pt->prevcp.x = current.x; pt->prevcp.y = current.y;
 		    current.x = rint((current.x+dx6)*1024)/1024; current.y = rint((current.y+dy6)*1024)/1024;
 		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->nonextcp = true;
+		    pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -4426,7 +4421,7 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		pt = chunkalloc(sizeof(SplinePoint));
 		pt->hintmask = pending_hm; pending_hm = NULL;
 		pt->me.x = current.x; pt->me.y = current.y;
-		pt->noprevcp = true; pt->nonextcp = true;
+		pt->prevcp = pt->nextcp = pt->me;
 		if ( v==4 || v==21 || v==22 ) {
 		    if ( cur!=NULL && cur->first==cur->last && cur->first->prev==NULL && is_type2 ) {
 			/* Two adjacent movetos should not create single point paths */
@@ -4463,7 +4458,7 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    pt->hintmask = pending_hm; pending_hm = NULL;
 		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->noprevcp = true; pt->nonextcp = true;
+		    pt->prevcp = pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -4541,14 +4536,13 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    current.x = rint((current.x+dx)*1024)/1024; current.y = rint((current.y+dy)*1024)/1024;
 		    cur->last->nextcp.x = current.x; cur->last->nextcp.y = current.y;
-		    cur->last->nonextcp = false;
 		    current.x = rint((current.x+dx2)*1024)/1024; current.y = rint((current.y+dy2)*1024)/1024;
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    pt->hintmask = pending_hm; pending_hm = NULL;
 		    pt->prevcp.x = current.x; pt->prevcp.y = current.y;
 		    current.x = rint((current.x+dx3)*1024)/1024; current.y = rint((current.y+dy3)*1024)/1024;
 		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->nonextcp = true;
+		    pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -4561,7 +4555,7 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    pt->hintmask = pending_hm; pending_hm = NULL;
 		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->noprevcp = true; pt->nonextcp = true;
+		    pt->prevcp = pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -733,6 +733,7 @@ static void circlearcto(real a1, real a2, real cx, real cy, real r,
 	SplineSet *cur, real *transform ) {
     SplinePoint *pt;
     DBasePoint temp, base, cp;
+    BasePoint ocp;
     real cplen;
     int sign=1;
     real s1, s2, c1, c2;
@@ -745,8 +746,8 @@ return;
     s1 = sin(a1); s2 = sin(a2); c1 = cos(a1); c2 = cos(a2);
     temp.x = cx+r*c2; temp.y = cy+r*s2;
     base.x = cx+r*c1; base.y = cy+r*s1;
-    pt = chunkalloc(sizeof(SplinePoint));
-    Transform(&pt->me,&temp,transform);
+    Transform(&ocp,&temp,transform);
+    pt = SplinePointCreate(ocp.x, ocp.y);
     cp.x = temp.x-cplen*s2; cp.y = temp.y + cplen*c2;
     if ( (cp.x-base.x)*(cp.x-base.x)+(cp.y-base.y)*(cp.y-base.y) >
 	     (temp.x-base.x)*(temp.x-base.x)+(temp.y-base.y)*(temp.y-base.y) ) {
@@ -754,7 +755,6 @@ return;
 	cp.x = temp.x+cplen*s2; cp.y = temp.y - cplen*c2;
     }
     Transform(&pt->prevcp,&cp,transform);
-    pt->nextcp = pt->me;
     cp.x = base.x + sign*cplen*s1; cp.y = base.y - sign*cplen*c1;
     Transform(&cur->last->nextcp,&cp,transform);
     CheckMake(cur->last,pt);
@@ -1271,6 +1271,7 @@ return;		/* Hunh. I don't understand it. I give up */
 static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
     SplinePointList *cur=NULL, *head=NULL;
     DBasePoint current, temp;
+    BasePoint ini_me;
     int tok, i, j;
     struct psstack stack[100];
     real dval;
@@ -2041,9 +2042,8 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		    current.y = stack[sp-1].u.val;
 		    sp -= 2;
 		}
-		pt = chunkalloc(sizeof(SplinePoint));
-		Transform(&pt->me,&current,transform);
-		pt->prevcp = pt->nextcp = pt->me;
+		Transform(&ini_me,&current,transform);
+		pt = SplinePointCreate(ini_me.x, ini_me.y);
 		if ( tok==pt_moveto || tok==pt_rmoveto ) {
 		    SplinePointList *spl = chunkalloc(sizeof(SplinePointList));
 		    spl->first = spl->last = pt;
@@ -2077,11 +2077,10 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    temp.x = stack[sp-6].u.val; temp.y = stack[sp-5].u.val;
 		    Transform(&cur->last->nextcp,&temp,transform);
-		    pt = chunkalloc(sizeof(SplinePoint));
+		    Transform(&ini_me,&current,transform);
+		    pt = SplinePointCreate(ini_me.x, ini_me.y);
 		    temp.x = stack[sp-4].u.val; temp.y = stack[sp-3].u.val;
 		    Transform(&pt->prevcp,&temp,transform);
-		    Transform(&pt->me,&current,transform);
-		    pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -2103,9 +2102,8 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		temp.y = cy+r*sin(a1/180 * FF_PI);
 		if ( temp.x!=current.x || temp.y!=current.y ||
 			!( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) )) {
-		    pt = chunkalloc(sizeof(SplinePoint));
-		    Transform(&pt->me,&temp,transform);
-		    pt->prevcp = pt->nextcp = pt->me;
+		    Transform(&ini_me,&temp,transform);
+		    pt = SplinePointCreate(ini_me.x, ini_me.y);
 		    if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 			CheckMake(cur->last,pt);
 			SplineMake3(cur->last,pt);
@@ -2146,9 +2144,8 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 			(current.x-x1)*(y2-y1) == (x2-x1)*(current.y-y1) ) {
 		    /* Degenerate case */
 		    current.x = x1; current.y = y1;
-		    pt = chunkalloc(sizeof(SplinePoint));
-		    Transform(&pt->me,&current,transform);
-		    pt->prevcp = pt->nextcp = pt->me;
+		    Transform(&ini_me,&current,transform);
+		    pt = SplinePointCreate(ini_me.x, ini_me.y);
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -2179,9 +2176,8 @@ static void _InterpretPS(IO *wrapper, EntityChar *ec, RetStack *rs) {
 		    if ( xt1!=current.x || yt1!=current.y ) {
 			DBasePoint temp;
 			temp.x = xt1; temp.y = yt1;
-			pt = chunkalloc(sizeof(SplinePoint));
-			Transform(&pt->me,&temp,transform);
-			pt->prevcp = pt->me; pt->nextcp = pt->me;
+			Transform(&ini_me,&temp,transform);
+			pt = SplinePointCreate(ini_me.x, ini_me.y);
 			CheckMake(cur->last,pt);
 			SplineMake3(cur->last,pt);
 			cur->last = pt;
@@ -3628,6 +3624,7 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
     SplinePointList *cur=NULL, *oldcur=NULL;
     RefChar *r1, *r2, *rlast=NULL;
     DBasePoint current;
+    BasePoint ini_me;
     real dx, dy, dx2, dy2, dx3, dy3, dx4, dy4, dx5, dy5, dx6, dy6;
     SplinePoint *pt;
     /* subroutines may be nested to a depth of 10 */
@@ -3964,19 +3961,16 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 			    cur = oldcur;
 			    if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 				cur->last->nextcp = old_nextcp;
-				pt = chunkalloc(sizeof(SplinePoint));
+				pt = SplinePointCreate(mid.x, mid.y);
 			        pt->hintmask = pending_hm; pending_hm = NULL;
 				pt->prevcp = mid_prevcp;
-				pt->me = mid;
 				pt->nextcp = mid_nextcp;
 				/*pt->flex = pops[2];*/
 			        CheckMake(cur->last,pt);
 				SplineMake3(cur->last,pt);
 				cur->last = pt;
-				pt = chunkalloc(sizeof(SplinePoint));
+				pt = SplinePointCreate(end.x, end.y);
 				pt->prevcp = end_prevcp;
-				pt->me = end;
-				pt->nextcp = pt->me;
 			        CheckMake(cur->last,pt);
 				SplineMake3(cur->last,pt);
 				cur->last = pt;
@@ -3986,9 +3980,7 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 			    /* Um, something's wrong. Let's just draw a line */
 			    /* do the simple method, which consists of creating */
 			    /*  the appropriate line */
-			    pt = chunkalloc(sizeof(SplinePoint));
-			    pt->me.x = pops[1]; pt->me.y = pops[0];
-			    pt->prevcp = pt->nextcp = pt->me;
+			    pt = SplinePointCreate(pops[1], pops[0]);
 			    SplinePointListFree(oldcur->next); oldcur->next = NULL; spl = NULL;
 			    cur = oldcur;
 			    if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
@@ -4184,12 +4176,11 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		    current.x = rint((current.x+dx)*1024)/1024; current.y = rint((current.y+dy)*1024)/1024;
 		    cur->last->nextcp.x = current.x; cur->last->nextcp.y = current.y;
 		    current.x = rint((current.x+dx2)*1024)/1024; current.y = rint((current.y+dy2)*1024)/1024;
-		    pt = chunkalloc(sizeof(SplinePoint));
-		    pt->hintmask = pending_hm; pending_hm = NULL;
-		    pt->prevcp.x = current.x; pt->prevcp.y = current.y;
+		    ini_me.x = current.x; ini_me.y = current.y; // Store for setting prevcp;
 		    current.x = rint((current.x+dx3)*1024)/1024; current.y = rint((current.y+dy3)*1024)/1024;
-		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->nextcp = pt->me;
+		    pt = SplinePointCreate(current.x, current.y);
+		    pt->hintmask = pending_hm; pending_hm = NULL;
+		    pt->prevcp = ini_me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -4197,11 +4188,10 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		    current.x = rint((current.x+dx4)*1024)/1024; current.y = rint((current.y+dy4)*1024)/1024;
 		    cur->last->nextcp.x = current.x; cur->last->nextcp.y = current.y;
 		    current.x = rint((current.x+dx5)*1024)/1024; current.y = rint((current.y+dy5)*1024)/1024;
-		    pt = chunkalloc(sizeof(SplinePoint));
-		    pt->prevcp.x = current.x; pt->prevcp.y = current.y;
+		    ini_me.x = current.x; ini_me.y = current.y; // Store for setting prevcp;
 		    current.x = rint((current.x+dx6)*1024)/1024; current.y = rint((current.y+dy6)*1024)/1024;
-		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->nextcp = pt->me;
+		    pt = SplinePointCreate(current.x, current.y);
+		    pt->prevcp = ini_me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -4418,10 +4408,8 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		}
 		++polarity;
 		current.x = rint((current.x+dx)*1024)/1024; current.y = rint((current.y+dy)*1024)/1024;
-		pt = chunkalloc(sizeof(SplinePoint));
+		pt = SplinePointCreate(current.x, current.y);
 		pt->hintmask = pending_hm; pending_hm = NULL;
-		pt->me.x = current.x; pt->me.y = current.y;
-		pt->prevcp = pt->nextcp = pt->me;
 		if ( v==4 || v==21 || v==22 ) {
 		    if ( cur!=NULL && cur->first==cur->last && cur->first->prev==NULL && is_type2 ) {
 			/* Two adjacent movetos should not create single point paths */
@@ -4455,10 +4443,8 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 	    while ( sp>base+6 ) {
 		current.x = rint((current.x+stack[base++])*1024)/1024; current.y = rint((current.y+stack[base++])*1024)/1024;
 		if ( cur!=NULL ) {
-		    pt = chunkalloc(sizeof(SplinePoint));
+		    pt = SplinePointCreate(current.x, current.y);
 		    pt->hintmask = pending_hm; pending_hm = NULL;
-		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->prevcp = pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -4537,12 +4523,11 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 		    current.x = rint((current.x+dx)*1024)/1024; current.y = rint((current.y+dy)*1024)/1024;
 		    cur->last->nextcp.x = current.x; cur->last->nextcp.y = current.y;
 		    current.x = rint((current.x+dx2)*1024)/1024; current.y = rint((current.y+dy2)*1024)/1024;
-		    pt = chunkalloc(sizeof(SplinePoint));
-		    pt->hintmask = pending_hm; pending_hm = NULL;
-		    pt->prevcp.x = current.x; pt->prevcp.y = current.y;
+		    ini_me.x = current.x; ini_me.y = current.y; // Store for setting prevcp;
 		    current.x = rint((current.x+dx3)*1024)/1024; current.y = rint((current.y+dy3)*1024)/1024;
-		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->nextcp = pt->me;
+		    pt = SplinePointCreate(current.x, current.y);
+		    pt->hintmask = pending_hm; pending_hm = NULL;
+		    pt->prevcp = ini_me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;
@@ -4552,10 +4537,8 @@ SplineChar *PSCharStringToSplines(uint8 *type1, int len, struct pscontext *conte
 	    if ( v==24 ) {
 		current.x = rint((current.x+stack[base++])*1024)/1024; current.y = rint((current.y+stack[base++])*1024)/1024;
 		if ( cur!=NULL ) {	/* In legal code, cur can't be null here, but I got something illegal... */
-		    pt = chunkalloc(sizeof(SplinePoint));
+		    pt = SplinePointCreate(current.x, current.y);
 		    pt->hintmask = pending_hm; pending_hm = NULL;
-		    pt->me.x = current.x; pt->me.y = current.y;
-		    pt->prevcp = pt->nextcp = pt->me;
 		    CheckMake(cur->last,pt);
 		    SplineMake3(cur->last,pt);
 		    cur->last = pt;

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -5146,7 +5146,6 @@ return( NULL );
 		    sp->prevcp.x = c->points[index]->x;
 		    sp->prevcp.y = c->points[index]->y;
 		    sp->prevcpselected = c->points[index]->selected;
-		    sp->noprevcp = false;
 		}
 		if ( ss->last==NULL ) {
 		    ss->first = sp;
@@ -5162,7 +5161,6 @@ return( NULL );
 		    sp->prevcp.x = c->points[i-1]->x;
 		    sp->prevcp.y = c->points[i-1]->y;
 		    sp->prevcpselected = c->points[i-1]->selected;
-		    sp->noprevcp = false;
 		    if ( ss->last==NULL ) {
 			ss->first = sp;
 			ss->start_offset = 0;
@@ -5173,7 +5171,6 @@ return( NULL );
 		ss->last->nextcp.x = c->points[i]->x;
 		ss->last->nextcp.y = c->points[i]->y;
 		ss->last->nextcpselected = c->points[i]->selected;
-		ss->last->nonextcp = false;
 		ss->last->nextcpindex = next++;
 	    }
 	    ++i;
@@ -5186,7 +5183,6 @@ return( NULL );
 		sp->prevcp.x = c->points[i-1]->x;
 		sp->prevcp.y = c->points[i-1]->y;
 		sp->prevcpselected = c->points[i-1]->selected;
-		sp->noprevcp = false;
 		if ( ss->last==NULL ) {
 		    ss->first = sp;
 		    ss->start_offset = 0;
@@ -5197,7 +5193,6 @@ return( NULL );
 	    ss->last->nextcp.x = c->points[0]->x;
 	    ss->last->nextcp.y = c->points[0]->y;
 	    ss->last->nextcpselected = c->points[0]->selected;
-	    ss->last->nonextcp = false;
 	    ss->last->nextcpindex = start;
 	}
     } else {
@@ -5223,8 +5218,6 @@ return( NULL );
 		sp->prevcp.x = c->points[previ]->x;
 		sp->prevcp.y = c->points[previ]->y;
 		sp->prevcpselected = c->points[previ]->selected;
-		// if ( sp->prevcp.x!=sp->me.x || sp->prevcp.y!=sp->me.y ) // This is unnecessary since the other converter only makes a control point if there is supposed to be one.
-		    sp->noprevcp = false;
 	    }
 	    if ( i==c->pt_cnt-1 )
 		nexti = 0;
@@ -5235,8 +5228,6 @@ return( NULL );
 		sp->nextcp.y = c->points[nexti]->y;
 		sp->nextcpselected = c->points[nexti]->selected;
 		next += 2;
-		// if ( sp->nextcp.x!=sp->me.x || sp->nextcp.y!=sp->me.y ) // This is unnecessary since the other converter only makes a control point if there is supposed to be one.
-		    sp->nonextcp = false;
 		if ( nexti==c->pt_cnt-1 )
 		    nexti = 0;
 		else
@@ -5543,9 +5534,7 @@ return( NULL );
     ss = sc->layers[layer].splines;
     sp = SplinePointCreate(x[2],y[2]);
     sp->prevcp.x = x[1]; sp->prevcp.y = y[1];
-    sp->noprevcp = false;
     ss->last->nextcp.x = x[0], ss->last->nextcp.y = y[0];
-    ss->last->nonextcp = false;
     SplineMake(ss->last,sp,sc->layers[layer].order2);
     ss->last = sp;
 
@@ -5595,9 +5584,7 @@ return( NULL );
 	    if ( !PyArg_ParseTuple(pt_tuple,"dd", &x2, &y2 ))
 return( NULL );
 	    sp = SplinePointCreate((x1+x2)/2,(y1+y2)/2);
-	    sp->noprevcp = false;
 	    sp->prevcp.x = x1; sp->prevcp.y = y1;
-	    sp->nonextcp = false;
 	    sp->nextcp.x = x2; sp->nextcp.y = y2;
 	    if ( ss->first==NULL ) {
 		ss->first = ss->last = sp;
@@ -5609,9 +5596,7 @@ return( NULL );
 	    x1=x2; y1=y2;
 	}
 	sp = SplinePointCreate((x0+x2)/2,(y0+y2)/2);
-	sp->noprevcp = false;
 	sp->prevcp.x = x2; sp->prevcp.y = y2;
-	sp->nonextcp = false;
 	sp->nextcp.x = x0; sp->nextcp.y = y0;
 	SplineMake2(ss->last,sp);
 	SplineMake2(sp,ss->first);
@@ -5632,15 +5617,12 @@ return( NULL );
 	if ( !PyArg_ParseTuple(pt_tuple,"dd", &x1, &y1 ))
 return( NULL );
 	ss->last->nextcp.x = x1; ss->last->nextcp.y = y1;
-	ss->last->nonextcp = false;
 	for ( i=1; i<len-1; ++i ) {
 	    pt_tuple = PySequence_GetItem(args,i);
 	    if ( !PyArg_ParseTuple(pt_tuple,"dd", &x2, &y2 ))
 return( NULL );
 	    sp = SplinePointCreate((x1+x2)/2,(y1+y2)/2);
-	    sp->noprevcp = false;
 	    sp->prevcp.x = x1; sp->prevcp.y = y1;
-	    sp->nonextcp = false;
 	    sp->nextcp.x = x2; sp->nextcp.y = y2;
 	    SplineMake2(ss->last,sp);
 	    ss->last = sp;
@@ -5650,7 +5632,6 @@ return( NULL );
 	if ( !PyArg_ParseTuple(pt_tuple,"dd", &x2, &y2 ))
 return( NULL );
 	sp = SplinePointCreate(x2,y2);
-	sp->noprevcp = false;
 	sp->prevcp.x = x1; sp->prevcp.y = y1;
 	SplineMake2(ss->last,sp);
 	ss->last = sp;

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -5502,11 +5502,9 @@ static void SCMakeLine(SplineChar *sc) {
 			changed = true;
 		    }
 		    sp->prevcp = sp->me;
-		    sp->noprevcp = true;
 		    if ( sp->prev )
 			SplineRefigure(sp->prev);
 		    sp->nextcp = sp->me;
-		    sp->nonextcp = true;
 		    if ( sp->next )
 			SplineRefigure(sp->next);
 		}

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -4651,12 +4651,10 @@ static SplineSet *MakeBottomItalicSerif(double stemwidth,double endx,
 	    ++i;
 	} else {
 	    InterpBp(&last->nextcp,i,xscale,yscale,interp,endx,normal,bold);
-	    last->nonextcp = false;
 	    i+=2;
 	    InterpBp(&bp,i,xscale,yscale,interp,endx,normal,bold);
 	    cur = SplinePointCreate(bp.x,bp.y);
 	    InterpBp(&cur->prevcp,i-1,xscale,yscale,interp,endx,normal,bold);
-	    cur->noprevcp = false;
 	    SplineMake3(last,cur);
 	    ++i;
 	}
@@ -5185,7 +5183,8 @@ static void SerifRemove(SplinePoint *start,SplinePoint *end,SplineSet *ss) {
 	SplineFree(spnext->prev);
     }
     start->next = end->prev = NULL;
-    start->nonextcp = end->noprevcp = true;
+    start->nextcp = start->me;
+    end->prevcp = end->me;
 }
 
 static SplinePoint *StemMoveBottomEndTo(SplinePoint *sp,double y,int is_start) {
@@ -5200,7 +5199,6 @@ static SplinePoint *StemMoveBottomEndTo(SplinePoint *sp,double y,int is_start) {
 	    SplineRefigure(sp->prev);
 	} else {
 	    other = SplinePointCreate(sp->me.x,y);
-	    sp->nonextcp = true;
 	    SplineMake(sp,other,sp->prev->order2);
 	    sp = other;
 	}
@@ -5238,7 +5236,6 @@ static SplinePoint *StemMoveDBottomEndTo(SplinePoint *sp,double y,DStemInfo *d,
 	    SplineRefigure(sp->prev);
 	} else {
 	    other = SplinePointCreate(sp->me.x+xoff,y);
-	    sp->nonextcp = true;
 	    SplineMake(sp,other,sp->prev->order2);
 	    sp = other;
 	}
@@ -5352,7 +5349,8 @@ return;
     if ( ii->secondary_serif == srf_flat ) {
 	start = StemMoveBottomEndTo(start,y,true);
 	end = StemMoveBottomEndTo(end,y,false);
-	start->nonextcp = end->noprevcp = true;
+	start->nextcp = start->me;
+	end->prevcp = end->me;
 	SplineMake(start,end,sc->layers[layer].order2);
     } else if ( ii->secondary_serif == srf_simpleslant ) {
 	if ( ii->tan_ia<0 ) {
@@ -5362,7 +5360,8 @@ return;
 	    start = StemMoveBottomEndTo(start,y,true);
 	    end = StemMoveBottomEndTo(end,y - (end->me.x-start->me.x)*ii->tan_ia,false);
 	}
-	start->nonextcp = end->noprevcp = true;
+	start->nextcp = start->me;
+	end->prevcp = end->me;
 	SplineMake(start,end,sc->layers[layer].order2);
     } else {
 	if ( ii->tan_ia<0 ) {
@@ -5374,7 +5373,8 @@ return;
 	    end = StemMoveBottomEndTo(end,y- .8*(end->me.x-start->me.x)*ii->tan_ia,false);
 	    mid = SplinePointCreate(.2*end->me.x+.8*start->me.x,y);
 	}
-	start->nonextcp = end->noprevcp = true;
+	start->nextcp = start->me;
+	end->prevcp = end->me;
 	mid->pointtype = pt_corner;
 	SplineMake(start,mid,sc->layers[layer].order2);
 	SplineMake(mid,end,sc->layers[layer].order2);
@@ -5523,7 +5523,6 @@ static SplinePoint *StemMoveTopEndTo(SplinePoint *sp,double y,int is_start) {
 	    SplineRefigure(sp->prev);
 	} else {
 	    other = SplinePointCreate(sp->me.x,y);
-	    sp->nonextcp = true;
 	    SplineMake(sp,other,sp->prev->order2);
 	    sp = other;
 	}
@@ -5536,7 +5535,6 @@ static SplinePoint *StemMoveTopEndTo(SplinePoint *sp,double y,int is_start) {
 	    SplineRefigure(sp->next);
 	} else {
 	    other = SplinePointCreate(sp->me.x,y);
-	    sp->noprevcp = true;
 	    SplineMake(other,sp,sp->next->order2);
 	    sp = other;
 	}
@@ -5552,12 +5550,10 @@ static SplinePoint *StemMoveDTopEndTo(SplinePoint *sp,double y,DStemInfo *d,
     xoff = (y-sp->me.y)*d->unit.x/d->unit.y;
     if ( is_start ) {
 	other = SplinePointCreate(sp->me.x+xoff,y);
-	sp->nonextcp = true;
 	SplineMake(sp,other,sp->prev->order2);
 	sp = other;
     } else {
 	other = SplinePointCreate(sp->me.x+xoff,y);
-	sp->noprevcp = true;
 	SplineMake(other,sp,sp->next->order2);
 	sp = other;
     }
@@ -5875,7 +5871,8 @@ return;
 
     start = StemMoveBottomEndTo(start,y,true);
     end = StemMoveBottomEndTo(end,y,false);
-    start->nonextcp = end->noprevcp = true;
+    start->nextcp = start->me;
+    end->prevcp = end->me;
     SplineMake(start,end,sc->layers[layer].order2);
     start->pointtype = end->pointtype = pt_corner;
 }
@@ -6317,7 +6314,7 @@ static void FBottomGrows(SplineChar *sc,int layer,ItalicInfo *ii) {
 		sp = SplinePointCreate(start->me.x,start->me.y+ii->pq_depth);
 		sp->next = start->next;
 		sp->next->from = sp;
-		start->nonextcp = true;
+		start->nextcp = start->me;
 		SplineMake(start,sp,sc->layers[layer].order2);
 		start = sp;
 	    } else {
@@ -6328,7 +6325,7 @@ static void FBottomGrows(SplineChar *sc,int layer,ItalicInfo *ii) {
 		sp = SplinePointCreate(end->me.x,end->me.y+ii->pq_depth);
 		sp->prev = start->prev;
 		sp->prev->to = sp;
-		end->noprevcp = true;
+		end->prevcp = end->me;
 		SplineMake(sp,end,sc->layers[layer].order2);
 		end = sp;
 	    } else {
@@ -6538,7 +6535,8 @@ return;
 	end   = ltemp;
     }
     SerifRemove(start,end,sses[0]);
-    start->nonextcp = end->noprevcp = true;
+    start->nextcp = start->me;
+    end->prevcp = end->me;
     SplineMake(start,end,sc->layers[layer].order2);
  if ( sc->layers[layer].order2 )
   SSCPValidate(sses[0]);

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -5184,6 +5184,10 @@ static void SerifRemove(SplinePoint *start,SplinePoint *end,SplineSet *ss) {
     }
     start->next = end->prev = NULL;
     start->nextcp = start->me;
+    // The following is probably unneeded but restores the
+    // state of each now-open contour to what it would be when
+    // points are allocated with SplinePointCreate()
+    start->nonextcp = end->noprevcp = true;
     end->prevcp = end->me;
 }
 

--- a/fontforge/search.c
+++ b/fontforge/search.c
@@ -699,7 +699,7 @@ return( false );
 return( true );
 }
 
-static int AdjustBP(BasePoint *changeme,BasePoint *rel,
+static void AdjustBP(BasePoint *changeme,BasePoint *rel,
 	BasePoint *shouldbe, BasePoint *shouldberel,
 	BasePoint *fudge,
 	SearchData *s) {
@@ -715,7 +715,6 @@ static int AdjustBP(BasePoint *changeme,BasePoint *rel,
     yoff *= s->matched_scale;
     changeme->x = xoff*s->matched_co - yoff*s->matched_si + fudge->x  + rel->x;
     changeme->y = yoff*s->matched_co + xoff*s->matched_si + fudge->y  + rel->y;
-return( changeme->x==rel->x && changeme->y==rel->y );
 }
 
 static void AdjustAll(SplinePoint *change,BasePoint *rel,
@@ -728,9 +727,6 @@ static void AdjustAll(SplinePoint *change,BasePoint *rel,
     AdjustBP(&change->me,rel,shouldbe,shouldberel,fudge,s);
     change->nextcp.x += change->me.x-old.x; change->nextcp.y += change->me.y-old.y;
     change->prevcp.x += change->me.x-old.x; change->prevcp.y += change->me.y-old.y;
-
-    change->nonextcp = (change->nextcp.x==change->me.x && change->nextcp.y==change->me.y);
-    change->noprevcp = (change->prevcp.x==change->me.x && change->prevcp.y==change->me.y);
 }
 
 static SplinePoint *RplInsertSP(SplinePoint *after,SplinePoint *nrpl,SplinePoint *rpl,SearchData *s, BasePoint *fudge) {
@@ -745,8 +741,6 @@ static SplinePoint *RplInsertSP(SplinePoint *after,SplinePoint *nrpl,SplinePoint
     new->nextcp.y = after->me.y + transform[2]*(nrpl->nextcp.x-rpl->me.x) + transform[3]*(nrpl->nextcp.y-rpl->me.y) + fudge->y;
     new->prevcp.x = after->me.x + transform[0]*(nrpl->prevcp.x-rpl->me.x) + transform[1]*(nrpl->prevcp.y-rpl->me.y) + fudge->x;
     new->prevcp.y = after->me.y + transform[2]*(nrpl->prevcp.x-rpl->me.x) + transform[3]*(nrpl->prevcp.y-rpl->me.y) + fudge->y;
-    new->nonextcp = (new->nextcp.x==new->me.x && new->nextcp.y==new->me.y);
-    new->noprevcp = (new->prevcp.x==new->me.x && new->prevcp.y==new->me.y);
     new->pointtype = rpl->pointtype;
     new->selected = true;
     new->ticked = true;
@@ -833,7 +827,6 @@ static void DoReplaceIncomplete(SplineChar *sc,SearchData *s) {
 	dummy.me.x = sc_p->me.x + xoff*s->matched_co - yoff*s->matched_si;
 	dummy.me.y = sc_p->me.y + yoff*s->matched_co + xoff*s->matched_si;
 	dummy.nextcp = dummy.prevcp = dummy.me;
-	dummy.nonextcp = dummy.noprevcp = true;
 	dummy.next = &dummysp;
 	SplineRefigure(&dummysp);
 	sc_p = &dummy;
@@ -876,9 +869,9 @@ return;
 	    }
 	    np_p = p_p->next->to; nsc_p = sc_p->next->to; nr_p = r_p->next->to;
 	    if ( p_p==path->first ) {
-		sc_p->nonextcp = AdjustBP(&sc_p->nextcp,&sc_p->me,&r_p->nextcp,&r_p->me,&fudge,s);
+		AdjustBP(&sc_p->nextcp,&sc_p->me,&r_p->nextcp,&r_p->me,&fudge,s);
 		if ( p_p->prev!=NULL )
-		    sc_p->noprevcp = AdjustBP(&sc_p->prevcp,&sc_p->me,&r_p->prevcp,&r_p->me,&fudge,s);
+		    AdjustBP(&sc_p->prevcp,&sc_p->me,&r_p->prevcp,&r_p->me,&fudge,s);
 		if ( sc_p->prev!=NULL )
 		    SplineRefigure(sc_p->prev);
 		sc_p->ticked = true;
@@ -886,8 +879,8 @@ return;
 	    if ( np_p==path->first )
 return;
 	    if ( np_p->next!=NULL )
-		nsc_p->nonextcp = AdjustBP(&nsc_p->nextcp,&nsc_p->me,&nr_p->nextcp,&nr_p->me,&fudge,s);
-	    nsc_p->noprevcp = AdjustBP(&nsc_p->prevcp,&nsc_p->me,&nr_p->prevcp,&nr_p->me,&fudge,s);
+		AdjustBP(&nsc_p->nextcp,&nsc_p->me,&nr_p->nextcp,&nr_p->me,&fudge,s);
+	    AdjustBP(&nsc_p->prevcp,&nsc_p->me,&nr_p->prevcp,&nr_p->me,&fudge,s);
 	    AdjustAll(nsc_p,&sc_p->me,&nr_p->me,&r_p->me,&fudge,s);
 	    nsc_p->ticked = true;
 	    nsc_p->pointtype = nr_p->pointtype;

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -4126,9 +4126,7 @@ static SplineSet *SFDGetSplineSet(FILE *sfd,int order2) {
 		current.x = stack[sp-2];
 		current.y = stack[sp-1];
 		sp -= 2;
-		pt = chunkalloc(sizeof(SplinePoint));
-		pt->me = current;
-		pt->prevcp = pt->nextcp = pt->me;
+		pt = SplinePointCreate(current.x, current.y);
 		if ( ch=='m' ) {
 		    SplinePointList *spl = chunkalloc(sizeof(SplinePointList));
 		    spl->first = spl->last = pt;
@@ -4158,11 +4156,9 @@ static SplineSet *SFDGetSplineSet(FILE *sfd,int order2) {
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    cur->last->nextcp.x = stack[sp-6];
 		    cur->last->nextcp.y = stack[sp-5];
-		    pt = chunkalloc(sizeof(SplinePoint));
+		    pt = SplinePointCreate(current.x, current.y);
 		    pt->prevcp.x = stack[sp-4];
 		    pt->prevcp.y = stack[sp-3];
-		    pt->me = current;
-		    pt->nextcp = pt->me;
 		    if ( cur->last->nextcpindex==0xfffe )
 			cur->last->nextcpindex = ttfindex++;
 		    else if ( cur->last->nextcpindex!=0xffff )

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -4128,7 +4128,7 @@ static SplineSet *SFDGetSplineSet(FILE *sfd,int order2) {
 		sp -= 2;
 		pt = chunkalloc(sizeof(SplinePoint));
 		pt->me = current;
-		pt->noprevcp = true; pt->nonextcp = true;
+		pt->prevcp = pt->nextcp = pt->me;
 		if ( ch=='m' ) {
 		    SplinePointList *spl = chunkalloc(sizeof(SplinePointList));
 		    spl->first = spl->last = pt;
@@ -4145,8 +4145,6 @@ static SplineSet *SFDGetSplineSet(FILE *sfd,int order2) {
 			if ( cur->last->nextcpindex==0xfffe )
 			    cur->last->nextcpindex = 0xffff;
 			SplineMake(cur->last,pt,order2);
-			cur->last->nonextcp = 1;
-			pt->noprevcp = 1;
 			cur->last = pt;
 		    }
 		}
@@ -4160,12 +4158,11 @@ static SplineSet *SFDGetSplineSet(FILE *sfd,int order2) {
 		if ( cur!=NULL && cur->first!=NULL && (cur->first!=cur->last || cur->first->next==NULL) ) {
 		    cur->last->nextcp.x = stack[sp-6];
 		    cur->last->nextcp.y = stack[sp-5];
-		    cur->last->nonextcp = false;
 		    pt = chunkalloc(sizeof(SplinePoint));
 		    pt->prevcp.x = stack[sp-4];
 		    pt->prevcp.y = stack[sp-3];
 		    pt->me = current;
-		    pt->nonextcp = true;
+		    pt->nextcp = pt->me;
 		    if ( cur->last->nextcpindex==0xfffe )
 			cur->last->nextcpindex = ttfindex++;
 		    else if ( cur->last->nextcpindex!=0xffff )

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -628,6 +628,7 @@ return;
     } else if ( pointtype==pt_tangent ) {
 	if ( sp->next!=NULL && !sp->nonextcp && sp->next->knownlinear ) {
 	    sp->nextcp = sp->me;
+        SplineRefigure(sp->next);
 	} else if ( sp->prev!=NULL && !sp->nonextcp &&
 		BpColinear(&sp->prev->from->me,&sp->me,&sp->nextcp) ) {
 	    /* The current control point is reasonable */
@@ -637,6 +638,7 @@ return;
 	}
 	if ( sp->prev!=NULL && !sp->noprevcp && sp->prev->knownlinear ) {
 	    sp->prevcp = sp->me;
+        SplineRefigure(sp->prev);
 	} else if ( sp->next!=NULL && !sp->noprevcp &&
 		BpColinear(&sp->next->to->me,&sp->me,&sp->prevcp) ) {
 	    /* The current control point is reasonable */

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -627,7 +627,6 @@ return;
 	sp->prevcpdef = sp->noprevcp;
     } else if ( pointtype==pt_tangent ) {
 	if ( sp->next!=NULL && !sp->nonextcp && sp->next->knownlinear ) {
-	    sp->nonextcp = true;
 	    sp->nextcp = sp->me;
 	} else if ( sp->prev!=NULL && !sp->nonextcp &&
 		BpColinear(&sp->prev->from->me,&sp->me,&sp->nextcp) ) {
@@ -637,7 +636,6 @@ return;
 	    if ( sp->next ) SplineRefigure(sp->next);
 	}
 	if ( sp->prev!=NULL && !sp->noprevcp && sp->prev->knownlinear ) {
-	    sp->noprevcp = true;
 	    sp->prevcp = sp->me;
 	} else if ( sp->next!=NULL && !sp->noprevcp &&
 		BpColinear(&sp->next->to->me,&sp->me,&sp->prevcp) ) {
@@ -754,10 +752,6 @@ void SplinePointRound(SplinePoint *sp,real factor) {
 	sp->next->to->prevcp = sp->nextcp;
     if ( sp->prev!=NULL && sp->prev->order2 )
 	sp->prev->from->nextcp = sp->prevcp;
-    if ( sp->nextcp.x==sp->me.x && sp->nextcp.y==sp->me.y )
-	sp->nonextcp = true;
-    if ( sp->prevcp.x==sp->me.x && sp->prevcp.y==sp->me.y )
-	sp->noprevcp = true;
 }
 
 static void SpiroRound2Int(spiro_cp *cp,real factor) {
@@ -1900,7 +1894,6 @@ static SplinePoint *CirclePoint(int which) {
     };
 
     sp = SplinePointCreate(ellipse3[which].me.x,ellipse3[which].me.y);
-    sp->nonextcp = sp->noprevcp = false;
     sp->nextcp = ellipse3[which].nextcp;
     sp->prevcp = ellipse3[which].prevcp;
 return( sp );
@@ -2038,7 +2031,6 @@ static int EllipseClockwise(SplinePoint *sp1,SplinePoint *sp2,BasePoint *slope1,
     e1 = SplinePointCreate(sp1->me.x,sp1->me.y);
     e2 = SplinePointCreate(sp2->me.x,sp2->me.y);
     SplineMake3(e2,e1);
-    e1->nonextcp = false; e2->noprevcp = false;
     len = sqrt((sp1->me.x-sp2->me.x) * (sp1->me.x-sp2->me.x)  +
 	  (sp1->me.y-sp2->me.y) * (sp1->me.y-sp2->me.y));
     e1->nextcp.x = e1->me.x + len*slope1->x;
@@ -2337,9 +2329,7 @@ static int MakeShape(CharViewBase *cv,SplinePointList *spl1,SplinePointList *spl
     if ( !do_arc || ( sp1->me.x==sp2->me.x && sp1->me.y==sp2->me.y )) {
 	if ( !changed )
 	    CVPreserveState(cv);
-	sp1->nonextcp = true;
 	sp1->nextcp = sp1->me;
-	sp2->noprevcp = true;
 	sp2->prevcp = sp2->me;
 	if ( sp1->next==NULL )
 	    SplineMake(sp1,sp2,order2);
@@ -2458,7 +2448,6 @@ void _CVMenuMakeLine(CharViewBase *cv,int do_arc,int ellipse_to_back) {
 		    }
 		    if (!do_arc) {
 			sp->nextcp = sp->me;
-			sp->nonextcp = true;
 			sp->next->to->prevcp = sp->next->to->me;
 			sp->next->to->noprevcp = true;
 		    }

--- a/fontforge/splinefit.c
+++ b/fontforge/splinefit.c
@@ -58,7 +58,8 @@ return( NULL );
 	    if ( !RealWithin(mid[i].p.x,from->me.x+slope*(mid[i].p.y-from->me.y),.7) )
 return( NULL );
     }
-    from->nonextcp = to->noprevcp = true;
+    from->nextcp = from->me;
+    to->prevcp = to->me;
 return( SplineMake(from,to,order2) );
 }
 
@@ -270,16 +271,16 @@ static void TestForLinear(SplinePoint *from,SplinePoint *to) {
 	}
 	co = cpoff.x*off.y - cpoff.y*off.x; co2 = cpoff2.x*off.y - cpoff2.y*off.x;
 	if ( co<.05 && co>-.05 && co2<.05 && co2>-.05 ) {
-	    from->nextcp = from->me; from->nonextcp = true;
-	    to->prevcp = to->me; to->noprevcp = true;
+	    from->nextcp = from->me;
+	    to->prevcp = to->me;
 	} else {
 	    Spline temp;
 	    memset(&temp,0,sizeof(temp));
 	    temp.from = from; temp.to = to;
 	    SplineRefigure(&temp);
 	    if ( SplineIsLinear(&temp)) {
-		from->nextcp = from->me; from->nonextcp = true;
-		to->prevcp = to->me; to->noprevcp = true;
+		from->nextcp = from->me;
+		to->prevcp = to->me;
 	    }
 	}
     }
@@ -376,7 +377,6 @@ return( SplineMake2(from,to));
 		from->nextcp.x = (-xconst[1]-t_term[1]*to->prevcp.x)/f_term[1];
 		from->nextcp.y = (-yconst[1]-t_term[1]*to->prevcp.y)/f_term[1];
 	    }
-	    to->noprevcp = from->nonextcp = false;
 return( SplineMake3(from,to));
 	}
     }
@@ -388,17 +388,13 @@ return( spline );
 
     if ( ret&1 ) {
 	from->nextcp = nextcp;
-	from->nonextcp = false;
     } else {
 	from->nextcp = from->me;
-	from->nonextcp = true;
     }
     if ( ret&2 ) {
 	to->prevcp = prevcp;
-	to->noprevcp = false;
     } else {
 	to->prevcp = to->me;
-	to->noprevcp = true;
     }
     TestForLinear(from,to);
     spline = SplineMake(from,to,order2);
@@ -690,7 +686,6 @@ return( ApproximateSplineFromPoints(from,to,mid,cnt,order2) );
 	    from->nextcp = from->next->to->me;
 	if ( to->noprevcp )
 	    to->prevcp = to->prev->from->me;
-	from->nonextcp = to->noprevcp = false;
 	fromunit.x = from->nextcp.x-from->me.x; fromunit.y = from->nextcp.y-from->me.y;
 	tounit.x = to->prevcp.x-to->me.x; tounit.y = to->prevcp.y-to->me.y;
 
@@ -699,13 +694,11 @@ return( ApproximateSplineFromPoints(from,to,mid,cnt,order2) );
 		(nextcp.x-to->me.x)*tounit.x + (nextcp.y-to->me.y)*tounit.y < 0 ) {
 	    /* If the slopes don't intersect then use a line */
 	    /*  (or if the intersection is patently absurd) */
-	    from->nonextcp = to->noprevcp = true;
 	    from->nextcp = from->me;
 	    to->prevcp = to->me;
 	    TestForLinear(from,to);
 	} else {
 	    from->nextcp = to->prevcp = nextcp;
-	    from->nonextcp = to->noprevcp = false;
 	}
 return( SplineMake2(from,to));
     }
@@ -716,7 +709,6 @@ return( SplineMake2(from,to));
 	/* But we do sometimes get some cps which are too big */
 	bigreal len = sqrt((to->me.x-from->me.x)*(to->me.x-from->me.x) + (to->me.y-from->me.y)*(to->me.y-from->me.y));
 	if ( len==0 ) {
-	    from->nonextcp = to->noprevcp = true;
 	    from->nextcp = from->me;
 	    to->prevcp = to->me;
 	} else {
@@ -799,7 +791,6 @@ return( SplineMake3(from,to));
     if ( (dot=fromunit.x*tounit.y - fromunit.y*tounit.x)<.0001 && dot>-.0001 &&
 	    (dot=ftunit.x*tounit.y - ftunit.y*tounit.x)<.0001 && dot>-.0001 ) {
 	/* It's a line. Slopes are parallel, and parallel to vector between (from,to) */
-	from->nonextcp = to->noprevcp = true;
 	from->nextcp = from->me; to->prevcp = to->me;
 return( SplineMake3(from,to));
     }
@@ -1132,8 +1123,6 @@ return( SplineMake3(from,to));
 	    from->nextcp.y = from->me.y + rf*fromunit.y;
 	    to->prevcp.x = to->me.x - rt*tounit.x;
 	    to->prevcp.y = to->me.y - rt*tounit.y;
-	    from->nonextcp = rf==0;
-	    to->noprevcp = rt==0;
 return( SplineMake3(from,to));
 	}
     }
@@ -1170,8 +1159,6 @@ return( SplineMake3(from,to));
     fdiff = flen/DECIMATION;
     tdiff = tlen/DECIMATION;
     from->nextcp = from->me;
-    from->nonextcp = false;
-    to->noprevcp = false;
     memset(&temp,0,sizeof(Spline));
     temp.from = from; temp.to = to;
     for ( i=1; i<DECIMATION; ++i ) {

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -239,10 +239,11 @@ static SplinePoint *LinearSpline(Spline *ps,SplinePoint *start, real tmax) {
     y = ((ps->splines[1].a*tmax+ps->splines[1].b)*tmax+ps->splines[1].c)*tmax+ps->splines[1].d;
     if ( tmax==1 ) {
 	SplinePoint *oldend = ps->to;
-	end->roundx = oldend->roundx; end->roundy = oldend->roundy; end->dontinterpolate = oldend->dontinterpolate;
 	x = oldend->me.x; y = oldend->me.y;	/* Want it to compare exactly */
-    }
-    end = SplinePointCreate(x, y);
+	end = SplinePointCreate(x, y);
+	end->roundx = oldend->roundx; end->roundy = oldend->roundy; end->dontinterpolate = oldend->dontinterpolate;
+    } else
+	end = SplinePointCreate(x, y);
     end->ttfindex = 0xfffe;
     end->nextcpindex = 0xfffe;
     start->nextcp.x = start->me.x;

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -244,8 +244,6 @@ static SplinePoint *LinearSpline(Spline *ps,SplinePoint *start, real tmax) {
 	end->roundx = oldend->roundx; end->roundy = oldend->roundy; end->dontinterpolate = oldend->dontinterpolate;
     } else
 	end = SplinePointCreate(x, y);
-    end->ttfindex = 0xfffe;
-    end->nextcpindex = 0xfffe;
     start->nextcp.x = start->me.x;
     start->nextcp.y = start->me.y;
     new->from = start;		start->next = new;
@@ -1253,8 +1251,6 @@ void SplineRefigure2(Spline *spline) {
 
     if (    ( from->nextcp.x==from->me.x && from->nextcp.y==from->me.y && from->nextcpindex>=0xfffe )
          || ( to->prevcp.x==to->me.x && to->prevcp.y==to->me.y && from->nextcpindex>=0xfffe ) ) {
-    /*if (    ( from->nextcp.x==from->me.x && from->nextcp.y==from->me.y )
-         || ( to->prevcp.x==to->me.x && to->prevcp.y==to->me.y ) ) {*/
 	from->nonextcp = to->noprevcp = true;
 	from->nextcp = from->me;
 	to->prevcp = to->me;

--- a/fontforge/splineorder2.c
+++ b/fontforge/splineorder2.c
@@ -172,8 +172,6 @@ static SplinePoint *MakeQuadSpline(SplinePoint *start,Spline *ttf,real x,
 	end->roundx = oldend->roundx; end->roundy = oldend->roundy; end->dontinterpolate = oldend->dontinterpolate;
 	x = oldend->me.x; y = oldend->me.y;	/* Want it to compare exactly */
     }
-    end->ttfindex = 0xfffe;
-    end->nextcpindex = 0xfffe;
 
     *new = *ttf;
     new->from = start;		start->next = new;

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -3816,7 +3816,7 @@ return;
 		    isp = SplineBisect(sp->prev,t);
 		    nsp->prevcp.x = nsp->me.x + (isp->prevcp.x-isp->me.x);
 		    nsp->prevcp.y = nsp->me.y + (isp->prevcp.y-isp->me.y);
-		    psp->noprevcp = isp->noprevcp;
+		    nsp->noprevcp = isp->noprevcp;
 		    nsp->prev = isp->prev;
 		    isp->prev->to = nsp;
 		    SplineFree(isp->next);

--- a/fontforge/splinerefigure.c
+++ b/fontforge/splinerefigure.c
@@ -52,13 +52,13 @@ void SplineRefigure3(Spline *spline) {
     if ( spline->acceptableextrema )
 	old = *spline;
     xsp->d = from->me.x; ysp->d = from->me.y;
-    int nonextcp_effective = 0;
-    int noprevcp_effective = 0;
-    if ( from->nonextcp ) { from->nextcp = from->me; nonextcp_effective = true; }
-    else if ( from->nextcp.x==from->me.x && from->nextcp.y == from->me.y ) { nonextcp_effective = true; }
-    if ( to->noprevcp ) { to->prevcp = to->me; noprevcp_effective = true; }
-    else if ( to->prevcp.x==to->me.x && to->prevcp.y == to->me.y ) { noprevcp_effective = true; }
-    if ( nonextcp_effective && noprevcp_effective ) {
+    // Set noprevcp and nonextcp based on point values but then make sure both
+    // have the same value
+    from->nonextcp = from->nextcp.x==from->me.x && from->nextcp.y == from->me.y;
+    to->noprevcp = to->prevcp.x==to->me.x && to->prevcp.y == to->me.y;
+    if ( !from->nonextcp || !to->noprevcp )
+	from->nonextcp = to->noprevcp = false;
+    if ( from->nonextcp && to->noprevcp ) {
 	spline->islinear = true;
 	xsp->c = to->me.x-from->me.x;
 	ysp->c = to->me.y-from->me.y;

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -932,7 +932,6 @@ SplinePoint *AppendCubicSplinePortion(Spline *s, bigreal t_fm, bigreal t_to,
     sp = SplinePointCreate(qcf.x*u_to + qt.x*t_to + v.x,
                             qcf.y*u_to + qt.y*t_to + v.y);
 
-    tailp->nonextcp = false; sp->noprevcp = false;
     tailp->nextcp.x = qf.x*u_to + qct.x*t_to + v.x;
     tailp->nextcp.y = qf.y*u_to + qct.y*t_to + v.y;
     sp->prevcp.x = qcf.x*u_fm + qt.x*t_fm + v.x;
@@ -943,7 +942,6 @@ SplinePoint *AppendCubicSplinePortion(Spline *s, bigreal t_fm, bigreal t_to,
     if ( SplineIsLinear(tailp->next)) { // Linearish instead?
         tailp->nextcp = tailp->me;
         sp->prevcp = sp->me;
-        tailp->nonextcp = sp->noprevcp = true;
         SplineRefigure(tailp->next);
     }
     return sp;
@@ -2381,7 +2379,6 @@ static SplinePoint *SpOnCircle(int i,bigreal radius,BasePoint *center) {
     sp->prevcp.y = unitcircle[i].prevcp.y*radius + center->y;
     sp->nextcp.x = unitcircle[i].nextcp.x*radius + center->x;
     sp->nextcp.y = unitcircle[i].nextcp.y*radius + center->y;
-    sp->nonextcp = sp->noprevcp = false;
 return( sp );
 }
 

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -7097,13 +7097,13 @@ return( changed );
 		    (&ptspace[i]->prevcp.x)[is_y]-cur<within ) {
 		(&ptspace[i]->prevcp.x)[is_y] = cur;
 		if ( (&ptspace[i]->prevcp.x)[!is_y]==(&ptspace[i]->me.x)[!is_y] )
-		    ptspace[i]->noprevcp = true;
+		    ptspace[i]->prevcp = ptspace[i]->me;
 	    }
 	    if ( (&ptspace[i]->nextcp.x)[is_y]-cur>-within &&
 		    (&ptspace[i]->nextcp.x)[is_y]-cur<within ) {
 		(&ptspace[i]->nextcp.x)[is_y] = cur;
 		if ( (&ptspace[i]->nextcp.x)[!is_y]==(&ptspace[i]->me.x)[!is_y] )
-		    ptspace[i]->nonextcp = true;
+		    ptspace[i]->nextcp = ptspace[i]->me;
 	    }
 	    cspace[i].cnt = 0;
 	}
@@ -7395,7 +7395,7 @@ int SplineRemoveWildControlPoints(Spline *s, bigreal distratio) {
 	if (!s->to->noprevcp)
 		bcdisplacement1 = DistanceBetweenPoints(&s->to->me, &s->to->prevcp);
 	if (pdisplacement == 0 || MAX(bcdisplacement0, bcdisplacement1) / pdisplacement > distratio) {
-		changed = s->islinear = s->from->nonextcp = s->to->noprevcp = true;
+		changed = s->islinear = true;
 		s->from->nextcp = s->from->me;
 		s->to->prevcp = s->to->me;
 		SplineRefigure(s);
@@ -7454,10 +7454,6 @@ SplinePoint *SplineBisect(Spline *spline, extended t) {
 	mid->nextcp.x = xend.c0;	mid->nextcp.y = yend.c0;
 	mid->prevcp.x = xstart.c1;	mid->prevcp.y = ystart.c1;
     }
-    if ( mid->me.x==mid->nextcp.x && mid->me.y==mid->nextcp.y )
-	mid->nonextcp = true;
-    if ( mid->me.x==mid->prevcp.x && mid->me.y==mid->prevcp.y )
-	mid->noprevcp = true;
 
     old0 = spline->from; old1 = spline->to;
     if ( order2 ) {
@@ -7467,8 +7463,6 @@ SplinePoint *SplineBisect(Spline *spline, extended t) {
 	old0->nextcp.x = xstart.c0;	old0->nextcp.y = ystart.c0;
 	old1->prevcp.x = xend.c1;	old1->prevcp.y = yend.c1;
     }
-    old0->nonextcp = (old0->nextcp.x==old0->me.x && old0->nextcp.y==old0->me.y);
-    old1->noprevcp = (old1->prevcp.x==old1->me.x && old1->prevcp.y==old1->me.y);
     old0->nextcpdef = false;
     old1->prevcpdef = false;
     SplineFree(spline);
@@ -7481,7 +7475,7 @@ SplinePoint *SplineBisect(Spline *spline, extended t) {
     old0->next = spline1;
     mid->prev = spline1;
     if ( SplineIsLinear(spline1)) {
-	spline1->islinear = spline1->from->nonextcp = spline1->to->noprevcp = true;
+	spline1->islinear = true;
 	spline1->from->nextcp = spline1->from->me;
 	spline1->to->prevcp = spline1->to->me;
     }
@@ -7495,7 +7489,7 @@ SplinePoint *SplineBisect(Spline *spline, extended t) {
     mid->next = spline2;
     old1->prev = spline2;
     if ( SplineIsLinear(spline2)) {
-	spline2->islinear = spline2->from->nonextcp = spline2->to->noprevcp = true;
+	spline2->islinear = true;
 	spline2->from->nextcp = spline2->from->me;
 	spline2->to->prevcp = spline2->to->me;
     }

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -7535,9 +7535,7 @@ return( spline );
 	if ( i==cnt )
 	    sp = spline->to;
 	else {
-	    sp = chunkalloc(sizeof(SplinePoint));
-	    sp->me.x = splines[0][i+1].sp.d;
-	    sp->me.y = splines[1][i+1].sp.d;
+	    sp = SplinePointCreate(splines[0][i+1].sp.d, splines[1][i+1].sp.d);
 	}
 	if ( order2 ) {
 	    sp->prevcp = last->nextcp;

--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -325,7 +325,7 @@ int SplineIsLinearMake(Spline *spline) {
     if ( spline->islinear )
 return( true );
     if ( SplineIsLinear(spline)) {
-	spline->islinear = spline->from->nonextcp = spline->to->noprevcp = true;
+	spline->islinear = true;
 	spline->from->nextcp = spline->from->me;
 	if ( spline->from->nonextcp && spline->from->noprevcp )
 	    spline->from->pointtype = pt_corner;
@@ -845,19 +845,19 @@ return;
 		if ( curp->prev!=NULL && plen<=bound && plen<nlen ) {
 		    SplinePoint *other = curp->prev->from;
 		    other->nextcp = curp->nextcp;
-		    other->nonextcp = curp->nonextcp;
 		    other->nextcpdef = curp->nextcpdef;
 		    other->next = curp->next;
 		    if ( curp->next!=NULL ) other->next->from = other;
 		    SplineFree(curp->prev);
+		    SplineRefigure(other->next); // To set nonextcp correctly
 		} else {
 		    SplinePoint *other = next;
 		    other->prevcp = curp->prevcp;
-		    other->noprevcp = curp->noprevcp;
 		    other->prevcpdef = curp->prevcpdef;
 		    other->prev = curp->prev;
 		    if ( curp->prev!=NULL ) other->prev->to = other;
 		    SplineFree(curp->next);
+		    SplineRefigure(other->prev); // To set noprevcp correctly
 		}
 		SplinePointFree(curp);
 		if ( spl->first==curp ) {
@@ -916,7 +916,6 @@ static void RemoveStupidControlPoints(SplineSet *spl) {
 		if (( normal<dir && normal<1 && dir<0 ) || (normal<.5 && dir<-.5) ||
 			(normal<.1 && dir>len)) {
 		    s->from->nextcp = s->from->me;
-		    s->from->nonextcp = true;
 		    refigure = true;
 		}
 	    }
@@ -928,7 +927,6 @@ static void RemoveStupidControlPoints(SplineSet *spl) {
 		if (( normal<-dir && normal<1 && dir<0 ) || (normal<.5 && dir>-.5 && dir<0) ||
 			(normal<.1 && dir>len)) {
 		    s->to->prevcp = s->to->me;
-		    s->to->noprevcp = true;
 		    refigure = true;
 		}
 	    }
@@ -1292,11 +1290,12 @@ static int SplinesRemoveBetweenMaybe(SplineChar *sc,
     BasePoint test;
     int good;
     BasePoint fncp, tpcp;
-    int fpt, tpt;
+    int fpt, tpt, fnoncp, tnopcp;
     int order2 = from->next->order2;
 
     afterfrom = from->next->to;
     fncp = from->nextcp; tpcp = to->prevcp;
+    fnoncp = from->nonextcp; tnopcp = to->noprevcp;
     fpt = from->pointtype; tpt = to->pointtype;
 
     if ( afterfrom==to || from==to )
@@ -1338,12 +1337,12 @@ return( false );
 	SplineFree(from->next);
 	from->next = afterfrom->prev;
 	from->nextcp = fncp;
-	from->nonextcp = ( fncp.x==from->me.x && fncp.y==from->me.y);
+	from->nonextcp = fnoncp;
 	from->pointtype = fpt;
 	for ( sp=afterfrom; sp->next->to!=to; sp=sp->next->to );
 	to->prev = sp->next;
 	to->prevcp = tpcp;
-	to->noprevcp = ( tpcp.x==to->me.x && tpcp.y==to->me.y);
+	to->noprevcp = tnopcp;
 	to->pointtype = tpt;
     }
 return( good );
@@ -1518,23 +1517,19 @@ void SPLNearlyHvCps(SplineChar *sc,SplineSet *ss,bigreal err) {
 	if ( !from->nonextcp && from->nextcp.x-from->me.x<err && from->nextcp.x-from->me.x>-err ) {
 	    from->nextcp.x = from->me.x;
 	    if ( s->order2 ) to->prevcp = from->nextcp;
-	    if ( from->nextcp.y==from->me.y ) from->nonextcp = true;
 	    refresh = true;
 	} else if ( !from->nonextcp && from->nextcp.y-from->me.y<err && from->nextcp.y-from->me.y>-err ) {
 	    from->nextcp.y = from->me.y;
 	    if ( s->order2 ) to->prevcp = from->nextcp;
-	    if ( from->nextcp.x==from->me.x ) from->nonextcp = true;
 	    refresh = true;
 	}
 	if ( !to->noprevcp && to->prevcp.x-to->me.x<err && to->prevcp.x-to->me.x>-err ) {
 	    to->prevcp.x = to->me.x;
 	    if ( s->order2 ) from->nextcp = to->prevcp;
-	    if ( to->prevcp.y==to->me.y ) to->noprevcp = true;
 	    refresh = true;
 	} else if ( !to->noprevcp && to->prevcp.y-to->me.y<err && to->prevcp.y-to->me.y>-err ) {
 	    to->prevcp.y = to->me.y;
 	    if ( s->order2 ) from->nextcp = to->prevcp;
-	    if ( to->prevcp.x==to->me.x ) to->noprevcp = true;
 	    refresh = true;
 	}
 	if ( refresh )
@@ -1555,7 +1550,6 @@ void SPLNearlyHvLines(SplineChar *sc,SplineSet *ss,bigreal err) {
 		s->to->me.x = s->from->me.x;
 		s->to->prevcp = s->to->me;
 		s->from->nextcp = s->from->me;
-		s->from->nonextcp = s->to->noprevcp = true;
 		SplineRefigure(s);
 		if ( s->to->next != NULL )
 		    SplineRefigure(s->to->next);
@@ -1566,7 +1560,6 @@ void SPLNearlyHvLines(SplineChar *sc,SplineSet *ss,bigreal err) {
 		s->to->me.y = s->from->me.y;
 		s->to->prevcp = s->to->me;
 		s->from->nextcp = s->from->me;
-		s->from->nonextcp = s->to->noprevcp = true;
 		SplineRefigure(s);
 		if ( s->to->next != NULL )
 		    SplineRefigure(s->to->next);
@@ -1667,9 +1660,7 @@ int SPLNearlyLines(SplineChar *sc,SplineSet *ss,bigreal err) {
 	    /* Nothing to be done */;
 	else if ( s->knownlinear || SplineCloseToLinear(s,err)) {
 	    s->from->nextcp = s->from->me;
-	    s->from->nonextcp = true;
 	    s->to->prevcp = s->to->me;
-	    s->to->noprevcp = true;
 	    SplineRefigure(s);
 	    changed = true;
 	}
@@ -1710,7 +1701,7 @@ static void SPLForceLines(SplineChar *sc,SplineSet *ss,bigreal bump_size) {
 			sp->prevcp.x -= xoff; sp->prevcp.y -= yoff;
 			if ( order2 && sp->prev!=NULL && !sp->noprevcp )
 			    sp->prev->from->nextcp = sp->prevcp;
-			sp->nextcp = sp->me; sp->nonextcp = true;
+			sp->nextcp = sp->me;
 			if ( sp->next==first ) first = NULL;
 			SplineFree(sp->next);
 			if ( s->from==ss->first ) {
@@ -1749,7 +1740,7 @@ static void SPLForceLines(SplineChar *sc,SplineSet *ss,bigreal bump_size) {
 			sp->nextcp.x -= xoff; sp->nextcp.y -= yoff;
 			if ( order2 && sp->next!=NULL && !sp->nonextcp )
 			    sp->next->to->prevcp = sp->nextcp;
-			sp->prevcp = sp->me; sp->noprevcp = true;
+			sp->prevcp = sp->me;
 			if ( sp->prev==first ) first = NULL;
 			SplineFree(sp->prev);
 			if ( s->to==ss->last ) {
@@ -2062,12 +2053,12 @@ return;
 		if ( sp->next!=NULL )
 		    sp->next->from = sp;
 		sp->nextcp = next->nextcp;
-		sp->nonextcp = next->nonextcp;
 		sp->nextcpdef = next->nextcpdef;
 		SplinePointMDFree(sc,next);
-		if ( sp->next!=NULL )
+		if ( sp->next!=NULL ) {
+		    SplineRefigure(sp->next); // To set nonextcp accurately
 		    next = sp->next->to;
-		else {
+		} else {
 		    next = NULL;
 	    break;
 		}
@@ -2318,7 +2309,6 @@ static int SplineSetMakeLoop(SplineSet *spl,real fudge) {
 	spl->first->prev = spl->last->prev;
 	spl->first->prev->to = spl->first;
 	spl->first->prevcp = spl->last->prevcp;
-	spl->first->noprevcp = spl->last->noprevcp;
 	spl->first->prevcpdef = spl->last->prevcpdef;
 	SplinePointFree(spl->last);
 	spl->last = spl->first;
@@ -2326,9 +2316,8 @@ static int SplineSetMakeLoop(SplineSet *spl,real fudge) {
 	    spl->spiros[0].ty = spl->spiros[spl->spiro_cnt-2].ty;
 	    spl->spiros[spl->spiro_cnt-2] = spl->spiros[spl->spiro_cnt-1];
 	    --spl->spiro_cnt;
-	} else {
-	    SplineSetJoinCpFixup(spl->first);
 	}
+	SplineSetJoinCpFixup(spl->first);
 return( true );
     }
 return( false );
@@ -2378,7 +2367,6 @@ SplineSet *SplineSetJoin(SplineSet *start,int doall,real fudge,int *changed,
 			spl->first->prev = spl2->last->prev;
 			spl->first->prev->to = spl->first;
 			spl->first->prevcp = spl2->last->prevcp;
-			spl->first->noprevcp = spl2->last->noprevcp;
 			spl->first->prevcpdef = spl2->last->prevcpdef;
 			SplinePointFree(spl2->last);
 			SplineSetJoinCpFixup(spl->first);
@@ -2436,7 +2424,6 @@ SplineSet *SplineCharRemoveTiny(SplineChar *sc,SplineSet *head) {
 		if ( first==spline->from->prev ) first=NULL;
 		/*SplinesRemoveBetween(sc,spline->from->prev->from,spline->to);*/
 		spline->to->prevcp = spline->from->prevcp;
-		spline->to->noprevcp = spline->from->noprevcp;
 		spline->to->prevcpdef = spline->from->prevcpdef;
 		spline->from->prev->to = spline->to;
 		spline->to->prev = spline->from->prev;
@@ -2550,10 +2537,8 @@ return( -1 );
 	if ( mylen==0 )
 	    return -1;
 	if ( isto ) {
-	    s->to->noprevcp = true;
 	    s->to->prevcp = s->to->me;
 	} else {
-	    s->from->nonextcp = true;
 	    s->from->nextcp = s->from->me;
 	}
 	end->pointtype = pt_corner;
@@ -3240,7 +3225,6 @@ return;
     ulen = sqrt(unit.x*unit.x + unit.y*unit.y);
     if ( ulen!=0 )
 	unit.x /= ulen, unit.y /= ulen;
-    base->nonextcp = false;
 
     if ( base->pointtype == pt_curve || base->pointtype == pt_hvcurve ) {
 	if ( prev!=NULL && (base->prevcpdef || base->noprevcp)) {
@@ -3270,18 +3254,17 @@ return;
 		unit.x /= ulen, unit.y /= ulen;
 	} else {
 	    base->prevcp = base->me;
-	    base->noprevcp = true;
 	    base->prevcpdef = true;
 	}
 	if ( base->pointtype == pt_hvcurve )
 	    BP_HVForce(&unit);
     } else if ( base->pointtype == pt_corner ) {
 	if ( next->pointtype != pt_curve && next->pointtype != pt_hvcurve ) {
-	    base->nonextcp = true;
+	    base->nextcp = base->me;
 	}
     } else /* tangent */ {
 	if ( next->pointtype != pt_curve ) {
-	    base->nonextcp = true;
+	    base->nextcp = base->me;
 	} else {
 	    if ( prev!=NULL ) {
 		if ( !base->noprevcp ) {
@@ -3299,9 +3282,7 @@ return;
 	    }
 	}
     }
-    if ( base->nonextcp )
-	base->nextcp = base->me;
-    else {
+    if ( base->nextcp.x!=base->me.x || base->nextcp.y!=base->me.y ) {
 	base->nextcp.x = base->me.x + len*unit.x;
 	base->nextcp.y = base->me.y + len*unit.y;
 	if ( snaptoint ) {
@@ -3344,7 +3325,6 @@ return;
     ulen = sqrt(unit.x*unit.x + unit.y*unit.y);
     if ( ulen!=0 )
 	unit.x /= ulen, unit.y /= ulen;
-    base->noprevcp = false;
 
     if ( base->pointtype == pt_curve || base->pointtype == pt_hvcurve ) {
 	if ( next!=NULL && (base->nextcpdef || base->nonextcp)) {
@@ -3374,7 +3354,6 @@ return;
 		unit.x /= ulen, unit.y /= ulen;
 	} else {
 	    base->nextcp = base->me;
-	    base->nonextcp = true;
 	    base->nextcpdef = true;
 	}
 	if ( base->pointtype == pt_hvcurve )
@@ -3385,7 +3364,7 @@ return;
 	}
     } else /* tangent */ {
 	if ( prev->pointtype != pt_curve ) {
-	    base->noprevcp = true;
+	    base->prevcp = base->me;
 	} else {
 	    if ( next!=NULL ) {
 		if ( !base->nonextcp ) {
@@ -3403,9 +3382,7 @@ return;
 	    }
 	}
     }
-    if ( base->noprevcp )
-	base->prevcp = base->me;
-    else {
+    if ( base->prevcp.x!=base->me.x || base->prevcp.y!=base->me.y ) {
 	base->prevcp.x = base->me.x + len*unit.x;
 	base->prevcp.y = base->me.y + len*unit.y;
 	if ( snaptoint ) {
@@ -3604,13 +3581,6 @@ void SPAdjustControl(SplinePoint *sp,BasePoint *cp, BasePoint *to,int order2) {
 	}
     }
 
-    if ( cp->x==sp->me.x && cp->y==sp->me.y ) {
-	if ( cp==&sp->nextcp ) sp->nonextcp = true;
-	else sp->noprevcp = true;
-    }  else {
-	if ( cp==&sp->nextcp ) sp->nonextcp = false;
-	else sp->noprevcp = false;
-    }
     if ( cp==&sp->nextcp ) sp->nextcpdef = false;
     else sp->prevcpdef = false;
 
@@ -3624,7 +3594,6 @@ void SPAdjustControl(SplinePoint *sp,BasePoint *cp, BasePoint *to,int order2) {
     if ( sp->prev!=NULL && cp==&sp->prevcp ) {
 	if ( order2 && !sp->noprevcp ) {
 	    sp->prev->from->nextcp = *cp;
-	    sp->prev->from->nonextcp = false;
 	}
 	SplineRefigureFixup(sp->prev);
     }

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -1371,10 +1371,10 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		if ( RealNear(cur->last->me.x,cur->first->me.x) &&
 			RealNear(cur->last->me.y,cur->first->me.y) ) {
 		    cur->first->prevcp = cur->last->prevcp;
-		    cur->first->noprevcp = cur->last->noprevcp;
 		    cur->first->prev = cur->last->prev;
 		    cur->first->prev->to = cur->first;
 		    SplinePointFree(cur->last);
+		    SplineRefigure(cur->first->prev);
 		    cur->last = cur->first;
 		}
 	    }
@@ -1401,9 +1401,9 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		if ( RealNear(cur->last->me.x,cur->first->me.x) &&
 			RealNear(cur->last->me.y,cur->first->me.y) ) {
 		    cur->first->prevcp = cur->last->prevcp;
-		    cur->first->noprevcp = cur->last->noprevcp;
 		    cur->first->prev = cur->last->prev;
 		    cur->first->prev->to = cur->first;
+		    SplineRefigure(cur->first->prev);
 		    SplinePointFree(cur->last);
 		} else
 		    SplineMake(cur->last,cur->first,order2);
@@ -1476,8 +1476,8 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		    x += current.x; y += current.y;
 		}
 		sp = SplinePointCreate(x,y);
-		sp->prevcp.x = x2; sp->prevcp.y = y2; sp->noprevcp = false;
-		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1; cur->last->nonextcp = false;
+		sp->prevcp.x = x2; sp->prevcp.y = y2;
+		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1;
 		current = sp->me;
 		SplineMake(cur->last,sp,false);
 		cur->last = sp;
@@ -1497,8 +1497,8 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		    x += current.x; y += current.y;
 		}
 		sp = SplinePointCreate(x,y);
-		sp->prevcp.x = x2; sp->prevcp.y = y2; sp->noprevcp = false;
-		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1; cur->last->nonextcp = false;
+		sp->prevcp.x = x2; sp->prevcp.y = y2;
+		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1;
 		current = sp->me;
 		SplineMake(cur->last,sp,false);
 		cur->last = sp;
@@ -1516,8 +1516,8 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		    x += current.x; y += current.y;
 		}
 		sp = SplinePointCreate(x,y);
-		sp->prevcp.x = x1; sp->prevcp.y = y1; sp->noprevcp = false;
-		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1; cur->last->nonextcp = false;
+		sp->prevcp.x = x1; sp->prevcp.y = y1;
+		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1;
 		current = sp->me;
 		SplineMake(cur->last,sp,true);
 		cur->last = sp;
@@ -1533,8 +1533,8 @@ static SplineSet *SVGParsePath(xmlChar *path) {
 		x1 = 2*cur->last->me.x - cur->last->prevcp.x;
 		y1 = 2*cur->last->me.y - cur->last->prevcp.y;
 		sp = SplinePointCreate(x,y);
-		sp->prevcp.x = x1; sp->prevcp.y = y1; sp->noprevcp = false;
-		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1; cur->last->nonextcp = false;
+		sp->prevcp.x = x1; sp->prevcp.y = y1;
+		cur->last->nextcp.x = x1; cur->last->nextcp.y = y1;
 		current = sp->me;
 		SplineMake(cur->last,sp,true);
 		cur->last = sp;
@@ -1654,7 +1654,6 @@ return( cur );
 	cur->last = SplinePointCreate(x+rx,y+height);
 	cur->first->nextcp.x = x; cur->first->nextcp.y = y+height;
 	cur->last->prevcp = cur->first->nextcp;
-	cur->first->nonextcp = cur->last->noprevcp = false;
 	SplineMake(cur->first,cur->last,false);
 	if ( rx<2*width ) {
 	    sp = SplinePointCreate(x+width-rx,y+height);
@@ -1664,7 +1663,6 @@ return( cur );
 	sp = SplinePointCreate(x+width,y+height-ry);
 	sp->prevcp.x = x+width; sp->prevcp.y = y+height;
 	cur->last->nextcp = sp->prevcp;
-	cur->last->nonextcp = sp->noprevcp = false;
 	SplineMake(cur->last,sp,false);
 	cur->last = sp;
 	if ( ry<2*height ) {
@@ -1675,7 +1673,6 @@ return( cur );
 	sp = SplinePointCreate(x+width-rx,y);
 	sp->prevcp.x = x+width; sp->prevcp.y = y;
 	cur->last->nextcp = sp->prevcp;
-	cur->last->nonextcp = sp->noprevcp = false;
 	SplineMake(cur->last,sp,false);
 	cur->last = sp;
 	if ( rx<2*width ) {
@@ -1684,14 +1681,11 @@ return( cur );
 	    cur->last = sp;
 	}
 	cur->last->nextcp.x = x; cur->last->nextcp.y = y;
-	cur->last->nonextcp = false;
 	if ( ry>=2*height ) {
 	    cur->first->prevcp = cur->last->nextcp;
-	    cur->first->noprevcp = false;
 	} else {
 	    sp = SplinePointCreate(x,y+ry);
 	    sp->prevcp = cur->last->nextcp;
-	    sp->noprevcp = false;
 	    SplineMake(cur->last,sp,false);
 	    cur->last = sp;
 	}
@@ -1797,22 +1791,18 @@ return( NULL );
     cur->first = SplinePointCreate(cx-rx,cy);
     cur->first->nextcp.x = cx-rx; cur->first->nextcp.y = cy+dry;
     cur->first->prevcp.x = cx-rx; cur->first->prevcp.y = cy-dry;
-    cur->first->noprevcp = cur->first->nonextcp = false;
     cur->last = SplinePointCreate(cx,cy+ry);
     cur->last->prevcp.x = cx-drx; cur->last->prevcp.y = cy+ry;
     cur->last->nextcp.x = cx+drx; cur->last->nextcp.y = cy+ry;
-    cur->last->noprevcp = cur->last->nonextcp = false;
     SplineMake(cur->first,cur->last,false);
     sp = SplinePointCreate(cx+rx,cy);
     sp->prevcp.x = cx+rx; sp->prevcp.y = cy+dry;
     sp->nextcp.x = cx+rx; sp->nextcp.y = cy-dry;
-    sp->nonextcp = sp->noprevcp = false;
     SplineMake(cur->last,sp,false);
     cur->last = sp;
     sp = SplinePointCreate(cx,cy-ry);
     sp->prevcp.x = cx+drx; sp->prevcp.y = cy-ry;
     sp->nextcp.x = cx-drx; sp->nextcp.y = cy-ry;
-    sp->nonextcp = sp->noprevcp = false;
     SplineMake(cur->last,sp,false);
     SplineMake(sp,cur->first,false);
     cur->last = cur->first;

--- a/fontforge/ttfspecial.c
+++ b/fontforge/ttfspecial.c
@@ -1195,10 +1195,8 @@ return;
 
 	    current->nextcp.x = current->me.x+offx;
 	    current->nextcp.y = current->me.y+offy;
-	    current->nonextcp = false;
 	    sp = SplinePointCreate(current->nextcp.x+offx1,current->nextcp.y+offy1);
 	    sp->prevcp = current->nextcp;
-	    sp->noprevcp = false;
 	    if ( was_implicit ) {
 		current->me.x = (current->prevcp.x + current->nextcp.x)/2;
 		current->me.y = (current->prevcp.y + current->nextcp.y)/2;
@@ -1227,11 +1225,9 @@ return;
 	    }
 	    current->nextcp.x = current->me.x+offx;
 	    current->nextcp.y = current->me.y+offy;
-	    current->nonextcp = false;
 	    sp = SplinePointCreate(current->nextcp.x+offx1+offx2,current->nextcp.y+offy1+offy2);
 	    sp->prevcp.x = current->nextcp.x+offx1;
 	    sp->prevcp.y = current->nextcp.y+offy1;
-	    sp->noprevcp = false;
 	} else {
 	    LogError(_("Whoops, unexpected verb in contour %d.%d\n"), v, m );
     break;

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -2951,7 +2951,6 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 			        // We have decided that the curve is quadratic, so we can make the next implied point as well.
 			        sp = SplinePointCreate((x+pre[1].x)/2,(y+pre[1].y)/2);
 			        sp->prevcp = pre[1];
-			        sp->noprevcp = false;
 					sp->ttfindex = 0xffff;
 			        SplineMake(ss->last,sp,true);
 			        ss->last = sp;
@@ -2972,7 +2971,6 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 						sp->name = copy(pname);
 					}
 			        sp->prevcp = pre[0];
-			        sp->noprevcp = false;
 					sp->ttfindex = 0xffff;
 			        if ( ss->first==NULL ) {
 				    	ss->first = sp;

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -2892,9 +2892,7 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 				}
 				if ( precnt==2 && ss->first != sp ) {
 				    ss->last->nextcp = pre[0];
-				    ss->last->nonextcp = false;
 				    sp->prevcp = pre[1];
-				    sp->noprevcp = false;
 				    SplineMake(ss->last,sp,false);
 				}
 			        ss->last = sp;
@@ -2908,14 +2906,12 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 							// If we have two cached control points and the end point is quadratic, we need an implied point between the two control points.
 							sp2 = SplinePointCreate((pre[1].x+pre[0].x)/2,(pre[1].y+pre[0].y)/2);
 							sp2->prevcp = ss->last->nextcp = pre[0];
-							sp2->noprevcp = ss->last->nonextcp = false;
 							sp2->ttfindex = 0xffff;
 							SplineMake(ss->last,sp2,true);
 							ss->last = sp2;
 						}
 						// Now we connect the real point.
 						sp->prevcp = ss->last->nextcp = pre[precnt-1];
-						sp->noprevcp = ss->last->nonextcp = false;
 					}
 					SplineMake(ss->last,sp,true);
 					ss->last = sp;
@@ -2939,7 +2935,6 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 						sp->name = copy(pname);
 					}
 			        sp->nextcp = pre[1];
-			        sp->nonextcp = false;
 			        if ( ss->first==NULL ) {
 				    // This is indeed possible if the first three points are control points.
 				    ss->first = sp;
@@ -2947,7 +2942,6 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 				    initcnt = 1;
 				} else {
 				    ss->last->nextcp = sp->prevcp = pre[0];
-				    ss->last->nonextcp = sp->noprevcp = false;
 				    initcnt = 0;
 				    SplineMake(ss->last,sp,true);
 				}
@@ -2986,8 +2980,7 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 			            initcnt = 1;
 					} else {
 					    ss->last->nextcp = sp->prevcp;
-			            ss->last->nonextcp = false;
-				    	SplineMake(ss->last,sp,true);
+					    SplineMake(ss->last,sp,true);
 					}
 					ss->last = sp;
 			        pre[0].x = x; pre[0].y = y;
@@ -3021,18 +3014,15 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
 					// If the final curve is declared quadratic but has more than one control point, we add implied points.
 					sp = SplinePointCreate((init[i+1].x+init[i].x)/2,(init[i+1].y+init[i].y)/2);
 			        sp->prevcp = ss->last->nextcp = init[i];
-			        sp->noprevcp = ss->last->nonextcp = false;
 					sp->ttfindex = 0xffff;
 			        SplineMake(ss->last,sp,true);
 			        ss->last = sp;
 			    }
 			    ss->last->nextcp = ss->first->prevcp = init[initcnt-1];
-			    ss->last->nonextcp = ss->first->noprevcp = false;
 			    wasquad = true;
 			} else if ( initcnt==2 ) {
 			    ss->last->nextcp = init[0];
 			    ss->first->prevcp = init[1];
-			    ss->last->nonextcp = ss->first->noprevcp = false;
 				wasquad = false;
 			}
 			SplineMake(ss->last, ss->first, (firstpointsaidquad==true || (firstpointsaidquad == -1 && wasquad == true)));

--- a/fontforgeexe/cvdebug.c
+++ b/fontforgeexe/cvdebug.c
@@ -492,20 +492,16 @@ static SplineSet *SplineSetsFromPoints(TT_GlyphZoneRec *pts, real scalex, real s
 		if ( last_off && cur->last!=NULL ) {
 		    ScalePoint(&cur->last->nextcp,&pts->cur[i-1],scalex,scaley,actives);
 		    sp->prevcp = cur->last->nextcp;
-		    cur->last->nonextcp = false;
 		    cur->last->nextcpindex = i-1;
-		    sp->noprevcp = false;
 		}
 		last_off = false;
 	    } else if ( last_off ) {
 		ScalePoint(&me,&pts->cur[i],scalex,scaley,actives);
 		ScalePoint(&me2,&pts->cur[i-1],scalex,scaley,actives);
 		sp = SplinePointCreate((me.x+me2.x)/2, (me.y+me2.y)/2 );
-		sp->noprevcp = false;
 		sp->ttfindex = 0xffff;
 		if ( last_off && cur->last!=NULL ) {
 		    cur->last->nextcp = sp->prevcp = me2;
-		    cur->last->nonextcp = false;
 		    cur->last->nextcpindex = i-1;
 		}
 		/* last_off continues to be true */
@@ -532,22 +528,18 @@ static SplineSet *SplineSetsFromPoints(TT_GlyphZoneRec *pts, real scalex, real s
 	    ScalePoint(&me,&pts->cur[start],scalex,scaley,actives);
 	    ScalePoint(&me2,&pts->cur[i-1],scalex,scaley,actives);
 	    sp = SplinePointCreate((me.x+me2.x)/2 , (me.y+me2.y)/2);
-	    sp->noprevcp = sp->nonextcp = false;
 	    cur->last->nextcp = sp->prevcp = me2;
 	    SplineMake2(cur->last,sp);
 	    cur->last = sp;
 	    cur->last->nextcp = cur->first->prevcp = me;
-	    cur->first->noprevcp = false;
 	    cur->last->nextcpindex = start;
 	} else if ( !(pts->tags[i-1]&FT_Curve_Tag_On)) {
 	    ScalePoint(&me,&pts->cur[i-1],scalex,scaley,actives);
 	    cur->last->nextcp = cur->first->prevcp = me;
-	    cur->last->nonextcp = cur->first->noprevcp = false;
 	    cur->last->nextcpindex = i-1;
 	} else if ( !(pts->tags[start]&FT_Curve_Tag_On) ) {
 	    ScalePoint(&me,&pts->cur[start],scalex,scaley,actives);
 	    cur->last->nextcp = cur->first->prevcp = me;
-	    cur->last->nonextcp = cur->first->noprevcp = false;
 	    cur->last->nextcpindex = start;
 	}
 	if ( cur->last!=cur->first ) {

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -573,7 +573,8 @@ static SplineSet *TraceCurve(CharView *cv) {
 	    SplineMake(last,cur,false);
 	else {
 	    TraceFigureCPs(last,cur,base,pt);
-	    if ( !last->nonextcp && !cur->noprevcp )
+	    if ( last->nextcp.x == last->me.x && last->nextcp.y == last->me.y &&
+	         cur->prevcp.x == cur->me.x && cur->prevcp.y == cur->me.y )
 		ApproximateSplineFromPointsSlopes(last,cur,mids+base->num+1,pt->num-base->num-1,false,mt_matrix);
 	    else {
 		last->nextcp = last->me; cur->prevcp=cur->me;

--- a/fontforgeexe/cvfreehand.c
+++ b/fontforgeexe/cvfreehand.c
@@ -440,8 +440,6 @@ return( ((p-si->pressure1)*si->radius2 + (si->pressure2-p)*(si->width/2))/
 static void TraceFigureCPs(SplinePoint *last,SplinePoint *cur,TraceData *tlast,TraceData *tcur) {
     TraceData *pt;
 
-    last->nonextcp = false; cur->noprevcp=false;
-
     for ( pt=tlast; !pt->use_as_pt ; pt=pt->prev );
     if ( pt->online ) {
 	last->nextcp.x = last->me.x + ( tlast->x-pt->x );
@@ -456,7 +454,7 @@ static void TraceFigureCPs(SplinePoint *last,SplinePoint *cur,TraceData *tlast,T
 	last->nextcp.x = last->me.x + (last->me.x - last->prevcp.x);
 	last->nextcp.y = last->me.y + (last->me.y - last->prevcp.y);
     } else
-	last->nonextcp = true;
+	last->nextcp = last->me;
 
     if ( tcur->online ) {
 	for ( pt=tcur; !pt->use_as_pt ; pt=pt->next );
@@ -472,7 +470,7 @@ static void TraceFigureCPs(SplinePoint *last,SplinePoint *cur,TraceData *tlast,T
 	cur->prevcp.x = cur->me.x + (cur->me.x - cur->nextcp.x);
 	cur->prevcp.y = cur->me.y + (cur->me.y - cur->nextcp.y);
     } else
-	cur->noprevcp = true;
+	cur->prevcp = cur->me;
 }
 
 static SplineSet *TraceCurve(CharView *cv) {
@@ -578,7 +576,7 @@ static SplineSet *TraceCurve(CharView *cv) {
 	    if ( !last->nonextcp && !cur->noprevcp )
 		ApproximateSplineFromPointsSlopes(last,cur,mids+base->num+1,pt->num-base->num-1,false,mt_matrix);
 	    else {
-		last->nonextcp = false; cur->noprevcp=false;
+		last->nextcp = last->me; cur->prevcp=cur->me;
 		ApproximateSplineFromPoints(last,cur,mids+base->num+1,pt->num-base->num-1,false);
 	    }
 	}

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -2197,14 +2197,12 @@ static int PI_InterpChanged(GGadget *g, GEvent *e) {
 		    cursp->nextcp.x = rint((n->me.x+cursp->me.x)/2);
 		    cursp->nextcp.y = rint((n->me.y+cursp->me.y)/2);
 		    n->prevcp = cursp->nextcp;
-		    cursp->nonextcp = n->noprevcp = false;
 		}
 		if ( cursp->noprevcp && cursp->prev ) {
 		    SplinePoint *p = cursp->prev->from;
 		    cursp->prevcp.x = rint((p->me.x+cursp->me.x)/2);
 		    cursp->prevcp.y = rint((p->me.y+cursp->me.y)/2);
 		    p->nextcp = cursp->prevcp;
-		    cursp->noprevcp = p->nonextcp = false;
 		}
 		cursp->me.x = (cursp->nextcp.x + cursp->prevcp.x)/2;
 		cursp->me.y = (cursp->nextcp.y + cursp->prevcp.y)/2;
@@ -2323,7 +2321,6 @@ return( true );
 	}
 	cursp->nextcp.x += dx;
 	cursp->nextcp.y += dy;
-	cursp->nonextcp = false;
 	SplineSetSpirosClear(ci->curspl);
 	ci->nextchanged = true;
 	if (( dx>.1 || dx<-.1 || dy>.1 || dy<-.1 ) && cursp->nextcpdef ) {
@@ -2400,7 +2397,6 @@ return( true );
 	}
 	cursp->prevcp.x += dx;
 	cursp->prevcp.y += dy;
-	cursp->noprevcp = false;
 	ci->prevchanged = true;
 	SplineSetSpirosClear(ci->curspl);
 	if (( dx>.1 || dx<-.1 || dy>.1 || dy<-.1 ) && cursp->prevcpdef ) {

--- a/fontforgeexe/cvshapes.c
+++ b/fontforgeexe/cvshapes.c
@@ -133,7 +133,6 @@ static void SetCurve(SplinePoint *sp,BasePoint *center,real xrad, real yrad,
     sp->me.x = center->x+xrad*pt_d->me.x; sp->me.y = center->y+yrad*pt_d->me.y;
     sp->nextcp.x = center->x+xrad*pt_d->nextcp.x; sp->nextcp.y = center->y+yrad*pt_d->nextcp.y;
     sp->prevcp.x = center->x+xrad*pt_d->prevcp.x; sp->prevcp.y = center->y+yrad*pt_d->prevcp.y;
-    sp->nonextcp = sp->noprevcp = (xrad==0 && yrad==0);
 }
 
 static void SetPTangent(SplinePoint *sp,real x, real y,real xrad, real yrad) {
@@ -146,7 +145,6 @@ static void SetPTangent(SplinePoint *sp,real x, real y,real xrad, real yrad) {
     }
     sp->prevcp.x += xrad;
     sp->prevcp.y += yrad;
-    sp->noprevcp = (xrad==0 && yrad==0);
 }
 
 static void SetNTangent(SplinePoint *sp,real x, real y,real xrad, real yrad) {
@@ -159,7 +157,6 @@ static void SetNTangent(SplinePoint *sp,real x, real y,real xrad, real yrad) {
     sp->nextcp.x += xrad;
     sp->nextcp.y += yrad;
     sp->prevcp = sp->me;
-    sp->nonextcp = (xrad==0 && yrad==0);
 }
 
 static void RedoActiveSplineSet(SplineSet *ss) {

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -416,7 +416,6 @@ return;
 		    (sp->me.y-sp->nextcp.y)*(sp->me.y-sp->nextcp.y));
 	    if ( cplen!=0 && cplen<p->irrelevantfactor*len ) {
 		sp->nextcp = sp->me;
-		sp->nonextcp = true;
 		ncp_changed = true;
 	    }
 	}
@@ -427,7 +426,6 @@ return;
 		    (sp->me.y-sp->prevcp.y)*(sp->me.y-sp->prevcp.y));
 	    if ( cplen!=0 && cplen<p->irrelevantfactor*len ) {
 		sp->prevcp = sp->me;
-		sp->noprevcp = true;
 		pcp_changed = true;
 	    }
 	}

--- a/fontforgeexe/tilepath.c
+++ b/fontforgeexe/tilepath.c
@@ -609,12 +609,7 @@ static SplinePoint *TDMakePoint(TD *td,Spline *old,real t) {
     SplinePoint *new;
 
     AdjustPoint(td,old,t,&fp);
-    new = chunkalloc(sizeof(SplinePoint));
-    new->me.x = fp.p.x; new->me.y = fp.p.y;
-    new->nextcp = new->me;
-    new->prevcp = new->me;
-    new->nextcpdef = new->prevcpdef = false;
-return( new );
+    return SplinePointCreate(fp.p.x, fp.p.y);
 }
 
 static Spline *AdjustSpline(TD *td,Spline *old,SplinePoint *newfrom,SplinePoint *newto,

--- a/fontforgeexe/tilepath.c
+++ b/fontforgeexe/tilepath.c
@@ -660,6 +660,7 @@ static void AdjustSplineSet(TD *td,int order2) {
 	    new->first->prevcpdef = lastsp->prevcpdef;
 	    lastsp->prev->to = new->first;
 	    new->last = new->first;
+	    SplineRefigure(new->first->prev);
 	    SplinePointFree(lastsp);
 	} else
 	    new->last = lastsp;

--- a/fontforgeexe/tilepath.c
+++ b/fontforgeexe/tilepath.c
@@ -613,7 +613,6 @@ static SplinePoint *TDMakePoint(TD *td,Spline *old,real t) {
     new->me.x = fp.p.x; new->me.y = fp.p.y;
     new->nextcp = new->me;
     new->prevcp = new->me;
-    new->nonextcp = new->noprevcp = true;
     new->nextcpdef = new->prevcpdef = false;
 return( new );
 }
@@ -663,7 +662,6 @@ static void AdjustSplineSet(TD *td,int order2) {
 		RealNearish(lastsp->me.y,new->first->me.y) ) {
 	    new->first->prev = lastsp->prev;
 	    new->first->prevcp = lastsp->prevcp;
-	    new->first->noprevcp = lastsp->noprevcp;
 	    new->first->prevcpdef = lastsp->prevcpdef;
 	    lastsp->prev->to = new->first;
 	    new->last = new->first;

--- a/tests/test931.py
+++ b/tests/test931.py
@@ -27,7 +27,7 @@ for (i,t) in [(0,hv),(3,hv),(6,hv),(9,hv)]:
 
 g.setLayer(l,1,('select_all','hvcurve','force'))
 cc = g.layers[1][0]
-for (i,t) in [(1,False),(2,True),(4,True),(5,False),(7,False),(8,False)]:
+for (i,t) in [(1,True),(2,True),(4,True),(5,False),(7,False),(8,False)]:
     if (cc[i] == c[i]) != t:
         print(cc[i],c[i])
         raise ValueError("Coordinates of point " + str(i) + " should have " + ("stayed the same" if t else "changed"))


### PR DESCRIPTION
The reasoning is in #4125. `nonextcp` and `noprevcp` are handy in a number of circumstances, mostly for special-casing lines, but it's bad to make them authoritative for cubic splines because you can really only have a full cublic spline or a line: There's no such thing as a cubic spline with one control point.

The solution is to set these flags based on the spline data in (both flavors of) `SplineRefigure()`. The remaining cases are isolated spline points and the ends of open contours, which are never passed to `SplineRefigure()`. It's OK for a control point to "dangle" in some cases (like when a following point is removed) but normally one should initialize `...cp` location to `me` and set the `no...cp` flag to true. This is best achieved by allocating all spline points with `SplinePointCreate()` to set everything up well in the first place.

There's code in `contrib/fonttools/acorn2sfd.c` that doesn't allocate `Spline` or `SplinePoint` structs with `chunkalloc()`, so I just left that as-is. It may or may not cause problems.

The existing tests were helpful in turning up some problems, particularly with isolated TrueType points and point numbering. The fact that point numbers are used "substantially" strongly suggests that the TrueType paths come through this pretty well. The OpenType path issues are simpler but perhaps slightly less well tested, at least by those tests. I did some testing with SVGs and Glifs and such and that's all working now.

Closes #4125 
Closes #2601
Closes #4327