### PR TITLE
Don’t write empty device tables to SFD files

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -807,6 +807,9 @@ return;
 static void SFDDumpValDevTab(FILE *sfd,ValDevTab *adjust) {
     if ( adjust==NULL )
 return;
+    if ( !( adjust->xadjust.corrections || adjust->yadjust.corrections || adjust->xadv.corrections || adjust->yadv.corrections ) )
+return;
+
     fprintf( sfd, " [ddx=" ); SFDDumpDeviceTable(sfd,&adjust->xadjust);
     fprintf( sfd, " ddy=" ); SFDDumpDeviceTable(sfd,&adjust->yadjust);
     fprintf( sfd, " ddh=" ); SFDDumpDeviceTable(sfd,&adjust->xadv);


### PR DESCRIPTION
Depending on how the font was opened they might be written or not, and either way it is just 0’s noise.

### Type of change
- **Non-breaking change**
