### PR TITLE
GroupFindLPos() in fontforgeexe/groupsdlg.c null pointer fix

### DIFF
--- a/fontforgeexe/groupsdlg.c
+++ b/fontforgeexe/groupsdlg.c
@@ -98,6 +98,10 @@ return( NULL );
 	    if ( lpos<group->kids[i+1]->lpos )
 	break;
 	}
+
+   // Return null if this is an empty node (prevents segfault on clicks under a group list)
+   if(!group->kids) return NULL;
+
 	group = group->kids[i];
 	++*depth;
     }


### PR DESCRIPTION
Fixes a segfault caused by clicking in the empty space below encoding groups lists where the last node is empty.

### Type of change
- **Bug fix**
- **Non-breaking change**
