### PR TITLE
Allow bitmap strike magnification up to 30 times

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -3355,7 +3355,7 @@ static void FVMenuMagnify(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUS
     if ( ret==NULL )
 return;
     val = strtol(ret,&end,10);
-    if ( val<1 || val>5 || *end!='\0' )
+    if ( val<1 || val>30 || *end!='\0' )
 	ff_post_error( _("Bad Number"),_("Bad Number") );
     else {
 	fv->user_requested_magnify = val;


### PR DESCRIPTION
Closes #4599 

I experimented with different bitmap strike sizes at 30x. If the glyph doesn't fit on the screen you get a collapsed window with just a menu (so it's easy to back out to another setting). Otherwise you see the glyph or glyphs. Seems OK.  