### PR TITLE
Autoselect internal WOFF2 format

### DIFF
--- a/.github/workflows/scripts/setup_linux_deps.sh
+++ b/.github/workflows/scripts/setup_linux_deps.sh
@@ -7,7 +7,7 @@ sudo add-apt-repository -y ppa:deadsnakes/ppa && sudo apt-get update -y
 sudo apt-get install -y autoconf automake libtool gcc g++ gettext \
     libjpeg-dev libtiff5-dev libpng-dev libfreetype6-dev libgif-dev \
     libx11-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev \
-    libbrotli-dev ninja-build cmake lcov $PYTHON-dev $PYTHON-venv
+    libbrotli-dev libwoff-dev ninja-build cmake lcov $PYTHON-dev $PYTHON-venv
 curl https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON
 
 PREFIX=$GITHUB_WORKSPACE/target

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Upon success, this will leave binary packages in `~/rpmbuild/RPMS` and source pa
 
 You may need to install dependencies, typically packaged for Fedora-derived systems as:
 
-    rpm-devel rpm-build git ninja-build cmake gcc g++ python3-devel libjpeg-devel libtiff-devel libpng-devel giflib-devel freetype-devel libxml2-devel libspiro-devel pango-devel cairo-devel gtk3-devel
+    rpm-devel rpm-build git ninja-build cmake gcc g++ python3-devel libjpeg-devel libtiff-devel libpng-devel giflib-devel freetype-devel libxml2-devel libspiro-devel pango-devel cairo-devel gtk3-devel woff2-devel
 
 ### Building a Mac OS X app bundle
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ The exact method to do this depends on your OS distribution.
 To download all dependencies on Ubuntu, run:
 
 ```sh
-sudo apt-get install libjpeg-dev libtiff5-dev libpng-dev libfreetype6-dev libgif-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev python3-dev ninja-build cmake build-essential gettext;
+sudo apt-get install libjpeg-dev libtiff5-dev libpng-dev libfreetype6-dev libgif-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev libwoff-dev python3-dev ninja-build cmake build-essential gettext;
 ```
 
 Now run the build and installation scripts:

--- a/Packaging/debian/cp-src/control
+++ b/Packaging/debian/cp-src/control
@@ -24,6 +24,7 @@ Build-Depends: bzip2,
                libpng-dev,
                libspiro-dev,
                libtiff-dev,
+               libwoff-dev,
                libxml2-dev,
                python3-dev (>= 3.3)
 Standards-Version: 3.9.7

