### PR TITLE
Fix drawing outside of expose calls

### DIFF
--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -878,7 +878,8 @@ return;
 	GDrawDrawImage(pixmap,&gi,NULL, 5,bv->mbh+(bv->infoh-base.height)/2);
 
 	GDrawPopClip(pixmap,&old2);
-
+    }
+    if (event->u.expose.rect.y < bv->mbh + bv->infoh - 1) {
 	GDrawDrawImage(pixmap,&GIcon_rightpointer,NULL,bv->infoh+RPT_BASE,bv->mbh+8);
 	GDrawDrawImage(pixmap,&GIcon_press2ptr,NULL,bv->infoh+RPT_BASE,bv->mbh+18+bv->sfh);
 	BVInfoDrawText(bv,pixmap );
@@ -901,7 +902,10 @@ return;
 }
 
 static void BVShowInfo(BitmapView *bv) {
-    BVInfoDrawText(bv,bv->gw );
+    GRect r;
+    r.x = bv->infoh+RPT_DATA; r.width = 39;
+    r.y = bv->mbh; r.height = 36 /* bv->infoh-1 */;
+    GDrawRequestExpose(bv->gw, &r, false);
 }
 
 static void BVResize(BitmapView *bv, GEvent *event ) {

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -4152,9 +4152,26 @@ static void CVInfoDrawRulers(CharView *cv, GWindow pixmap ) {
 }
 
 void CVInfoDraw(CharView *cv, GWindow pixmap ) {
-    CVInfoDrawText(cv,pixmap);
-    if ( cv->showrulers )
-	CVInfoDrawRulers(cv,pixmap);
+    GRect r;
+    r.x = 0;
+    r.y = cv->mbh+cv->charselectorh;
+    r.width = cv->width;
+    r.height = cv->infoh-1;
+    GDrawRequestExpose(pixmap, &r, false);
+    if (cv->showrulers) {
+        int rstart = cv->mbh+cv->charselectorh+cv->infoh;
+        r.x = cv->rulerh;
+        r.y = rstart;
+        r.height = cv->rulerh;
+        r.width = cv->width;
+        GDrawRequestExpose(pixmap, &r, false);
+
+        r.x = 0;
+        r.y = rstart + cv->rulerh;
+        r.width = cv->rulerh;
+        r.height = cv->height;
+        GDrawRequestExpose(pixmap, &r, false);
+    }
 }
 
 static void CVCrossing(CharView *cv, GEvent *event ) {

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -234,6 +234,7 @@ static void CVMenuSimplify(GWindow gw,struct gmenuitem *mi,GEvent *e);
 static void CVMenuSimplifyMore(GWindow gw,struct gmenuitem *mi,GEvent *e);
 static void CVPreviewModeSet(GWindow gw, int checked);
 static void CVExposeRulers(CharView *cv, GWindow pixmap);
+static void CVDrawGuideLine(CharView *cv, int guide_pos);
 
 static int cvcolsinited = false;
 
@@ -3100,6 +3101,10 @@ static void CVExpose(CharView *cv, GWindow pixmap, GEvent *event ) {
 	    CVDrawRubberLine(pixmap,cv);
     }
     CVRulerExpose(pixmap,cv);
+
+    if (cv->guide_pos != -1) {
+        CVDrawGuideLine(cv, cv->guide_pos);
+    }
 
     GDrawPopClip(pixmap,&old);
 }
@@ -6192,7 +6197,7 @@ static void CVLogoExpose(CharView *cv,GWindow pixmap,GEvent *event) {
 	    cv->b.layerheads[cv->b.drawmode]->background ? dm_back : dm_fore );
 }
 
