### PR TITLE
Fix rect extraction from graphics stream for type3 fonts

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1520,7 +1520,7 @@ static void _InterpretPdf(FILE *in, struct pdfcontext *pc, EntityChar *ec) {
 		temp1.x += stack[sp-2].u.val;
 		Transform(&temp2,&temp1,transform);
 		second = SplinePointCreate(temp2.x,temp2.y);
-		temp1.y += stack[sp-3].u.val;
+		temp1.y += stack[sp-1].u.val;
 		Transform(&temp2,&temp1,transform);
 		third = SplinePointCreate(temp2.x,temp2.y);
 		temp1.x = stack[sp-4].u.val;


### PR DESCRIPTION
 **Bug fix**

The existing code has a bug where it is accidentally using the y coordinate (`sp-3`) instead of the height (`sp-1`) when extracting a rect from the graphics stream.

The result is that all rects are collapsed to have no height.