### PR TITLE
Solve `-Wstringop-overflow` compiler complaints

### DIFF
--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -315,7 +315,7 @@ return;
     gi->bcnt = 0;
 }
 
-static int NumberHints(SplineChar *scs[MmMax], int instance_count) {
+static int NumberHints(SplineChar **scs, int instance_count) {
     int i,j, cnt=-1;
     StemInfo *s;
 

--- a/gdraw/gcolor.c
+++ b/gdraw/gcolor.c
@@ -770,6 +770,6 @@ struct hslrgb GWidgetColor(const char *title,struct hslrgb *defcol,struct hslrgb
     def.alpha = 1.0;
     d = &def;
     temp = GWidgetColorA(title,d,u);
-    memcpy(&ret,&temp,sizeof(ret));
+    memcpy(&ret,&temp,sizeof(struct hslrgb));
 return( ret );
 }

--- a/inc/gwidget.h
+++ b/inc/gwidget.h
@@ -115,8 +115,8 @@ int GWidgetChoicesB8(char *title, const char **choices, int cnt, int def,
 int GWidgetChoicesBM8(const char *title, const char **choices, char *sel,
 	int cnt, char *buts[2], const char *question,...);
 
-extern struct hslrgb GWidgetColor(const char *title,struct hslrgb *defcol,struct hslrgb fontcols[6]);
-extern struct hslrgba GWidgetColorA(const char *title,struct hslrgba *defcol,struct hslrgba fontcols[6]);
+extern struct hslrgb GWidgetColor(const char *title,struct hslrgb *defcol,struct hslrgb *fontcols);
+extern struct hslrgba GWidgetColorA(const char *title,struct hslrgba *defcol,struct hslrgba *fontcols);
 
 #define gwwv_choose_multiple	GWidgetChoicesBM8
 #define gwwv_choose_with_buttons	GWidgetChoicesB8


### PR DESCRIPTION
```
[fred@🍇葡萄🍇fontforge]$ (cd build;ninja)
[3/112] Building C object gdraw/CMakeFiles/gdraw.dir/gbuttons.c.o
/home/fred/Workspace/fontforge/gdraw/gbuttons.c: In function ‘GButtonInvoked’:
/home/fred/Workspace/fontforge/gdraw/gbuttons.c:236:15: warning: ‘GWidgetColorA’ accessing 432 bytes in a region of size 72 [-Wstringop-overflow=]
  236 |         hsl = GWidgetColorA(_("Pick a color"),&hsl,NULL);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fred/Workspace/fontforge/gdraw/gbuttons.c:236:15: note: referencing argument 3 of type ‘struct hslrgba *’
In file included from /home/fred/Workspace/fontforge/gdraw/gbuttons.c:34:
/home/fred/Workspace/fontforge/inc/gwidget.h:119:23: note: in a call to function ‘GWidgetColorA’
  119 | extern struct hslrgba GWidgetColorA(const char *title,struct hslrgba *defcol,struct hslrgba fontcols[6]);
      |                       ^~~~~~~~~~~~~
[4/112] Building C object gdraw/CMakeFiles/gdraw.dir/gcolor.c.o
/home/fred/Workspace/fontforge/gdraw/gcolor.c: In function ‘GWidgetColor’:
/home/fred/Workspace/fontforge/gdraw/gcolor.c:772:12: warning: ‘GWidgetColorA’ accessing 432 bytes in a region of size 72 [-Wstringop-overflow=]
  772 |     temp = GWidgetColorA(title,d,u);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~
/home/fred/Workspace/fontforge/gdraw/gcolor.c:772:12: note: referencing argument 3 of type ‘struct hslrgba *’
/home/fred/Workspace/fontforge/gdraw/gcolor.c:536:16: note: in a call to function ‘GWidgetColorA’
  536 | struct hslrgba GWidgetColorA(const char *title,struct hslrgba *defcol,struct hslrgba *usercols) {
      |                ^~~~~~~~~~~~~
[15/112] Building C object fontforge/CMakeFiles/fontforge.dir/splineoverlap.c.o
In file included from /home/fred/Workspace/fontforge/fontforge/edgelist2.h:31,
                 from /home/fred/Workspace/fontforge/fontforge/splineoverlap.h:4,
                 from /home/fred/Workspace/fontforge/fontforge/splineoverlap.c:30:
/home/fred/Workspace/fontforge/fontforge/splinefont.h:468:43: warning: ISO C restricts enumerator values to range of ‘int’ [-Wpedantic]
  468 |         pst_markclass=0xff00, pst_markset=0xffff0000 };
      |                                           ^~~~~~~~~~
[21/112] Building C object fontforge/CMakeFiles/fontforge.dir/splinesave.c.o
/home/fred/Workspace/fontforge/fontforge/splinesave.c: In function ‘RSC2PS2’:
/home/fred/Workspace/fontforge/fontforge/splinesave.c:2939:59: warning: ‘NumberHints’ accessing 128 bytes in a region of size 8 [-Wstringop-overflow=]
 2939 |         if ( allwithouthints && unsafe!=NULL && hdb->cnt!=NumberHints(&unsafe->sc,1))
      |                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fred/Workspace/fontforge/fontforge/splinesave.c:2939:59: note: referencing argument 1 of type ‘SplineChar **’ {aka ‘struct splinechar **’}
/home/fred/Workspace/fontforge/fontforge/splinesave.c:318:12: note: in a call to function ‘NumberHints’
  318 | static int NumberHints(SplineChar *scs[MmMax], int instance_count) {
      |            ^~~~~~~~~~~
[36/112] Building C object fontforgeexe/CMakeFiles/fontforgeexe.dir/charinfo.c.o
/home/fred/Workspace/fontforge/fontforgeexe/charinfo.c: In function ‘CI_PickColor’:
/home/fred/Workspace/fontforge/fontforgeexe/charinfo.c:3878:19: warning: ‘GWidgetColor’ accessing 384 bytes in a region of size 64 [-Wstringop-overflow=]
 3878 |             col = GWidgetColor(_("Pick a color"),&col,SFFontCols(ci->sc->parent,font_cols));
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fred/Workspace/fontforge/fontforgeexe/charinfo.c:3878:19: note: referencing argument 3 of type ‘struct hslrgb *’
In file included from /home/fred/Workspace/fontforge/fontforge/fontforgeui.h:41,
                 from /home/fred/Workspace/fontforge/fontforgeexe/charinfo.c:33:
/home/fred/Workspace/fontforge/inc/gwidget.h:118:22: note: in a call to function ‘GWidgetColor’
  118 | extern struct hslrgb GWidgetColor(const char *title,struct hslrgb *defcol,struct hslrgb fontcols[6]);
      |                      ^~~~~~~~~~~~
[57/112] Building C object fontforgeexe/CMakeFiles/fontforgeexe.dir/cvstroke.c.o
/home/fred/Workspace/fontforge/fontforgeexe/cvstroke.c: In function ‘Layer_DoColorWheel’:
/home/fred/Workspace/fontforge/fontforgeexe/cvstroke.c:2746:19: warning: ‘GWidgetColor’ accessing 384 bytes in a region of size 64 [-Wstringop-overflow=]
 2746 |             col = GWidgetColor(_("Pick a color"),&col,NULL);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fred/Workspace/fontforge/fontforgeexe/cvstroke.c:2746:19: note: referencing argument 3 of type ‘struct hslrgb *’
In file included from /home/fred/Workspace/fontforge/fontforge/fontforgeui.h:41,
                 from /home/fred/Workspace/fontforge/fontforgeexe/cvstroke.c:31:
/home/fred/Workspace/fontforge/inc/gwidget.h:118:22: note: in a call to function ‘GWidgetColor’
  118 | extern struct hslrgb GWidgetColor(const char *title,struct hslrgb *defcol,struct hslrgb fontcols[6]);
      |                      ^~~~~~~~~~~~
[64/112] Building C object fontforgeexe/CMakeFiles/fontforgeexe.dir/groupsdlg.c.o
/home/fred/Workspace/fontforge/fontforgeexe/groupsdlg.c: In function ‘Group_AddColor’:
/home/fred/Workspace/fontforge/fontforgeexe/groupsdlg.c:1013:19: warning: ‘GWidgetColor’ accessing 384 bytes in a region of size 64 [-Wstringop-overflow=]
 1013 |             col = GWidgetColor(_("Pick a color"),&col,SFFontCols(grp->fv->b.sf,font_cols));
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fred/Workspace/fontforge/fontforgeexe/groupsdlg.c:1013:19: note: referencing argument 3 of type ‘struct hslrgb *’
In file included from /home/fred/Workspace/fontforge/fontforge/fontforgeui.h:41,
                 from /home/fred/Workspace/fontforge/fontforgeexe/groupsdlg.c:30:
/home/fred/Workspace/fontforge/inc/gwidget.h:118:22: note: in a call to function ‘GWidgetColor’
  118 | extern struct hslrgb GWidgetColor(const char *title,struct hslrgb *defcol,struct hslrgb fontcols[6]);
      |                      ^~~~~~~~~~~~
[112/112] Linking C executable bin/fontforge
```
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**