### PR TITLE
Fix 'Testing equality to None' issues

### DIFF
--- a/pycontrib/svg2glyph/svg2glyph
+++ b/pycontrib/svg2glyph/svg2glyph
@@ -246,12 +246,12 @@ for fname in args:
         queue = deque(re.findall('([mlhvcsqtaz]|-?\d+(?:\.\d+)?(?:e-?\d+)?)', data, re.I))
         indent = 0
         while len(queue) > 0:
-            if cmd == None or re.match('[mlhvcsqtaz]', queue[0], re.I):
+            if cmd is None or re.match('[mlhvcsqtaz]', queue[0], re.I):
                 last_cmd = cmd
                 cmd = queue.popleft()
             if cmd == 'M' or cmd == 'm':
                 pt = getpoint(queue)
-                if pos == None:
+                if pos is None:
                     init_pos = pos = pt
                 elif cmd == 'M':
                     pos = pt


### PR DESCRIPTION
Testing whether an object is 'None' using the `==` operator is inefficient and potentially incorrect.  
ref: https://lgtm.com/projects/g/fontforge/fontforge/?mode=tree&ruleFocus=7900090