### PR TITLE
Defer crowdin update to the end of the pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,12 +55,6 @@ jobs:
         run: |
           DESTDIR=appdir cmake -DCMAKE_INSTALL_PREFIX=/usr -P cmake_install.cmake
           ../.github/workflows/scripts/ffappimagebuild.sh appdir $GITHUB_SHA
-      - name: Update Potfile for Crowdin
-        if: matrix.target == 'Release' && github.ref == 'refs/heads/master' && github.repository == 'fontforge/fontforge' && github.event_name == 'push'
-        working-directory: repo
-        env:
-          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
-        run: java -jar $DEPSPREFIX/crowdin-cli.jar -c .crowdin.yml upload
       - name: Dist archive artifact
         uses: actions/upload-artifact@v3
         if: matrix.target == 'NoUI'
@@ -73,6 +67,12 @@ jobs:
         with:
           name: appimage
           path: repo/build/FontForge-*-x86_64.AppImage
+      - name: Update Potfile for Crowdin
+        if: matrix.target == 'Release' && github.ref == 'refs/heads/master' && github.repository == 'fontforge/fontforge' && github.event_name == 'push'
+        working-directory: repo
+        env:
+          CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
+        run: java -jar $DEPSPREFIX/crowdin-cli.jar -c .crowdin.yml upload
   mac:
     runs-on: macos-11
     steps:


### PR DESCRIPTION
Crowdin update is currently failing for unknown reason. Defer it to the end of the CI pipeline, so that artifacts creation is not affected.

This pipeline step is performed only after the merge into master, so Pull Request workflows should keep running successfully. The post-merge CI will likely fail for now, but if the problem is on the Crowdin side, it will hopefully resolve by itself in a reasonable amount of time.