### PR TITLE
lookups.c: fix variable used in ApplyAppleStateMachine

### DIFF
--- a/fontforge/lookups.c
+++ b/fontforge/lookups.c
@@ -2996,7 +2996,7 @@ static void ApplyAppleStateMachine(OTLookup *otl,struct lookup_data *data) {
 		class = 0;
 	    else {
 		for ( class = sm->class_cnt-1; class>3; --class )
-		    if ( GlyphNameInClass(data->str[i].sc->name,sm->classes[class]) )
+		    if ( GlyphNameInClass(data->str[pos].sc->name,sm->classes[class]) )
 		break;
 		if ( class==3 )
 		    class = 1;		/* Glyph not in any class */;


### PR DESCRIPTION
Maybe fixes #4985

Not entirely sure tbh but this seems to be more correct based on the context of the original commit https://github.com/fontforge/fontforge/commit/1827b9dfe169348f860fff1b524eaeae61007b2d

And it does fix a crash that I observed

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
