### PR TITLE
Fix crashes on importing Mac-style dfont/NFNT bitmap fonts with some legal (but unusual?) values 

### DIFF
--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -2348,7 +2348,7 @@ static FOND *BuildFondList(FILE *f,long rlistpos,int subcnt,long rdata_pos,
 		cur->stylewidths[j].style = getushort(f);
 		cur->stylewidths[j].widthtab = malloc((cur->last-cur->first+3)*sizeof(short));
 		for ( k=cur->first; k<=cur->last+2; ++k )
-		    cur->stylewidths[j].widthtab[k] = getushort(f);
+		    cur->stylewidths[j].widthtab[k-cur->first] = getushort(f);
 	    }
 	}
 	if ( kernoff!=0 && (flags&ttf_onlykerns) ) {

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -2395,13 +2395,13 @@ static FOND *BuildFondList(FILE *f,long rlistpos,int subcnt,long rdata_pos,
 	    continue;		/* this style doesn't exist */
 		format = stringoffsets[j]-1;
 		stringlen = strings[0][0];
-		if ( format!=0 )
+		if ( format>0 )
 		    for ( k=0; k<strings[format][0]; ++k )
 			stringlen += strings[ strings[format][k+1]-1 ][0];
 		pt = cur->psnames[j] = malloc(stringlen+1);
 		strcpy(pt,strings[ 0 ]+1);
 		pt += strings[ 0 ][0];
-		if ( format!=0 )
+		if ( format>0 )
 		    for ( k=0; k<strings[format][0]; ++k ) {
 			strcpy(pt,strings[ strings[format][k+1]-1 ]+1);
 			pt += strings[ strings[format][k+1]-1 ][0];


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

This PR contains two commits fixing different crashes due to out-of-bounds array access when reading certain dfont bitmap font files.
- the first crash occurs when a `FOND` resource has a nonzero `startChar` value in its header, and a family glyph-width table is present. The out-of-bounds access is caused as the array index is not adjusted for the start value in the loop.
- the second crash occurs when a `FOND` resource as a Style Mapping table with a Style Index Table with any zero-valued entries. This leads to accessing array index -1.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix** - fixes a bug that is not presently reported as an Issue
