### PR TITLE
Fix missed nonextcp edit

### DIFF
--- a/fontforge/splineutil2.c
+++ b/fontforge/splineutil2.c
@@ -3526,7 +3526,7 @@ return;
 	    BP_HVForce(&unit);
     } else if ( base->pointtype == pt_corner ) {
 	if ( prev->pointtype != pt_curve && prev->pointtype != pt_hvcurve ) {
-	    base->noprevcp = true;
+	    base->prevcp = base->me;
 	}
     } else /* tangent */ {
 	if ( prev->pointtype != pt_curve ) {


### PR DESCRIPTION
Missed edit in `SplineCharDefaultPrevCP`, `SplineCharDefaultNextCP` is already correct. 

Closes #4957 