### PR TITLE
Fix name extraction for Type3 fonts from pdfs

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1942,6 +1942,8 @@ static SplineFont *pdf_loadtype3(struct pdfcontext *pc) {
 return( sf );
 
   fail:
+    if ( name!=NULL )
+        free(name);
     LogError( _("Syntax errors while parsing Type3 font headers") );
 return( NULL );
 }

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1942,8 +1942,7 @@ static SplineFont *pdf_loadtype3(struct pdfcontext *pc) {
 return( sf );
 
   fail:
-    if ( name!=NULL )
-        free(name);
+    free(name);
     LogError( _("Syntax errors while parsing Type3 font headers") );
 return( NULL );
 }

--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1893,7 +1893,9 @@ static SplineFont *pdf_loadtype3(struct pdfcontext *pc) {
 
     name=PSDictHasEntry(&pc->pdfdict,"Name");
     if ( name==NULL )
-	name=PSDictHasEntry(&pc->pdfdict,"BaseFont");
+        name=PSDictHasEntry(&pc->pdfdict,"BaseFont");
+    if ( name!=NULL )
+        name = copy(name+1);
     if ( (enc=PSDictHasEntry(&pc->pdfdict,"Encoding"))==NULL )
   goto fail;
     if ( (cp=PSDictHasEntry(&pc->pdfdict,"CharProcs"))==NULL )
@@ -1910,7 +1912,6 @@ static SplineFont *pdf_loadtype3(struct pdfcontext *pc) {
 
     sf = SplineFontBlank(charprocdict->next);
     if ( name!=NULL ) {
-        name = copy(name+1);
 	free(sf->fontname); free(sf->fullname); free(sf->familyname);
 	sf->fontname = name;
 	sf->familyname = copy(name);


### PR DESCRIPTION
Fixes a bug when extracting Type3 fonts from PDFs. In the existing code, `name` is pointed to the correct place in the font dictionary, but `pdf_getcharprocs` reads the Charprocs dictionary before the name is copied. This causes the later name copy step to read a random section of the CharProcs dict instead. This change copies the name out _before_ loading CharProcs.

### Type of change
 **Bug fix**
