### PR TITLE
Don't require individual tuple encapsulation in fontforge.font.bitmapSizes setter

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -12003,7 +12003,8 @@ return(-1);
 return( -1 );
     sizes = malloc((cnt+1)*sizeof(int));
     for ( i=0; i<cnt; ++i ) {
-	if ( !PyArg_ParseTuple(PyTuple_GetItem(value,i),"i", &sizes[i])) {
+	sizes[i] = PyLong_AsLong(PyTuple_GetItem(value,i));
+	if (PyErr_Occurred() && !PyArg_ParseTuple(PyTuple_GetItem(value,i),"i", &sizes[i])) {
 	    free(sizes);
 return( -1 );
 	}


### PR DESCRIPTION
Documentation specs that this should take the same format as font.bitmapSizes returns: it doesn't;
```
>>> f.bitmapSizes = ((1,), (2,))
```
yields
```
>>> f.bitmapSizes
(1, 2)
```

Which is fun, but what actually happens is the user gets
```
>>> f.bitmapSizes = (1, 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: new style getargs format but argument is not a tuple
```
and gives up, as in #5137. This is also, obviously, not reversible, unlike specced.

The new behaviour is congruent with the documentation (error cases included at the end):
```
(sid-with-nab ff)root@tarta:/srv/fontforge/build# bin/fontforge -
Copyright (c) 2000-2022. See AUTHORS for Contributors.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
 with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.
 Version: 20220308
 Based on sources from 2022-11-10 01:12 UTC-ML-D-GDK3.
 Based on source from git with hash: 8ce3216d492d4a249ffec163c005d098df28e58c
>>> f=fontforge.font()
>>> f.bitmapSizes = (16, 32, 64, 128)
Number out of range: 2.14748e+09 in type2 output (must be [-65536,65535])
>>> f.bitmapSizes
(16, 32, 64, 128)
>>> f.bitmapSizes = ()
>>> f.bitmapSizes
()
>>> f.bitmapSizes = (48,)
Number out of range: 2.14748e+09 in type2 output (must be [-65536,65535])
>>> f.bitmapSizes
(48,)
>>>
>>>
>>> f.bitmapSizes = (48,())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'tuple' object cannot be interpreted as an integer
>>> f.bitmapSizes = 48
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: ../Objects/tupleobject.c:172: bad argument to internal function
```

idk what the ERANGEs are but they're unrelated

### Type of change
- **Bug fix**: #5137