### PR TITLE
contextchain.c: allocate nclassnames

### DIFF
--- a/fontforgeexe/contextchain.c
+++ b/fontforgeexe/contextchain.c
@@ -1025,6 +1025,7 @@ return;
 	continue;
 	    (&fpst->nccnt)[i] = clen[i];
 	    (&fpst->nclass)[i] = malloc(clen[i]*sizeof(char*));
+	    (&fpst->nclassnames)[i] = malloc(clen[i]*sizeof(char*));
 	    (&fpst->nclass)[i][0] = NULL;
 	    had_class0 = i==0 && !isEverythingElse(classes[i][0].u.md_str);
 	    for ( k=had_class0 ? 0 : 1 ; k<clen[i]; ++k )


### PR DESCRIPTION
Attempted fix for #3440

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
