### PR TITLE
fix memleak in function DlgCreate8

### DIFF
--- a/gdraw/gaskdlg.c
+++ b/gdraw/gaskdlg.c
@@ -209,12 +209,13 @@ static GWindow DlgCreate8(const char *title,const char *question,va_list ap,
     extern GBox _GGadget_defaultbutton_box;
 
     if ( d!=NULL )
-	memset(d,0,sizeof(*d));
+        memset(d,0,sizeof(*d));
     buf = vsmprintf(question, ap);
     if ( screen_display==NULL ) {
-	fprintf(stderr, "%s\n", buf );
-	if ( d!=NULL ) d->done = true;
-return( NULL );
+        fprintf(stderr, "%s\n", buf);
+        if ( d!=NULL ) d->done = true;
+        free(buf);
+        return( NULL );
     }
     ubuf = utf82u_copy(buf);
     free(buf);


### PR DESCRIPTION
- **Bug fix**
A memory leak issue exist in function DlgCreate8

LeakSanitizer result：
==340050==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7f8d150b4887 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f8d12adac69 in vsmprintf /root/fuzz/fuzz_fontforge/fontforge/Unicode/memory.c:85
    #2 0x564d1803ed52 in DlgCreate8 /root/fuzz/fuzz_fontforge/fontforge/gdraw/gaskdlg.c:213
    #3 0x564d180731c3 in GWidgetError8 /root/fuzz/fuzz_fontforge/fontforge/gdraw/gaskdlg.c:563
    #4 0x7f8d10eb320c in _ReadSplineFont /root/fuzz/fuzz_fontforge/fontforge/fontforge/splinefont.c:1336
    #5 0x7f8d10ebf915 in LoadSplineFont /root/fuzz/fuzz_fontforge/fontforge/fontforge/splinefont.c:1416
    #6 0x7f8d102240d8 in bOpen /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:1803
    #7 0x7f8d10275f19 in docall /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9226
    #8 0x7f8d10282fc1 in handlename /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9339
    #9 0x7f8d102ae282 in term /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9577
    #10 0x7f8d102bade9 in mul /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9722
    #11 0x7f8d102bfbb7 in add /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9768
    #12 0x7f8d102c7c09 in comp /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9843
    #13 0x7f8d102cd3dd in _and /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9887
    #14 0x7f8d102d1271 in _or /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9919
    #15 0x7f8d102d1271 in assign /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:9952
    #16 0x7f8d1025e3fa in expr /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:10030
    #17 0x7f8d1025e3fa in ff_statement /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:10243
    #18 0x7f8d102e4347 in ProcessNativeScript /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:10390
    #19 0x7f8d102eb760 in _CheckIsScript /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:10490
    #20 0x7f8d102eb760 in CheckIsScript /root/fuzz/fuzz_fontforge/fontforge/fontforge/scripting.c:10531
    #21 0x564d17d57fe6 in fontforge_main /root/fuzz/fuzz_fontforge/fontforge/fontforgeexe/startui.c:744
    #22 0x7f8d09c29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 40 byte(s) leaked in 1 allocation(s).

Reproduction:
export CFLAGS="-g -O0 -fsanitize=address,undefined" CXXFLAGS="-g -O0 -fsanitize=address,undefined"
export CC=afl-gcc CXX=afl-g++
cmake ..
make && make install
/usr/local/bin/fontforge -lang=ff -c 'Open($1)' 123
