### PR TITLE
IRC has moved to irc.libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use it to create, edit and convert fonts in OpenType, TrueType, UFO, CID-keyed, 
 The bug tracker is for _reporting bugs_, not for asking questions. Please direct questions to one of the following:
 
 * [Mailing list](https://sourceforge.net/p/fontforge/mailman/fontforge-users/)
-* [Live chat](https://webchat.freenode.net/?channel=#fontforge) &mdash; #fontforge on [Freenode](https://freenode.net/)
+* [Live chat](https://web.libera.chat/?channel=#fontforge) &mdash; #fontforge on [Libera](https://libera.chat/)
 
 # Installation & contributing
 


### PR DESCRIPTION
The Wiki has already been updated, but this should be too.

Users were requesting this on Twitter. Most other large channels have abandoned Freenode (#archlinux, #ubuntu…) due to what's becoming known as the [Andrew Lee incident](https://www.theregister.com/2021/05/19/freenode_staff_resigns/), which caused most Freenode network staff to resign in protest to a sale of Freenode. The new replacement is a 501(c)(3) organization with a Board of Directors, not a saleable entity.

I moved ahead with the change given the many requests and the fact that most users have abandoned Freenode, so it's not even practical to stay there even if we want to.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Documentation**