### PR TITLE
tottfgpos: Fix needless warning about 16-bit field

### DIFF
--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -2030,7 +2030,7 @@ static void dumpGSUBsimplesubs(FILE *gsub,SplineFont *sf,struct lookup_subtable 
 	putshort(gsub,1);	/* delta format */
 	coverage_pos = ftell(gsub);
 	putshort(gsub,0);		/* offset to coverage table */
-	putshort(gsub,diff);
+	putshort(gsub,diff & 0xFFFF);
     } else {
 	putshort(gsub,2);		/* glyph list format */
 	coverage_pos = ftell(gsub);


### PR DESCRIPTION
**[why]**
When a single substitution table (format 1) is to be written and the substitution offset is very big and backwards (i.e. to lower numbers) a warning is issued although the encoded font is correct.

For example codepoint 65342 is to be replaced by 1683. The offset is -63659 in this case (old codepoint + offset = new codepoint).

The warning in putshort() triggers: `if(sval < -32768 || sval > 65535) ...`

**[how]**
The offset is calculated with signed ints, so we have the result above. The actual calculations 'in the font' are done with uint16_t. According to specs "Addition of deltaGlyphID is modulo 65536" [1]. So we simply need to drop all the bits outside uint16_t and still have the correct calculation.

With the new offset value of -63659 & 0xFFFF = 1877 the calculation is

65342 + 1877 = 67219 == 1683 (assuming unit16_t arithmetic)

[1] https://learn.microsoft.com/en-us/typography/opentype/spec/gsub#11-single-substitution-format-1

Fixes: #3009

Reported-by: Thayne McCombs @tmccombs
Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>

### Type of change
- **Bug fix**


### Reproduction / Test

Font to try:

Repo link https://github.com/googlefonts/noto-cjk/releases/tag/Sans2.004
Zip link https://github.com/googlefonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip
Font file in zip `NotoSansCJKjp-Bold.otf`

Affected lookup: CID -> CID font info -> Lookups -> 31 ('hist')

Just open and immediately re-generate new CID font.

See comments in #3009.