-static void CVDrawGuideLine(CharView *cv, int old_guide_pos, int guide_pos) {
+static void CVDrawGuideLine(CharView *cv, int guide_pos) {
     GWindow pixmap = cv->v;
 
     if ( guide_pos<0 )
@@ -6201,16 +6206,8 @@ return;
     GDrawSetLineWidth(pixmap,0);
 
     if ( cv->ruler_pressedv ) {
-        if (old_guide_pos >= 0) {
-            GRect r = {.x = old_guide_pos, .y = 0, .width = 1, .height = cv->height};
-            GDrawRequestExpose(pixmap,&r,false);
-        }
 	GDrawDrawLine(pixmap,guide_pos,0,guide_pos,cv->height,guidedragcol);
     } else {
-        if (old_guide_pos >= 0) {
-            GRect r = {.x = 0, .y = old_guide_pos, .width = cv->width, .height = 1};
-            GDrawRequestExpose(pixmap,&r,false);
-        }
 	GDrawDrawLine(pixmap,0,guide_pos,cv->width,guide_pos,guidedragcol);
     }
     GDrawSetDashedLine(pixmap,0,0,0);
@@ -6355,7 +6352,6 @@ return( GGadgetDispatchEvent(cv->vsb,event));
 		}
 		cv->guide_pos = -1;
 	    } else if ( event->type==et_mouseup && cv->ruler_pressed ) {
-		CVDrawGuideLine(cv,-1,cv->guide_pos);
 		cv->guide_pos = -1;
 		cv->showing_tool = cvt_none;
 		CVToolsSetCursor(cv,event->u.mouse.state&~(1<<(7+event->u.mouse.button)),event->u.mouse.device);		/* X still has the buttons set in the state, even though we just released them. I don't want em */
@@ -6372,7 +6368,6 @@ return( GGadgetDispatchEvent(cv->vsb,event));
       break;
       case et_mousemove:
 	if ( cv->ruler_pressed ) {
-        int old_pos = cv->guide_pos;
         CharViewTab* tab = CVGetActiveTab(cv);
 	    cv->e.x = event->u.mouse.x - cv->rulerh;
 	    cv->e.y = event->u.mouse.y-(cv->mbh+cv->charselectorh+cv->infoh+cv->rulerh);
@@ -6382,7 +6377,7 @@ return( GGadgetDispatchEvent(cv->vsb,event));
 		cv->guide_pos = cv->e.x;
 	    else
 		cv->guide_pos = cv->e.y;
-	    CVDrawGuideLine(cv,old_pos,cv->guide_pos);
+	    GDrawRequestExpose(cv->v,NULL,false);
 	    CVInfoDraw(cv,cv->gw);
 	}
     else if ( event->u.mouse.y > cv->mbh )

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -194,10 +194,7 @@ return;
 		GRect r;
 		r.x = j*fv->cbw+1; r.width = fv->cbw-1;
 		r.y = i*fv->cbh+1; r.height = fv->lab_height-1;
-		GDrawDrawLine(fv->v,r.x,r.y,r.x,r.y+r.height-1,fvhintingneededcol);
-		GDrawDrawLine(fv->v,r.x+1,r.y,r.x+1,r.y+r.height-1,fvhintingneededcol);
-		GDrawDrawLine(fv->v,r.x+r.width-1,r.y,r.x+r.width-1,r.y+r.height-1,fvhintingneededcol);
-		GDrawDrawLine(fv->v,r.x+r.width-2,r.y,r.x+r.width-2,r.y+r.height-1,fvhintingneededcol);
+		GDrawRequestExpose(fv->v, &r, false);
 	    }
 	}
     }

