### PR TITLE
Don’t handle reference offsets differently on macOS

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -2147,13 +2147,8 @@ return;
 	    cur->transform[3] = get2dot14(ttf);
 	}
 	if ( flags & _ARGS_ARE_XY ) {	/* Only muck with these guys if they are real offsets and not point matching */
-#ifdef __Mac
-	/* On mac assume scaled offsets unless told unscaled explicitly */
-	if ( !(flags&_UNSCALED_OFFSETS) &&
-#else
 	/* everywhere else assume unscaled offsets unless told scaled explicitly */
 	if ( (flags & _SCALED_OFFSETS) &&
-#endif
 		(flags & _ARGS_ARE_XY) && (flags&(_SCALE|_XY_SCALE|_MATRIX))) {
 	    /*static int asked = 0;*/
 	    /* This is not what Apple documents on their website. But it is */


### PR DESCRIPTION
This might have made sense 20 years ago but 1) platforms have long converged on this 2) handling a font differently based on what platform FontForge is running on is very very bad.

### Type of change
- **Bug fix**
