### PR TITLE
Fix initialisation of cv_pointnumberfont from bitmap view

### DIFF
--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -2137,7 +2137,9 @@ GResInfo bitmapview_ri = {
 };
 
 void BVColInit(void) {
+    extern GResInfo charviewpoints_ri;
     GResEditDoInit(&bitmapview_ri);
+    GResEditDoInit(&charviewpoints_ri);
 }
 
 static GMenuItem2 wnmenu[] = {


### PR DESCRIPTION
Fixes #4910

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
