### PR TITLE
parsettf.c: fix bounds checking when reading ps names

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -5226,7 +5226,7 @@ static void readttfpostnames(FILE *ttf,struct ttfinfo *info) {
 	    i = 258;
 	    /* Read the pascal strings. There can be more strings than the
 	     * glyph count, so we read tell the end of the table */
-	    while ( ftell(ttf)+1<bounds ) {
+	    while ( i<65536 && ftell(ttf)+1<bounds ) {
 		len = getc(ttf);
 		if ( len<0 )		/* Don't crash on EOF */
 	    break;


### PR DESCRIPTION
Fixes #4418

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
