### PR TITLE
gtabset.c: fix out of bounds access on GTabSet::tabs

### DIFF
--- a/gdraw/gtabset.c
+++ b/gdraw/gtabset.c
@@ -533,7 +533,7 @@ return(false);
 		else
 		    sel = i;
 	    }
-        if ( i <= gts->tabcnt && i >= 0 )
+        if ( i < gts->tabcnt && i >= 0 )
 		if ( gts->closable && event->type==et_mouseup && event->u.mouse.x>=gts->tabs[i].x+gts->tabs[i].width+(-GTS_TABPADDING/2-10) ) {
 			TRACE("Closing tab %d\n", sel);
 			GTabSetRemoveTabByPos(&gts->g, i);


### PR DESCRIPTION
Fixes this:

* Add two tabs to the charview
* Click and drag a tab past the last tab:
   ![image](https://user-images.githubusercontent.com/5137410/123902833-1a0d3500-d9a0-11eb-81de-d333b06130db.png)


```
=================================================================
==2671==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60c000769bc8 at pc 0x000000b57299 bp 0x7fffffffcd10 sp 0x7fffffffcd00
READ of size 2 at 0x60c000769bc8 thread T0
    #0 0xb57298 in gtabset_mouse ../gdraw/gtabset.c:537
    #1 0xa7ebe6 in _GWidget_Container_eh ../gdraw/gcontainer.c:295
    #2 0xa824d4 in _GWidget_TopLevel_eh ../gdraw/gcontainer.c:621
    #3 0xaad82f in _GGDKDraw_CallEHChecked ../gdraw/ggdkdraw.c:346
    #4 0xab464d in _GGDKDraw_DispatchEvent ../gdraw/ggdkdraw.c:1249
    #5 0x7ffff4df8d91  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x5ad91)
    #6 0x7ffff4117196 in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4a196)
    #7 0x7ffff41173ef  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4a3ef)
    #8 0x7ffff411749b in g_main_context_iteration (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4a49b)
    #9 0xababb0 in GGDKDrawEventLoop ../gdraw/ggdkdraw.c:2146
    #10 0xa8c335 in GDrawEventLoop ../gdraw/gdraw.c:685
    #11 0xa06c02 in fontforge_main ../fontforgeexe/startui.c:1422
    #12 0x41b3a5 in main ../fontforgeexe/main.c:33
    #13 0x7ffff3d2382f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #14 0x41b2b8 in _start (/home/jeremy/fontforge/build/bin/fontforge+0x41b2b8)

0x60c000769bc8 is located 8 bytes to the right of 128-byte region [0x60c000769b40,0x60c000769bc0)
allocated by thread T0 here:
    #0 0x7ffff6f02961 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98961)
    #1 0xb5d42e in GTabSetChangeTabName ../gdraw/gtabset.c:1034
    #2 0x4e4563 in CVChangeSC ../fontforgeexe/charview.c:3738
    #3 0x77a7a4 in FVMouse ../fontforgeexe/fontview.c:6457
    #4 0x77f088 in v_e_h ../fontforgeexe/fontview.c:6740
    #5 0xa80279 in _GWidget_Container_eh ../gdraw/gcontainer.c:396
    #6 0xaad82f in _GGDKDraw_CallEHChecked ../gdraw/ggdkdraw.c:346
    #7 0xab464d in _GGDKDraw_DispatchEvent ../gdraw/ggdkdraw.c:1249
    #8 0x7ffff4df8d91  (/usr/lib/x86_64-linux-gnu/libgdk-3.so.0+0x5ad91)

SUMMARY: AddressSanitizer: heap-buffer-overflow ../gdraw/gtabset.c:537 gtabset_mouse
Shadow bytes around the buggy address:
  0x0c18800e5320: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c18800e5330: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c18800e5340: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x0c18800e5350: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c18800e5360: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
=>0x0c18800e5370: 00 00 00 00 00 00 00 00 fa[fa]fa fa fa fa fa fa
  0x0c18800e5380: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c18800e5390: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c18800e53a0: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x0c18800e53b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c18800e53c0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==2671==ABORTING
```
### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**