### PR TITLE
Check for NULL value of SplineChar parent

### DIFF
--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -311,7 +311,7 @@ static AnchorPoint *AnchorPointsDuplicate(AnchorPoint *base,SplineChar *sc) {
     AnchorPoint *head=NULL, *last=NULL, *cur;
     AnchorClass *ac;
 
-    for ( ; base!=NULL; base = base->next ) {
+    for ( ; base!=NULL && sc->parent!=NULL; base = base->next ) {
 	cur = chunkalloc(sizeof(AnchorPoint));
 	*cur = *base;
 	cur->next = NULL;


### PR DESCRIPTION
When bulk operations are performed on a font, FontForge runs `AnchorPoint *AnchorPointsDuplicate(AnchorPoint *base, SplineChar *sc)`. Early in the function there is a `for` loop which runs while `base` isn't NULL, but it later accesses `sc->parent->anchor` without checking if `sc->parent` itself is NULL first.

This seems to be because the function assumes it will only be called when the duplication of anchor points is actually desired, and thus there should be a valid place to copy the anchor points to. Instead, it's being called from within
`SplineChar *SplineCharCopy(SplineChar *sc, SplineFont *into, struct sfmergecontext *mc)`, which is itself being called with `into` set to 0 within 2 different cases handled by
`void SFDDumpUndo(FILE *sfd, SplineChar *sc, Undoes *u, const char *keyPrefix, int idx)`, and also once within
`Undoes *SFDGetUndo(FILE *sfd, SplineChar *sc, const char *startTag, int current_layer)`.

`SFDDumpUndo()` seems to only call `SplineCharCopy` as a means toward some of its side effects. It appears to make a new empty SplineChar copy the SplineChar it's working on into the new SplineChar, extract and dump hints from it, and then delete the SplineChar it created. Likewise, `SFDGetUndo()` seems to also only call `SplineCharCopy()` to do some temporary managing of hint information.

Since these appear to be the only scenarios where `SplineCharCopy` is called with `into` set to NULL, and the only thing that is being done in those situations is do some stuff relating to font hints, I've determined that it's safe to simply not duplicate the AnchorPoints when sc->parent is set to NULL.

This fixes #5130, and indeed is just the same fix I proposed back then. At the time I wasn't confident this was safe, but I've extensively used FontForge with this change made and had no further AnchorPoint crashes. I also further investigated the root causes, which I describe above.

A more 'proper' fix would probably include systematic changes to how hint undoes are saved and loaded from SFD files, but that's beyond my skill and, quite honestly, not something I even care about that much. The code appears to work despite it's oddities, and simply checking if `sc->parent` is NULL before doing anything with the AnchorPoints allows all the hint-related stuff that `SplineCharCopy()` does continue to work for the sake of both `SFDDumpUndo()` and `SFDGetUndo()`.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
    Fixes #5130