### PR TITLE
Fix export of supplementary plane characters in font name to TTF

### DIFF
--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -920,6 +920,15 @@ extern unichar_t *utf162u_strcpy(unichar_t*ubuf, const uint16_t *utf16buf) {
     return( ubuf );
 }
 
+uint16_t *utf82utf16_copy(const char* utf8buf) {
+    unichar_t *utf32_str = utf82u_copy(utf8buf); /* Convert from utf8 to utf32 */
+    uint16_t *utf16buf = (uint16_t *) malloc(2*(u_strlen(utf32_str)+1)*sizeof(uint16_t));
+    u2utf16_strcpy(utf16buf, utf32_str);
+    free(utf32_str);
+
+    return utf16buf;
+}
+
 char *StripToASCII(const char *utf8_str) {
     /* Remove any non-ascii characters: Special case, convert the copyright symbol to (c) */
     char *newcr, *pt, *end;

--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -894,7 +894,7 @@ uint16_t *u2utf16_strcpy(uint16_t *utf16buf,const unichar_t *ubuf) {
 }
 
 extern unichar_t *utf162u_strcpy(unichar_t*ubuf, const uint16_t *utf16buf) {
-    uint16_t uch = 0x0, uch2 = 0x0;
+    unichar_t uch = 0x0, uch2 = 0x0;
     unichar_t *pt = ubuf;
 
     if (utf16buf == NULL || ubuf == NULL)

--- a/Unicode/ustring.c
+++ b/Unicode/ustring.c
@@ -871,10 +871,9 @@ void utf8_strncpy(register char *to, const char *from, int len) {
     to[old-from] = 0;
 }
 
-unichar_t *u2utf16_strcpy(unichar_t *utf16buf,const unichar_t *ubuf) {
+uint16_t *u2utf16_strcpy(uint16_t *utf16buf,const unichar_t *ubuf) {
 /* Copy unichar string 'ubuf' into utf16 buffer string 'utf16buf' */
-/* Technically, uint16_t is sufficient for utf-16 encoding, feel free to replace. */
-    unichar_t *pt = utf16buf;
+    uint16_t *pt = utf16buf;
     unichar_t ch;
 
     if (utf16buf == NULL || ubuf == NULL)
@@ -894,8 +893,8 @@ unichar_t *u2utf16_strcpy(unichar_t *utf16buf,const unichar_t *ubuf) {
     return( utf16buf );
 }
 
-extern unichar_t *utf162u_strcpy(unichar_t*ubuf, const unichar_t *utf16buf) {
-    uint32_t uch = 0x0, uch2 = 0x0;
+extern unichar_t *utf162u_strcpy(unichar_t*ubuf, const uint16_t *utf16buf) {
+    uint16_t uch = 0x0, uch2 = 0x0;
     unichar_t *pt = ubuf;
 
     if (utf16buf == NULL || ubuf == NULL)

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -414,7 +414,7 @@ return( e );
 static char *_readencstring(FILE *ttf,int offset,int len,
 	int platform,int specific,int language) {
     long pos = ftell(ttf);
-    unichar_t *ustr, *str, *pt;
+    unichar_t *str, *pt;
     char *ret;
     int i, ch;
     Encoding *enc;
@@ -439,12 +439,18 @@ static char *_readencstring(FILE *ttf,int offset,int len,
 	  return( NULL );
 	}
 	if ( enc->is_unicodebmp ) {
-	    str = pt = malloc((sizeof(unichar_t)/2)*len+sizeof(unichar_t));
+            uint16_t *utf16_str, *utf16_pt;
+
+	    utf16_str = utf16_pt = malloc((len+1)*sizeof(utf16_str));
 	    for ( i=0; i<len/2; ++i ) {
 		ch = getc(ttf)<<8;
 		*pt++ = ch | getc(ttf);
 	    }
 	    *pt = 0;
+
+            str = (unichar_t *) malloc((len+1)*sizeof(unichar_t));
+            utf162u_strcpy(str, utf16_str); /* Convert from ucs2 to unicode */
+            free(utf16_str);
 	} else if ( enc->unicode!=NULL ) {
 	    str = pt = malloc(sizeof(unichar_t)*len+sizeof(unichar_t));
 	    for ( i=0; i<len; ++i )
@@ -466,11 +472,7 @@ static char *_readencstring(FILE *ttf,int offset,int len,
 	} else {
 	    str = uc_copy("");
 	}
-        ustr = (unichar_t *) malloc((u_strlen(str)+1)*sizeof(unichar_t));
-        utf162u_strcpy(ustr, str);
-        ret = u2utf8_copy(ustr); /* Convert from ucs2 to utf8 */
-
-        free(ustr);
+	ret = u2utf8_copy(str);
 	free(str);
     }
     fseek(ttf,pos,SEEK_SET);

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -414,7 +414,7 @@ return( e );
 static char *_readencstring(FILE *ttf,int offset,int len,
 	int platform,int specific,int language) {
     long pos = ftell(ttf);
-    unichar_t *str, *pt;
+    unichar_t *ustr, *str, *pt;
     char *ret;
     int i, ch;
     Encoding *enc;
@@ -466,7 +466,11 @@ static char *_readencstring(FILE *ttf,int offset,int len,
 	} else {
 	    str = uc_copy("");
 	}
-	ret = u2utf8_copy(str);
+        ustr = (unichar_t *) malloc((u_strlen(str)+1)*sizeof(unichar_t));
+        utf162u_strcpy(ustr, str);
+        ret = u2utf8_copy(ustr); /* Convert from ucs2 to utf8 */
+
+        free(ustr);
 	free(str);
     }
     fseek(ttf,pos,SEEK_SET);

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -416,7 +416,7 @@ static char *_readencstring(FILE *ttf,int offset,int len,
     long pos = ftell(ttf);
     unichar_t *str, *pt;
     char *ret;
-    int i, ch;
+    int i;
     Encoding *enc;
 
     fseek(ttf,offset,SEEK_SET);
@@ -439,14 +439,14 @@ static char *_readencstring(FILE *ttf,int offset,int len,
 	  return( NULL );
 	}
 	if ( enc->is_unicodebmp ) {
-            uint16_t *utf16_str, *utf16_pt;
+            uint16_t *utf16_str, *utf16_pt, ch;
 
 	    utf16_str = utf16_pt = malloc((len+1)*sizeof(utf16_str));
 	    for ( i=0; i<len/2; ++i ) {
 		ch = getc(ttf)<<8;
-		*pt++ = ch | getc(ttf);
+		*utf16_pt++ = ch | getc(ttf);
 	    }
-	    *pt = 0;
+	    *utf16_pt = 0;
 
             str = (unichar_t *) malloc((len+1)*sizeof(unichar_t));
             utf162u_strcpy(str, utf16_str); /* Convert from ucs2 to unicode */

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -213,13 +213,14 @@ char *utf8toutf7_copy(const char *_str) {
     int prev_cnt=0, prev=0, in=0;
     int i, len;
     char *ret=NULL, *ostr=NULL;
-    unichar_t *ucs2_str, *utf16buf, *pt;
+    unichar_t *ucs2_str;
+    uint16_t *utf16buf, *pt;
 
     if ( _str==NULL )
         return( NULL );
 
     ucs2_str = utf82u_copy(_str); /* Convert from utf8 to ucs2 */
-    utf16buf = (unichar_t *) malloc(2*(u_strlen(ucs2_str)+1)*sizeof(unichar_t));
+    utf16buf = (uint16_t *) malloc(2*(u_strlen(ucs2_str)+1)*sizeof(uint16_t));
     u2utf16_strcpy(utf16buf, ucs2_str);
     free(ucs2_str);
 
@@ -368,7 +369,7 @@ char *SFDReadUTF7Str(FILE *sfd) {
 }
 
 char *utf7toutf8_copy(const char *_str) {
-    unichar_t *utf16buf = NULL, *pt;
+    uint16_t *utf16buf = NULL, *pt;
     int ch1, ch2, ch3, ch4, done;
     int prev_cnt=0, prev=0, in=0;
     const char *str = _str;
@@ -378,7 +379,7 @@ char *utf7toutf8_copy(const char *_str) {
     if ( str==NULL )
 return( NULL );
 
-    pt = utf16buf = (unichar_t *) malloc((strlen(_str)+1)*sizeof(unichar_t));
+    pt = utf16buf = (uint16_t *) malloc((strlen(_str)+1)*sizeof(uint16_t));
     while ( (ch1=*str++)!='\0' ) {
 	done = 0;
 	if ( !done && !in ) {
@@ -419,6 +420,7 @@ return( NULL );
 			}
 		    }
 		}
+                /* Fill ch1 up to at most 24 bits */
 		ch1 = (ch1<<18) | (ch2<<12) | (ch3<<6) | ch4;
 		if ( prev_cnt==0 ) {
 		    prev = ch1&0xff;
@@ -430,6 +432,7 @@ return( NULL );
 		    ch1 = (ch1>>16)&0xffff;
 		    prev_cnt = 2;
 		}
+                /* ch1 is guaranteed to have at most 16 significant bits at this point */
 		done = true;
 	    }
 	}
@@ -448,7 +451,7 @@ return( NULL );
         return NULL;
     }
 
-    ucs2_str = (unichar_t *) malloc((u_strlen(utf16buf)+1)*sizeof(unichar_t));
+    ucs2_str = (unichar_t *) malloc((strlen(_str)+1)*sizeof(unichar_t));
     utf162u_strcpy(ucs2_str, utf16buf);
     utf8_buf = u2utf8_copy(ucs2_str); /* Convert from ucs2 to utf8 */
     free(ucs2_str);

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -365,7 +365,7 @@ char *SFDReadUTF7Str(FILE *sfd) {
 }
 
 char *utf7toutf8_copy(const char *_str) {
-    uint16_t *utf16buf = NULL, *pt;
+    uint16_t *pt, *utf16buf = NULL;
     int ch1, ch2, ch3, ch4, done;
     int prev_cnt=0, prev=0, in=0;
     const char *str = _str;

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -209,23 +209,19 @@ void SFDDumpUTF7Str(FILE *sfd, const char *str) {
 
 
 char *utf8toutf7_copy(const char *_str) {
-    unichar_t ch;
+    uint16_t ch;
     int prev_cnt=0, prev=0, in=0;
     int i, len;
     char *ret=NULL, *ostr=NULL;
-    unichar_t *ucs2_str;
-    uint16_t *utf16buf, *pt;
+    uint16_t *utf16_str, *pt;
 
     if ( _str==NULL )
         return( NULL );
 
-    ucs2_str = utf82u_copy(_str); /* Convert from utf8 to ucs2 */
-    utf16buf = (uint16_t *) malloc(2*(u_strlen(ucs2_str)+1)*sizeof(uint16_t));
-    u2utf16_strcpy(utf16buf, ucs2_str);
-    free(ucs2_str);
+    utf16_str = utf82utf16_copy(_str);
 
     for ( i=0; i<2; ++i ) {
-        pt = utf16buf;
+        pt = utf16_str;
 	len= prev_cnt= prev= in=0;
 	while ( (ch = *pt++)!='\0' ) {
 	    if ( ch<127 && ch!='\n' && ch!='\r' && ch!='\\' && ch!='~' &&
@@ -323,7 +319,7 @@ char *utf8toutf7_copy(const char *_str) {
 	    ostr = ret = malloc(len+1);
     }
     *ostr = '\0';
-    free(utf16buf);
+    free(utf16_str);
 return( ret );
 }
 

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3841,7 +3841,6 @@ static void AddEncodedName(NamTab *nt,char *utf8name,uint16_t lang,uint16_t stri
     NameEntry *ne;
     int maclang, macenc= -1, specific;
     char *macname = NULL;
-    uint16_t new_offset;
 
     if ( strid==ttf_postscriptname && lang!=0x409 )
 return;		/* Should not happen, but it did */
@@ -3862,8 +3861,6 @@ return;		/* Should not happen, but it did */
     ne->offset   = ftell(nt->strings);
     ne->len      = 2*utf82u_strlen(utf8name);
     dumpustr(nt->strings,utf8name);
-    new_offset = ftell(nt->strings);
-    printf("Len %d vs offset diff %d\n", ne->len, new_offset-ne->offset);
     ++ne;
 
     if ( nt->format==ff_ttfsym ) {

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3733,8 +3733,8 @@ static void dumpstr(FILE *file,char *str) {
 
 static void dumpustr(FILE *file,char *utf8_str) {
     unichar_t *ustr = utf82u_copy(utf8_str);
-    unichar_t *utf16buf = (unichar_t *) malloc(2*(u_strlen(ustr)+1)*sizeof(unichar_t));
-    unichar_t *pt;
+    uint16_t *utf16buf = (uint16_t *) malloc(2*(u_strlen(ustr)+1)*sizeof(uint16_t));
+    uint16_t *pt;
     
     u2utf16_strcpy(utf16buf, ustr);
     free(ustr);

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3732,19 +3732,14 @@ static void dumpstr(FILE *file,char *str) {
 }
 
 static void dumpustr(FILE *file,char *utf8_str) {
-    unichar_t *ustr = utf82u_copy(utf8_str);
-    uint16_t *utf16buf = (uint16_t *) malloc(2*(u_strlen(ustr)+1)*sizeof(uint16_t));
-    uint16_t *pt;
+    uint16_t *utf16_str = utf82utf16_copy(utf8_str);
+    uint16_t *pt = utf16_str;
     
-    u2utf16_strcpy(utf16buf, ustr);
-    free(ustr);
-
-    pt=utf16buf;
     do {
 	putc(*pt>>8,file);
 	putc(*pt&0xff,file);
     } while ( *pt++!='\0' );
-    free(utf16buf);
+    free(utf16_str);
 }
 
 static void dumppstr(FILE *file,const char *str) {

--- a/inc/ustring.h
+++ b/inc/ustring.h
@@ -159,8 +159,8 @@ extern char *u2def_strncpy(char *to, const unichar_t *ufrom, size_t n);
 extern unichar_t *def2u_copy(const char *from);
 extern char *u2def_copy(const unichar_t *ufrom);
 
-extern unichar_t *u2utf16_strcpy(unichar_t *utf16buf,const unichar_t *ubuf);
-extern unichar_t *utf162u_strcpy(unichar_t*ubuf, const unichar_t *utf16buf);
+extern uint16_t *u2utf16_strcpy(uint16_t *utf16buf,const unichar_t *ubuf);
+extern unichar_t *utf162u_strcpy(unichar_t*ubuf, const uint16_t *utf16buf);
 
 extern int uAllAscii(const unichar_t *str);
 extern int AllAscii(const char *);

--- a/inc/ustring.h
+++ b/inc/ustring.h
@@ -162,6 +162,8 @@ extern char *u2def_copy(const unichar_t *ufrom);
 extern uint16_t *u2utf16_strcpy(uint16_t *utf16buf,const unichar_t *ubuf);
 extern unichar_t *utf162u_strcpy(unichar_t*ubuf, const uint16_t *utf16buf);
 
+extern uint16_t *utf82utf16_copy(const char* utf8buf);
+
 extern int uAllAscii(const unichar_t *str);
 extern int AllAscii(const char *);
 extern char *StripToASCII(const char *utf8_str);

--- a/tests/bulk_test.sh
+++ b/tests/bulk_test.sh
@@ -35,7 +35,9 @@ while read font_url; do
         $FF_BIN_PROJECT -c "$FF_PY_SCRIPT_LINE" $SFD_FILE $FF_OUTPUT_FILE >/dev/null 2>&1
         popd > /dev/null
 
-        if (cmp --quiet $TMP_DIR_SYS/$FF_OUTPUT_FILE $TMP_DIR_PROJ/$FF_OUTPUT_FILE); then
+        if [ ! -f $TMP_DIR_SYS/$FF_OUTPUT_FILE ] && [ ! -f $TMP_DIR_PROJ/$FF_OUTPUT_FILE ]; then
+            echo "NO OUTPUT: $font_url"
+        elif (cmp --quiet $TMP_DIR_SYS/$FF_OUTPUT_FILE $TMP_DIR_PROJ/$FF_OUTPUT_FILE); then
             echo "PASS: $font_url"
         else
             echo -e "\e[0;31mFAIL\e[0m: $font_url"

--- a/tests/fonts/PublicFontList.txt
+++ b/tests/fonts/PublicFontList.txt
@@ -119,7 +119,6 @@ https://gitlab.com/ameliedumont/fonts/-/raw/master/Ductus/regular/source/DuctusR
 https://gitlab.com/ameliedumont/fonts/-/raw/master/Ductus/regular/source/DuctusGeometric.sfd
 https://gitlab.com/ameliedumont/fonts/-/raw/master/Ductus/regular/source/DuctusCalligraphic.sfd
 https://gitlab.com/ameliedumont/fonts/-/raw/master/Ductus/regular/DuctusGeometric.sfd
-https://gitlab.com/ekaunt/ran-soushotai/-/raw/master/extra-fonts/ran-soushotai-complete.sfd
 https://gitlab.com/kreativekorp/bitsnpicas/-/raw/master/fonts/sfsu/tos/ibm8.sfd
 https://gitlab.com/kreativekorp/bitsnpicas/-/raw/master/fonts/sfsu/tos/rgb.sfd
 https://gitlab.com/kreativekorp/bitsnpicas/-/raw/master/fonts/sfsu/tos/tosx.sfd


### PR DESCRIPTION
### Type of change
- **Bug fix**
- **New feature**

TTF names must be encoded as UTF-16BE to support supplementary plane characters (emojis etc.). This PR fixes export and import of TTF names. The resulting font names are correctly displayed in Linux and in Windows.

![Screenshot_LibreOffice_Linux](https://github.com/fontforge/fontforge/assets/3698866/080e2c1e-8382-4a72-b7b4-9bc435b7e5ec)

![Screenshot 2024-04-04 003611](https://github.com/fontforge/fontforge/assets/3698866/122fc1a9-e775-4ff0-8382-cabb775848d6)
