### PR TITLE
Remove duplicate namelist entry (Rfractur 0x211C)

### DIFF
--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -20709,7 +20709,6 @@ static struct psaltnames psaltnames[] = {
 	{ "circlecopyrt", 0xa9, 0 },
 	{ "smile", 0x263a, 0 },
 	{ "Ifractur", 0x2111, 0 },
-	{ "Rfractur", 0x211C, 0 },
 	{ "Omegainv", 0x2127, 0 },
 	{ "mho", 0x2127, 0 },
 	{ "alephmath", 0x2135, 0 },


### PR DESCRIPTION
`namelist.c` has a duplicate entry in `psaltnames`:
line 20085: `{ "Rfractur", 0x211c, 0 },`
line 20712: `{ "Rfractur", 0x211C, 0 },`

<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
- **Non-breaking change**
