### PR TITLE
Default to unassigned glyph class for binary fonts

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -5615,6 +5615,11 @@ return( 0 );
     if ( info->os2_start!=0 )
 	readttfos2metrics(ttf,info);
     readttfpostnames(ttf,info);		/* If no postscript table we'll guess at names */
+
+    for ( i=0; i<info->glyph_cnt; ++i )
+	if ( info->chars[i]!=NULL)
+	    info->chars[i]->glyph_class = 1;
+
     if ( info->gdef_start!=0 )		/* ligature caret positioning info */
 	readttfgdef(ttf,info);
     else {


### PR DESCRIPTION
When reading binary files, don’t default to automatic glyph class as it would change font behaviour if the guessed glyph class at export time is semantically different from unassigned.

### Type of change
- **Bug fix**
