### PR TITLE
Support setting SplineChar width from importOutlines.

### DIFF
--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -62,6 +62,7 @@ void InitImportParams(ImportParams *ip) {
     ip->scale = true;
     ip->accuracy_target = 0.25;
     ip->default_joinlimit = JLIMIT_INHERITED;
+    ip->dimensions = false;
 }
 
 ImportParams *ImportParamsState() {
@@ -350,6 +351,8 @@ void SCImportSVG(SplineChar *sc,int layer,char *path,char *memory, int memlen,
                  bool doclear, ImportParams *ip) {
     SplinePointList *spl, *espl, **head;
 
+    if (ip->dimensions)
+	SCDimensionFromSVGFile(path, sc, false);
     if ( sc->parent->multilayer && layer>ly_back ) {
 	SCAppendEntityLayers(sc,
 	       EntityInterpretSVG(path,memory,memlen,

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -8545,7 +8545,7 @@ Py_RETURN( self );
 
 static char *glyph_import_keywords[] = { "filename", "correctdir",
     "simplify", "handle_clip", "handle_eraser", "scale", "accuracy",
-    "default_joinlimit", "usesystem", "asksystem", NULL };
+    "default_joinlimit", "usesystem", "asksystem", "dimensions", NULL };
 
 /* Legacy PostScript importing flags */
 static struct flaglist import_ps_flags[] = {
@@ -8569,10 +8569,10 @@ static PyObject *PyFFGlyph_import(PyObject *self, PyObject *args,
     InitImportParams(&ip);
 
     if ( !PyArg_ParseTupleAndKeywords(args, keywds,
-                "s|$pppppddpp", glyph_import_keywords, &filename,
+                "s|$pppppddppp", glyph_import_keywords, &filename,
                 &ip.correct_direction, &ip.simplify, &ip.clip, &ip.erasers,
                 &ip.scale, &ip.accuracy_target, &jl_tmp, &use_system,
-		&ask_system) ) {
+		&ask_system, &ip.dimensions) ) {
 	PyErr_Clear();
 	if ( !PyArg_ParseTuple(args,"s|O",&filename, &flags) )
 	    return NULL;

--- a/fontforge/sd.h
+++ b/fontforge/sd.h
@@ -189,6 +189,7 @@ typedef struct importparams {
     int clip;			// SVG
     int erasers;		// PS
     int scale;			// Misc
+    int dimensions;		// Misc
     bigreal accuracy_target;
     bigreal default_joinlimit;
 } ImportParams;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2779,18 +2779,21 @@ return( eret );
 
 void SCDimensionFromSVG(xmlNodePtr svg, SplineChar *sc, bool vert) {
     char *num;
+    char *end;
     double width, height;
     num = (char *) xmlGetProp(svg,(xmlChar *) "width");
     if ( num!=NULL ) {
-	width = strtod(num,NULL);
+	width = strtod(num, &end);
+	if (sc && (*end == '\0' || *end == ' ') && !vert)
+		sc->width = width;
 	xmlFree(num);
-	if (sc && !vert) sc->width = width;
     }
     num = (char *) xmlGetProp(svg,(xmlChar *) "height");
     if ( num!=NULL ) {
-	height = strtod(num,NULL);
+	height = strtod(num, &end);
+	if (sc && (*end == '\0' || *end == ' ') && vert)
+		sc->vwidth = height;
 	xmlFree(num);
-	if (sc && vert) sc->vwidth = height;
     }
     return;
 }
@@ -2829,15 +2832,17 @@ static Entity *SVGParseSVG(xmlNodePtr svg,int em_size,int ascent,bool scale,Spli
 
     num = (char *) xmlGetProp(svg,(xmlChar *) "width");
     if ( num!=NULL ) {
-	width = strtod(num,NULL);
+	width = strtod(num, &end);
+	if (sc && (*end == '\0' || *end == ' ') && !vert)
+		sc->width = width;
 	xmlFree(num);
-	if (sc && !vert) sc->width = width;
     }
     num = (char *) xmlGetProp(svg,(xmlChar *) "height");
     if ( num!=NULL ) {
-	height = strtod(num,NULL);
+	height = strtod(num, &end);
+	if (sc && (*end == '\0' || *end == ' ') && vert)
+		sc->vwidth = height;
 	xmlFree(num);
-	if (sc && vert) sc->vwidth = height;
     }
     if ( height<=0 ) height = 1;
     if ( width<=0 ) width = 1;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2777,7 +2777,36 @@ return( NULL );
 return( eret );
 }
 
-static Entity *SVGParseSVG(xmlNodePtr svg,int em_size,int ascent,bool scale) {
+void SCDimensionFromSVG(xmlNodePtr svg, SplineChar *sc, bool vert) {
+    char *num;
+    double width, height;
+    num = (char *) xmlGetProp(svg,(xmlChar *) "width");
+    if ( num!=NULL ) {
+	width = strtod(num,NULL);
+	xmlFree(num);
+	if (sc && !vert) sc->width = width;
+    }
+    num = (char *) xmlGetProp(svg,(xmlChar *) "height");
+    if ( num!=NULL ) {
+	height = strtod(num,NULL);
+	xmlFree(num);
+	if (sc && vert) sc->vwidth = height;
+    }
+    return;
+}
+
+void SCDimensionFromSVGFile(const char *path, SplineChar *sc, bool vert) {
+    xmlDocPtr doc;
+    xmlNodePtr svg;
+    doc = xmlParseFile(path);
+    if (doc != NULL)
+	svg = xmlDocGetRootElement(doc);
+    if (svg != NULL)
+	SCDimensionFromSVG(svg, sc, vert);
+    return;
+}
+
+static Entity *SVGParseSVG(xmlNodePtr svg,int em_size,int ascent,bool scale,SplineChar *sc,bool vert) {
     struct svg_state st;
     char *num, *end;
     double swidth,sheight,width=1,height=1;
@@ -2802,11 +2831,13 @@ static Entity *SVGParseSVG(xmlNodePtr svg,int em_size,int ascent,bool scale) {
     if ( num!=NULL ) {
 	width = strtod(num,NULL);
 	xmlFree(num);
+	if (sc && !vert) sc->width = width;
     }
     num = (char *) xmlGetProp(svg,(xmlChar *) "height");
     if ( num!=NULL ) {
 	height = strtod(num,NULL);
 	xmlFree(num);
+	if (sc && vert) sc->vwidth = height;
     }
     if ( height<=0 ) height = 1;
     if ( width<=0 ) width = 1;
@@ -2842,7 +2873,7 @@ static void SVGParseGlyphBody(SplineChar *sc, xmlNodePtr glyph,
 	xmlFree(path);
     } else {
 	Entity *ent = SVGParseSVG(glyph,sc->parent->ascent+sc->parent->descent,
-		sc->parent->ascent,ip->scale);
+		sc->parent->ascent,ip->scale,ip->dimensions ? sc : NULL,false);
 	sc->layer_cnt = 1;
 	SCAppendEntityLayers(sc,ent,ip);
 	if ( sc->layer_cnt==1 ) ++sc->layer_cnt;
@@ -3693,7 +3724,7 @@ return( NULL );
     strncpy( oldloc,setlocale(LC_NUMERIC,NULL),24 );
     oldloc[24]=0;
     setlocale(LC_NUMERIC,"C");
-    ret = SVGParseSVG(top,em_size,ascent,scale);
+    ret = SVGParseSVG(top,em_size,ascent,scale,NULL,false);
     setlocale(LC_NUMERIC,oldloc);
     xmlFreeDoc(doc);
 

--- a/fontforge/svg.h
+++ b/fontforge/svg.h
@@ -18,5 +18,6 @@ extern SplineFont *SFReadSVGMem(char *data, int flags);
 extern SplineSet *SplinePointListInterpretSVG(char *filename, char *memory, int memlen, int em_size, int ascent, int is_stroked, ImportParams *eip);
 extern void SFLSetOrder(SplineFont *sf, int layerdest, int order2);
 extern void SFSetOrder(SplineFont *sf, int order2);
+extern void SCDimensionFromSVGFile(const char *path, SplineChar *sc, bool vert);
 
 #endif /* FONTFORGE_SVG_H */

--- a/fontforgeexe/cvimportdlg.c
+++ b/fontforgeexe/cvimportdlg.c
@@ -267,11 +267,11 @@ void _ImportParamsDlg(ImportParams *ip) {
     GRect pos;
     GWindow gw;
     GWindowAttrs wattrs;
-    GGadgetCreateData gcd[12], boxes[4], *hvarray[12][4], *barray[10];
-    GTextInfo label[12];
+    GGadgetCreateData gcd[13], boxes[4], *hvarray[13][4], *barray[10];
+    GTextInfo label[13];
     char accbuf[20], jlbuf[20];
     int done = false, err = false;
-    int k, he_k, cd_k, si_k, sc_k, cl_k, al_k;
+    int k, he_k, cd_k, si_k, sc_k, cl_k, di_k, al_k;
 
     if ( no_windowing_ui )
 	return;
@@ -373,13 +373,26 @@ void _ImportParamsDlg(ImportParams *ip) {
     hvarray[5][2] = GCD_ColSpan;
     hvarray[5][3] = NULL;
 
+    di_k = k;
+    label[k].text = (unichar_t *) _("Infer glyph width (Misc)");
+    label[k].text_is_1byte = true;
+    gcd[k].gd.label = &label[k];
+    gcd[k].gd.pos.x = gcd[k-1].gd.pos.x; gcd[k].gd.pos.y = gcd[k-1].gd.pos.y+15;
+    gcd[k].gd.flags = gg_enabled | gg_visible|
+	    (ip->dimensions?gg_cb_on:0);
+    gcd[k++].creator = GCheckBoxCreate;
+    hvarray[6][0] = &gcd[k-1];
+    hvarray[6][1] = GCD_ColSpan;
+    hvarray[6][2] = GCD_ColSpan;
+    hvarray[6][3] = NULL;
+
     label[k].text = (unichar_t *) _("Default Join Limit (PS/EPS/SVG):");
     label[k].text_is_1byte = true;
     label[k].text_in_resource = true;
     gcd[k].gd.label = &label[k];
     gcd[k].gd.flags = gg_visible | gg_enabled;
     gcd[k++].creator = GLabelCreate;
-    hvarray[6][0] = &gcd[k-1];
+    hvarray[7][0] = &gcd[k-1];
 
     sprintf( jlbuf, "%g", (double) (ip->default_joinlimit) );
     label[k].text = (unichar_t *) jlbuf;
@@ -392,9 +405,9 @@ void _ImportParamsDlg(ImportParams *ip) {
       "of 1/2 stroke-width. Set to -1 to use the format-\n"
       "specific limits of 10.0 for PostScript and 4.0 for SVG.");
     gcd[k++].creator = GTextFieldCreate;
-    hvarray[6][1] = &gcd[k-1];
-    hvarray[6][2] = GCD_Glue;
-    hvarray[6][3] = NULL;
+    hvarray[7][1] = &gcd[k-1];
+    hvarray[7][2] = GCD_Glue;
+    hvarray[7][3] = NULL;
 
     label[k].text = (unichar_t *) _("Accuracy _Target:");
     label[k].text_is_1byte = true;
@@ -402,7 +415,7 @@ void _ImportParamsDlg(ImportParams *ip) {
     gcd[k].gd.label = &label[k];
     gcd[k].gd.flags = gg_visible | gg_enabled;
     gcd[k++].creator = GLabelCreate;
-    hvarray[7][0] = &gcd[k-1];
+    hvarray[8][0] = &gcd[k-1];
 
     sprintf( accbuf, "%g", (double) (ip->accuracy_target) );
     label[k].text = (unichar_t *) accbuf;
@@ -414,9 +427,9 @@ void _ImportParamsDlg(ImportParams *ip) {
       "The Expand Stroke algorithm will attempt to be (at\n"
       "least) this accurate, but there may be exceptions.");
     gcd[k++].creator = GTextFieldCreate;
-    hvarray[7][1] = &gcd[k-1];
-    hvarray[7][2] = GCD_Glue;
-    hvarray[7][3] = NULL;
+    hvarray[8][1] = &gcd[k-1];
+    hvarray[8][2] = GCD_Glue;
+    hvarray[8][3] = NULL;
 
     al_k = k;
     label[k].text = (unichar_t *) _("_Always raise this dialog when importing");
@@ -425,10 +438,10 @@ void _ImportParamsDlg(ImportParams *ip) {
     gcd[k].gd.label = &label[k];
     gcd[k].gd.flags = gg_enabled | gg_visible | (ip->show_always?gg_cb_on:0);
     gcd[k++].creator = GCheckBoxCreate;
-    hvarray[8][0] = &gcd[k-1];
-    hvarray[8][1] = GCD_ColSpan;
-    hvarray[8][2] = GCD_ColSpan;
-    hvarray[8][3] = NULL;
+    hvarray[9][0] = &gcd[k-1];
+    hvarray[9][1] = GCD_ColSpan;
+    hvarray[9][2] = GCD_ColSpan;
+    hvarray[9][3] = NULL;
 
     gcd[k].gd.flags = gg_visible | gg_enabled | gg_but_default;
     label[k].text = (unichar_t *) _("_OK");
@@ -445,15 +458,15 @@ void _ImportParamsDlg(ImportParams *ip) {
     boxes[2].gd.flags = gg_enabled | gg_visible;
     boxes[2].gd.u.boxelements = barray;
     boxes[2].creator = GHBoxCreate;
-    hvarray[9][0] = GCD_Glue;
-    hvarray[9][1] = GCD_ColSpan;
-    hvarray[9][2] = GCD_ColSpan;
-    hvarray[9][3] = NULL;
-    hvarray[10][0] = &boxes[2];
+    hvarray[10][0] = GCD_Glue;
     hvarray[10][1] = GCD_ColSpan;
     hvarray[10][2] = GCD_ColSpan;
     hvarray[10][3] = NULL;
-    hvarray[11][0] = NULL;
+    hvarray[11][0] = &boxes[2];
+    hvarray[11][1] = GCD_ColSpan;
+    hvarray[11][2] = GCD_ColSpan;
+    hvarray[11][3] = NULL;
+    hvarray[12][0] = NULL;
 
     boxes[0].gd.pos.x = boxes[0].gd.pos.y = 2;
     boxes[0].gd.flags = gg_enabled | gg_visible;
@@ -475,6 +488,7 @@ void _ImportParamsDlg(ImportParams *ip) {
     ip->simplify = GGadgetIsChecked(gcd[si_k].ret);
     ip->clip = GGadgetIsChecked(gcd[cl_k].ret);
     ip->scale = GGadgetIsChecked(gcd[sc_k].ret);
+    ip->dimensions = GGadgetIsChecked(gcd[di_k].ret);
     ip->default_joinlimit = GetReal8(gw,CID_JoinLimitVal,_("Default Join Limit (PS/EPS/SVG):"),&err);
     if ( err ) {
 	ip->default_joinlimit = JLIMIT_INHERITED;


### PR DESCRIPTION
This supersedes #5004.

This set of changes allows setting SplineChar width from an imported discrete SVG file by setting the new "dimensions" flag in the Python routine `SplineChar.importOutlines`. Default behavior remains ignoring the SVG dimensions.

Test as follows.

```
frank@Luther-1:~/Projects_1/2022/Weather_Typeface_1/Samples_1$ /var/tmp/ff10/fontforge/build/bin/fontforge -lang=py -script
Copyright (c) 2000-2019. See AUTHORS for Contributors.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
 with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.
 Version: 20220308
 Based on sources from 17:58 UTC 23-Jul-2019-ML-D-GDK3.
 Based on source from git with hash: 4f83172d44db72544b1bacf11b79bddf1d236647
PythonUI_Init()
copyUIMethodsToBaseTable()
Program root: /var/tmp/ff10/fontforge/build
Python 3.7.5 (default, Dec  9 2021, 17:04:37)
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> font0 = fontforge.font()
>>> font0.ascent = 55
>>> font0.descent = 0
>>> char0 = font0.createChar(257)
>>> char0.importOutlines(filename="WeatherSymbol_WMO_CloudHigh_CH_1.svg",scale=False,dimensions=True)
<fontforge.glyph at 0x0x7f27eb78e4b0 U+0101 "glyph0">
>>> font0.save("font0_5.sfd")
<fontforge.font at 0x0x7f27eb78e430 "Untitled1">
>>> quit()
```

![WeatherSymbol_WMO_CloudHigh_CH_1](https://user-images.githubusercontent.com/2512464/166948037-8f8c5f7b-b25e-4229-9afc-6205e157d1d6.svg)
