### PR TITLE
Prevents memory underflow in GFileMimeType() in gutils/fsys.c

### DIFF
--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -1039,7 +1039,7 @@ char* GFileMimeType(const char *path) {
         } else {
             pt = copy(pt + 1);
             int len = strlen(pt);
-            if (pt[len - 1] == '~') {
+            if (len && pt[len - 1] == '~') {
                 pt[len - 1] = '\0';
             }
 


### PR DESCRIPTION
Short-circuits out the function in the specific case of '..', which was under-flowing the later check `if (pt[len - 1] == '~')`

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**
