### PR TITLE
python.c: fix stroke flag checks

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -4590,9 +4590,9 @@ static int Stroke_Parse(StrokeInfo *si, PyObject *args, PyObject *keywds) {
 	f = FlagsFromTuple(flagtuple,strokeflags,"stroke flag");
 	if ( f==FLAG_UNKNOWN )
 	    return( -1 );
-	si->removeinternal = ( f&1!=0 );
-	si->removeexternal = ( f&2!=0 );
-	si->simplify = ( f&4!=0 );
+	si->removeinternal = ( (f&1)!=0 );
+	si->removeexternal = ( (f&2)!=0 );
+	si->simplify = ( (f&4)!=0 );
     }
     return( 0 );
 }


### PR DESCRIPTION
Fixes e.g.

    ../fontforge/python.c:4593:26: warning: & has lower precedence than !=; != will be evaluated first [-Wparentheses]
        si->removeinternal = ( f&1!=0 );
                                ^~~~~

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**