### PR TITLE
Fix coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ env:
   PYTHON: python3.9
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deps/install
-          key: ${{ matrix.os }}-deps-${{ hashFiles('repo/.github/workflows/scripts/setup_linux_deps.sh') }}
+          key: ${{ runner.os }}-deps-${{ hashFiles('repo/.github/workflows/scripts/setup_linux_deps.sh') }}
       - name: Install dependencies and setup env vars
         run: ${{ github.workspace }}/repo/.github/workflows/scripts/setup_linux_deps.sh
       - name: Build FontForge with Coverity
@@ -35,7 +35,7 @@ jobs:
           mkdir build && pushd build
           cmake -GNinja $FFCONFIG ..
           cov-build --dir cov-int ninja
-          cat build/cov-int/build-log.txt
+          # cat cov-int/build-log.txt
       - name: Submit the result to Coverity Scan
         working-directory: repo/build
         run: |


### PR DESCRIPTION
Coverity doesn't like the glib version in Ubuntu 20.04

2021-04-01T09:37:00.3065253Z "/usr/include/glib-2.0/gobject/gparam.h", line 159: error #67: expected a "}"
2021-04-01T09:37:00.3066082Z     G_PARAM_PRIVATE GLIB_DEPRECATED_ENUMERATOR_IN_2_26 = G_PARAM_STATIC_NAME,

https://community.synopsys.com/s/article/capture-failure-on-glib-macro-code-GLIB-DEPRECATED-ENUMERATOR-IN-2-32-FOR

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**