### PR TITLE
Handle non-array cm transforms while reading graphics stream from PDFs

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1382,6 +1382,16 @@ static void _InterpretPdf(FILE *in, struct pdfcontext *pc, EntityChar *ec) {
 			MatMultiply(t,transform,transform);
 		    }
 		}
+		else if ( sp>=6 && stack[sp-1].type==ps_num && stack[sp-2].type==ps_num && stack[sp-3].type==ps_num
+		    && stack[sp-4].type==ps_num && stack[sp-5].type==ps_num && stack[sp-6].type==ps_num) {
+		    t[5] = stack[--sp].u.val;
+		    t[4] = stack[--sp].u.val;
+		    t[3] = stack[--sp].u.val;
+		    t[2] = stack[--sp].u.val;
+		    t[1] = stack[--sp].u.val;
+		    t[0] = stack[--sp].u.val;
+		    MatMultiply(t,transform,transform);
+		}
 	    }
 	  break;
 	  case pt_setmiterlimit:


### PR DESCRIPTION
- **Bug fix**

Currently the PDF graphics stream reader expects `cm` operations to have been preceded by an array of 6 values, but the spec suggests that we should be expecting numbers instead.

> "Although operands specify a matrix, they shall be written as six separate numbers, not as an array."

This fix allows for popping the number operands from the stack. I've left the array behaviour in place because there are bound to be non-compliant writers producing array versions.
