### PR TITLE
cmake: Install fonttools and pycontrib

### DIFF
--- a/contrib/fonttools/CMakeLists.txt
+++ b/contrib/fonttools/CMakeLists.txt
@@ -18,3 +18,27 @@ target_link_libraries(dewoff PRIVATE ZLIB::ZLIB)
 target_link_libraries(pcl2ttf PRIVATE MathLib::MathLib)
 target_link_libraries(ttf2eps PRIVATE fontforge)
 target_link_libraries(woff PRIVATE ZLIB::ZLIB)
+
+install(
+  TARGETS
+    acorn2sfd
+    dewoff
+    findtable
+    pcl2ttf
+    pfadecrypt
+    rmligamarks
+    showttf
+    stripttc
+    ttf2eps
+    woff
+  RUNTIME
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(
+  FILES
+    acorn2sfd.1
+    showttf.1
+    ttf2eps.1
+  DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+)


### PR DESCRIPTION
Restore the files that were installed to fontforge-extras Debian package prior to the FontForge 2020 March Release.

The [patch this is based on](https://salsa.debian.org/fonts-team/fontforge/-/blob/e5764cc23f4aaf2b84d454430aff78328bf75645/debian/patches/0001-add-extra-cmake-install-rules.patch) is also used by the [NixOS package](https://github.com/NixOS/nixpkgs/pull/163439).

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**

cc @anthonyfok who created this patch.