### PR TITLE
Support setting SplineChar width from importOutlines.

### DIFF
--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -62,6 +62,7 @@ void InitImportParams(ImportParams *ip) {
     ip->scale = true;
     ip->accuracy_target = 0.25;
     ip->default_joinlimit = JLIMIT_INHERITED;
+    ip->dimensions = false;
 }
 
 ImportParams *ImportParamsState() {
@@ -350,6 +351,8 @@ void SCImportSVG(SplineChar *sc,int layer,char *path,char *memory, int memlen,
                  bool doclear, ImportParams *ip) {
     SplinePointList *spl, *espl, **head;
 
+    if (ip->dimensions)
+	SCDimensionFromSVGFile(path, sc, false);
     if ( sc->parent->multilayer && layer>ly_back ) {
 	SCAppendEntityLayers(sc,
 	       EntityInterpretSVG(path,memory,memlen,

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -8545,7 +8545,7 @@ Py_RETURN( self );
 
 static char *glyph_import_keywords[] = { "filename", "correctdir",
     "simplify", "handle_clip", "handle_eraser", "scale", "accuracy",
-    "default_joinlimit", "usesystem", "asksystem", NULL };
+    "default_joinlimit", "usesystem", "asksystem", "dimensions", NULL };
 
 /* Legacy PostScript importing flags */
 static struct flaglist import_ps_flags[] = {
@@ -8569,10 +8569,10 @@ static PyObject *PyFFGlyph_import(PyObject *self, PyObject *args,
     InitImportParams(&ip);
 
     if ( !PyArg_ParseTupleAndKeywords(args, keywds,
-                "s|$pppppddpp", glyph_import_keywords, &filename,
+                "s|$pppppddppp", glyph_import_keywords, &filename,
                 &ip.correct_direction, &ip.simplify, &ip.clip, &ip.erasers,
                 &ip.scale, &ip.accuracy_target, &jl_tmp, &use_system,
-		&ask_system) ) {
+		&ask_system, &ip.dimensions) ) {
 	PyErr_Clear();
 	if ( !PyArg_ParseTuple(args,"s|O",&filename, &flags) )
 	    return NULL;

--- a/fontforge/sd.h
+++ b/fontforge/sd.h
@@ -189,6 +189,7 @@ typedef struct importparams {
     int clip;			// SVG
     int erasers;		// PS
     int scale;			// Misc
+    int dimensions;		// Misc
     bigreal accuracy_target;
     bigreal default_joinlimit;
 } ImportParams;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2872,7 +2872,6 @@ static void SVGParseGlyphBody(SplineChar *sc, xmlNodePtr glyph,
 	sc->layers[ly_fore].splines = SVGParseExtendedPath(glyph,glyph);
 	xmlFree(path);
     } else {
-	fprintf(stderr, "Parsing.");
 	Entity *ent = SVGParseSVG(glyph,sc->parent->ascent+sc->parent->descent,
 		sc->parent->ascent,ip->scale,ip->dimensions ? sc : NULL,false);
 	sc->layer_cnt = 1;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2777,7 +2777,36 @@ return( NULL );
 return( eret );
 }
 
-static Entity *SVGParseSVG(xmlNodePtr svg,int em_size,int ascent,bool scale) {
+void SCDimensionFromSVG(xmlNodePtr svg, SplineChar *sc, bool vert) {
+    char *num;
+    double width, height;
+    num = (char *) xmlGetProp(svg,(xmlChar *) "width");
+    if ( num!=NULL ) {
+	width = strtod(num,NULL);
+	xmlFree(num);
+	if (sc && !vert) sc->width = width;
+    }
+    num = (char *) xmlGetProp(svg,(xmlChar *) "height");
+    if ( num!=NULL ) {
+	height = strtod(num,NULL);
+	xmlFree(num);
+	if (sc && vert) sc->vwidth = height;
+    }
+    return;
+}
+
+void SCDimensionFromSVGFile(const char *path, SplineChar *sc, bool vert) {
+    xmlDocPtr doc;
+    xmlNodePtr svg;
+    doc = xmlParseFile(path);
+    if (doc != NULL)
+	svg = xmlDocGetRootElement(doc);
+    if (svg != NULL)
+	SCDimensionFromSVG(svg, sc, vert);
+    return;
+}
+
+static Entity *SVGParseSVG(xmlNodePtr svg,int em_size,int ascent,bool scale,SplineChar *sc,bool vert) {
     struct svg_state st;
     char *num, *end;
     double swidth,sheight,width=1,height=1;
@@ -2802,11 +2831,13 @@ static Entity *SVGParseSVG(xmlNodePtr svg,int em_size,int ascent,bool scale) {
     if ( num!=NULL ) {
 	width = strtod(num,NULL);
 	xmlFree(num);
+	if (sc && !vert) sc->width = width;
     }
     num = (char *) xmlGetProp(svg,(xmlChar *) "height");
     if ( num!=NULL ) {
 	height = strtod(num,NULL);
 	xmlFree(num);
+	if (sc && vert) sc->vwidth = height;
     }
     if ( height<=0 ) height = 1;
     if ( width<=0 ) width = 1;
@@ -2841,8 +2872,9 @@ static void SVGParseGlyphBody(SplineChar *sc, xmlNodePtr glyph,
 	sc->layers[ly_fore].splines = SVGParseExtendedPath(glyph,glyph);
 	xmlFree(path);
     } else {
+	fprintf(stderr, "Parsing.");
 	Entity *ent = SVGParseSVG(glyph,sc->parent->ascent+sc->parent->descent,
-		sc->parent->ascent,ip->scale);
+		sc->parent->ascent,ip->scale,ip->dimensions ? sc : NULL,false);
 	sc->layer_cnt = 1;
 	SCAppendEntityLayers(sc,ent,ip);
 	if ( sc->layer_cnt==1 ) ++sc->layer_cnt;
@@ -3693,7 +3725,7 @@ return( NULL );
     strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
     oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
-    ret = SVGParseSVG(top,em_size,ascent,scale);
+    ret = SVGParseSVG(top,em_size,ascent,scale,NULL,false);
     setlocale(LC_NUMERIC,oldloc);
     xmlFreeDoc(doc);
 

--- a/fontforge/svg.h
+++ b/fontforge/svg.h
@@ -18,5 +18,6 @@ extern SplineFont *SFReadSVGMem(char *data, int flags);
 extern SplineSet *SplinePointListInterpretSVG(char *filename, char *memory, int memlen, int em_size, int ascent, int is_stroked, ImportParams *eip);
 extern void SFLSetOrder(SplineFont *sf, int layerdest, int order2);
 extern void SFSetOrder(SplineFont *sf, int order2);
+extern void SCDimensionFromSVGFile(const char *path, SplineChar *sc, bool vert);
 
 #endif /* FONTFORGE_SVG_H */


### PR DESCRIPTION
This set of changes allows setting SplineChar width from an imported discrete SVG file by setting the new "dimensions" flag in the Python routine `SplineChar.importOutlines`. Default behavior remains ignoring the SVG dimensions.

Test as follows.

```
frank@Luther-1:~/Projects_1/2022/Weather_Typeface_1/Samples_1$ /var/tmp/ff10/fontforge/build/bin/fontforge -lang=py -script
Copyright (c) 2000-2019. See AUTHORS for Contributors.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
 with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.
 Version: 20220308
 Based on sources from 17:58 UTC 23-Jul-2019-ML-D-GDK3.
 Based on source from git with hash: 4f83172d44db72544b1bacf11b79bddf1d236647
PythonUI_Init()
copyUIMethodsToBaseTable()
Program root: /var/tmp/ff10/fontforge/build
Python 3.7.5 (default, Dec  9 2021, 17:04:37)
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> font0 = fontforge.font()
>>> font0.ascent = 55
>>> font0.descent = 0
>>> char0 = font0.createChar(257)
>>> char0.importOutlines(filename="WeatherSymbol_WMO_CloudHigh_CH_1.svg",scale=False)
<fontforge.glyph at 0x0x7f27eb78e4b0 U+0101 "glyph0">
>>> font0.save("font0_5.sfd")
<fontforge.font at 0x0x7f27eb78e430 "Untitled1">
>>> quit()
```

![WeatherSymbol_WMO_CloudHigh_CH_1](https://user-images.githubusercontent.com/2512464/166948037-8f8c5f7b-b25e-4229-9afc-6205e157d1d6.svg)
