### PR TITLE
Always set `usDefaultChar` to 0 (.notdef)

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3509,8 +3509,6 @@ docs are wrong.
         os2->capHeight = (caph >= 0.0 ? caph : 0);
     }
 	os2->defChar = 0;
-	if ( format==ff_otf || format==ff_otfcid )
-	    os2->defChar = ' ';
 	os2->breakChar = ' ';
 	os2->maxContext = 1;	/* Kerning will set this to 2, ligature to whatever */
     }


### PR DESCRIPTION
`usDefaultChar` is the code point to use for a default glyph for an unsupported code point. If it is 0, the font uses glyph 0 (.notdef), which is always what you want instead of FontForge’s current behavior of defaulting to U+0020 SPACE.

### Type of change
- **Non-breaking change**
