### PR TITLE
Include `SFDUTF7` functions in `libfontforge.so`

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -204,7 +204,7 @@ static char *base64_encode(char *ostr, long ch) {
 return( ostr );
 }
 
-static void SFDDumpUTF7Str(FILE *sfd, const char *_str) {
+void SFDDumpUTF7Str(FILE *sfd, const char *_str) {
     int ch, prev_cnt=0, prev=0, in=0;
     const unsigned char *str = (const unsigned char *) _str;
 
@@ -410,7 +410,7 @@ return( nlgetc(sfd));
 return( ch );
 }
 
-static char *SFDReadUTF7Str(FILE *sfd) {
+char *SFDReadUTF7Str(FILE *sfd) {
     char *buffer = NULL, *pt, *end = NULL;
     int ch1, ch2, ch3, ch4, done, c;
     int prev_cnt=0, prev=0, in=0;

--- a/fontforge/sfd.h
+++ b/fontforge/sfd.h
@@ -132,4 +132,7 @@ extern int SFDWrite(char *filename,SplineFont *sf,EncMap *map,EncMap *normal, in
 typedef void (*visitSFDFragmentFunc)(FILE *sfd, char *tokbuf, SplineFont *sf, void* udata);
 extern void visitSFDFragment(FILE *sfd, SplineFont *sf, visitSFDFragmentFunc ufunc, void* udata);
 
+extern void SFDDumpUTF7Str(FILE *sfd, const char *_str);
+extern char *SFDReadUTF7Str(FILE *sfd);
+
 #endif /* FONTFORGE_SFD_H */


### PR DESCRIPTION
I understand that the API's there are not guaranteed stable, but this
would help a lot with `sfdnormalize` project, as it givess me a way to
actually test that my library `sfdutf7` returns correct results.

See also <https://twitter.com/fr_brennan/status/1555879287840034817/>.

cc: @alerque

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
