### PR TITLE
replace CMAKE_{SOURCE/BINARY}_DIR with CMAKE_CURRENT_*_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,19 +2,19 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-# No in source builds
-if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
-  message(FATAL_ERROR "In-source builds are disallowed. Create a build folder to run CMake from.")
-endif()
-
 # Update the version for each new release
 project(fontforge VERSION 20201107 LANGUAGES C CXX)
 
+# No in source builds
+if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+  message(FATAL_ERROR "In-source builds are disallowed. Create a build folder to run CMake from.")
+endif()
+
 # Add folder for custom cmake modules
-list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_SOURCE_DIR}/cmake/packages)
+list(INSERT CMAKE_MODULE_PATH 0 ${PROJECT_SOURCE_DIR}/cmake ${PROJECT_SOURCE_DIR}/cmake/packages)
 if(${CMAKE_VERSION} VERSION_LESS "3.15.7")
   # This could be more targeted, but keep it simple
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/backports/3.15.7)
+  list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/backports/3.15.7)
 endif()
 
 # Include any required modules
@@ -33,9 +33,9 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_THREAD_PREFER_PTHREAD 1)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
 set_default_build_type(RelWithDebInfo) # Sets CMAKE_BUILD_TYPE
 set_default_rpath()

--- a/cmake/CPackSetup.cmake
+++ b/cmake/CPackSetup.cmake
@@ -50,10 +50,10 @@ function(setup_cpack)
   # CPACK_SOURCE_INSTALLED_DIRECTORIES won't work because the files we want to include
   # can be in an ignored directory (build/). So use a script instead
   set(CPACK_INSTALL_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/CPackExtraDist.cmake")
-  configure_file("${CMAKE_SOURCE_DIR}/cmake/scripts/ExtraDist.cmake.in" "CPackExtraDist.cmake" @ONLY)
+  configure_file("${PROJECT_SOURCE_DIR}/cmake/scripts/ExtraDist.cmake.in" "CPackExtraDist.cmake" @ONLY)
   include(CPack)
   add_custom_target(dist
-    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target package_source
+    COMMAND "${CMAKE_COMMAND}" --build "${PROJECT_BINARY_DIR}" --target package_source
     DEPENDS test_dependencies
     VERBATIM
     USES_TERMINAL

--- a/cmake/TargetUtils.cmake
+++ b/cmake/TargetUtils.cmake
@@ -119,12 +119,12 @@ endfunction()
 function(add_uninstall_target)
   if(NOT TARGET uninstall)
     configure_file(
-        "${CMAKE_SOURCE_DIR}/cmake/scripts/Uninstall.cmake.in"
-        "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake"
+        "${PROJECT_SOURCE_DIR}/cmake/scripts/Uninstall.cmake.in"
+        "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake"
         IMMEDIATE @ONLY
     )
     add_custom_target(uninstall
-        COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_BINARY_DIR}/cmake_uninstall.cmake"
+        COMMAND "${CMAKE_COMMAND}" -P "${PROJECT_BINARY_DIR}/cmake_uninstall.cmake"
         VERBATIM USES_TERMINAL
     )
   endif()

--- a/cmake/packages/FindSphinx.cmake
+++ b/cmake/packages/FindSphinx.cmake
@@ -33,8 +33,8 @@ function(_find_sphinx)
   find_program(Sphinx_BUILD_BINARY NAMES sphinx-build
     HINTS
       $ENV{SPHINX_DIR}
-      ${CMAKE_BINARY_DIR}/sphinx-venv/Scripts
-      ${CMAKE_BINARY_DIR}/sphinx-venv/bin
+      ${PROJECT_BINARY_DIR}/sphinx-venv/Scripts
+      ${PROJECT_BINARY_DIR}/sphinx-venv/bin
     PATH_SUFFIXES bin
     DOC "Sphinx documentation generator"
   )
@@ -46,13 +46,13 @@ function(_sphinx_from_venv)
     message(STATUS "Python3 not found, skipping")
     return()
   endif()
-  execute_process(COMMAND "${Python3_EXECUTABLE}" -m venv "${CMAKE_BINARY_DIR}/sphinx-venv")
+  execute_process(COMMAND "${Python3_EXECUTABLE}" -m venv "${PROJECT_BINARY_DIR}/sphinx-venv")
 
   find_program(_venv_bin NAMES python
     NO_DEFAULT_PATH
     HINTS
-      "${CMAKE_BINARY_DIR}/sphinx-venv/Scripts"
-      "${CMAKE_BINARY_DIR}/sphinx-venv/bin"
+      "${PROJECT_BINARY_DIR}/sphinx-venv/Scripts"
+      "${PROJECT_BINARY_DIR}/sphinx-venv/bin"
   )
   if(NOT _venv_bin)
     message(WARNING "could not make venv")
@@ -71,7 +71,7 @@ endfunction()
 
 _find_sphinx()
 
-if(NOT Sphinx_BUILD_BINARY AND SPHINX_USE_VENV AND NOT EXISTS "${CMAKE_BINARY_DIR}/sphinx-venv")
+if(NOT Sphinx_BUILD_BINARY AND SPHINX_USE_VENV AND NOT EXISTS "${PROJECT_BINARY_DIR}/sphinx-venv")
   message(STATUS "sphinx-build not found, attempting to install it into a venv...")
   _sphinx_from_venv()
 endif()

--- a/cmake/scripts/ExtraDist.cmake.in
+++ b/cmake/scripts/ExtraDist.cmake.in
@@ -11,6 +11,6 @@ Currently used to:
 #]=======================================================================]
 
 if(CPACK_SOURCE_INSTALLED_DIRECTORIES)
-  message(STATUS "Adding retrieved/generated fonts from @CMAKE_BINARY_DIR@/tests/fonts to ${CMAKE_CURRENT_BINARY_DIR}/tests/fonts...")
-  file(INSTALL "@CMAKE_BINARY_DIR@/tests/fonts" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/tests")
+  message(STATUS "Adding retrieved/generated fonts from @PROJECT_BINARY_DIR@/tests/fonts to ${CMAKE_CURRENT_BINARY_DIR}/tests/fonts...")
+  file(INSTALL "@PROJECT_BINARY_DIR@/tests/fonts" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/tests")
 endif()

--- a/cmake/scripts/Uninstall.cmake.in
+++ b/cmake/scripts/Uninstall.cmake.in
@@ -7,11 +7,11 @@ https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-wit
 
 #]=======================================================================]
 
-if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
-  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
-endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+if(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @PROJECT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
 
-file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+file(READ "@PROJECT_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -9,9 +9,9 @@ if(UNIX)
   endforeach()
   install(FILES "${THEME}/scalable/org.fontforge.FontForge.svg" DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
 
-  file(STRINGS "${CMAKE_SOURCE_DIR}/po/LINGUAS" _langs)
+  file(STRINGS "${PROJECT_SOURCE_DIR}/po/LINGUAS" _langs)
   foreach(_lang ${_langs})
-    list(APPEND _pofiles "${CMAKE_SOURCE_DIR}/po/${_lang}.po")
+    list(APPEND _pofiles "${PROJECT_SOURCE_DIR}/po/${_lang}.po")
   endforeach()
 
   macro(msgfmt_desktop_file _mode _file _installdir)
@@ -20,7 +20,7 @@ if(UNIX)
     add_custom_command(OUTPUT "${_output}"
       COMMAND "${GETTEXT_MSGFMT_EXECUTABLE}"
         --${_mode} --template "${_input}"
-        -d "${CMAKE_SOURCE_DIR}/po"
+        -d "${PROJECT_SOURCE_DIR}/po"
         -o "${_output}"
       DEPENDS "${_input}" ${_pofiles}
       VERBATIM

--- a/osx/CMakeLists.txt
+++ b/osx/CMakeLists.txt
@@ -18,8 +18,8 @@ add_custom_target(macbundle
   COMMAND "${CMAKE_COMMAND}" -E remove -f "FontForge.app/Contents/Info.plist.in" "FontForge.app/Contents/Resources/English.lproj/Info.plist.in"
   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_BINARY_DIR}/Info.plist" "FontForge.app/Contents/Info.plist"
   COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_BINARY_DIR}/InfoPlist.string" "FontForge.app/Contents/Resources/English.lproj/InfoPlist.string"
-  COMMAND "${CMAKE_COMMAND}" "-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/FontForge.app/Contents/Resources/opt/local" -P "${CMAKE_BINARY_DIR}/cmake_install.cmake"
-  COMMAND "${CMAKE_SOURCE_DIR}/.github/workflows/scripts/ffosxbuild.sh" "${CMAKE_CURRENT_BINARY_DIR}/FontForge.app" "${FONTFORGE_GIT_VERSION}"
+  COMMAND "${CMAKE_COMMAND}" "-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/FontForge.app/Contents/Resources/opt/local" -P "${PROJECT_BINARY_DIR}/cmake_install.cmake"
+  COMMAND "${PROJECT_SOURCE_DIR}/.github/workflows/scripts/ffosxbuild.sh" "${CMAKE_CURRENT_BINARY_DIR}/FontForge.app" "${FONTFORGE_GIT_VERSION}"
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   VERBATIM
   USES_TERMINAL


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

importing your CMake with `add_subdirectory` will not work because `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` will point to the wrong directory.

I am currently trying to get this library built and packaged with conan. While doing so I had to patch the source.
Maybe these patches are interesting for others too.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**
