### PR TITLE
Fix pfadecrypt bugs

### DIFF
--- a/contrib/fonttools/pfadecrypt.c
+++ b/contrib/fonttools/pfadecrypt.c
@@ -67,7 +67,7 @@ static void decodestr(unsigned char *str, int len) {
 
     while ( len-->0 ) {
 	cypher = *str;
-	plain = ( cypher ^ (r>>8));
+	plain = ( cypher ^ (rc>>8));
 	rc = (cypher + rc) * c1 + c2;
 	*str++ = plain;
     }

--- a/contrib/fonttools/pfadecrypt.c
+++ b/contrib/fonttools/pfadecrypt.c
@@ -325,7 +325,7 @@ return;
 		    putc(decode(ch1),temp);
 		}
 	    } else {
-		if ( ch1=='0' ) ++zcnt; else {dumpzeros(temp,zeros,zcnt); zcnt = 0; }
+		if ( ch1=='0' || isspace(ch1) ) ++zcnt; else {dumpzeros(temp,zeros,zcnt); zcnt = 0; }
 		if ( zcnt>EODMARKLEN )
 	break;
 		if ( zcnt==0 )


### PR DESCRIPTION
The pfadecrypt T1 font decryption utility had a couple simple bugs that resulted gibberish when decoding a font.  A bit more detail is given in the commit messages.



### Type of change
- **Bug fix**
