### PR TITLE
Fix Ascent & Descent Importing from SVG Font

### DIFF
--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -3382,9 +3382,9 @@ return( NULL );
 		descent = strtod((char *) name,NULL);
 		xmlFree(name);
 	    }
-	    if ( ascent-descent==sf->ascent+sf->descent ) {
+	    if ( ascent+descent==sf->ascent+sf->descent ) {
 		sf->ascent = ascent;
-		sf->descent = -descent;
+		sf->descent = descent;
 	    }
 	    sf->pfminfo.pfmset = true;
 	} else if ( xmlStrcmp(kids->name,(const xmlChar *) "glyph")==0 ||


### PR DESCRIPTION
Fixed sign error when importing the ascent and descent from an SVG font.

Fixes #5028 

### Type of change
- **Bug fix**
- **Non-breaking change**
