### PR TITLE
gtextfield.c: fix length calculation for type 2 completions

### DIFF
--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -35,6 +35,7 @@
 #include "ustring.h"
 #include "utype.h"
 
+#include <assert.h>
 #include <math.h>
 
 GBox _GGadget_gtextfield_box = GBOX_EMPTY; /* Don't initialize here */
@@ -3085,8 +3086,10 @@ static void GTextFieldComplete(GTextField *gt,int from_tab) {
 		    } else if ( !doit )
 			ret2 = malloc((cnt+1)*sizeof(unichar_t *));
 		    else {
-			if ( type2 )
-			    cnt = type2;
+			if ( type2 ) {
+			    cnt = (cnt+MAXBRACKETS-1)/MAXBRACKETS;
+			    assert(cnt <= type2);
+			}
 			ret2[cnt] = NULL;
 		    }
 		}


### PR DESCRIPTION
This part may cause an overestimation on first calculation:

    if ( ret[i][len]=='\0' )
        continue;

Fixes #4751

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
