### PR TITLE
Quiet strict prototypes warnings.

### DIFF
--- a/fontforge/glif_name_hash.h
+++ b/fontforge/glif_name_hash.h
@@ -10,7 +10,7 @@ struct glif_name {
   char * glif_name;
 };
 
-struct glif_name_index * glif_name_index_new();
+struct glif_name_index * glif_name_index_new(void);
 void glif_name_index_destroy(struct glif_name_index * hash);
 
 void glif_name_track_new(struct glif_name_index * hash, long int gid, const char * glif_name);

--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -949,7 +949,7 @@ extern void PI_ShowHints(SplineChar *sc, GGadget *list, int set);
 extern GTextInfo *SCHintList(SplineChar *sc,HintMask *);
 extern void CVResize(CharView *cv );
 extern CharView *CharViewCreate(SplineChar *sc,FontView *fv,int enc);
-extern void CharViewFinishNonStatic();
+extern void CharViewFinishNonStatic(void);
 
 /**
  * Extended version of CharViewCreate() which allows a window to be created but
@@ -1075,7 +1075,7 @@ extern int GotoChar(SplineFont *sf,EncMap *map, int *merge_with_selection);
 
 extern void CVShowPoint(CharView *cv, BasePoint *me);
 
-extern void BitmapViewFinishNonStatic();
+extern void BitmapViewFinishNonStatic(void);
 extern BitmapView *BitmapViewCreate(BDFChar *bc, BDFFont *bdf, FontView *fv,int enc);
 extern BitmapView *BitmapViewCreatePick(int enc, FontView *fv);
 extern void BitmapViewFree(BitmapView *bv);
@@ -1091,7 +1091,7 @@ extern void MVSetSCs(MetricsView *mv, SplineChar **scs);
 extern void MVRefreshChar(MetricsView *mv, SplineChar *sc);
 extern void MVRegenChar(MetricsView *mv, SplineChar *sc);
 extern void MVReKern(MetricsView *mv);
-extern void MetricsViewFinishNonStatic();
+extern void MetricsViewFinishNonStatic(void);
 extern MetricsView *MetricsViewCreate(FontView *fv,SplineChar *sc,BDFFont *bdf);
 extern void MetricsViewFree(MetricsView *mv);
 extern void MVRefreshAll(MetricsView *mv);
@@ -1313,7 +1313,7 @@ extern void CVColInit( void );
 extern void BVColInit( void );
 
 extern void FontViewRemove(FontView *fv);
-extern void FontViewFinishNonStatic();
+extern void FontViewFinishNonStatic(void);
 extern void FVChar(FontView *fv,GEvent *event);
 extern void FVDrawInfo(FontView *fv,GWindow pixmap,GEvent *event);
 extern void FVRedrawAllCharViews(FontView *fv);

--- a/inc/gdraw.h
+++ b/inc/gdraw.h
@@ -279,7 +279,7 @@ extern int _GDraw_res_synchronize;
 extern unichar_t *GDrawKeysyms[];
 extern GDisplay *screen_display;
 
-extern void GDrawResourceFind();
+extern void GDrawResourceFind(void);
 
 extern void GDrawDestroyDisplays(void);
 extern void GDrawCreateDisplays(char *displayname,char *programname);

--- a/inc/ggadget.h
+++ b/inc/ggadget.h
@@ -608,8 +608,8 @@ GGadget *CreateGadgets(struct gwindow *base, GGadgetCreateData *gcd);
 
 GTextInfo **GTextInfoArrayFromList(GTextInfo *ti, uint16_t *cnt);
 
-void InitImageCache();
-void ClearImageCache();
+void InitImageCache(void);
+void ClearImageCache(void);
 void GGadgetSetImageDir(const char *dir);
 void GGadgetSetImagePath(const char *path);
 GImage *GGadgetImageCache(const char *filename);


### PR DESCRIPTION
This quiets `-Wstrict-prototypes` warnings emitted by recent versions of Clang.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

