### PR TITLE
GroupFindLPos() in fontforgeexe/groupsdlg.c null pointer fix

### DIFF
--- a/fontforgeexe/groupsdlg.c
+++ b/fontforgeexe/groupsdlg.c
@@ -98,6 +98,7 @@ return( NULL );
 	    if ( lpos<group->kids[i+1]->lpos )
 	break;
 	}
+   if(!group->kids) return NULL;
 	group = group->kids[i];
 	++*depth;
     }

--- a/gutils/fsys.c
+++ b/gutils/fsys.c
@@ -1027,6 +1027,15 @@ char* GFileMimeType(const char *path) {
 
     if (!mres || uncertain || strstr(mres, "application/x-ext") || !strcmp(mres, "application/octet-stream")) {
         path = GFileNameTail(path);
+
+        // Prevents a 1-byte underflow when trying to strip '~' further down, as well as breaking
+        // early for this exact match. This may be better abstracted out alongside altering the
+        // behaviour when clicking 'Open' on any directory, however?
+        if (strcmp(path, "..") == 0) {
+            ret = copy("inode/directory");
+            return ret;
+        }
+
         pt = strrchr(path, '.');
 
         if (pt == NULL) {


### PR DESCRIPTION
Fixes a segfault caused by clicking in the empty space below encoding groups lists where the last node is empty.

### Type of change
- **Bug fix**
- **Non-breaking change**
