### PR TITLE
Fix typo in man page

### DIFF
--- a/fontforgeexe/fontforge.1
+++ b/fontforgeexe/fontforge.1
@@ -171,10 +171,10 @@ Executes argument as scripting commands.  Must be the first option.
 All other arguments are passed to the script.
 .TP
 .B \-skippyfile
-Do not execute Python init scripts when initialiszing.
+Do not execute Python init scripts when initializing.
 .TP
 .B \-skippyplug
-Do not load (enabled) Python plugins when initialiszing.
+Do not load (enabled) Python plugins when initializing.
 .SH EXAMPLE
 Sample usage:
 .PP


### PR DESCRIPTION
(Uses the US spelling instead of both UK and US at the same time, LOL. This'll match the rest of the docs.)

### Type of change
- **Non-breaking change**
