### PR TITLE
Fix bug in font.appendSFNTName

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -11870,11 +11870,6 @@ return( 1 );
 	Py_XDECREF(val);
 return( 0 );
     }
-    if ( lang==0x409 && english!=NULL && english->names[strid]!=NULL &&
-         strcmp(string,english->names[strid])==0 ) {
-	Py_DECREF(val);
-return( 1 );	/* If they set it to the default, there's nothing to do */
-    }
 
     if ( names==NULL ) {
 	names = chunkalloc(sizeof( struct ttflangname ));


### PR DESCRIPTION
This unneeded if-statement made it impossible to change e.g. the 'Family' SFNT data from 'Sans Bold' to 'Sans'. Fixes #2635.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**