### PR TITLE
Display the block name for reserved code points

### DIFF
--- a/fontforge/unicoderange.c
+++ b/fontforge/unicoderange.c
@@ -116,8 +116,7 @@ return( ri );
 const char *UnicodeRange(int32_t unienc) {
 /* Return the best name that describes this Unicode value */
     const struct unicode_range* block;
-    if (isunicodepointassigned(unienc) &&
-        (block = uniname_block(unienc)) != NULL) {
+    if ((block = uniname_block(unienc)) != NULL) {
         return block->name;
     }
     return "Unencoded Unicode";


### PR DESCRIPTION
In version 20220308, for reserved code points, FontForge prints “Unencoded Unicode” above the character grid. I changed it so it prints the block name. If there is no block name, it still falls back to “Unencoded Unicode”.

### Type of change
- **Non-breaking change**
