### PR TITLE
Fix data corruption on SFD reading

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -403,7 +403,7 @@ return( NULL );
 	    } else {
 		ch1 = inbase64[ch1];
 		ch2 = inbase64[(unsigned char) *str++];
-		if ( ch2==1 ) {
+		if ( ch2==-1 ) {
 		    --str;
 		    ch2 = ch3 = ch4 = 0;
 		} else {

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -308,12 +308,16 @@ char *utf8toutf7_copy(const char *_str) {
 	    } else
 		len += 4;
 	}
+        /* Base64 block can optionally end with a hyphen '-'. We omit it at the
+           end of the encoded string to preserve the existing SFD convention. */
+        /*
 	if ( in ) {
 	    if ( i )
 		*ostr++ = '-';
 	    else
 		++len;
 	}
+        */
 	if ( i==0 )
 	    ostr = ret = malloc(len+1);
     }


### PR DESCRIPTION
Followup to PR #5364.

This fixes a **localized data corruption** occurring when reading certain UTF-7 strings from SFD files.

I noticed this issue while running `bulk_test.sh`. Somehow missed it when running the bulk tester earlier on that PR.