--- a/fontforge/savefont.c
+++ b/fontforge/savefont.c
@@ -66,9 +66,9 @@ const char *savefont_extensions[] = { ".pfa", ".pfb", ".res", "%s.pfb", ".pfa", 
 	".cid", ".cff", ".cid.cff",
 	".t42", ".t11",
 	".ttf", ".ttf", ".suit", ".ttc", ".dfont", ".otf", ".otf.dfont", ".otf",
-	".otf.dfont", ".svg", ".ufo", ".ufo2", ".ufo3", ".woff",
+	".otf.dfont", ".svg", ".ufo", ".ufo2", ".ufo3", ".woff", ".woff",
 #ifdef FONTFORGE_CAN_USE_WOFF2
-	".woff2",
+	".woff2", ".woff2",
 #else
         NULL,
 #endif
@@ -84,9 +84,9 @@ const char *savefont_extensions[] = { ".pfa", ".pfb", ".bin", "%s.pfb", ".pfa", 
 	".ufo",
 	".ufo2",
 	".ufo3",
-	".woff",
+	".woff", ".woff",
 #ifdef FONTFORGE_CAN_USE_WOFF2
-	".woff2",
+	".woff2", ".woff2",
 #else
         NULL,
 #endif
@@ -843,12 +843,12 @@ return( true );
 	    oerr = !WriteTTFFont(newname,sf,oldformatstate,sizes,bmap,
 		flags,map,layer);
 	  break;
-	  case ff_woff:
+	  case ff_woff_ttf: case ff_woff_otf:
 	    oerr = !WriteWOFFFont(newname,sf,oldformatstate,sizes,bmap,
 		flags,map,layer);
 	  break;
 #ifdef FONTFORGE_CAN_USE_WOFF2
-	  case ff_woff2:
+	  case ff_woff2_ttf: case ff_woff2_otf:
 	    oerr = !WriteWOFF2Font(newname,sf,oldformatstate,sizes,bmap,
 		flags,map,layer);
 	  break;

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -1970,8 +1970,10 @@ return( vs_maskttf );
 return( vs_maskps );
     else if ( format==ff_svg )
 return( vs_maskttf );
-    else if ( format==ff_woff2 )
+    else if ( format==ff_woff_ttf || format==ff_woff2_ttf )
 return( vs_maskttf );
+    else if ( format==ff_woff_otf || format==ff_woff2_otf )
+return( vs_maskps );
     else
 return( sf->subfontcnt!=0 || sf->cidmaster!=NULL ? vs_maskcid :
 	sf->layers[layer].order2 ? vs_maskttf : vs_maskps );

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -2105,9 +2105,10 @@ enum fontformat { ff_pfa, ff_pfb, ff_pfbmacbin, ff_multiple, ff_mma, ff_mmb,
 	ff_ptype3, ff_ptype0, ff_cid, ff_cff, ff_cffcid,
 	ff_type42, ff_type42cid,
 	ff_ttf, ff_ttfsym, ff_ttfmacbin, ff_ttc, ff_ttfdfont, ff_otf, ff_otfdfont,
-	ff_otfcid, ff_otfciddfont, ff_svg, ff_ufo, ff_ufo2, ff_ufo3, ff_woff, ff_woff2, ff_none };
+	ff_otfcid, ff_otfciddfont, ff_svg, ff_ufo, ff_ufo2, ff_ufo3,
+   ff_woff_ttf, ff_woff_otf, ff_woff2_ttf, ff_woff2_otf, ff_none };
 #define isttf_ff(ff) ((ff)>=ff_ttf && (ff)<=ff_ttfdfont)
-#define isttflike_ff(ff) (((ff)>=ff_ttf && (ff)<=ff_otfdfont) || (ff)==ff_woff2)
+#define isttflike_ff(ff) (((ff)>=ff_ttf && (ff)<=ff_otfdfont) || (ff)==ff_woff_ttf || (ff)==ff_woff2_ttf)
 extern struct pschars *SplineFont2ChrsSubrs(SplineFont *sf, int iscjk,
 	struct pschars *subrs,int flags,enum fontformat format,int layer);
 struct cidbytes;

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -424,10 +424,10 @@ int _WriteWOFFFont(FILE *woff,SplineFont *sf, enum fontformat format,
 	}
     }
 
-    format = sf->subfonts!=NULL ? ff_otfcid :
-		sf->layers[layer].order2 ? ff_ttf : ff_otf;
+    enum fontformat inner_format = (format == ff_woff_ttf) ? ff_ttf :
+                                   (sf->subfonts!=NULL) ? ff_otfcid : ff_otf;
     sfnt = GFileTmpfile();
