### PR TITLE
Update GinHub CI runners

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ env:
   PYTHON: python3.10
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         os: ["ubuntu-latest"]
         target: ["NoUI", "Debug"]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             target: Release
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           name: appimage
           path: repo/build/FontForge-*-x86_64.AppImage
   mac:
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       PYTHON: python3
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Disable fc-cache on fontconfig install. Because it's slow.
-          sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb"
+          sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/f/fontconfig.rb"
           brew install pkg-config ruby cmake ninja
           brew install cairo coreutils fontconfig gettext giflib gtk+3 jpeg libpng libspiro libtiff libtool libuninameslist python@3 wget woff2
           PREFIX=$GITHUB_WORKSPACE/target

--- a/.github/workflows/scripts/ffappimagebuild.sh
+++ b/.github/workflows/scripts/ffappimagebuild.sh
@@ -45,6 +45,6 @@ export PATH=$(readlink -f ./squashfs-root/usr/bin):$PATH
 rm $APPDIR/AppRun
 install -m 755 $SCRIPT_BASE/../../../Packaging/AppDir/AppRun $APPDIR/AppRun # custom AppRun
 ARCH=x86_64 ./squashfs-root/usr/bin/appimagetool -g $APPDIR/
-find $APPDIR -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+find $APPDIR -executable -type f -exec ldd {} \; | grep " => /lib" | cut -d " " -f 2-3 | sort | uniq
 
 mv FontForge*.AppImage FontForge-$(date +%Y-%m-%d)-$VERSION-x86_64.AppImage


### PR DESCRIPTION
Partially fixed CI pipelines.
1. Linux ubuntu-release now passes
2. MacOS now runs to the point where msgfmt fails for some localization messages
3. Windows not changed, also runs till msgfmt failure

The localization messages need to be addressed separately - see https://github.com/fontforge/fontforge/pull/5257