### PR TITLE
Fix for #4815 genericGlyphChange vMap segfault

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -17280,7 +17280,7 @@ static bool PyFFParse_genericGlyphChange(PyObject *args, PyObject *keywds,
 	    &rsbScale, &rsbAdd,
 /* Vertical counter info */
 	    &vCounterType,
-	    &vCounterScale, vCounterAdd,
+	    &vCounterScale, &vCounterAdd,
 	    &vScale,
 	    &vMap
 	    ) )


### PR DESCRIPTION
Self-evident.

Closes #4815 