### PR TITLE
Fix menu item “Hints” can show up in wrong language

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7609,6 +7609,9 @@ msgstr "Hinting für diagonales Kreuzen"
 msgid "HintMasks only if conflicts"
 msgstr "Hint-Masken nur bei Problemen"
 
+msgid "Hints"
+msgstr "Hints"
+
 #, c-format
 msgid "Hints differ in glyph “%s”\n"
 msgstr "Hints unterscheiden sich in der Glyphe „%s”\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8856,6 +8856,9 @@ msgstr "Masques de hint si conflit"
 msgid "Hinting Needed Color"
 msgstr "Couleur lorsque le hinting est requis"
 
+msgid "Hints"
+msgstr "Hints"
+
 #, c-format
 msgid "Hints differ in glyph “%s”\n"
 msgstr "Les hints diffèrent dans le glyphe \"%s\"\n"


### PR DESCRIPTION
The menu item “Hints” is incorrectly untranslated in the German translation, since the term ”Hints“ is used in German as well. When there is a second locale active, untranslated items can show up in the secondary language.
I found it also missing in the French translation.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
**Bug fix** see screenshot
![fontforge-hints](https://user-images.githubusercontent.com/1122393/160148545-3a5ff3ac-39f9-40fa-843b-6e8c192d9c87.png)

