### PR TITLE
Use sysconfig for Python module locations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,8 @@ jobs:
       - name: Checkout FontForgeBuilds
         uses: actions/checkout@v3
         with:
-          repository: fontforge/fontforgebuilds
+          repository: iorsh/fontforgebuilds
+          ref: py_sysconfig
           path: fontforgebuilds
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
         run: java -jar $DEPSPREFIX/crowdin-cli.jar -c .crowdin.yml upload
   mac:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
         with:
@@ -106,7 +106,7 @@ jobs:
           # MacOS runner has way too much preinstalled Python versions. We must
           # use the exact one discovered by CMake.
           PYTHON=`cat build/CMake_Python3_EXECUTABLE`
-          PYTHONPATH=$PYTHONPATH:$PREFIX/$($PYTHON -c "import distutils.sysconfig as sc; print(sc.get_python_lib(prefix='', plat_specific=True,standard_lib=False))")
+          PYTHONPATH=$PYTHONPATH:$PREFIX/$($PYTHON -c "import sysconfig as sc; print(sc.get_path('platlib', sc.get_preferred_scheme('user'), vars={'userbase': '.'}))")
           $PYTHON tests/pyhook_smoketest.py
       - name: Build App Bundle
         working-directory: repo/build

--- a/.github/workflows/scripts/ffosxbuild.sh
+++ b/.github/workflows/scripts/ffosxbuild.sh
@@ -32,6 +32,12 @@ fi
 # Now we bundle the Python libraries
 echo "Bundling Python libraries..."
 
+# MacOS runner has way too much preinstalled Python versions. We must
+# use the exact one discovered by CMake.
+# The CMake_Python3_EXECUTABLE file resides in build/CMake_Python3_EXECUTABLE
+PYTHON_EXE=`cat ../CMake_Python3_EXECUTABLE`
+PY_DLLS_PATH=`$PYTHON_EXE -c "import sysconfig as sc; print(sc.get_path('platlib', sc.get_preferred_scheme('user'), vars={'userbase': '.'}))"`
+
 PYLIB=$(otool -L $APPDIR/Contents/Resources/opt/local/bin/fontforge | grep -i python | sed -e 's/ \(.*\)//')
 PYVER=$(echo $PYLIB | rev | cut -d/ -f2 | rev)
 PYTHON=python$PYVER
@@ -42,10 +48,10 @@ mkdir -p $APPDIR/Contents/Frameworks
 cp -a $pycruft/Python.framework $APPDIR/Contents/Frameworks
 pushd $APPDIR/Contents/Frameworks/Python.framework/Versions/$PYVER/lib/$PYTHON/
 rm site-packages || rm -rf site-packages
-ln -s ../../../../../../Resources/opt/local/lib/$PYTHON/site-packages
+ln -s ../../../../../../Resources/opt/local/$PY_DLLS_PATH
 popd
 
-pushd $APPDIR/Contents/Resources/opt/local/lib/$PYTHON/site-packages
+pushd $APPDIR/Contents/Resources/opt/local/$PY_DLLS_PATH
 cp -Rn "$pycruft/Python.framework/Versions/$PYVER/lib/$PYTHON/site-packages/" .
 popd
 

--- a/.github/workflows/scripts/setup_linux_deps.sh
+++ b/.github/workflows/scripts/setup_linux_deps.sh
@@ -17,7 +17,7 @@ echo "DEPSPREFIX=$DEPSPREFIX" >> $GITHUB_ENV
 echo "PATH=$PATH:$DEPSPREFIX/bin:$PREFIX/bin:~/.local/bin" >> $GITHUB_ENV
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DEPSPREFIX/lib:$PREFIX/lib" >> $GITHUB_ENV
 echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$DEPSPREFIX/lib/pkgconfig" >> $GITHUB_ENV
-echo "PYTHONPATH=$PYTHONPATH:$PREFIX/$($PYTHON -c "import distutils.sysconfig as sc; print(sc.get_python_lib(prefix='', plat_specific=True,standard_lib=False))")" >> $GITHUB_ENV
+echo "PYTHONPATH=$PYTHONPATH:$PREFIX/$($PYTHON -c "import sysconfig as sc; print(sc.get_path('platlib', sc.get_preferred_scheme('user'), vars={'userbase': '.'}))")" >> $GITHUB_ENV
 
 if [ ! -d deps/install ]; then
     echo "Custom dependencies not present - will build them"

--- a/pyhook/CMakeLists.txt
+++ b/pyhook/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(psMat_pyhook PRIVATE Python3::Module)
 # So do it ourselves, getting the prefix-relative path instead
 if(NOT DEFINED PYHOOK_INSTALL_DIR)
   execute_process(
-    COMMAND "${Python3_EXECUTABLE}" -c "import distutils.sysconfig as sc; print(sc.get_python_lib(prefix='', plat_specific=True,standard_lib=False))"
+    COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig as sc; print(sc.get_path('platlib', sc.get_preferred_scheme('user'), vars={'userbase': '.'}))"
     RESULT_VARIABLE _pyhook_install_dir_result
     OUTPUT_VARIABLE PYHOOK_INSTALL_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
[distutils](https://docs.python.org/3.10/library/distutils.html#module-distutils) is deprecated with removal planned for Python 3.12.

- Replace distutils with a similar functionality from sysconfig to avoid CI failure
- Update macos CI runner to 12

This change is necessary to update CI to macos-12, which doesn't have Python 3.10.

**TODO:** Revert `iorsh/fontforgebuilds` repo before merge and after https://github.com/jtanx/fontforgebuilds/pull/21 is merged into fontforgebuilds