### PR TITLE
FVSplineFontPieceMeal: Check that the clut is present before applying conversion

### DIFF
--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -235,14 +235,16 @@ return( gid );
 
 extern BDFFont *FVSplineFontPieceMeal(SplineFont *sf, int layer, int ptsize, int dpi, int flags, void *freetype_context) {
     BDFFont *new = SplineFontPieceMeal(sf, layer, ptsize, dpi, flags, freetype_context);
-    Color bg = view_bgcol;
-    Color fg = fvfgcol;
-    int l, scale = new->clut->clut_len;
-    for ( l=0; l<scale; ++l )
-	new->clut->clut[l] = COLOR_CREATE(
-                         COLOR_RED(bg) + ((int32_t) (l*(COLOR_RED(fg)-COLOR_RED(bg))))/(scale-1),
-                         COLOR_GREEN(bg) + ((int32_t) (l*(COLOR_GREEN(fg)-COLOR_GREEN(bg))))/(scale-1),
-                         COLOR_BLUE(bg) + ((int32_t) (l*(COLOR_BLUE(fg)-COLOR_BLUE(bg))))/(scale-1) );
+    if (new->clut != NULL) {
+        Color bg = view_bgcol;
+        Color fg = fvfgcol;
+        int l, scale = new->clut->clut_len;
+        for ( l=0; l<scale; ++l )
+        new->clut->clut[l] = COLOR_CREATE(
+                             COLOR_RED(bg) + ((int32_t) (l*(COLOR_RED(fg)-COLOR_RED(bg))))/(scale-1),
+                             COLOR_GREEN(bg) + ((int32_t) (l*(COLOR_GREEN(fg)-COLOR_GREEN(bg))))/(scale-1),
+                             COLOR_BLUE(bg) + ((int32_t) (l*(COLOR_BLUE(fg)-COLOR_BLUE(bg))))/(scale-1) );
+    }
     return new;
 }
 


### PR DESCRIPTION
The clut is only present when antialiasing is turned on

Fixes #4959

I was contemplating removing GDrawDrawGlyph (looks redundant to me especially considering it's only used when no magnification is applied) but decided against it

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
