### PR TITLE
Remove pre-gettext resource management functions

### DIFF
--- a/fontforgeexe/sftextfield.c
+++ b/fontforgeexe/sftextfield.c
@@ -2221,9 +2221,7 @@ static SFTextArea *_SFTextAreaCreate(SFTextArea *st, struct gwindow *base, GGadg
 
     st->g.takes_input = true; st->g.takes_keyboard = true; st->g.focusable = true;
     if ( gd->label!=NULL ) {
-	if ( gd->label->text_in_resource )	/* This one use of GStringGetResource is ligit */
-	    st->li.text = u_copy((unichar_t *) GStringGetResource((intpt) gd->label->text,&st->g.mnemonic));
-	else if ( gd->label->text_is_1byte )
+	if ( gd->label->text_is_1byte )
 	    st->li.text = utf82u_copy((char *) gd->label->text);
 	else
 	    st->li.text = u_copy(gd->label->text);

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -1072,7 +1072,6 @@ int fontforge_main( int argc, char **argv ) {
     bind_textdomain_codeset("FontForge","UTF-8");
     bindtextdomain("FontForge", getLocaleDir());
     textdomain("FontForge");
-    GResourceUseGetText();
     {
 	char path[PATH_MAX];
 	snprintf(path, PATH_MAX, "%s%s", getShareDir(), "/pixmaps" );

--- a/fontforgeexe/windowmenu.c
+++ b/fontforgeexe/windowmenu.c
@@ -91,17 +91,11 @@ return;
     mi->sub = sub;
 
     for ( i=0; sub[i].ti.text!=NULL || sub[i].ti.line; ++i ) {
-	if ( sub[i].ti.text_is_1byte && sub[i].ti.text_in_resource) {
+	if ( sub[i].ti.text_is_1byte ) {
 	    sub[i].ti.text = utf82u_mncopy((char *) sub[i].ti.text,&sub[i].ti.mnemonic);
-	    sub[i].ti.text_is_1byte = sub[i].ti.text_in_resource = false;
-	} else if ( sub[i].ti.text_is_1byte ) {
-	    sub[i].ti.text = utf82u_copy((char *) sub[i].ti.text);
-	    sub[i].ti.text_is_1byte = false;
-	} else if ( sub[i].ti.text_in_resource ) {
-	    sub[i].ti.text = u_copy(GStringGetResource((intpt) sub[i].ti.text,NULL));
-	    sub[i].ti.text_in_resource = false;
 	} else
 	    sub[i].ti.text = u_copy(sub[i].ti.text);
+	sub[i].ti.text_is_1byte = sub[i].ti.text_in_resource = false;
     }
     cnt = precnt;
     for ( fv = (FontViewBase *) fv_list; fv!=NULL; fv = fv->next ) {

--- a/gdraw/gaskdlg.c
+++ b/gdraw/gaskdlg.c
@@ -313,75 +313,6 @@ return( NULL );
 return( gw );
 }
 
-int GWidgetAsk(const unichar_t *title,
-	const unichar_t **answers, const unichar_t *mn, int def, int cancel,
-	const unichar_t *question,...) {
-    struct dlg_info d;
-    GWindow gw;
-    va_list ap;
-
-    if ( screen_display==NULL )
-return( def );
-
-    va_start(ap,question);
-    gw = DlgCreate(title,question,ap,answers,mn,def,cancel,&d,false,true,false);
-    va_end(ap);
-
-    while ( !d.done )
-	GDrawProcessOneEvent(NULL);
-    GDrawDestroyWindow(gw);
-    GDrawSync(NULL);
-    GDrawProcessPendingEvents(NULL);
-return(d.ret);
-}
-
-unichar_t *GWidgetAskStringR(int title,const unichar_t *def,int question,...) {
-    struct dlg_info d;
-    GWindow gw;
-    unichar_t *ret = NULL;
-    const unichar_t *ocb[3]; unichar_t ocmn[2];
-    va_list ap;
-
-    if ( screen_display==NULL )
-return( u_copy(def ));
-
-    ocb[2]=NULL;
-    ocb[0] = GStringGetResource( _STR_OK, &ocmn[0]);
-    ocb[1] = GStringGetResource( _STR_Cancel, &ocmn[1]);
-    va_start(ap,question);
-    gw = DlgCreate(GStringGetResource( title,NULL),GStringGetResource( question,NULL),ap,
-	    ocb,ocmn,0,1,&d,true,true,false);
-    va_end(ap);
-    if ( def!=NULL && *def!='\0' )
-	GGadgetSetTitle(GWidgetGetControl(gw,2),def);
-    while ( !d.done )
-	GDrawProcessOneEvent(NULL);
-    if ( d.ret==0 )
-	ret = GGadgetGetTitle(GWidgetGetControl(gw,2));
-    GDrawDestroyWindow(gw);
-    GDrawSync(NULL);
-    GDrawProcessPendingEvents(NULL);
-return(ret);
-}
-
-void GWidgetError(const unichar_t *title,const unichar_t *statement, ...) {
-    struct dlg_info d;
-    GWindow gw;
-    const unichar_t *ob[2]; unichar_t omn[1];
-    va_list ap;
-
-    ob[1]=NULL;
-    ob[0] = GStringGetResource( _STR_OK, &omn[0]);
-    va_start(ap,statement);
-    gw = DlgCreate(title,statement,ap,ob,omn,0,0,&d,false,true,true);
-    va_end(ap);
-    if ( gw!=NULL ) {
-	while ( !d.done )
-	    GDrawProcessOneEvent(NULL);
-	GDrawDestroyWindow(gw);
-    }
-}
-
 /* ************************************************************************** */
 
 #define CID_Cancel	0
@@ -684,13 +615,8 @@ char *GWidgetAskString8(const char *title,const char *def,
 return( copy(def ));
 
     ocb[2]=NULL;
-    if ( _ggadget_use_gettext ) {
-	ocb[0] = _("_OK");
-	ocb[1] = _("_Cancel");
-    } else {
-	ocb[0] = u2utf8_copy(GStringGetResource( _STR_OK, NULL));
-	ocb[1] = u2utf8_copy(GStringGetResource( _STR_Cancel, NULL));
-    }
+    ocb[0] = _("_OK");
+    ocb[1] = _("_Cancel");
     va_start(ap,question);
     gw = DlgCreate8(title,question,ap,(const char **) ocb,0,1,&d,true,def,true,false);
     va_end(ap);
@@ -703,9 +629,6 @@ return( copy(def ));
     GDrawDestroyWindow(gw);
     GDrawSync(NULL);
     GDrawProcessPendingEvents(NULL);
-    if ( !_ggadget_use_gettext ) {
-	free(ocb[0]); free(ocb[1]);
-    }
 return(ret);
 }
 
@@ -720,14 +643,10 @@ char *GWidgetAskPassword8(const char *title,const char *def,
     if ( screen_display==NULL )
 return( copy(def ));
 
+    ocb[0] = _("_OK");
+    ocb[1] = _("_Cancel");
     ocb[2]=NULL;
-    if ( _ggadget_use_gettext ) {
-	ocb[0] = _("_OK");
-	ocb[1] = _("_Cancel");
-    } else {
-	ocb[0] = u2utf8_copy(GStringGetResource( _STR_OK, NULL));
-	ocb[1] = u2utf8_copy(GStringGetResource( _STR_Cancel, NULL));
-    }
+
     va_start(ap,question);
     gw = DlgCreate8(title,question,ap,(const char **) ocb,0,1,&d,2,def,true,false);
     va_end(ap);
@@ -740,9 +659,6 @@ return( copy(def ));
     GDrawDestroyWindow(gw);
     GDrawSync(NULL);
     GDrawProcessPendingEvents(NULL);
-    if ( !_ggadget_use_gettext ) {
-	free(ocb[0]); free(ocb[1]);
-    }
 return(ret);
 }
 
@@ -757,18 +673,13 @@ void _GWidgetPostNotice8(const char *title,const char *statement,va_list ap, int
 return;
     }
 
+    ob[0] = _("_OK");
     ob[1]=NULL;
-    if ( _ggadget_use_gettext )
-	ob[0] = _("_OK");
-    else
-	ob[0] = u2utf8_copy(GStringGetResource( _STR_OK, NULL));
     gw = DlgCreate8(title,statement,ap,(const char **) ob,0,0,NULL,false,NULL,false,true);
     if ( gw!=NULL && timeout>0 ) 
 	GDrawRequestTimer(gw,timeout*1000,0,NULL);
     /* Continue merrily on our way. Window will destroy itself in 40 secs */
     /*  or when user kills it. We can ignore it */
-    if ( !_ggadget_use_gettext )
-	free(ob[0]);
     last = gw;
     last_title = title;
 }
@@ -813,11 +724,8 @@ void GWidgetError8(const char *title,const char *statement, ...) {
     char *ob[2];
     va_list ap;
 
+    ob[0] = _("_OK");
     ob[1]=NULL;
-    if ( _ggadget_use_gettext )
-	ob[0] = _("_OK");
-    else
-	ob[0] = u2utf8_copy(GStringGetResource( _STR_OK, NULL));
     va_start(ap,statement);
     gw = DlgCreate8(title,statement,ap,(const char **) ob,0,0,&d,false,NULL,true,true);
     va_end(ap);
@@ -826,8 +734,6 @@ void GWidgetError8(const char *title,const char *statement, ...) {
 	    GDrawProcessOneEvent(NULL);
 	GDrawDestroyWindow(gw);
     }
-    if ( !_ggadget_use_gettext )
-	free(ob[0]);
 }
 
 static GWindow ChoiceDlgCreate8(struct dlg_info *d,const char *title,
@@ -964,11 +870,9 @@ static GWindow ChoiceDlgCreate8(struct dlg_info *d,const char *title,
 	gcd[i].gd.pos.x = GDrawPointsToPixels(gw,15); gcd[i].gd.pos.y = y;
 	gcd[i].gd.flags = gg_visible | gg_enabled | gg_pos_in_pixels | gg_pos_use0;
 	gcd[i].gd.label = &blabel[2];
-	if ( _ggadget_use_gettext ) {
-	    blabel[2].text = (unichar_t *) _("Select _All");
-	    blabel[2].text_is_1byte = true;
-	} else
-	    blabel[2].text = (unichar_t *) _STR_SelectAll;
+
+	blabel[2].text = (unichar_t *) _("Select _All");
+	blabel[2].text_is_1byte = true;
 	blabel[2].text_in_resource = true;
 	gcd[i].gd.cid = CID_SelectAll;
 	gcd[i].gd.handle_controlevent = GCD_Select;
@@ -981,11 +885,8 @@ static GWindow ChoiceDlgCreate8(struct dlg_info *d,const char *title,
 	gcd[i].gd.pos.width = -1;
 	gcd[i].gd.flags = gg_visible | gg_enabled | gg_pos_in_pixels | gg_pos_use0 ;
 	gcd[i].gd.label = &blabel[3];
-	if ( _ggadget_use_gettext ) {
-	    blabel[3].text = (unichar_t *) _("_None");
-	    blabel[3].text_is_1byte = true;
-	} else
-	    blabel[3].text = (unichar_t *) _STR_None;
+	blabel[3].text = (unichar_t *) _("_None");
+	blabel[3].text_is_1byte = true;
 	blabel[3].text_in_resource = true;
 	gcd[i].gd.cid = CID_SelectNone;
 	gcd[i].gd.handle_controlevent = GCD_Select;
@@ -1068,13 +969,8 @@ int GWidgetChoices8(const char *title, const char **choices,int cnt, int def,
 return( -2 );
 
     va_start(ap,question);
-    if ( _ggadget_use_gettext ) {
 	buts[0] = _("_OK");
 	buts[1] = _("_Cancel");
-    } else {
-	buts[0] = u2utf8_copy(GStringGetResource(_STR_OK,NULL));
-	buts[1] = u2utf8_copy(GStringGetResource(_STR_Cancel,NULL));
-    }
     buts[2] = NULL;
     gw = ChoiceDlgCreate8(&d,title,question,ap,
 	    choices,cnt,NULL, buts,def,true,false);
@@ -1084,9 +980,6 @@ return( -2 );
     GDrawDestroyWindow(gw);
     GDrawSync(NULL);
     GDrawProcessPendingEvents(NULL);
-    if ( !_ggadget_use_gettext ) {
-	free(buts[0]); free(buts[1]);
-    }
 return(d.ret);
 }
 
@@ -1127,13 +1020,8 @@ return( -2 );
     if ( buts==NULL ) {
 	buts = buttons;
 	buttons[2] = NULL;
-	if ( _ggadget_use_gettext ) {
-	    buts[0] = _("_OK");
-	    buts[1] = _("_Cancel");
-	} else {
-	    buts[0] = u2utf8_copy(GStringGetResource(_STR_OK,NULL));
-	    buts[1] = u2utf8_copy(GStringGetResource(_STR_Cancel,NULL));
-	}
+	buts[0] = _("_OK");
+	buts[1] = _("_Cancel");
     }
     va_start(ap,question);
     gw = ChoiceDlgCreate8(&d,title,question,ap,
@@ -1153,8 +1041,5 @@ return( -2 );
     GDrawDestroyWindow(gw);
     GDrawSync(NULL);
     GDrawProcessPendingEvents(NULL);
-    if ( !_ggadget_use_gettext ) {
-	free(buts[0]); free(buts[1]);
-    }
 return(d.ret);
 }

--- a/gdraw/gbuttons.c
+++ b/gdraw/gbuttons.c
@@ -1036,12 +1036,8 @@ static GLabel *_GLabelCreate(GLabel *gl, struct gwindow *base, GGadgetData *gd,v
 	gl->image_precedes = gd->label->image_precedes;
 	if ( gd->label->font!=NULL )
 	    gl->font = gd->label->font;
-	if ( gd->label->text_in_resource && gd->label->text_is_1byte )
+	if ( gd->label->text_is_1byte )
 	    gl->label = utf82u_mncopy((char *) gd->label->text,&gl->g.mnemonic);
-	else if ( gd->label->text_in_resource )
-	    gl->label = u_copy((unichar_t *) GStringGetResource((intpt) gd->label->text,&gl->g.mnemonic));
-	else if ( gd->label->text_is_1byte )
-	    gl->label = /* def2u_*/ utf82u_copy((char *) gd->label->text);
 	else
 	    gl->label = u_copy(gd->label->text);
 	gl->image = gd->label->image;

--- a/gdraw/gfiledlg.c
+++ b/gdraw/gfiledlg.c
@@ -120,11 +120,8 @@ static unichar_t *GWidgetOpenFileWPath(const unichar_t *title, const unichar_t *
     gcd[1].gd.pos.x = 12; gcd[1].gd.pos.y = 192-3;
     gcd[1].gd.pos.width = -1;
     gcd[1].gd.flags = gg_visible | gg_enabled | gg_but_default;
-    if ( _ggadget_use_gettext ) {
-	label[1].text = (unichar_t *) _("_OK");
-	label[1].text_is_1byte = true;
-    } else
-	label[1].text = (unichar_t *) _STR_OK;
+    label[1].text = (unichar_t *) _("_OK");
+    label[1].text_is_1byte = true;
     label[1].text_in_resource = true;
     gcd[1].gd.mnemonic = 'O';
     gcd[1].gd.label = &label[1];
@@ -135,11 +132,8 @@ static unichar_t *GWidgetOpenFileWPath(const unichar_t *title, const unichar_t *
     gcd[2].gd.pos.x = (totwid-bs)*100/GIntGetResource(_NUM_ScaleFactor)/2; gcd[2].gd.pos.y = gcd[1].gd.pos.y+3;
     gcd[2].gd.pos.width = -1;
     gcd[2].gd.flags = gg_visible | gg_enabled;
-    if ( _ggadget_use_gettext ) {
-	label[2].text = (unichar_t *) _("_Filter");
-	label[2].text_is_1byte = true;
-    } else
-	label[2].text = (unichar_t *) _STR_Filter;
+    label[2].text = (unichar_t *) _("_Filter");
+    label[2].text_is_1byte = true;
     label[2].text_in_resource = true;
     gcd[2].gd.mnemonic = 'F';
     gcd[2].gd.label = &label[2];
@@ -150,11 +144,8 @@ static unichar_t *GWidgetOpenFileWPath(const unichar_t *title, const unichar_t *
     gcd[3].gd.pos.x = -gcd[1].gd.pos.x; gcd[3].gd.pos.y = gcd[2].gd.pos.y;
     gcd[3].gd.pos.width = -1;
     gcd[3].gd.flags = gg_visible | gg_enabled | gg_but_cancel;
-    if ( _ggadget_use_gettext ) {
-	label[3].text = (unichar_t *) _("_Cancel");
-	label[3].text_is_1byte = true;
-    } else
-	label[3].text = (unichar_t *) _STR_Cancel;
+    label[3].text = (unichar_t *) _("_Cancel");
+    label[3].text_is_1byte = true;
     label[3].text_in_resource = true;
     gcd[3].gd.label = &label[3];
     gcd[3].gd.mnemonic = 'C';
@@ -203,12 +194,6 @@ static unichar_t *GWidgetOpenFileWPath(const unichar_t *title, const unichar_t *
     GDrawProcessPendingEvents(NULL);		/* Give the window a chance to vanish... */
     GProgressResumeTimer();
 return(d.ret);
-}
-
-unichar_t *GWidgetOpenFile(const unichar_t *title, const unichar_t *defaultfile,
-	const unichar_t *initial_filter, unichar_t **mimetypes,
-	GFileChooserFilterType filter) {
-return( GWidgetOpenFileWPath(title,defaultfile,initial_filter,mimetypes,filter,NULL));
 }
 
 char *GWidgetOpenFileWPath8(const char *title, const char *defaultfile,

--- a/gdraw/ggadgetP.h
+++ b/gdraw/ggadgetP.h
@@ -589,8 +589,6 @@ extern void GListMarkDraw(GWindow pixmap,int x, int y, int height, enum gadget_s
 extern const char* const* _GGadget_GetImagePath(void);
 extern int _GGadget_ImageInCache(GImage *image);
 
-extern int _ggadget_use_gettext;
-
 extern GResInfo ggadget_ri, listmark_ri;
 extern GResInfo *_GGadgetRIHead(void), *_GButtonRIHead(void), *_GTextFieldRIHead(void);
 extern GResInfo *_GRadioRIHead(void), *_GScrollBarRIHead(void), *_GLineRIHead(void);

--- a/gdraw/ggadgets.c
+++ b/gdraw/ggadgets.c
@@ -690,10 +690,6 @@ void GGadgetPreparePopup(GWindow base,const unichar_t *msg) {
     GGadgetPreparePopupImage(base,msg,NULL,NULL,NULL);
 }
 
-void GGadgetPreparePopupR(GWindow base,int msg) {
-    GGadgetPreparePopupImage(base,GStringGetResource(msg,NULL),NULL,NULL,NULL);
-}
-
 void GGadgetPreparePopup8(GWindow base, const char *msg) {
     static unichar_t popup_msg[500];
     utf82u_strncpy(popup_msg,msg,sizeof(popup_msg)/sizeof(popup_msg[0]));

--- a/gdraw/gmatrixedit.c
+++ b/gdraw/gmatrixedit.c
@@ -1213,11 +1213,8 @@ static void GME_StrBigEdit(GMatrixEdit *gme,char *str) {
     mgcd[1].gd.pos.x = 30-3; mgcd[1].gd.pos.y = GDrawPixelsToPoints(NULL,pos.height)-35-3;
     mgcd[1].gd.pos.width = -1; mgcd[1].gd.pos.height = 0;
     mgcd[1].gd.flags = gg_visible | gg_enabled | gg_but_default;
-    if ( _ggadget_use_gettext ) {
-	mlabel[1].text = (unichar_t *) _("_OK");
-	mlabel[1].text_is_1byte = true;
-    } else
-	mlabel[1].text = (unichar_t *) _STR_OK;
+    mlabel[1].text = (unichar_t *) _("_OK");
+    mlabel[1].text_is_1byte = true;
     mlabel[1].text_in_resource = true;
     mgcd[1].gd.label = &mlabel[1];
     mgcd[1].gd.cid = CID_OK;
@@ -1226,11 +1223,8 @@ static void GME_StrBigEdit(GMatrixEdit *gme,char *str) {
     mgcd[2].gd.pos.x = -30; mgcd[2].gd.pos.y = mgcd[1].gd.pos.y+3;
     mgcd[2].gd.pos.width = -1; mgcd[2].gd.pos.height = 0;
     mgcd[2].gd.flags = gg_visible | gg_enabled | gg_but_cancel;
-    if ( _ggadget_use_gettext ) {
-	mlabel[2].text = (unichar_t *) _("_Cancel");
-	mlabel[2].text_is_1byte = true;
-    } else
-	mlabel[2].text = (unichar_t *) _STR_Cancel;
+    mlabel[2].text = (unichar_t *) _("_Cancel");
+    mlabel[2].text_is_1byte = true;
     mlabel[2].text_in_resource = true;
     mgcd[2].gd.label = &mlabel[2];
     mgcd[2].gd.cid = CID_Cancel;
@@ -1626,14 +1620,8 @@ static void GMatrixEdit_SubExpose(GMatrixEdit *gme,GWindow pixmap,GEvent *event)
 		    if ( !gme->no_edit ) {
 			if ( gme->newtext!=NULL )
 			    buf = smprintf( "<%s>", gme->newtext );
-			else if ( _ggadget_use_gettext )
+			else
 			    buf = smprintf( "<%s>", S_("Row|New") );
-			else {
-			    gchar *tmp = g_ucs4_to_utf8( (const gunichar *) GStringGetResource( _STR_New, NULL ),
-				   -1, NULL, NULL, NULL );
-			    buf = smprintf( "<%s>", tmp );
-			    g_free( tmp ); tmp = NULL;
-			}
 			GDrawDrawText8( pixmap, gme->col_data[0].x - gme->off_left,y,
 				(char *) buf, -1, gmatrixedit_activecol );
 			free( buf ) ; buf = NULL ;

--- a/gdraw/gprogress.c
+++ b/gdraw/gprogress.c
@@ -325,15 +325,6 @@ return;
     GProgressTimeCheck();
 }
 
-void GProgressStartIndicatorR( int delay, int win_titler, int line1r, int line2r,
-    int tot, int stages ) {
-    GProgressStartIndicator(delay,
-	GStringGetResource(win_titler,NULL),
-	GStringGetResource(line1r,NULL),
-	line2r==0?NULL:GStringGetResource(line2r,NULL),
-	tot,stages);
-}
-
 void GProgressEndIndicator(void) {
     GProgress *old=current;
 
@@ -370,10 +361,6 @@ return;
 	GDrawRequestExpose(current->gw,NULL,false);
 }
 
-void GProgressChangeLine1R(int line1r) {
-    GProgressChangeLine1(GStringGetResource(line1r,NULL));
-}
-
 void GProgressChangeLine2(const unichar_t *line2) {
     if ( current==NULL )
 return;
@@ -385,10 +372,6 @@ return;
     }
     if ( current->visible )
 	GDrawRequestExpose(current->gw,NULL,false);
-}
-
-void GProgressChangeLine2R(int line2r) {
-    GProgressChangeLine2(GStringGetResource(line2r,NULL));
 }
 
 void GProgressChangeTotal(int tot) {

--- a/gdraw/gradio.c
+++ b/gdraw/gradio.c
@@ -755,12 +755,8 @@ static GCheckBox *_GCheckBoxCreate(GCheckBox *gl, struct gwindow *base, GGadgetD
 	gl->image_precedes = gd->label->image_precedes;
 	if ( gd->label->font!=NULL )
 	    gl->font = gd->label->font;
-	if ( gd->label->text_in_resource && gd->label->text_is_1byte )
+	if ( gd->label->text_is_1byte )
 	    gl->label = utf82u_mncopy((char *) gd->label->text,&gl->g.mnemonic);
-	else if ( gd->label->text_in_resource )
-	    gl->label = u_copy((unichar_t *) GStringGetResource((intpt) gd->label->text,&gl->g.mnemonic));
-	else if ( gd->label->text_is_1byte )
-	    gl->label = /*def2u*/ utf82u_copy((char *) gd->label->text);
 	else
 	    gl->label = u_copy(gd->label->text);
 	gl->image = gd->label->image;

--- a/gdraw/gsavefiledlg.c
+++ b/gdraw/gsavefiledlg.c
@@ -53,32 +53,18 @@ static void GFD_exists(GIOControl *gio) {
     /* The filename the user chose exists, ask user if s/he wants to overwrite */
     struct gfc_data *d = gio->userdata;
 
-    if ( !_ggadget_use_gettext ) {
-	const unichar_t *rcb[3]; unichar_t rcmn[2];
-    unichar_t buffer[200];
-	rcb[2]=NULL;
-	rcb[0] = GStringGetResource( _STR_Replace, &rcmn[0]);
-	rcb[1] = GStringGetResource( _STR_Cancel, &rcmn[1]);
+    const char *rcb[3];
+    char *temp;
+    rcb[2]=NULL;
+    rcb[0] = _("Replace");
+    rcb[1] = _("Cancel");
 
-	u_strcpy(buffer, GStringGetResource(_STR_Fileexistspre,NULL));
-	u_strcat(buffer, u_GFileNameTail(d->ret));
-	u_strcat(buffer, GStringGetResource(_STR_Fileexistspost,NULL));
-	if ( GWidgetAsk(GStringGetResource(_STR_Fileexists,NULL),rcb,rcmn,0,1,buffer)==0 ) {
-	    d->done = true;
-	}
-    } else {
-	const char *rcb[3];
-	char *temp;
-	rcb[2]=NULL;
-	rcb[0] = _("Replace");
-	rcb[1] = _("Cancel");
-
-	if ( GWidgetAsk8(_("File Exists"),rcb,0,1,_("File, %s, exists. Replace it?"),
-		temp = u2utf8_copy(u_GFileNameTail(d->ret)))==0 ) {
-	    d->done = true;
-	}
-	free(temp);
+    if ( GWidgetAsk8(_("File Exists"),rcb,0,1,_("File, %s, exists. Replace it?"),
+	temp = u2utf8_copy(u_GFileNameTail(d->ret)))==0 ) {
+	d->done = true;
     }
+    free(temp);
+
     GFileChooserReplaceIO(d->gfc,NULL);
 }
 
@@ -117,30 +103,12 @@ static void GFD_dircreatefailed(GIOControl *gio) {
     /* We couldn't create the directory */
     struct gfc_data *d = gio->userdata;
 
-    if ( !_ggadget_use_gettext ) {
-	unichar_t buffer[500];
-	unichar_t title[30];
-
-	u_strcpy(title, GStringGetResource(_STR_Couldntcreatedir,NULL));
-	u_strcpy(buffer, title);
-	uc_strcat(buffer,": ");
-	u_strcat(buffer, u_GFileNameTail(gio->path));
-	uc_strcat(buffer, ".\n");
-	if ( gio->error!=NULL ) {
-	    u_strcat(buffer,gio->error);
-	    uc_strcat(buffer, "\n");
-	}
-	if ( gio->status[0]!='\0' )
-	    u_strcat(buffer,gio->status);
-	GWidgetError(title,buffer);
-    } else {
-	char *t1=NULL, *t2=NULL;
-	GWidgetError8(_("Couldn't create directory"),
-		_("Couldn't create directory: %1$s\n%2$s\n%3$s"),
-		gio->error!=NULL ? t1 = u2utf8_copy(gio->error) : "",
-		t2 = u2utf8_copy(gio->status));
-	free(t1); free(t2);
-    }
+    char *t1=NULL, *t2=NULL;
+    GWidgetError8(_("Couldn't create directory"),
+	_("Couldn't create directory: %1$s\n%2$s\n%3$s"),
+	gio->error!=NULL ? t1 = u2utf8_copy(gio->error) : "",
+	t2 = u2utf8_copy(gio->status));
+    free(t1); free(t2);
 
     GFileChooserReplaceIO(d->gfc,NULL);
 }
@@ -149,13 +117,10 @@ static int GFD_NewDir(GGadget *g, GEvent *e) {
     if ( e->type==et_controlevent && e->u.control.subtype == et_buttonactivate ) {
 	struct gfc_data *d = GDrawGetUserData(GGadgetGetWindow(g));
 	unichar_t *newdir;
-	if ( _ggadget_use_gettext ) {
-	    char *temp;
-	    temp = GWidgetAskString8(_("Create directory..."),NULL,_("Directory name?"));
-	    newdir = utf82u_copy(temp);
-	    free(temp);
-	} else
-	    newdir = GWidgetAskStringR(_STR_Createdir,NULL,_STR_Dirname);
+	char *temp;
+	temp = GWidgetAskString8(_("Create directory..."),NULL,_("Directory name?"));
+	newdir = utf82u_copy(temp);
+	free(temp);
 	if ( newdir==NULL )
 return( true );
 	if ( !u_GFileIsAbsolute(newdir)) {
@@ -191,7 +156,7 @@ return( GGadgetDispatchEvent((GGadget *) (d->gfc),event));
 return( true );
 }
 
-unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *defaultfile,
+static unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *defaultfile,
 				       const unichar_t *initial_filter, unichar_t **mimetypes,
 				       GFileChooserFilterType filter,
 				       GFileChooserInputFilenameFuncType filenamefunc,
@@ -239,11 +204,8 @@ unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *
     gcd[1].gd.pos.x = 12; gcd[1].gd.pos.y = 222-3;
     gcd[1].gd.pos.width = -1;
     gcd[1].gd.flags = gg_visible | gg_enabled | gg_but_default;
-    if ( _ggadget_use_gettext ) {
-	label[1].text = (unichar_t *) _("_Save");
-	label[1].text_is_1byte = true;
-    } else
-	label[1].text = (unichar_t *) _STR_Save;
+    label[1].text = (unichar_t *) _("_Save");
+    label[1].text_is_1byte = true;
     label[1].text_in_resource = true;
     gcd[1].gd.mnemonic = 'S';
     gcd[1].gd.label = &label[1];
@@ -254,11 +216,8 @@ unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *
     gcd[2].gd.pos.x = (totwid-bs)*100/GIntGetResource(_NUM_ScaleFactor)/2; gcd[2].gd.pos.y = 222;
     gcd[2].gd.pos.width = -1;
     gcd[2].gd.flags = gg_visible | gg_enabled;
-    if ( _ggadget_use_gettext ) {
-	label[2].text = (unichar_t *) _("_Filter");
-	label[2].text_is_1byte = true;
-    } else
-	label[2].text = (unichar_t *) _STR_Filter;
+    label[2].text = (unichar_t *) _("_Filter");
+    label[2].text_is_1byte = true;
     label[2].text_in_resource = true;
     gcd[2].gd.mnemonic = 'F';
     gcd[2].gd.label = &label[2];
@@ -269,11 +228,8 @@ unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *
     gcd[3].gd.pos.x = gcd[2].gd.pos.x; gcd[3].gd.pos.y = 192;
     gcd[3].gd.pos.width = -1;
     gcd[3].gd.flags = gg_visible | gg_enabled;
-    if ( _ggadget_use_gettext ) {
-	label[3].text = (unichar_t *) S_("Directory|_New");
-	label[3].text_is_1byte = true;
-    } else
-	label[3].text = (unichar_t *) _STR_New;
+    label[3].text = (unichar_t *) S_("Directory|_New");
+    label[3].text_is_1byte = true;
     label[3].text_in_resource = true;
     label[3].image = &_GIcon_dir;
     label[3].image_precedes = false;
@@ -286,11 +242,8 @@ unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *
     gcd[4].gd.pos.x = -gcd[1].gd.pos.x; gcd[4].gd.pos.y = 222;
     gcd[4].gd.pos.width = -1;
     gcd[4].gd.flags = gg_visible | gg_enabled | gg_but_cancel;
-    if ( _ggadget_use_gettext ) {
-	label[4].text = (unichar_t *) _("_Cancel");
-	label[4].text_is_1byte = true;
-    } else
-	label[4].text = (unichar_t *) _STR_Cancel;
+    label[4].text = (unichar_t *) _("_Cancel");
+    label[4].text_is_1byte = true;
     label[4].text_in_resource = true;
     gcd[4].gd.label = &label[4];
     gcd[4].gd.mnemonic = 'C';
@@ -340,13 +293,6 @@ unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *
     GDrawDestroyWindow(gw);
     GProgressResumeTimer();
 return(d.ret);
-}
-
-unichar_t *GWidgetSaveAsFile(const unichar_t *title, const unichar_t *defaultfile,
-	const unichar_t *initial_filter, unichar_t **mimetypes,
-	GFileChooserFilterType filter) {
-return( GWidgetSaveAsFileWithGadget(title,defaultfile,initial_filter,mimetypes,
-				    filter, NULL, NULL ));
 }
 
 char *GWidgetSaveAsFileWithGadget8(const char *title, const char *defaultfile,

--- a/gdraw/gtabset.c
+++ b/gdraw/gtabset.c
@@ -885,9 +885,7 @@ GGadget *GTabSetCreate(struct gwindow *base, GGadgetData *gd,void *data) {
     gts->tabcnt = i;
     gts->tabs = calloc(i, sizeof(struct tabs));
     for ( i=0; gd->u.tabs[i].text!=NULL; ++i ) {
-	if ( gd->u.tabs[i].text_in_resource )
-	    gts->tabs[i].name = u_copy(GStringGetResource((intpt) (gd->u.tabs[i].text),NULL));
-	else if ( gd->u.tabs[i].text_is_1byte )
+	if ( gd->u.tabs[i].text_is_1byte )
 	    gts->tabs[i].name = utf82u_copy((char *) (gd->u.tabs[i].text));
 	else
 	    gts->tabs[i].name = u_copy(gd->u.tabs[i].text);

--- a/gdraw/gtextfield.c
+++ b/gdraw/gtextfield.c
@@ -900,14 +900,9 @@ static void GTextFieldImport(GTextField *gt) {
     char *cret;
     unichar_t *str;
 
-    if ( _ggadget_use_gettext ) {
-	char *temp = GWidgetOpenFile8(_("Open"),NULL,"*.{txt,py}",NULL,NULL);
-	ret = utf82u_copy(temp);
-	free(temp);
-    } else {
-	ret = GWidgetOpenFile(GStringGetResource(_STR_Open,NULL),NULL,
-		txt,NULL,NULL);
-    }
+    char *temp = GWidgetOpenFile8(_("Open"),NULL,"*.{txt,py}",NULL,NULL);
+    ret = utf82u_copy(temp);
+    free(temp);
 
     if ( ret==NULL )
 return;
@@ -915,10 +910,7 @@ return;
     free(ret);
     str = _GGadgetFileToUString(cret,65536);
     if ( str==NULL ) {
-	if ( _ggadget_use_gettext )
-	    GWidgetError8(_("Could not open file"), _("Could not open %.100s"),cret);
-	else
-	    GWidgetError(errort,error,cret);
+	GWidgetError8(_("Could not open file"), _("Could not open %.100s"),cret);
 	free(cret);
 return;
     }
@@ -933,13 +925,9 @@ static void GTextFieldSave(GTextField *gt,int utf8) {
     FILE *file;
     unichar_t *pt;
 
-    if ( _ggadget_use_gettext ) {
-	char *temp = GWidgetOpenFile8(_("Save"),NULL,"*.{txt,py}",NULL,NULL);
-	ret = utf82u_copy(temp);
-	free(temp);
-    } else
-	ret = GWidgetSaveAsFile(GStringGetResource(_STR_Save,NULL),NULL,
-		txt,NULL,NULL);
+    char *temp = GWidgetOpenFile8(_("Save"),NULL,"*.{txt,py}",NULL,NULL);
+    ret = utf82u_copy(temp);
+    free(temp);
 
     if ( ret==NULL )
 return;
@@ -947,10 +935,7 @@ return;
     free(ret);
     file = fopen(cret,"w");
     if ( file==NULL ) {
-	if ( _ggadget_use_gettext )
-	    GWidgetError8(_("Could not open file"), _("Could not open %.100s"),cret);
-	else
-	    GWidgetError(errort,error,cret);
+	GWidgetError8(_("Could not open file"), _("Could not open %.100s"),cret);
 	free(cret);
 return;
     }
@@ -2725,8 +2710,6 @@ static GTextField *_GTextFieldCreate(GTextField *gt, struct gwindow *base, GGadg
     if ( gd->label!=NULL ) {
 	if ( gd->label->text_is_1byte )
 	    gt->text = /* def2u_*/ utf82u_copy((char *) gd->label->text);
-	else if ( gd->label->text_in_resource )
-	    gt->text = u_copy((unichar_t *) GStringGetResource((intpt) gd->label->text,&gt->g.mnemonic));
 	else
 	    gt->text = u_copy(gd->label->text);
 	gt->sel_start = gt->sel_end = gt->sel_base = u_strlen(gt->text);

--- a/inc/ggadget.h
+++ b/inc/ggadget.h
@@ -317,26 +317,6 @@ typedef int (*GFileChooserInputFilenameFuncType)( GGadget *g,
 						  const unichar_t ** currentFilename,
 						  unichar_t* oldfilename );
 
-    /* Obsolete */
-#define _STR_NULL	(-1)		/* Null string resource */
-#define _STR_Language	0
-#define _STR_OK		1
-#define _STR_Cancel	2
-#define _STR_Open	3
-#define _STR_Save	4
-#define _STR_Filter	5
-#define _STR_New	6
-#define _STR_Replace	7
-#define _STR_Fileexists	8
-#define _STR_Fileexistspre	9
-#define _STR_Fileexistspost	10
-#define _STR_Createdir	11
-#define _STR_Dirname	12
-#define _STR_Couldntcreatedir	13
-#define _STR_SelectAll	14
-#define _STR_None	15
-#define __STR_LastStd	15
-
 #define _NUM_Buttonsize		0
 #define _NUM_ScaleFactor	1
 #define __NUM_LastStd		1
@@ -345,17 +325,8 @@ extern void GTextInfoFree(GTextInfo *ti);
 extern void GTextInfoListFree(GTextInfo *ti);
 extern void GTextInfoArrayFree(GTextInfo **ti);
 extern GTextInfo **GTextInfoFromChars(char **array, int len);
-extern const unichar_t *GStringGetResource(int index,unichar_t *mnemonic);
 extern int GGadgetScale(int xpos);
 extern int GIntGetResource(int index);
-extern int GStringSetResourceFileV(char *filename,uint32 checksum);
-extern int GStringSetResourceFile(char *filename);	/* returns 1 for success, 0 for failure */
-/* fallback string arrays are null terminated. mnemonics is same length as string */
-/* fallback integer arrays are terminated by 0x80000000 (negative infinity) */
-extern void GStringSetFallbackArray(const unichar_t **array,const unichar_t *mn,
-	const int *ires);
-unichar_t *GStringFileGetResource(char *filename, int index,unichar_t *mnemonic);
-extern void GResourceUseGetText(void);
 extern void *GResource_font_cvt(char *val, void *def);
 extern FontInstance *GResourceFindFont(char *resourcename,FontInstance *deffont);
 
@@ -542,7 +513,6 @@ extern void GGadgetPreparePopupImage(GWindow base,const unichar_t *msg,
 	GImage *(*get_image)(const void *data),
 	void (*free_image)(const void *data,GImage *img));
 extern void GGadgetPreparePopup(GWindow base,const unichar_t *msg);
-extern void GGadgetPreparePopupR(GWindow base,int msg);
 extern void GGadgetPreparePopup8(GWindow base, const char *msg);
 extern void GGadgetEndPopup(void);
 extern void GGadgetPopupExternalEvent(GEvent *e);

--- a/inc/gprogress.h
+++ b/inc/gprogress.h
@@ -39,13 +39,9 @@ extern void GProgressStartIndicator(
     int tot,			/* Number of sub-entities in the operation */
     int stages			/* Number of stages, each processing tot sub-entities */
 );
-extern void GProgressStartIndicatorR(int delay, int win_titler, int line1r,
-	int line2r, int tot, int stages);
 extern void GProgressEndIndicator(void);	/* Ends the topmost indicator */
 extern void GProgressChangeLine1(const unichar_t *line1); /* Changes the text in the topmost */
 extern void GProgressChangeLine2(const unichar_t *line2); /* Changes the text in the topmost */
-extern void GProgressChangeLine1R(int line1r);		/* Changes the text in the topmost */
-extern void GProgressChangeLine2R(int line2r);		/* Changes the text in the topmost */
 extern void GProgressChangeTotal(int tot);		/* Changes the expected length in the topmost */
 extern void GProgressChangeStages(int stages);		/* Changes the expected number of stages in the topmost */
 extern void GProgressEnableStop(int enabled);		/* Allows you to disable and enable the stop button if it can't be used in a section of code */

--- a/inc/gwidget.h
+++ b/inc/gwidget.h
@@ -83,15 +83,6 @@ extern void GWidgetFlowGadgets(GWindow gw);
 extern void GWidgetToDesiredSize(GWindow gw);
 
 	/* Built in dialogs */
-unichar_t *GWidgetOpenFile(const unichar_t *title, const unichar_t *defaultfile,
-	const unichar_t *initial_filter, unichar_t **mimetypes,GFileChooserFilterType filter);
-unichar_t *GWidgetSaveAsFile(const unichar_t *title, const unichar_t *defaultfile,
-	const unichar_t *initial_filter, unichar_t **mimetypes,GFileChooserFilterType filter );
-unichar_t *GWidgetSaveAsFileWithGadget(const unichar_t *title, const unichar_t *defaultfile,
-				       const unichar_t *initial_filter, unichar_t **mimetypes,
-				       GFileChooserFilterType filter,
-				       GFileChooserInputFilenameFuncType filenamefunc,
-				       GGadgetCreateData *optional_gcd);
 char *GWidgetOpenFile8(const char *title, const char *defaultfile,
 	const char *initial_filter, char **mimetypes,GFileChooserFilterType filter);
 char *GWidgetOpenFileWPath8(const char *title, const char *defaultfile,
@@ -103,10 +94,6 @@ char *GWidgetSaveAsFileWithGadget8(const char *title, const char *defaultfile,
 				   GGadgetCreateData *optional_gcd);
 char *GWidgetSaveAsFile8(const char *title, const char *defaultfile,
 	const char *initial_filter, char **mimetypes,GFileChooserFilterType filter );
-int GWidgetAsk(const unichar_t *title, const unichar_t **answers, const unichar_t *mn,
-	int def, int cancel,const unichar_t *question,...);
-void GWidgetError(const unichar_t *title,const unichar_t *statement,...);
-unichar_t *GWidgetAskStringR(int title, const unichar_t *def,int question,...);
 int GWidgetAsk8(const char *title, const char **answers,
 	int def, int cancel,const char *question,...);
 int GWidgetAskCentered8(const char *title,

--- a/inc/intl.h
+++ b/inc/intl.h
@@ -70,7 +70,6 @@
 /* For messages in the shortcuts domain */
 #define H_(str)		(str)
 
-extern void GResourceUseGetText(void);
 char *sgettext(const char *msgid);
 
 #endif /* FONTFORGE_INTL_H */


### PR DESCRIPTION
This removes old (and extremely obsolete) functionality to get string resources outside of gettext

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