-    ret = _WriteTTFFont(sfnt,sf,format,bsizes,bf,flags,enc,layer);
+    ret = _WriteTTFFont(sfnt,sf,inner_format,bsizes,bf,flags,enc,layer);
     if ( !ret ) {
 	fclose(sfnt);
 return( ret );
@@ -633,11 +633,9 @@ int _WriteWOFF2Font(FILE *fp, SplineFont *sf, enum fontformat format, int32_t *b
     if (!tmp) {
         return 0;
     }
-    /* WOFF2 internal format can be either TTF or OTF. We select it
-       automatically to preserve maximum font data. */
-    format = sf->subfonts!=NULL ? ff_otfcid :
-		sf->layers[layer].order2 ? ff_ttf : ff_otf;
-    int ret = _WriteTTFFont(tmp, sf, format, bsizes, bf, flags, enc, layer);
+    enum fontformat inner_format = (format == ff_woff2_ttf) ? ff_ttf :
+                                   (sf->subfonts!=NULL) ? ff_otfcid : ff_otf;
+    int ret = _WriteTTFFont(tmp, sf, inner_format, bsizes, bf, flags, enc, layer);
     if (!ret) {
         fclose(tmp);
         return 0;

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -635,8 +635,9 @@ int _WriteWOFF2Font(FILE *fp, SplineFont *sf, enum fontformat format, int32_t *b
     }
     /* WOFF2 internal format can be either TTF or OTF. We select it
        automatically to preserve maximum font data. */
-    enum fontformat internal_format = (sf->layers[ly_fore].order2) ? ff_ttf : ff_otf;
-    int ret = _WriteTTFFont(tmp, sf, internal_format, bsizes, bf, flags, enc, layer);
+    format = sf->subfonts!=NULL ? ff_otfcid :
+		sf->layers[layer].order2 ? ff_ttf : ff_otf;
+    int ret = _WriteTTFFont(tmp, sf, format, bsizes, bf, flags, enc, layer);
     if (!ret) {
         fclose(tmp);
         return 0;

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -633,7 +633,10 @@ int _WriteWOFF2Font(FILE *fp, SplineFont *sf, enum fontformat format, int32_t *b
     if (!tmp) {
         return 0;
     }
-    int ret = _WriteTTFFont(tmp, sf, format, bsizes, bf, flags, enc, layer);
+    /* WOFF2 internal format can be either TTF or OTF. We select it
+       automatically to preserve maximum font data. */
+    enum fontformat internal_format = (sf->layers[ly_fore].order2) ? ff_ttf : ff_otf;
+    int ret = _WriteTTFFont(tmp, sf, internal_format, bsizes, bf, flags, enc, layer);
     if (!ret) {
         fclose(tmp);
         return 0;

--- a/fontforge/woff.c
+++ b/fontforge/woff.c
@@ -387,6 +387,22 @@ compareOffsets(const void * lhs, const void * rhs)
            0;
 }
 
+static FILE* WriteSfnt(SplineFont *sf, enum fontformat format,
+	int32_t *bsizes, enum bitmapformat bf,int flags,EncMap *enc,int layer) {
+    FILE *sfnt = GFileTmpfile();
+    if (!sfnt) {
+        return NULL;
+    }
+    enum fontformat inner_format = (isttflike_ff(format)) ? ff_ttf :
+                                   (sf->subfonts!=NULL) ? ff_otfcid : ff_otf;
+    bool ret = _WriteTTFFont(sfnt, sf, inner_format, bsizes, bf, flags, enc, layer);
+    if (!ret) {
+        fclose(sfnt);
+        return NULL;
+    }
+    return sfnt;
+}
+
 int _WriteWOFFFont(FILE *woff,SplineFont *sf, enum fontformat format,
 	int32_t *bsizes, enum bitmapformat bf,int flags,EncMap *enc,int layer) {
     int ret;
@@ -424,13 +440,9 @@ int _WriteWOFFFont(FILE *woff,SplineFont *sf, enum fontformat format,
 	}
     }
 
-    enum fontformat inner_format = (format == ff_woff_ttf) ? ff_ttf :
-                                   (sf->subfonts!=NULL) ? ff_otfcid : ff_otf;
-    sfnt = GFileTmpfile();
-    ret = _WriteTTFFont(sfnt,sf,inner_format,bsizes,bf,flags,enc,layer);
-    if ( !ret ) {
-	fclose(sfnt);
-return( ret );
+    sfnt = WriteSfnt(sf,format,bsizes,bf,flags,enc,layer);
+    if ( !sfnt ) {
+        return false ;
     }
 
     fseek(sfnt,0,SEEK_END);
@@ -629,27 +641,20 @@ int WriteWOFF2Font(char *fontname, SplineFont *sf, enum fontformat format, int32
 
 int _WriteWOFF2Font(FILE *fp, SplineFont *sf, enum fontformat format, int32_t *bsizes, enum bitmapformat bf, int flags, EncMap *enc, int layer)
 {
-    FILE *tmp = GFileTmpfile();
-    if (!tmp) {
-        return 0;
-    }
-    enum fontformat inner_format = (format == ff_woff2_ttf) ? ff_ttf :
-                                   (sf->subfonts!=NULL) ? ff_otfcid : ff_otf;
-    int ret = _WriteTTFFont(tmp, sf, inner_format, bsizes, bf, flags, enc, layer);
-    if (!ret) {
-        fclose(tmp);
-        return 0;
+    FILE* sfnt = WriteSfnt(sf,format,bsizes,bf,flags,enc,layer);
+    if ( !sfnt ) {
+        return false ;
     }
 
     size_t raw_input_length = 0, comp_size;
-    uint8_t *raw_input = ReadFileToBuffer(tmp, &raw_input_length);
-    fclose(tmp);
+    uint8_t *raw_input = ReadFileToBuffer(sfnt, &raw_input_length);
+    fclose(sfnt);
     if (!raw_input) {
         return 0;
     }
 
     uint8_t *comp_buffer;
-    ret = woff2_convert_ttf_to_woff2(raw_input, raw_input_length, &comp_buffer, &comp_size);
+    int ret = woff2_convert_ttf_to_woff2(raw_input, raw_input_length, &comp_buffer, &comp_size);
     free(raw_input);
     if (!ret) {
         free(comp_buffer);

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -1400,7 +1400,8 @@ return;
     }
 
     if ( likecff || oldformatstate<=ff_cffcid ||
-	    (oldformatstate>=ff_otf && oldformatstate<=ff_otfciddfont)) {
+	     (oldformatstate>=ff_otf && oldformatstate<=ff_otfciddfont) ||
+        oldformatstate==ff_woff_otf || oldformatstate==ff_woff2_otf) {
 	if ( d->sf->ascent+d->sf->descent!=1000 && !psscalewarned ) {
 	    if ( gwwv_ask(_("Non-standard Em-Size"),(const char **) buts,0,1,_("The convention is that PostScript fonts should have an Em-Size of 1000. But this font has a size of %d. This is not an error, but you might consider altering the Em-Size with the Element->Font Info->General dialog.\nDo you wish to continue to generate your font in spite of this?"),
 		    d->sf->ascent+d->sf->descent)==1 )

--- a/fontforgeexe/savefontdlg.c
+++ b/fontforgeexe/savefontdlg.c
@@ -163,8 +163,10 @@ static GTextInfo formattypes[] = {
     { (unichar_t *) N_("Unified Font Object (UFO3)"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
     { (unichar_t *) N_("Unified Font Object 2"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
     { (unichar_t *) N_("Unified Font Object 3"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
-    { (unichar_t *) N_("Web Open Font (WOFF)"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
-    { (unichar_t *) N_("Web Open Font (WOFF2)"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
+    { (unichar_t *) N_("Web Open Font (WOFF TTF)"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
+    { (unichar_t *) N_("Web Open Font (WOFF OTF)"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
+    { (unichar_t *) N_("Web Open Font (WOFF2 TTF)"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
+    { (unichar_t *) N_("Web Open Font (WOFF2 OTF)"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
     { (unichar_t *) N_("No Outline Font"), NULL, 0, 0, NULL, NULL, 0, 0, 0, 0, 0, 0, 1, 0, 0, '\0' },
     GTEXTINFO_EMPTY
 };
@@ -1655,14 +1657,12 @@ static void GFD_FigureWhich(struct gfc_data *d) {
 	which = 1;		/* truetype options */ /* type42 also */
     else
 	which = 2;		/* opentype options */
-    if ( fs==ff_woff || fs==ff_woff2 ) {
-	SplineFont *sf = d->sf;
-	int layer = d->layer;
-	if ( sf->layers[layer].order2 )
+
+    if ( fs==ff_woff_ttf || fs==ff_woff2_ttf )
 	    which = 1;			/* truetype */
-	else
+	else if ( fs==ff_woff_otf || fs==ff_woff2_otf )
 	    which = 2;			/* opentype */
-    }
+       
     if ( bf == bf_otb && which==0 )
 	which = 3;		/* postscript options with opentype bitmap options */
     d->sod_which = which;
@@ -2317,7 +2317,8 @@ return( 0 );
 	ofs = ff_ttc;
     }
 #ifndef FONTFORGE_CAN_USE_WOFF2
-	formattypes[ff_woff2].disabled = true;
+	formattypes[ff_woff2_ttf].disabled = true;
+	formattypes[ff_woff2_otf].disabled = true;
 #endif
 
     for ( i=0; i<sizeof(formattypes)/sizeof(formattypes[0]); ++i )


### PR DESCRIPTION
WOFF2 format is a wrapper for TTF/OTF font (see https://en.wikipedia.org/wiki/Web_Open_Font_Format). We select the underlying format according to the foreground spline curve type: TTF for quadratic, OTF for cubic. This logic is already employed in WOFF.

Fixes #5240.