### PR TITLE
fontinfo.c: fix crash from uninitialised other_pos

### DIFF
--- a/fontforgeexe/fontinfo.c
+++ b/fontforgeexe/fontinfo.c
@@ -2876,6 +2876,7 @@ static int CheckActiveStyleTranslation(struct gfi_data *d,
 	else
 	    new = copy(english);
 	for ( i=0; stylelist[i]!=NULL; ++i ) {
+	    other_pos = -1;
 	    for ( j=0; stylelist[i][j].str!=NULL; ++j ) {
 		if ( stylelist[i][j].lang == other_lang ) {
 		    other_pos = j;


### PR DESCRIPTION
Fixes #5162

Regression from #4889

https://github.com/fontforge/fontforge/commit/2b15c0e80083aefa5392164f6add62e9a1449c38#diff-d15a109191a6ac28861dafcc1e3ee5a96544c68911601ac42e6462cad71aa58eL2879

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**