### PR TITLE
Fix CMake function _get_git_version()

### DIFF
--- a/cmake/FontForgeConfigure.cmake
+++ b/cmake/FontForgeConfigure.cmake
@@ -112,7 +112,7 @@ function(_get_git_version)
     if(Git_FOUND)
       execute_process(
         COMMAND
-          "${GIT_EXECUTABLE}" "log" "--no-show-signature" "--pretty=format:%H" "-n" "1"
+          "${GIT_EXECUTABLE}" "rev-list" "-n" "1" "HEAD"
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         RESULT_VARIABLE GIT_RETVAL
         OUTPUT_VARIABLE GIT_OUTPUT

--- a/cmake/FontForgeConfigure.cmake
+++ b/cmake/FontForgeConfigure.cmake
@@ -112,7 +112,7 @@ function(_get_git_version)
     if(Git_FOUND)
       execute_process(
         COMMAND
-          "${GIT_EXECUTABLE}" "log" "--pretty=format:%H" "-n" "1"
+          "${GIT_EXECUTABLE}" "log" "--no-show-signature" "--pretty=format:%H" "-n" "1"
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         RESULT_VARIABLE GIT_RETVAL
         OUTPUT_VARIABLE GIT_OUTPUT


### PR DESCRIPTION
Fixes #5341
Root cause:  `git log` always shows GPG signatures when user has `git config log.showSignature true`, breaks extraction of current commit hash

Git bug report: https://lore.kernel.org/git/CADQ_TR56X_iMitPEiaOyR_h=1dp9ThUQMu_Vqjest1i8xbh9Tw@mail.gmail.com/T/#u

### Type of change
- **Bug fix**