### PR TITLE
Define PATH_MAX and MAXPATHLEN for GNU/Hurd compatibility

### DIFF
--- a/inc/basics.h
+++ b/inc/basics.h
@@ -124,6 +124,8 @@ static inline int imax(int a, int b)
 		    }
 
 #ifdef __GNU__
+// This is for GNU Hurd, not GCC.
+// cf. <https://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html>
 # ifndef PATH_MAX
 #  define PATH_MAX 4096
 # endif

--- a/inc/basics.h
+++ b/inc/basics.h
@@ -123,5 +123,13 @@ static inline int imax(int a, int b)
 			last = newitem;		       \
 		    }
 
+#ifdef __GNU__
+# ifndef PATH_MAX
+#  define PATH_MAX 4096
+# endif
+# ifndef MAXPATHLEN
+#  define MAXPATHLEN 4096
+# endif
+#endif
 
 #endif /* FONTFORGE_BASICS_H */


### PR DESCRIPTION
On GNU Hurd systems (such as Debian GNU/Hurd), Fontforge failed to build from source (FTBFS) because of `MAXPATHLEN` and `PATH_MAX` being undefined on Hurd, e.g.

```
/usr/bin/cc  -I../../inc -Iinc -isystem /usr/include/glib-2.0 -isystem /usr/lib/i386-gnu/glib-2.0/include -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -Werror=implicit-function-declaration -Werror=int-conversion -fdiagnostics-color=always -std=gnu99 -MD -MT gutils/CMakeFiles/gutils.dir/fsys.c.o -MF gutils/CMakeFiles/gutils.dir/fsys.c.o.d -o gutils/CMakeFiles/gutils.dir/fsys.c.o -c ../../gutils/fsys.c
../../gutils/fsys.c:51:22: error: ‘MAXPATHLEN’ undeclared here (not in a function); did you mean ‘MAXNAMLEN’?
   51 | static char dirname_[MAXPATHLEN+1];
      |                      ^~~~~~~~~~
      |                      MAXNAMLEN
```

Special thanks to fellow Debian Developers @henrich, @ucko and @kilobyte for reporting the issue and offering suggestions on a fix back in 2017; see #3119 and <https://bugs.debian.org/877795>.

[Hurd's philosophy of using dynamic memory allocation for these variables](https://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html) aside (thanks to @jtanx for the reference), defining `PATH_MAX` and `MAXPATHLEN` as `4096` for GNU Hurd (distinguished by its unique `__GNU__` definition) is an easy and non-intrusive solution that would make Fontforge truly universal, as can be seen in the Fontforge build for all 23 architectures that Debian builds for at <https://buildd.debian.org/status/package.php?p=fontforge>.

This patch has been tested to build successfully on Hurd (and all architectures) with the Debian release of fontforge (1:20201107~dfsg-4) on 2021-01-15.

Fixes #3119

### Type of change

- **Bug fix**
- **Non-breaking change**
