### PR TITLE
Fix woff2 decoding

### DIFF
--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -639,20 +639,15 @@ int _WriteWOFF2Font(FILE *fp, SplineFont *sf, enum fontformat format, int32_t *b
         return 0;
     }
 
-    size_t raw_input_length = 0;
+    size_t raw_input_length = 0, comp_size;
     uint8_t *raw_input = ReadFileToBuffer(tmp, &raw_input_length);
     fclose(tmp);
     if (!raw_input) {
         return 0;
     }
 
-    size_t comp_size = woff2_max_woff2_compressed_size(raw_input, raw_input_length);
-    uint8_t *comp_buffer = calloc(comp_size, 1);
-    if (!comp_buffer) {
-        free(raw_input);
-        return 0;
-    }
-    ret = woff2_convert_ttf_to_woff2(raw_input, raw_input_length, comp_buffer, &comp_size);
+    uint8_t *comp_buffer;
+    ret = woff2_convert_ttf_to_woff2(raw_input, raw_input_length, &comp_buffer, &comp_size);
     free(raw_input);
     if (!ret) {
         free(comp_buffer);
@@ -666,23 +661,14 @@ int _WriteWOFF2Font(FILE *fp, SplineFont *sf, enum fontformat format, int32_t *b
 
 SplineFont *_SFReadWOFF2(FILE *fp, int flags, enum openflags openflags, char *filename,char *chosenname,struct fontdict *fd)
 {
-    size_t raw_input_length = 0;
+    size_t raw_input_length = 0, decomp_size;
     if (!fp) {
         return NULL;
     }
 
     uint8_t *raw_input = ReadFileToBuffer(fp, &raw_input_length);
-
-    size_t decomp_size = woff2_compute_woff2_final_size(raw_input, raw_input_length);
-    if (decomp_size > WOFF2_DEFAULT_MAX_SIZE) {
-        decomp_size = WOFF2_DEFAULT_MAX_SIZE;
-    }
-    uint8_t *decomp_buffer = calloc(decomp_size, 1);
-    if (!decomp_buffer) {
-        free(raw_input);
-        return NULL;
-    }
-    int success = woff2_convert_woff2_to_ttf(raw_input, raw_input_length, decomp_buffer, &decomp_size);
+    uint8_t *decomp_buffer;
+    int success = woff2_convert_woff2_to_ttf(raw_input, raw_input_length, &decomp_buffer, &decomp_size);
     free(raw_input);
     if (!success) {
         free(decomp_buffer);

--- a/fontforge/woff.h
+++ b/fontforge/woff.h
@@ -10,11 +10,8 @@ extern int _WriteWOFFFont(FILE *woff, SplineFont *sf, enum fontformat format, in
 extern SplineFont *_SFReadWOFF(FILE *woff, int flags, enum openflags openflags, char *filename, char *chosenname, struct fontdict *fd);
 
 #ifdef FONTFORGE_CAN_USE_WOFF2
-#define WOFF2_DEFAULT_MAX_SIZE (30 * 1024 * 1024) /* = woff2::kDefaultMaxSize */
-extern size_t woff2_max_woff2_compressed_size(const uint8_t* data, size_t length);
-extern size_t woff2_compute_woff2_final_size(const uint8_t *data, size_t length);
-extern int woff2_convert_ttf_to_woff2(const uint8_t *data, size_t length, uint8_t *result, size_t *result_length);
-extern int woff2_convert_woff2_to_ttf(const uint8_t *data, size_t length, uint8_t *result, size_t *result_length);
+extern int woff2_convert_ttf_to_woff2(const uint8_t *data, size_t length, uint8_t **result, size_t *result_length);
+extern int woff2_convert_woff2_to_ttf(const uint8_t *data, size_t length, uint8_t **result, size_t *result_length);
 
 extern int WriteWOFF2Font(char *fontname, SplineFont *sf, enum fontformat format, int32_t *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer);
 extern int _WriteWOFF2Font(FILE *woff, SplineFont *sf, enum fontformat format, int32_t *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer);


### PR DESCRIPTION
Fixes #5101

Re-reading the WOFF2 spec:

> The "totalSfntSize" value in the WOFF2 Header is intended to be
> used for reference purposes only. It may represent the size of
> the uncompressed input font file, but if the transformed 'glyf'
> and 'loca' tables are present, the uncompressed size of the
> reconstructed tables and the total decompressed font size may
> differ substantially from the original total size specified in
> the WOFF2 Header.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**