### PR TITLE
savefontdlg.c: fix ParseBitmapSizes for non-English locales

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -828,7 +828,6 @@ extern void mbDoGetText(GMenuItem *mb);
 extern int RecentFilesAny(void);
 extern void _aplistbuild(struct gmenuitem *mi,SplineFont *sf,
 	void (*func)(GWindow,struct gmenuitem *,GEvent *));
-extern int32 *ParseBitmapSizes(GGadget *g,char *msg,int *err);
 extern GTextInfo *AddMacFeatures(GTextInfo *opentype,enum possub_type type,SplineFont *sf);
 extern unichar_t *AskNameTag(char *title,unichar_t *def,uint32 def_tag,uint16 flags,
 	int script_lang_index, enum possub_type type, SplineFont *sf, SplineChar *default_script,

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -202,8 +202,9 @@ extern int oldbitmapstate;
 
 static const char *pfaeditflag = "SplineFontDB:";
 
-int32 *ParseBitmapSizes(GGadget *g,char *msg,int *err) {
+static int32 *ParseBitmapSizes(GGadget *g, int *err) {
     const unichar_t *val = _GGadgetGetTitle(g), *pt; unichar_t *end, *end2;
+    const char *msg = _("Pixel List"); // Before switching to C locale
     int i;
     int32 *sizes;
 
@@ -224,9 +225,7 @@ int32 *ParseBitmapSizes(GGadget *g,char *msg,int *err) {
 
     for ( i=0, pt = val; *pt!='\0' ; ) {
 	sizes[i]=rint(u_strtod(pt,&end));
-	if ( msg!=_("Pixel List") )
-	    /* No bit depth allowed */;
-	else if ( *end!='@' )
+	if ( *end!='@' )
 	    sizes[i] |= 0x10000;
 	else
 	    sizes[i] |= (u_strtol(end+1,&end,10)<<16);
@@ -1448,7 +1447,7 @@ return;
 
     oldbitmapstate = GGadgetGetFirstListSelectedItem(d->bmptype);
     if ( oldbitmapstate!=bf_none )
-	sizes = ParseBitmapSizes(d->bmpsizes,_("Pixel List"),&err);
+	sizes = ParseBitmapSizes(d->bmpsizes,&err);
     if ( err )
 return;
     if ( oldbitmapstate==bf_nfntmacbin && oldformatstate!=ff_pfbmacbin && !nfnt_warned ) {
@@ -1477,7 +1476,7 @@ return;
 		last = cur;
 		cur->sf = GGadgetGetUserData(GWidgetGetControl(d->gw,CID_Family+10*i));
 		if ( oldbitmapstate!=bf_none )
-		    cur->sizes = ParseBitmapSizes(GWidgetGetControl(d->gw,CID_Family+10*i+1),_("Pixel List"),&err);
+		    cur->sizes = ParseBitmapSizes(GWidgetGetControl(d->gw,CID_Family+10*i+1),&err);
 		if ( err ) {
 		    SfListFree(sfs);
 return;

--- a/gdraw/ctlvalues.c
+++ b/gdraw/ctlvalues.c
@@ -32,7 +32,7 @@
 #include "gwidget.h"
 #include "ustring.h"
 
-void GGadgetProtest8(char *label) {
+void GGadgetProtest8(const char *label) {
     char buf[80];
 
     snprintf( buf, sizeof(buf),_("Bad Number in %s"), label);

--- a/inc/ggadget.h
+++ b/inc/ggadget.h
@@ -620,7 +620,7 @@ extern double GetReal8(GWindow gw,int cid,char *namer,int *err);
 extern int GetCalmInt8(GWindow gw,int cid,char *name,int *err);
 extern int GetInt8(GWindow gw,int cid,char *namer,int *err);
 extern int GetUnicodeChar8(GWindow gw,int cid,char *namer,int *err);
-extern void GGadgetProtest8(char *labelr);
+extern void GGadgetProtest8(const char *labelr);
 
 extern void GMenuItemParseShortCut(GMenuItem *mi,char *shortcut);
 extern int GMenuItemParseMask(char *shortcut);


### PR DESCRIPTION
Fixes #4779

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**