### PR TITLE
Compare UTanVec equality by the same standard

### DIFF
--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -69,6 +69,11 @@ static inline int BPNear(BasePoint bp1, BasePoint bp2) {
     return BPWithin(bp1, bp2, INTRASPLINE_MARGIN);
 }
 
+// Not called "BPNear" because this is specific to UTanVecs
+static inline int UTNear(BasePoint bp1, BasePoint bp2) {
+    return BPWithin(bp1, bp2, UTMARGIN);
+}
+
 enum nibtype { nib_ellip, nib_rect, nib_convex };
 
 // c->nibcorners is a structure that models the "corners" of the current nib
@@ -634,7 +639,7 @@ static void BuildNibCorners(NibCorner **ncp, SplineSet *nib, int *maxp,
 	    // Flatten potential LineSameSide permissiveness
 	    nc[i].utv[NC_OUT_IDX] = nc[i].utv[NC_IN_IDX];
 	if (    UTanVecGreater(nc[i].utv[NC_IN_IDX], max_utanangle)
-	     || BPNear(nc[i].utv[NC_IN_IDX], max_utanangle) ) {
+	     || UTNear(nc[i].utv[NC_IN_IDX], max_utanangle) ) {
 	    max_utan_index = i;
 	    max_utanangle = nc[i].utv[NC_IN_IDX];
 	}
@@ -712,15 +717,15 @@ static NibOffset *_CalcNibOffset(NibCorner *nc, int n, BasePoint ut,
     // and therefore the only cases where the array values differ
     if (   nc[nci].linear
 	// "Capsule" case
-        && BPNear(ut, nc[ncni].utv[NC_IN_IDX])
-        && BPNear(ut, nc[nci].utv[NC_IN_IDX]) ) {
+        && UTNear(ut, nc[ncni].utv[NC_IN_IDX])
+        && UTNear(ut, nc[nci].utv[NC_IN_IDX]) ) {
 	no->nt = 0.0;
 	no->off[NIBOFF_CCW_IDX] = nc[nci].on_nib->me;
 	no->off[NIBOFF_CW_IDX] = nc[ncni].on_nib->me;
 	no->nci[NIBOFF_CW_IDX] = ncni;
 	no->at_line = true;
 	no->curve = false;
-    } else if ( nc[ncpi].linear && BPNear(ut, nc[ncpi].utv[NC_OUT_IDX]) ) {
+    } else if ( nc[ncpi].linear && UTNear(ut, nc[ncpi].utv[NC_OUT_IDX]) ) {
 	// Other lines
 	no->nt = 0.0;
 	no->off[NIBOFF_CCW_IDX] = nc[ncpi].on_nib->me;
@@ -732,7 +737,7 @@ static NibOffset *_CalcNibOffset(NibCorner *nc, int n, BasePoint ut,
     // draws the offset curve
     } else if (   UTanVecsSequent(nc[nci].utv[NC_IN_IDX], ut,
                                   nc[nci].utv[NC_OUT_IDX], false)
-               || BPNear(ut, nc[nci].utv[NC_OUT_IDX] ) ) {
+               || UTNear(ut, nc[nci].utv[NC_OUT_IDX] ) ) {
 	no->nt = 0.0;
 	no->off[0] = no->off[1] = nc[nci].on_nib->me;
 	no->curve = false;
@@ -774,11 +779,11 @@ static BasePoint SplineStrokeNextAngle(StrokeContext *c, BasePoint ut,
     ncni = NC_NEXTI(c, nci);
     ncpi = NC_PREVI(c, nci);
 
-    if ( BPNear(ut, c->nibcorners[nci].utv[NC_IN_IDX]) ) {
+    if ( UTNear(ut, c->nibcorners[nci].utv[NC_IN_IDX]) ) {
 	if ( is_ccw ) {
-	    if ( BPNear(c->nibcorners[nci].utv[NC_IN_IDX],
+	    if ( UTNear(c->nibcorners[nci].utv[NC_IN_IDX],
 	                c->nibcorners[ncpi].utv[NC_OUT_IDX]) ) {
-		if ( BPNear(c->nibcorners[nci].utv[NC_IN_IDX],
+		if ( UTNear(c->nibcorners[nci].utv[NC_IN_IDX],
 		            c->nibcorners[ncpi].utv[NC_IN_IDX]) ) {
 		    assert(c->nibcorners[ncpi].linear);
 		    *curved = true;
@@ -796,9 +801,9 @@ static BasePoint SplineStrokeNextAngle(StrokeContext *c, BasePoint ut,
 		nci = ncpi;
 	    }
 	} else { // CW
-	    if ( BPNear(c->nibcorners[nci].utv[NC_IN_IDX],
+	    if ( UTNear(c->nibcorners[nci].utv[NC_IN_IDX],
 	                c->nibcorners[nci].utv[NC_OUT_IDX]) ) {
-		if ( BPNear(c->nibcorners[nci].utv[NC_IN_IDX],
+		if ( UTNear(c->nibcorners[nci].utv[NC_IN_IDX],
 		            c->nibcorners[ncni].utv[NC_IN_IDX]) ) {
 		    assert(c->nibcorners[nci].linear);
 		    inout = NC_OUT_IDX;
@@ -813,14 +818,14 @@ static BasePoint SplineStrokeNextAngle(StrokeContext *c, BasePoint ut,
 		*curved = false;
 	    }
 	}
-    } else if ( BPNear(ut, c->nibcorners[nci].utv[NC_OUT_IDX]) ) {
-	assert( ! BPNear(c->nibcorners[nci].utv[NC_IN_IDX],
+    } else if ( UTNear(ut, c->nibcorners[nci].utv[NC_OUT_IDX]) ) {
+	assert( ! UTNear(c->nibcorners[nci].utv[NC_IN_IDX],
 	                 c->nibcorners[nci].utv[NC_OUT_IDX]) );
 	if ( is_ccw ) {
 	    inout = NC_IN_IDX;
 	    *curved = false;
 	} else { // CW
-	    if ( BPNear(c->nibcorners[nci].utv[NC_OUT_IDX],
+	    if ( UTNear(c->nibcorners[nci].utv[NC_OUT_IDX],
 	                c->nibcorners[ncni].utv[NC_IN_IDX]) ) {
 		assert(c->nibcorners[nci].linear);
 		inout = NC_OUT_IDX;

--- a/fontforge/splinestroke.c
+++ b/fontforge/splinestroke.c
@@ -69,11 +69,6 @@ static inline int BPNear(BasePoint bp1, BasePoint bp2) {
     return BPWithin(bp1, bp2, INTRASPLINE_MARGIN);
 }
 
-// Not called "BPNear" because this is specific to UTanVecs
-static inline int UTNear(BasePoint bp1, BasePoint bp2) {
-    return BPWithin(bp1, bp2, UTMARGIN);
-}
-
 enum nibtype { nib_ellip, nib_rect, nib_convex };
 
 // c->nibcorners is a structure that models the "corners" of the current nib

--- a/fontforge/splineutil2.h
+++ b/fontforge/splineutil2.h
@@ -84,8 +84,4 @@ extern void SPWeightedAverageCps(SplinePoint *sp);
 extern void SSOverlapClusterCpAngles(SplineSet *base, bigreal within);
 extern void SSRemoveStupidControlPoints(SplineSet *base);
 
-static inline int BPWithin(BasePoint bp1, BasePoint bp2, bigreal f) {
-	    return RealWithin(bp1.x, bp2.x, f) && RealWithin(bp1.y, bp2.y, f);
-}
-
 #endif /* FONTFORGE_SPLINEUTIL2_H */

--- a/fontforge/utanvec.c
+++ b/fontforge/utanvec.c
@@ -39,11 +39,6 @@
                             // ends of degenerate splines to find
                             // a slope.
 			    //
-// Not called "BPNear" because this is specific to UTanVecs
-static inline int UTNear(BasePoint bp1, BasePoint bp2) {
-    return BPWithin(bp1, bp2, UTMARGIN);
-}
-
 BasePoint MakeUTanVec(bigreal x, bigreal y) {
     BasePoint ret = { 0.0, 0.0 };
     bigreal len = x*x + y*y;

--- a/fontforge/utanvec.c
+++ b/fontforge/utanvec.c
@@ -34,12 +34,15 @@
 #include <math.h>
 #include <assert.h>
 
-#define UTMARGIN (1e-7)     // Arrived at through testing
 #define UTSOFTMARGIN (1e-5) // Fallback margin for some cases
-#define BPNEAR(bp1, bp2) BPWithin(bp1, bp2, UTMARGIN)
 #define UTRETRY (1e-9)      // Amount of "t" to walk back from the 
                             // ends of degenerate splines to find
                             // a slope.
+			    //
+// Not called "BPNear" because this is specific to UTanVecs
+static inline int UTNear(BasePoint bp1, BasePoint bp2) {
+    return BPWithin(bp1, bp2, UTMARGIN);
+}
 
 BasePoint MakeUTanVec(bigreal x, bigreal y) {
     BasePoint ret = { 0.0, 0.0 };
@@ -66,11 +69,11 @@ int UTanVecGreater(BasePoint uta, BasePoint utb) {
     if (uta.y >= 0) {
 	if (utb.y < 0)
 	    return true;
-	return uta.x < utb.x && !BPNEAR(uta, utb);
+	return uta.x < utb.x && !UTNear(uta, utb);
     }
     if (utb.y >= 0)
 	return false;
-    return uta.x > utb.x && !BPNEAR(uta, utb);
+    return uta.x > utb.x && !UTNear(uta, utb);
 }
 
 /* True if rotating from ut1 to ut3 in the specified direction
@@ -83,10 +86,10 @@ int UTanVecsSequent(BasePoint ut1, BasePoint ut2, BasePoint ut3,
                            int ccw) {
     BasePoint tmp;
 
-    if ( BPNEAR(ut1, ut2) )
+    if ( UTNear(ut1, ut2) )
 	return true;
 
-    if ( BPNEAR(ut2, ut3) || BPNEAR(ut1, ut3) )
+    if ( UTNear(ut2, ut3) || UTNear(ut1, ut3) )
 	return false;
 
     if (ccw) {
@@ -154,7 +157,7 @@ bigreal SplineSolveForUTanVec(Spline *spl, BasePoint ut, bigreal min_t,
         return -1;
 
     // Only check t==0 if min_t is negative
-    if ( min_t<0 && BPNEAR(ut, SplineUTanVecAt(spl, 0.0)) )
+    if ( min_t<0 && UTNear(ut, SplineUTanVecAt(spl, 0.0)) )
        return 0.0;
 
     // This is probably over-optimized
@@ -178,14 +181,14 @@ bigreal SplineSolveForUTanVec(Spline *spl, BasePoint ut, bigreal min_t,
     SplineFindExtrema(&ys1d, &te1, &te2);
 
     if (   te1 != -1 && te1 > (min_t+1e-9)
-        && BPNEAR(ut, SplineUTanVecAt(spl, te1)) )
+        && UTNear(ut, SplineUTanVecAt(spl, te1)) )
 	return te1;
     if (   te2 != -1 && te2 > (min_t+1e-9)
-        && BPNEAR(ut, SplineUTanVecAt(spl, te2)) )
+        && UTNear(ut, SplineUTanVecAt(spl, te2)) )
 	return te2;
 
     // Check t==1
-    if ( (min_t+UTRETRY) < 1 && BPNEAR(ut, SplineUTanVecAt(spl, 1.0)) )
+    if ( (min_t+UTRETRY) < 1 && UTNear(ut, SplineUTanVecAt(spl, 1.0)) )
         return 1.0;
 
     if ( picky )
@@ -229,7 +232,7 @@ void UTanVecTests() {
 	    else
 		assert(    UTanVecGreater(ut[j], ut[i])
 		       	&& !UTanVecGreater(ut[i], ut[j]));
-	    assert(!BPNEAR(ut[i], ut[j]));
+	    assert(!UTNear(ut[i], ut[j]));
 	    x = atan2(ut[i].x, ut[i].y);
 	    y = atan2(ut[j].x, ut[j].y);
 	    z = x-y;

--- a/fontforge/utanvec.h
+++ b/fontforge/utanvec.h
@@ -31,6 +31,7 @@
 #include <fontforge-config.h>
 
 #include "splinefont.h"
+#include "splineutil2.h"
 
 #include <math.h>
 
@@ -38,6 +39,10 @@
 #define UTZERO ((BasePoint) { 0.0, 1.0 })
 #define UTMIN ((BasePoint) { -1, -DBL_MIN })
 #define UTMARGIN (1e-7)     // Arrived at through testing
+
+static inline int BPWithin(BasePoint bp1, BasePoint bp2, bigreal f) {
+    return RealWithin(bp1.x, bp2.x, f) && RealWithin(bp1.y, bp2.y, f);
+}
 
 static inline bigreal BPLenSq(BasePoint v) {
     return v.x * v.x + v.y * v.y;
@@ -106,6 +111,11 @@ static inline BasePoint BP90CW(BasePoint v) {
 
 static inline BasePoint BPNeg(BasePoint v) {
     return (BasePoint) { v.x, -v.y };
+}
+
+// Not called "BPNear" because this is specific to UTanVecs
+static inline int UTNear(BasePoint bp1, BasePoint bp2) {
+    return BPWithin(bp1, bp2, UTMARGIN);
 }
 
 extern BasePoint MakeUTanVec(bigreal x, bigreal y);

--- a/fontforge/utanvec.h
+++ b/fontforge/utanvec.h
@@ -37,6 +37,7 @@
 #define BPUNINIT ((BasePoint) { -INFINITY, INFINITY })
 #define UTZERO ((BasePoint) { 0.0, 1.0 })
 #define UTMIN ((BasePoint) { -1, -DBL_MIN })
+#define UTMARGIN (1e-7)     // Arrived at through testing
 
 static inline bigreal BPLenSq(BasePoint v) {
     return v.x * v.x + v.y * v.y;


### PR DESCRIPTION
#4884 was caused by comparing utanvec (a normalized vector representing an angle) equality sometimes using UTMARGIN (1e-7) and sometimes using INTRASPLINE_MARGIN (1e-8). After this change the former is used consistently in the expand stroke code. 

This duplicates one inline function in two C files because I didn't want to change the minimal inclusion in utanvec.h or make the comparison non-inline. (This is negotiable.) 

Closes #4884