### PR TITLE
This partially fixes building on Python 3.13.

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -19804,7 +19804,10 @@ static void SetPythonProgramName(const char *progname) {
     if ( saved_progname )
 	free(saved_progname);
     saved_progname = copy_to_wide_string(progname);
-    Py_SetProgramName(saved_progname);
+    PyStatus status;
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+    status = PyConfig_SetString(&config, &config.program_name, saved_progname);
 }
 
 static wchar_t ** copy_argv(char *arg0, int argc ,char **argv) {

--- a/pycontrib/FontCompare/setup.py
+++ b/pycontrib/FontCompare/setup.py
@@ -15,7 +15,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 #!/usr/bin/env python
-from distutils.core import setup
 from setuptools import setup 
 setup(name='Font Compare',
       version='1.0',


### PR DESCRIPTION
Additional work is needed as distutils is removed; In Fedora we work around this by specifying PYHOOK_INSTALL_DIR at build time.

**Bug fix**
**Non-breaking change**
