### PR TITLE
Better font-level ascent and descent metrics

### DIFF
--- a/gdraw/ggdkcdraw.c
+++ b/gdraw/ggdkcdraw.c
@@ -1285,24 +1285,18 @@ void GGDKDrawClipPreserve(GWindow w) {
 // PANGO LAYOUT
 
 void GGDKDrawGetFontMetrics(GWindow gw, GFont *fi, int *as, int *ds, int *ld) {
-    //Log(LOGDEBUG, " ");
+    struct tf_arg arg = {0};
 
-    GGDKDisplay *gdisp = ((GGDKWindow) gw)->display;
-    PangoFont *pfont;
-    PangoFontMetrics *fm;
-    PangoFontMap *pfm;
-
-    _GGDKDraw_configfont(gw, fi);
-    pfm = pango_context_get_font_map(gdisp->pangoc_context);
-    pfont = pango_font_map_load_font(pfm, gdisp->pangoc_context, fi->pangoc_fd);
-    fm = pango_font_get_metrics(pfont, NULL);
-    *as = pango_font_metrics_get_ascent(fm) / PANGO_SCALE;
-    *ds = pango_font_metrics_get_descent(fm) / PANGO_SCALE;
+    arg.first = true;
+    gw->ggc->fi = fi;
+    GGDKDrawDoText8(gw, 0, 0, "AMOfgjyql47", 11, 0x0, tf_rect, &arg);
+    *as = arg.size.fas;
+    if ( *as<arg.size.as )
+        *as = arg.size.as;
+    *ds = arg.size.fds;
+    if ( *ds<arg.size.ds )
+        *ds = arg.size.ds;
     *ld = 0;
-    pango_font_metrics_unref(fm);
-    if (pfont != NULL) {
-        g_object_unref(pfont);
-    }
 }
 
 void GGDKDrawLayoutInit(GWindow w, char *text, int cnt, GFont *fi) {

--- a/gdraw/gxcdraw.c
+++ b/gdraw/gxcdraw.c
@@ -1085,27 +1085,18 @@ return( rect.width );
 }
 
 void _GXPDraw_FontMetrics(GWindow gw, GFont *fi, int *as, int *ds, int *ld) {
-    GXDisplay *gdisp = ((GXWindow) gw)->display;
-    PangoFont *pfont;
-    PangoFontMetrics *fm;
+    struct tf_arg arg = {0};
 
-    _GXPDraw_configfont(gw, fi);
-# if !defined(_NO_LIBCAIRO)
-    if ( gw->usecairo )
-	pfont = pango_font_map_load_font(gdisp->pangoc_fontmap,gdisp->pangoc_context,
-		fi->pangoc_fd);
-    else
-#endif
-	pfont = pango_font_map_load_font(gdisp->pango_fontmap,gdisp->pango_context,
-		fi->pango_fd);
-    fm = pango_font_get_metrics(pfont,NULL);
-    *as = pango_font_metrics_get_ascent(fm)/PANGO_SCALE;
-    *ds = pango_font_metrics_get_descent(fm)/PANGO_SCALE;
+    arg.first = true;
+    gw->ggc->fi = fi;
+    _GXPDraw_DoText8(gw, 0, 0, "AMOfgjyql47", 11, 0x0, tf_rect, &arg);
+    *as = arg.size.fas;
+    if ( *as<arg.size.as )
+	*as = arg.size.as;
+    *ds = arg.size.fds;
+    if ( *ds<arg.size.ds )
+	*ds = arg.size.ds;
     *ld = 0;
-    pango_font_metrics_unref(fm);
-    // pango_font_unref(pfont);
-    // This function has disappeared from Pango with no explanation.
-    // But we still leak memory here.
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
In the investigation of #4704 we discovered that the ascent and decent values set by `GDrawGetFontMetrics()` are routinely less than those for Latin alphanumeric strings. The Pango docs point out that there is no necessary relation between the font metrics and the "ink"-derived pixel sizes but there's code everywhere in FontForge that assumes the values returned by `GDrawGetFontMetrics()` are the "normal" case for pixel sizes.

This PR replaces the Pango statements with a call to DoText8 for the string "AMOfgjyql47" (which is easily changed or added to). Then the maximum of the fas,as (or fds,ds) from tf_arg.size is returned for as (ds). 