### PR TITLE
parsettf.c: fix off-by-one error in getstrid

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3354,7 +3354,7 @@ return( NULL );
     }
     else if ( sid<nStdStrings )
 return( cffnames[sid] );
-    else if ( sid-nStdStrings>scnt ) {
+    else if ( sid-nStdStrings>=scnt ) {
 	LogError( _("Bad sid %d (must be less than %d)\n"), sid, scnt+nStdStrings );
 	if ( info!=NULL ) info->bad_cff = true;
 return( NULL );


### PR DESCRIPTION
The SID should be considered bad in the equal case. This also prevents a segmentation fault when `scnt == 0` and `strings == NULL`.

### Type of change
- **Bug fix**
- **Non-breaking change**