### PR TITLE
Suppress license info in CLI when `-quiet` is set

### DIFF
--- a/fontforgeexe/startnoui.c
+++ b/fontforgeexe/startnoui.c
@@ -85,32 +85,10 @@ exit(0);
 }
 
 int fontforge_main( int argc, char **argv ) {
-    time_t tm = FONTFORGE_MODTIME_RAW;
-    struct tm* modtime = gmtime(&tm);
     int run_python_init_files = true;
     int import_python_plugins = true;
+    bool quiet = false;
     char *pt;
-
-    fprintf( stderr, "Copyright (c) 2000-%d. See AUTHORS for Contributors.\n", modtime->tm_year+1900 );
-    fprintf( stderr, " License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n" );
-    fprintf( stderr, " with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.\n" );
-    fprintf( stderr, " Version: %s\n", FONTFORGE_VERSION );
-    fprintf( stderr, " Based on sources from %s"
-#ifdef FREETYPE_HAS_DEBUGGER
-	    "-TtfDb"
-#endif
-#ifdef _NO_PYTHON
-	    "-NoPython"
-#endif
-#ifdef FONTFORGE_CONFIG_USE_DOUBLE
-	    "-D"
-#endif
-	    ".\n",
-	    FONTFORGE_MODTIME_STR );
-    // Can be empty if e.g. building from a tarball
-    if (FONTFORGE_GIT_VERSION[0] != '\0') {
-	fprintf( stderr, " Based on source from git with hash: %s\n", FONTFORGE_GIT_VERSION );
-    }
 
     FindProgDir(argv[0]);
     InitSimpleStuff();
@@ -125,7 +103,34 @@ int fontforge_main( int argc, char **argv ) {
 	    run_python_init_files = false;
 	} else if ( strcmp(pt,"-skippyplug")==0 ) {
 	    import_python_plugins = false;
+	} else if ( strcmp(pt,"-quiet")==0 ) {
+	    quiet = true;
 	}
+    }
+
+    if (!quiet) {
+        time_t tm = FONTFORGE_MODTIME_RAW;
+        struct tm* modtime = gmtime(&tm);
+        fprintf( stderr, "Copyright (c) 2000-%d. See AUTHORS for Contributors.\n", modtime->tm_year+1900 );
+        fprintf( stderr, " License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n" );
+        fprintf( stderr, " with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.\n" );
+        fprintf( stderr, " Version: %s\n", FONTFORGE_VERSION );
+        fprintf( stderr, " Based on sources from %s"
+#ifdef FREETYPE_HAS_DEBUGGER
+            "-TtfDb"
+#endif
+#ifdef _NO_PYTHON
+            "-NoPython"
+#endif
+#ifdef FONTFORGE_CONFIG_USE_DOUBLE
+            "-D"
+#endif
+            ".\n",
+            FONTFORGE_MODTIME_STR );
+        // Can be empty if e.g. building from a tarball
+        if (FONTFORGE_GIT_VERSION[0] != '\0') {
+            fprintf( stderr, " Based on source from git with hash: %s\n", FONTFORGE_GIT_VERSION );
+        }
     }
 
     if ( default_encoding==NULL )


### PR DESCRIPTION
Fixes #4254.