### PR TITLE
Choose a better default background color when no theme is present

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -117,7 +117,7 @@ extern int _GScrollBar_Width;
 static int fv_fs_init=0;
 Color fvfgcol = 0x000000;
 static Color fvselcol = 0xffff00, fvselfgcol=0x000000;
-Color view_bgcol;
+Color view_bgcol = 0xffffff;
 static Color fvslotcol = 0x000000;
 static Color fvslotdivcol = 0x808080;
 static Color fvlabelcol = 0x000000;

--- a/gdraw/gprogress.c
+++ b/gdraw/gprogress.c
@@ -57,7 +57,7 @@ typedef struct gprogress {
     struct gprogress *prev;
 } GProgress;
 
-static Color progress_background, progress_foreground;
+static Color progress_background = 0xffffff, progress_foreground;
 static Color progress_fillcol = 0xc0c0ff;
 static GResFont progress_font = GRESFONT_INIT("400 12pt " MONO_UI_FAMILIES);
 static int progress_init = false;


### PR DESCRIPTION
Follow-up from https://github.com/fontforge/fontforge/pull/4704#issuecomment-1018253917


### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**