### PR TITLE
doc: Add Python font.os2_stylemap

### DIFF
--- a/doc/sphinx/scripting/python/fontforge.rst
+++ b/doc/sphinx/scripting/python/fontforge.rst
@@ -3433,6 +3433,10 @@ This type may not be pickled.
 .. attribute:: font.os2_fstype
 
 
+.. attribute:: font.os2_stylemap
+
+   Write access to fsSelection, keep in sync with :attr:`font.macstyle`
+
 .. attribute:: font.os2_panose
 
 


### PR DESCRIPTION
[why]
The `font.os2_stylemap` is undocumented.

[how]
Add entry for `font.os2_stylemap` and reference `font.macstyle`.

No back reference added, albeit that might be useful,
considering Issue #3174.

See also https://github.com/fontforge/fontforge/issues/3174#issuecomment-335037255

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**

_Edit: Just formatting_