### PR TITLE
Fix lookup flags parsing

### DIFF
--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -3219,7 +3219,6 @@ static void fea_ParseLookupFlags(struct parseState *tok) {
 		fea_skip_to_semi(tok);
 	break;
 	    }
-	    fea_ParseTok(tok);
 	}
 	if ( tok->type != tk_char || tok->tokbuf[0]!=';' ) {
 	    LogError(_("Unexpected token in lookupflags on line %d of %s"), tok->line[tok->inc_depth], tok->filename[tok->inc_depth] );


### PR DESCRIPTION
Fixes parsing of lookup flags in an OT feature file import.

In a line like `lookupflag RightToLeft IgnoreMarks;` the first flag is parsed in line 
featurefile.c:3192, and the next token is parsed on featurefile.c:3213. The problem is that after the second token is verified, there is another parsing command at featurefile.c:3222, which effectively discard the second token and picks yet another one.