### PR TITLE
Fix several segfaults

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -2735,6 +2735,14 @@ return( NULL );
 		++i;
 	    }
 	    --i;
+	} else if ( (offsets[i+1]-offsets[i])==UINT32_MAX ) {
+		LogError(_("CFF name %u too large\n"), i );
+		if ( info!=NULL ) info->bad_cff = true;
+	    while ( i<count ) {
+		names[i] = copy("");
+		++i;
+	    }
+	    --i;
 	} else {
 	    names[i] = malloc(offsets[i+1]-offsets[i]+1);
 	    for ( j=0; j<offsets[i+1]-offsets[i]; ++j )
@@ -3940,6 +3948,9 @@ return( 0 );
     if ( hdrsize!=4 )
 	fseek(ttf,info->cff_start+hdrsize,SEEK_SET);
     fontnames = readcfffontnames(ttf,NULL,info);
+	if ( fontnames==NULL ) {
+return( 0 );
+	}
     which = 0;
     if ( fontnames[1]!=NULL ) {		/* More than one? Can that even happen in OpenType? */
 	which = PickCFFFont(fontnames);

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -3014,7 +3014,7 @@ SplineFont *SplineFontFromPSFont(FontDict *fd) {
 	SplineFontMetaData(sf,fd);
 	if ( fd->wascff ) {
 	    SplineFontFree(sf);
-	    sf = fd->sf;
+return ( NULL );
 	} else if ( fd->fdcnt!=0 )
 	    sf = SplineFontFromCIDType1(sf,fd,&pscontext);
 	else if ( fd->weightvector!=NULL )


### PR DESCRIPTION
Fixed segfaults in:
- `SplineFontFromPSFont()`
If `fd->wascff` was `true`, then `sf` was set to `fd->sf`, which is always `NULL`. And `sf->multilayer` check caused a segfault.
- `readcffglyphs`
`readcfffontnames` may return `NULL`.
- `readcfffontnames`
`(offsets[i+1]-offsets[i])` could be equal to `UINT32_MAX`, which led to `malloc(0)` call, but the loop exit condition remained `j < UINT32_MAX`.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**