### PR TITLE
Fix broken link on scripting page

### DIFF
--- a/doc/sphinx/scripting/scripting.rst
+++ b/doc/sphinx/scripting/scripting.rst
@@ -1041,7 +1041,7 @@ Deprecated Names
 Examples
 --------
 
-* `FontForge's testsuite in the test subdirectory <https://github.com/fontforge/fontforge/tree/master/test>`__
+* `FontForge's testsuite in the test subdirectory <https://github.com/fontforge/fontforge/tree/master/tests>`__
   (such as it is)
 * `Directory of donated scripts <https://github.com/fontforge/fontforge/tree/master/pycontrib>`__
 * Scripts used in other projects


### PR DESCRIPTION
Link at https://fontforge.org/docs/scripting/scripting.html#scripting-example for testsuite scripts directs to  https://github.com/fontforge/fontforge/tree/master/test it should use
https://github.com/fontforge/fontforge/tree/master/tests


### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **Non-breaking change**
Fixes https://github.com/fontforge/fontforge/issues/5134
