### PR TITLE
gfilechooser.c: fix behaviour when changing file type

### DIFF
--- a/gdraw/gfilechooser.c
+++ b/gdraw/gfilechooser.c
@@ -337,6 +337,12 @@ static void GFileChooserFillList(GFileChooser *gfc, const unichar_t *dirname_) {
         return;
     }
 
+    if (gfc->lastname!=NULL) {
+        GGadgetSetTitle(&gfc->name->g, gfc->lastname);
+        free(gfc->lastname);
+        gfc->lastname=NULL;
+    }
+
     GPtrArray *ti = g_ptr_array_new();
     GPtrArray *dti = (dir_placement == dirs_separate) ? g_ptr_array_new() : NULL;
     while ((dent = readdir(dir)) != NULL) {


### PR DESCRIPTION
Fixes the first issue raised in #4937.

Regression from #4828 - restores this code: https://github.com/fontforge/fontforge/blob/21ad4a18fb3d4becfe566d8215eba4483b0ddc4b/gdraw/gfilechooser.c#L405-L409

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**