### PR TITLE
Fix CI for Windows GitHub runner

### DIFF
--- a/fontforge/CMakeLists.txt
+++ b/fontforge/CMakeLists.txt
@@ -222,6 +222,11 @@ set_property(SOURCE splineoverlap.c APPEND PROPERTY COMPILE_OPTIONS ${FONTFORGE_
 set_property(TARGET fontforge PROPERTY VERSION 4)
 if(BUILD_SHARED_LIBS)
   if(WIN32 OR CYGWIN)
+    # Both fontforge.exe and *.pyd Python modules look for libfontforge.dll in
+    # their directory, so we need to produce a second copy.
+    add_custom_command(TARGET fontforge POST_BUILD
+      COMMAND cp $<TARGET_FILE:fontforge> ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    )
     target_link_options(fontforge PRIVATE -Wl,--export-all-symbols) # FIXME
   endif()
 endif()


### PR DESCRIPTION
Duplicate libfontforge.dll for "py" and "pyhook" tests.

Both `fontforge.exe` (used in embedded Python tests) and `psMat.pyd, fontforge.pyd` (used in Python hook tests) are looking for `libfontforge.dll` strictly in their respective directories. Both `PATH` environment variable and Python's `sys.path` seem to be ignored.