--- a/gdraw/ggdkcdraw.c
+++ b/gdraw/ggdkcdraw.c
@@ -48,8 +48,11 @@
 static void _GGDKDraw_CheckAutoPaint(GGDKWindow gw) {
     if (gw->cc == NULL) {
         assert(!gw->is_pixmap);
+        if (!gw->is_in_paint) {
+            assert(false && "No window should be drawing outside of expose calls");
+            Log(LOGWARN, "Dirty window is drawing outside of expose call: 0x%p [%s]", gw, gw->window_title);
+        }
 
-        //Log(LOGWARN, "Dirty dirty window! 0x%p", gw);
         if (gw->display->dirty_window != gw) {
             _GGDKDraw_CleanupAutoPaint(gw->display);
             gw->display->dirty_window = gw;

--- a/gdraw/gmatrixedit.c
+++ b/gdraw/gmatrixedit.c
@@ -331,7 +331,6 @@ return( 0 );
 return( width );
 }
 
-static void GME_RedrawTitles(GMatrixEdit *gme);
 static int GME_AdjustCol(GMatrixEdit *gme,int col) {
     int new_width, x,c, changed;
     int orig_width, min_width;
@@ -376,7 +375,7 @@ static int GME_AdjustCol(GMatrixEdit *gme,int col) {
     if ( changed ) {
 	GME_FixScrollBars(gme);
 	GDrawRequestExpose(gme->nested,NULL,false);
-	GME_RedrawTitles(gme);
+	_ggadget_redraw((GGadget*)gme);
     }
 return( changed );
 }
@@ -568,7 +567,7 @@ return( true );
 	gme->col_data[c].width = nw;
 	if ( event->type==et_mouseup )
 	    GME_FixScrollBars(gme);
-	GME_RedrawTitles(gme);
+	_ggadget_redraw((GGadget*)gme);
 	GME_PositionEdit(gme);
 	GDrawRequestExpose(gme->nested,NULL,false);
 	if ( event->type==et_mouseup ) {
@@ -644,10 +643,6 @@ static int GMatrixEdit_Expose(GWindow pixmap, GGadget *g, GEvent *event) {
 	GDrawPopClip(pixmap,&older);
     }
 return( true );
-}
-
-static void GME_RedrawTitles(GMatrixEdit *gme) {
-    GMatrixEdit_Expose(gme->g.base,&gme->g,NULL);
 }
 
 static void GMatrixEdit_SetVisible(GGadget *g, int visible ) {
@@ -1852,7 +1847,7 @@ static void GME_HScroll(GMatrixEdit *gme,struct sbevent *sb) {
 	}
 	GDrawScroll( gme->nested,&clip,diff,0 );
 	GME_PositionEdit(gme);
-	GME_RedrawTitles(gme);
+	_ggadget_redraw((GGadget*)gme);
     }
 }
 

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -515,24 +515,6 @@ static int gmenu_expose(struct gmenu *m, GEvent *event,GWindow pixmap) {
 return( true );
 }
 
-static void GMenuDrawLines(struct gmenu *m, int ln, int cnt) {
-    GRect r, old1, old2, winrect;
-
-    winrect.x = 0; winrect.width = m->width; winrect.y = 0; winrect.height = m->height;
-    r = winrect; r.height = cnt*m->fh;
-    r.y = (ln-m->offtop)*m->fh+m->bp;
-    GDrawPushClip(m->w,&r,&old1);
-    GBoxDrawBackground(m->w,&winrect,m->box,gs_active,false);
-    GBoxDrawBorder(m->w,&winrect,m->box,gs_active,false);
-    r.x = m->tickoff; r.width = m->rightedge-r.x;
-    GDrawPushClip(m->w,&r,&old2);
-    cnt += ln;
-    for ( ; ln<cnt; ++ln )
-	GMenuDrawMenuLine(m, &m->mi[ln], m->bp+(ln-m->offtop)*m->fh,m->w);
-    GDrawPopClip(m->w,&old2);
-    GDrawPopClip(m->w,&old1);
-}
-
 static void GMenuSetPressed(struct gmenu *m, int pressed) {
     while ( m->child!=NULL ) m = m->child;
     while ( m->parent!=NULL ) {
@@ -621,16 +603,7 @@ return;
     if ( old!=-1 )
 	m->mi[old].ti.selected = false;
 
-    if ( newsel==old+1 && old!=-1 ) {
-	GMenuDrawLines(m,old,2);
-    } else if ( old==newsel+1 && newsel!=-1 ) {
-	GMenuDrawLines(m,newsel,2);
-    } else {
-	if ( newsel!=-1 )
-	    GMenuDrawLines(m,newsel,1);
-	if ( old!=-1 )
-	    GMenuDrawLines(m,old,1);
-    }
+    GDrawRequestExpose(m->w, NULL, false);
     if ( newsel!=-1 ) {
 	if ( m->mi[newsel].moveto!=NULL )
 	    (m->mi[newsel].moveto)(m->owner,&m->mi[newsel],event);

--- a/gdraw/gprogress.c
+++ b/gdraw/gprogress.c
@@ -142,10 +142,10 @@ static int GProgressProcess(GProgress *p) {
 	else {
 	    GRect r;
 	    r.height = tenpt-1;
-	    r.width = amount - p->last_amount;
-	    r.x = tenpt + p->last_amount;
+	    r.width = width;
+	    r.x = tenpt;
 	    r.y = p->boxy+1;
-	    GDrawFillRect(p->gw,&r,progress_fillcol);
+	    GDrawRequestExpose(p->gw,&r,false);
 	}
 	p->last_amount = amount;
     }


### PR DESCRIPTION
This fixes all the cases that I can find where drawing occurs outside of expose calls.

All modern toolkits force you to draw within expose events, and even now, only somewhat works with more than a few hacks in the GDK code.

Fixing this allows some of those hacks to be removed (and at times, removes the need for some triple-buffering)

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**