### PR TITLE
Don't attempt to copy anchors into NULL font

### DIFF
--- a/fontforge/fvfonts.c
+++ b/fontforge/fvfonts.c
@@ -539,7 +539,7 @@ SplineChar *SplineCharCopy(SplineChar *sc,SplineFont *into,struct sfmergecontext
 	nsc->countermasks = malloc(sc->countermask_cnt*sizeof(HintMask));
 	memcpy(nsc->countermasks,sc->countermasks,sc->countermask_cnt*sizeof(HintMask));
     }
-    nsc->anchor = AnchorPointsDuplicate(nsc->anchor,nsc);
+    nsc->anchor = into==NULL?NULL:AnchorPointsDuplicate(nsc->anchor,nsc);
     nsc->changed = true;
     /* Fix up dependents later when we know more */
     nsc->dependents = NULL;


### PR DESCRIPTION
Any time `SFDDumpUndo()` or `SFDGetUndo()` are run, they end up calling `SplineCharCopy()` with `NULL` for the `SplineFont *into` parameter. When this happens, `SplineCharCopy()` attempts to copy the anchors into the new SplineChar's `parent` font, but since that is set to `NULL` it crashes when `AnchorPointsDuplicate()` attempts to read from `sc->parent->anchor`.

Because `SFDDumpUndo()` and `SFDGetUndo()` appear to only do this so that they can have a copy of the character's hints at a given undo state (and then copy thoes hints into or out of the .sfd file), never affect anchor classes, and delete the parentless SplineChar immediately after, I've determined that it's safe to simply not duplicate the AnchorPoints when `into` is set to `NULL`.

To do this, instead of setting `nsc->anchor` to the output returned by `AnchorPointsDuplicate()`, I use a ternary statement to detect whether or not `into` is NULL. If it is, then `nsc->anchor` is set to NULL, and otherwise the value returned by `AnchorPointsDuplicate()` is used. I decided not to do the reverse (which could have made the code shorter) simply because line 505 already includes a similar ternary statement that checks if `into` is `NULL`, and I decided to use the same format.

This fixes #5130, and is a slightly more elegant variation of the same fix that I had proposed back then (more elegant because I skip the entire `AnchorPointsDuplicate()` function call instead of merely skipping over the loop that makes up the majority of the function). I don't see a reason for this to be functionally any different from the originally proposed solution, and I've extensively used FontForge with that change made with no further `AnchorPoint` crashes.

A more 'proper' fix would probably include systematic changes to how hint undoes are saved and loaded from SFD files, but that's beyond my skill and, quite honestly, not something I even care about that much. That code appears to work despite it's oddities, and simply checking if `into==NULL` before doing anything with the `AnchorPoints` allows all the hint-related stuff that `SplineCharCopy()` does continue to work for the sake of both `SFDDumpUndo()` and `SFDGetUndo()`.

### Type of change
- **Bug fix**
    Fixes #5130