### PR TITLE
Support ToUnicode extraction from PDFs for Type3 fonts

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1962,8 +1962,12 @@ static SplineFont *pdf_loadfont(struct pdfcontext *pc,int font_num) {
     if ( !pdf_findobject(pc,pc->fontobjs[font_num]) || !pdf_readdict(pc) )
 return( NULL );
 
-    if ( (pt=PSDictHasEntry(&pc->pdfdict,"Subtype"))!=NULL && strcmp(pt,"/Type3")==0 )
-return( pdf_loadtype3(pc));
+    if ( (pt=PSDictHasEntry(&pc->pdfdict,"Subtype"))!=NULL && strcmp(pt,"/Type3")==0 ) {
+        sf = pdf_loadtype3(pc);
+        if ( sf != NULL && pc->cmapobjs[font_num] != -1 )
+            pdf_getcmap(pc, sf, font_num);
+        return( sf );
+    }
 
     if ( (pt=PSDictHasEntry(&pc->pdfdict,"FontDescriptor"))==NULL )
   goto fail;


### PR DESCRIPTION
For the most part, fontforge honours ToUnicode maps within PDFs, but not so for Type3 fonts. This change applies the cmaps for Type3 fonts if they're available (they're allowed within the spec and are often supplied).


### Type of change
 ** New feature**
