### PR TITLE
Use PyConfig API on Python 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ set(Python3_FIND_REGISTRY LAST)
 if(BUILD_SHARED_LIBS)
   set(Python3_USE_STATIC_LIBS FALSE)
 endif()
-find_package_auto(ENABLE_PYTHON_SCRIPTING Python3 3.6 COMPONENTS Development Interpreter)
+find_package_auto(ENABLE_PYTHON_SCRIPTING Python3 3.8 COMPONENTS Development Interpreter)
 find_package_auto(ENABLE_DOCS             Sphinx) # Should come after ENABLE_PYTHON_SCRIPTING
 find_package_auto(ENABLE_LIBSPIRO         Libspiro)
 find_package_auto(ENABLE_LIBGIF           GIF)

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -19751,16 +19751,18 @@ void FontForge_InitializeEmbeddedPython(void) {
                                      "fontforge");
     if (PyStatus_Exception(status)) {
         fprintf(stderr, "Failed to set the Python program name: %s\n",
-		status.err_msg);
+                status.err_msg);
     }
 
     RegisterAllPyModules();
     status = Py_InitializeFromConfig(&config);
     if (PyStatus_Exception(status)) {
+        PyConfig_Clear(&config);
         fprintf(stderr, "Python initialization failed: %s\n",
-		status.err_msg);
+                status.err_msg);
         exit(1);
     }
+    PyConfig_Clear(&config);
     python_initialized = 1;
 
     /* The embedded python interpreter is now functionally


### PR DESCRIPTION
The Py_SetProgramName() function used by fontforge is deprecated and was removed in Python 3.13 alpha 1.

Replace the deprecated function with the PyConfig API on Python 3.8. If the Python initialization fails, log an error to stderr and call exit(1).

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **New feature**
- **Breaking change**
- **Non-breaking change**
