### PR TITLE
Fix python binding of changeWidth: parse the tuple as int instead float

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -7904,7 +7904,7 @@ return( embolden_error );
     else if ( PyLong_Check(zoneO))
 	zones->top_bound = PyLong_AsLong(zoneO);
     else if ( PyTuple_Check(zoneO)) {
-	if ( !PyArg_ParseTuple(zoneO,"dddd",
+	if ( !PyArg_ParseTuple(zoneO,"iiii",
 		&zones->top_bound,&zones->top_zone,&zones->bottom_zone,&zones->bottom_bound))
 return( embolden_error );
 	just_top = false;


### PR DESCRIPTION
### Type of change
- **Bug fix**

This simple bug-fix changes the format string to parse the tuple of `(top_bound, top_zone, bottom_zone, bottom_bound)` in `CW_ParseArgs` from `dddd` (four `double`s) to `iiii` (four `int`s).

The reason is that the underlying data structure, `struct lcg_zones`, as defined in `fontforge/baseviews.h` line 207, has these numbers as `int`s.