### PR TITLE
Warning rollup from clang trunk

### DIFF
--- a/fontforge/crctab.c
+++ b/fontforge/crctab.c
@@ -46,10 +46,7 @@ static unsigned short crctab[256] = {
     0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0,
 };
 
-static unsigned long binhex_updcrc(icrc, icp, icnt)
-    unsigned long icrc;
-    unsigned char *icp;
-    int icnt;
+static unsigned long binhex_updcrc(unsigned long icrc, unsigned char *icp, int icnt)
 {
 #define M1 0xff
 #define M2 0xff00

--- a/fontforge/featurefile.c
+++ b/fontforge/featurefile.c
@@ -3810,11 +3810,10 @@ static struct markedglyphs *fea_parseBaseMarkSequence(struct parseState *tok,
 	    contents = fea_glyphname_validate(tok,tok->tokbuf);
 	else
 	    contents = fea_cid_validate(tok,tok->value);
-	if ( contents!=NULL ) {
-	    cur = chunkalloc(sizeof(struct markedglyphs));
-	    cur->is_name = true;
-	    cur->name_or_class = contents;
-	}
+
+	cur = chunkalloc(sizeof(struct markedglyphs));
+	cur->is_name = true;
+	cur->name_or_class = contents;
     } else if ( tok->type == tk_class || (tok->type==tk_char && tok->tokbuf[0]=='[')) {
 	cur = chunkalloc(sizeof(struct markedglyphs));
 	cur->is_name = false;
@@ -3874,11 +3873,10 @@ static struct markedglyphs *fea_parseLigatureSequence(struct parseState *tok,
 	    contents = fea_glyphname_validate(tok,tok->tokbuf);
 	else
 	    contents = fea_cid_validate(tok,tok->value);
-	if ( contents!=NULL ) {
-	    cur = chunkalloc(sizeof(struct markedglyphs));
-	    cur->is_name = true;
-	    cur->name_or_class = contents;
-	}
+
+	cur = chunkalloc(sizeof(struct markedglyphs));
+	cur->is_name = true;
+	cur->name_or_class = contents;
     } else if ( tok->type == tk_class || (tok->type==tk_char && tok->tokbuf[0]=='[')) {
 	cur = chunkalloc(sizeof(struct markedglyphs));
 	cur->is_name = false;

--- a/fontforge/parsepfa.c
+++ b/fontforge/parsepfa.c
@@ -1260,7 +1260,7 @@ static void findstring(struct fontparse *fp,struct pschars *subrs,int index,char
 	}
 	decodestr((unsigned char *) buffer,bpt-buffer);
 	bs = buffer + fp->fd->private->leniv;
-	if ( bpt<bs ) bs=bpt;		/* garbage */ 
+	if ( bpt<bs ) bs=bpt;		/* garbage */
 	subrs->lens[index] = bpt-bs;
 	subrs->keys[index] = copy(nametok);
 	subrs->values[index] = malloc(bpt-bs);
@@ -1874,7 +1874,7 @@ return;
 	    ContinueValue(fp,NULL,line);
 return;
 	}
-	
+
 	if ( endtok==NULL ) {
 	    if ( fp->skipping_mbf )
 		;
@@ -2634,7 +2634,7 @@ FontDict *_ReadPSFont(FILE *in) {
     temp = GFileTmpfile();
     if ( temp==NULL ) {
 	LogError( _("Cannot open a temporary file\n") );
-	fclose(in); 
+	fclose(in);
 return(NULL);
     }
 
@@ -2722,9 +2722,8 @@ static void FontInfoFree(struct fontinfo *fi) {
 void PSFontFree(FontDict *fd) {
     int i;
 
-    if ( fd->encoding!=NULL )
-	for ( i=0; i<256; ++i )
-	    free( fd->encoding[i]);
+    for ( i=0; i<256; ++i )
+        free( fd->encoding[i]);
     free(fd->fontname);
     free(fd->cidfontname);
     free(fd->registry);
@@ -2758,7 +2757,7 @@ void PSFontFree(FontDict *fd) {
 
     PSDictFree(fd->blendprivate);
     PSDictFree(fd->blendfontinfo);
-    
+
     free(fd);
 }
 

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -630,7 +630,7 @@ static int PickTTFFont(FILE *ttf, struct ttfinfo *info) {
     names = malloc(cnt*sizeof(char *));
     for ( i=0; i<cnt; ++i ) {
 	names[i] = TTFGetFontName(ttf,offsets[i],0);
-        if ( names[i]==NULL ) 
+        if ( names[i]==NULL )
             names[i] = smprintf("<Unknown font name %d>", i+1);
     }
     if ( info->chosenname!=NULL ) {
@@ -920,7 +920,7 @@ return;
     free(tabs);
     fseek(ttf,restore_this_pos,SEEK_SET);
 }
-	    
+
 static struct tablenames { uint32_t tag; const char *name; } stdtables[] = {
     { CHR('a','c','n','t'), N_("accent attachment table") },
     { CHR('a','n','k','r'), N_("anchor point table") },
@@ -1275,12 +1275,12 @@ static void readdate(FILE *ttf,struct ttfinfo *info,int ismod) {
     /* These timestamps are in "number of seconds since 00:00 1904-01-01",  */
     /* noted some places as a Mac OS epoch time value.  We use Unix epoch   */
     /* timestamps which are "number of seconds since 00:00 1970-01-01".     */
-    /* The difference between these two epoch values is a constant number   */ 
+    /* The difference between these two epoch values is a constant number   */
     /* of seconds, and so we convert from Mac to Unix time by simple        */
     /* subtraction of that constant difference.                             */
 
     /*      (31781 * 65536) + 45184 = 2082844800 secs is 24107 days */
-    int date1970[4] = {45184, 31781, 0, 0}; 
+    int date1970[4] = {45184, 31781, 0, 0};
 
     /* As there was not (nor still is?) a portable way to do 64-bit math aka*/
     /* "long long" the code below works on 16-bit slices of the full value. */
@@ -1675,7 +1675,7 @@ static char *FindLangEntry(struct ttfinfo *info, int id ) {
 	for ( cur=info->names; cur!=NULL && cur->names[id]==NULL; cur=cur->next );
     if ( cur==NULL )
 return( NULL );
-    ret = copy(cur->names[id]);	
+    ret = copy(cur->names[id]);
 return( ret );
 }
 
@@ -1750,7 +1750,7 @@ static void readttfcopyrights(FILE *ttf,struct ttfinfo *info) {
 	    name = getushort(ttf);
 	    str_len = getushort(ttf);
 	    stroff = getushort(ttf);
-    
+
 	    TTFAddLangStr(ttf,info,name,str_len,tableoff+stroff,
 		    platform,specific,language);
 	}
@@ -4046,7 +4046,7 @@ static int readtyp1glyphs(FILE *ttf,struct ttfinfo *info) {
 	    i = 0;
 	fseek(ttf,info->typ1_start+i,SEEK_SET);
     }
-    
+
     tmp = GFileTmpfile();
     for ( i=0; i<info->typ1_length; ++i )
 	putc(getc(ttf),tmp);
@@ -4138,7 +4138,7 @@ static void readttfwidths(FILE *ttf,struct ttfinfo *info) {
 	LogError( _("Invalid ttf hmtx table (or hhea), numOfLongMetrics is 0\n") );
 	info->bad_metrics = true;
     }
-	
+
     for ( j=i; j<info->glyph_cnt; ++j ) {
 	if ( (sc = info->chars[j])!=NULL ) {	/* In a ttc file we may skip some */
 	    sc->width = lastwidth;
@@ -4930,7 +4930,7 @@ return;
 	} else if ( format==2 ) {
 	    int max_sub_head_key = 0, cnt, max_pos= -1;
 	    struct subhead *subheads;
-	    
+
 	    for ( i=0; i<256; ++i ) {
 		table[i] = getushort(ttf)/8;	/* Sub-header keys */
 		if ( table[i]>max_sub_head_key ) {
@@ -5186,7 +5186,7 @@ static void readttfos2metrics(FILE *ttf,struct ttfinfo *info) {
 
 static void readttfpostnames(FILE *ttf,struct ttfinfo *info) {
     int i,j;
-    int format, len, gc, gcbig, val;
+    int format, len, gc, val;
     uint32_t bounds;
     const char *name;
     char buffer[30];
@@ -5232,19 +5232,16 @@ static void readttfpostnames(FILE *ttf,struct ttfinfo *info) {
 	    gc = getushort(ttf);
 	    indexes = calloc(65536,sizeof(uint16_t));
 	    /* the index table is backwards from the way I want to use it */
-	    gcbig = 0;
 	    for ( i=0; i<gc; ++i ) {
 		val = getushort(ttf);
 		if ( val<0 )		/* Don't crash on EOF */
 	    break;
 		indexes[val] = i;
-		if ( val>=258 ) ++gcbig;
 	    }
 
 	    /* if we are only loading bitmaps, we can get holes in our data */
 	    for ( i=0; i<258; ++i ) if ( indexes[i]!=0 || i==0 ) if ( indexes[i]<info->glyph_cnt && info->chars[indexes[i]]!=NULL )
 		info->chars[indexes[i]]->name = copy(ttfstandardnames[i]); /* Too many fonts have badly named glyphs to deduce encoding from name */
-	    gcbig += 258;
 	    i = 258;
 	    /* Read the pascal strings. There can be more strings than the
 	     * glyph count, so we read tell the end of the table */
@@ -6237,7 +6234,7 @@ static SplineFont *SFFillFromTTF(struct ttfinfo *info) {
 	sf->layers = info->layers;
 	sf->layer_cnt = info->layer_cnt;
     }
-	
+
 
     for ( i=0; i<info->glyph_cnt; ++i ) if ( info->chars[i]!=NULL ) {
 	SCOrderAP(info->chars[i]);
@@ -6258,7 +6255,7 @@ static SplineFont *SFFillFromTTF(struct ttfinfo *info) {
     ASCIIcheck(&sf->familyname);
     ASCIIcheck(&sf->weight);
     ASCIIcheck(&sf->version);
-    
+
     TTF_PSDupsDefault(sf);
 
     /* I thought the languages were supposed to be ordered, but it seems */
@@ -6343,7 +6340,7 @@ SplineFont *_SFReadTTF(FILE *ttf, int flags,enum openflags openflags, char *file
     info.fd = fd;
     /* Pass the subfont name (if present) via info->chosenname. This may
      * be free()d and replaced so make a copy */
-    if ( chosenname!=NULL) 
+    if ( chosenname!=NULL)
 	info.chosenname = copy(chosenname);
     ret = readttf(ttf,&info,filename);
     if ( !ret )

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -2341,7 +2341,7 @@ static void bExport(Context *c) {
 
     InitExportParams(&ep);
 
-    if ( c->a.argc<2 && c->a.argc>4 ) {
+    if ( c->a.argc<2 || c->a.argc>4 ) {
 	c->error = ce_wrongnumarg;
 	return;
     }
@@ -5008,7 +5008,7 @@ static void bNonLinearTransform(Context *c) {
 }
 
 static const int nibmap[] = { si_round, si_calligraphic, si_nib };
-static const int joinmap[] = { lj_miter, lj_round, lj_bevel, lj_nib, 
+static const int joinmap[] = { lj_miter, lj_round, lj_bevel, lj_nib,
                                lj_miterclip, lj_arcs, lj_inherited };
 static const int capmap[] = { lc_butt, lc_round, lc_square, lc_nib,
                               lc_inherited };
@@ -5068,7 +5068,7 @@ static void bExpandStroke(Context *c) {
 	6 => stroke width, line cap, line join, 0, flags
 	7 => stroke width, calligraphic angle, thickness-numerator, thickness-denom, 0, flags
 	11 => nib type, width, height, calligraphic angle, line cap, line join, join limit, extend cap, accuracy target, flags
-    */ 
+    */
 
     if ( c->a.argc<2 || (c->a.argc>7 && c->a.argc!=11) ) {
 	c->error = ce_wrongnumarg;
@@ -5119,13 +5119,13 @@ static void bExpandStroke(Context *c) {
 	i = c->a.vals[1].u.ival;
 	if ( i >= 0 && i<=2 )
 	    si.stroke_type = nibmap[i];
-	else 
+	else
 	    ScriptError(c,"Unrecognized stroke type");
 	if ( si.stroke_type == si_nib ) {
 	    if ( c->a.vals[2].type!=v_int )
 		ScriptError(c,"Bad argument type");
 	    si.nib = StrokeGetConvex(c->a.vals[2].u.ival, false);
-	    if ( si.nib==NULL ) 
+	    if ( si.nib==NULL )
 		ScriptError(c,"Convex nib unknown or not defined");
 	} else
 	    si.height = args[3];

--- a/fontforge/scstyles.c
+++ b/fontforge/scstyles.c
@@ -5380,11 +5380,10 @@ return;
 static void DeSerifDescender(SplineChar *sc,int layer,ItalicInfo *ii) {
     /* sc should only have one descender. Find it */
     StemInfo *h;
-    int i;
     HintInstance *hi;
     StemInfo *smallest=NULL;
 
-    for ( i=0, h=sc->vstem; h!=NULL; ++i, h=h->next ) {
+    for ( h=sc->vstem; h!=NULL; h=h->next ) {
 	for ( hi=h->where; hi!=NULL; hi=hi->next )
 	    if ( hi->begin<0 || hi->end<0 ) {
 		if ( smallest==NULL || h->width<smallest->width ) {

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -135,7 +135,7 @@ static void ValidateMListTs(struct mlist * input) {
 #ifdef FF_OVERLAP_VERBOSE
 #define ValidateMListTs_IF_VERBOSE(input) ValidateMListTs(input);
 #else
-#define ValidateMListTs_IF_VERBOSE(input) 
+#define ValidateMListTs_IF_VERBOSE(input)
 #endif
 
 static extended evalSpline(Spline *s, extended t, int dim) {
@@ -194,7 +194,7 @@ static void Validate(Monotonic *ms, Intersection *ilist) {
 	    SOError( "Mismatched intersection.\n (%g,%g)->(%g,%g) ends at (%g,%g) while (%g,%g)->(%g,%g) starts at (%g,%g)\n",
 		(double) ms->prev->s->from->me.x,(double) ms->prev->s->from->me.y,
 		(double) ms->prev->s->to->me.x,(double) ms->prev->s->to->me.y,
-		(double) (ms->prev->end!=NULL?ms->prev->end->inter.x:-999999), (double) (ms->prev->end!=NULL?ms->prev->end->inter.y:-999999), 
+		(double) (ms->prev->end!=NULL?ms->prev->end->inter.x:-999999), (double) (ms->prev->end!=NULL?ms->prev->end->inter.y:-999999),
 		(double) ms->s->from->me.x,(double) ms->s->from->me.y,
 		(double) ms->s->to->me.x,(double) ms->s->to->me.y,
 		(double) (ms->start!=NULL?ms->start->inter.x:-999999), (double) (ms->start!=NULL?ms->start->inter.y:-999999) );
@@ -423,7 +423,7 @@ ValidateMListTs_IF_VERBOSE(il->monos)
     // Add the new item to the monotonic list for the input intersection.
     ml->next = il->monos;
     il->monos = ml;
-    
+
     ml->s = m->s; // Set the spline.
     ml->m = m;			/* This may change. We'll fix it up later */
     ml->t = t;
@@ -504,7 +504,7 @@ static extended FixMonotonicT(struct monotonic * input_mono, extended startt, ex
 static int MonotonicCheckZeroLength(struct monotonic * input1) {
   if (input1->start == input1->end) return 1;
   if (input1->tstart == input1->tend) return 1;
-  if (input1->start != NULL && input1->end != NULL && 
+  if (input1->start != NULL && input1->end != NULL &&
     input1->start->inter.x == input1->end->inter.x && input1->start->inter.y == input1->end->inter.y) {
     SOError("Zero-length monotonic between unlike points.\n"); return 1;
   }
@@ -776,7 +776,7 @@ return;
 	m->start = il;
 	_AddSpline(il,m,m->tstart,false);
 	if (m->prev != NULL) _AddSpline(il,m->prev,m->prev->tend,true);
-    } else if ((t-m->tstart > m->tend-t) && ((m->tend == t) || 
+    } else if ((t-m->tstart > m->tend-t) && ((m->tend == t) ||
            (Within4RoundingErrors(m->tend,t) && ( m->end==NULL || (
            Within16RoundingErrors(m->end->inter.x,il->inter.x) &&
            Within16RoundingErrors(m->end->inter.y,il->inter.y)))))) {
@@ -1280,7 +1280,7 @@ return( true );
 	    }
 	    if ( t1p==t1 && t2p==t2 )
 	break;
-    
+
 	    x1p = ((s1->splines[0].a*t1p + s1->splines[0].b)*t1p + s1->splines[0].c)*t1p + s1->splines[0].d;
 	    x2p = ((s2->splines[0].a*t2p + s2->splines[0].b)*t2p + s2->splines[0].c)*t2p + s2->splines[0].d;
 	    y1p = ((s1->splines[1].a*t1p + s1->splines[1].b)*t1p + s1->splines[1].c)*t1p + s1->splines[1].d;
@@ -2092,7 +2092,7 @@ return( true );
 #define FF_DUMP_MONOTONIC_IF_VERBOSE(m) DumpMonotonic(m);
 static void DumpMonotonic(Monotonic *input) {
   fprintf(stderr, "Monotonic: %p\n", input);
-  fprintf(stderr, "  spline: %p; tstart: %f; tstop: %f; next: %p; prev: %p; start: %p; end: %p;\n", 
+  fprintf(stderr, "  spline: %p; tstart: %f; tstop: %f; next: %p; prev: %p; start: %p; end: %p;\n",
     input->s, input->tstart, input->tend, input->next, input->prev, input->start, input->end);
   fprintf(stderr, "  ");
   if (input->start != NULL) fprintf(stderr, "start: (%f, %f) ", input->start->inter.x, input->start->inter.y);
@@ -2102,7 +2102,7 @@ static void DumpMonotonic(Monotonic *input) {
   fprintf(stderr, "\n");
 }
 #else
-#define FF_DUMP_MONOTONIC_IF_VERBOSE(m) 
+#define FF_DUMP_MONOTONIC_IF_VERBOSE(m)
 #endif
 
 static Monotonic *FindMonoContaining(Monotonic *base, bigreal t) {
@@ -2415,7 +2415,7 @@ int CheckMonotonicClosed(struct monotonic *ms) {
   if (ms == NULL) return 0;
   current = ms->next;
   while (current != ms && current != NULL) {
-    current = current->next;    
+    current = current->next;
   }
   if (current == NULL) return 0;
   return 1;
@@ -2939,7 +2939,7 @@ static void TestForBadDirections(Intersection *ilist) {
     /*  this. */
     /* I think it happens if all exits from an intersection are needed */
     MList *ml, *ml2;
-    int cnt, ncnt;
+    int ncnt;
     Intersection *il;
 
     /* If we have two splines one going from a->b and the other from b->a */
@@ -2966,9 +2966,7 @@ static void TestForBadDirections(Intersection *ilist) {
     }
 
     while ( ilist!=NULL ) {
-	cnt = ncnt = 0;
 	for ( ml = ilist->monos; ml!=NULL; ml=ml->next ) {
-	    ++cnt;
 	    if ( ml->m->isneeded ) ++ncnt;
 	}
 	ilist = ilist->next;
@@ -3204,7 +3202,7 @@ static SplineSet *JoinAContour(Intersection *startil,MList *ml) {
 	    if ( ml==NULL )
 		for ( ml=curil->monos; ml!=NULL && !ml->m->isneeded; ml=ml->next );
 	} else {
-	    
+
 	    int k; MList *bestml; bigreal bestdot;
 	    for ( k=0; k<2; ++k ) {
 		bestml = NULL; bestdot = -2;
@@ -3771,7 +3769,7 @@ return( -1 );
     }
 return( t1 );
 }
-	
+
 void SSRemoveBacktracks(SplineSet *ss) {
     SplinePoint *sp;
 
@@ -3861,7 +3859,7 @@ static int BetweenForCollinearPoints( SplinePoint* a, SplinePoint* middle, Splin
     if( a->me.x <= middle->me.x && middle->me.x <= b->me.x )
 	if( a->me.y <= middle->me.y && middle->me.y <= b->me.y )
 	    return 1;
-    
+
     return ret;
 }
 
@@ -3902,7 +3900,7 @@ static SplineSet *SSRemoveReversals(SplineSet *base) {
 		    SplinePoint *nsp = sp->next->to;
 		    SplinePoint *psp = sp->prev->from;
 		    SplinePoint *isp = 0;
-		    
+
 		    if ( psp->me.x==nsp->me.x && psp->me.y==nsp->me.y &&
 			    psp->nextcp.x==nsp->prevcp.x && psp->nextcp.y==nsp->prevcp.y )
 		    {

--- a/fontforge/splineoverlap.c
+++ b/fontforge/splineoverlap.c
@@ -2939,7 +2939,6 @@ static void TestForBadDirections(Intersection *ilist) {
     /*  this. */
     /* I think it happens if all exits from an intersection are needed */
     MList *ml, *ml2;
-    int ncnt;
     Intersection *il;
 
     /* If we have two splines one going from a->b and the other from b->a */
@@ -2963,13 +2962,6 @@ static void TestForBadDirections(Intersection *ilist) {
 		}
 	    }
 	}
-    }
-
-    while ( ilist!=NULL ) {
-	for ( ml = ilist->monos; ml!=NULL; ml=ml->next ) {
-	    if ( ml->m->isneeded ) ++ncnt;
-	}
-	ilist = ilist->next;
     }
 }
 

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -2908,7 +2908,7 @@ static void RSC2PS2(GrowBuf *gb, SplineChar *base,SplineChar *rsc,
     BasePoint subtrans;
     int stationary = trans->x==0 && trans->y==0;
     RefChar *r, *unsafe=NULL;
-    int unsafecnt=0, allwithouthints=true;
+    int allwithouthints=true;
     int round = (flags&ps_flag_round)? true : false;
     StemInfo *oldh, *oldv;
     int hc, vc;
@@ -2929,7 +2929,6 @@ static void RSC2PS2(GrowBuf *gb, SplineChar *base,SplineChar *rsc,
 	    if ( !r->justtranslated )
 	continue;
 	    if ( r->sc->hconflicts || r->sc->vconflicts ) {
-		++unsafecnt;
 		unsafe = r;
 	    } else if ( r->sc->hstem!=NULL || r->sc->vstem!=NULL )
 		allwithouthints = false;

--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -2362,8 +2362,7 @@ return( 0 );
     /* fonts or fonts with quadratic splines). */
     /* But do that only for colinear spline segments and ensure that there are  */
     /* no bends between two splines. */
-    if ( !tp && ( !fp || t > 0.5 ) &&
-	topd->colinear && &other->to->next != NULL ) {
+    if ( !tp && ( !fp || t > 0.5 ) && topd->colinear ) {
 	testpt = topt->next->to; 
 	testpd = &gd->points[testpt->ptindex];
 	BasePoint *initdir = &topd->prevunit;
@@ -2378,8 +2377,7 @@ return( 0 );
 	}
 	if ( tp ) t_needs_recalc = true;
     }
-    if ( !fp && ( !fp || t < 0.5 ) &&
-	frompd->colinear && &other->from->prev != NULL ) {
+    if ( !fp && ( !fp || t < 0.5 ) && frompd->colinear ) {
 	testpt = frompt->prev->from; 
 	testpd = &gd->points[testpt->ptindex];
 	BasePoint *initdir = &frompd->prevunit;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -2800,7 +2800,7 @@ void SCDimensionFromSVG(xmlNodePtr svg, SplineChar *sc, bool vert) {
 
 void SCDimensionFromSVGFile(const char *path, SplineChar *sc, bool vert) {
     xmlDocPtr doc;
-    xmlNodePtr svg;
+    xmlNodePtr svg = NULL;
     doc = xmlParseFile(path);
     if (doc != NULL)
 	svg = xmlDocGetRootElement(doc);

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3734,7 +3734,7 @@ static void dumpstr(FILE *file,char *str) {
 static void dumpustr(FILE *file,char *utf8_str) {
     uint16_t *utf16_str = utf82utf16_copy(utf8_str);
     uint16_t *pt = utf16_str;
-    
+
     do {
 	putc(*pt>>8,file);
 	putc(*pt&0xff,file);
@@ -4504,7 +4504,7 @@ static FILE *NeedsUCS2Table(SplineFont *sf,int *ucs2len,EncMap *map,int issymbol
     /* But if it's symbol, only include encodings 0xff20 - 0xffff */
     int32_t *avail = malloc(65536*sizeof(int32_t));
     int i,j, first_delta=0, last_delta, slen;
-    int curseg=0, segcnt, segmax=SEGMAXINC, cnt=0, mapcnt=0;
+    int curseg=0, segcnt, segmax=SEGMAXINC, mapcnt=0;
     SplineChar *sc;
     FILE *format4 = NULL;
     /* the cmapseg elements are written as shorts. We keep them
@@ -4520,7 +4520,6 @@ static FILE *NeedsUCS2Table(SplineFont *sf,int *ucs2len,EncMap *map,int issymbol
     if ( map->enc->is_unicodebmp || map->enc->is_unicodefull ) { int gid;
 	for ( i=0; i<65536 && i<map->enccount; ++i ) if ( (gid=map->map[i])!=-1 && sf->glyphs[gid]!=NULL && sf->glyphs[gid]->ttf_glyph!=-1 ) {
 	    avail[i] = sf->glyphs[gid]->ttf_glyph;
-	    ++cnt;
 	}
     } else {
 	struct altuni *altuni;
@@ -4528,12 +4527,10 @@ static FILE *NeedsUCS2Table(SplineFont *sf,int *ucs2len,EncMap *map,int issymbol
 	    if ( (sc=sf->glyphs[i])!=NULL && sc->ttf_glyph!=-1 ) {
 		if ( sc->unicodeenc>=0 && sc->unicodeenc<=0xffff ) {
 		    avail[sc->unicodeenc] = sc->ttf_glyph;
-		    ++cnt;
 		}
 		for ( altuni=sc->altuni; altuni!=NULL; altuni = altuni->next ) {
 		    if ( altuni->unienc<=0xffff && altuni->vs==-1 && altuni->fid==0 ) {
 			avail[altuni->unienc] = sc->ttf_glyph;
-			++cnt;
 		    }
 		}
 	    }
@@ -4701,12 +4698,10 @@ static FILE *NeedsUCS2Table(SplineFont *sf,int *ucs2len,EncMap *map,int issymbol
 	    putshort(format4,0);
 	else
 	    putshort(format4,(cmapseg[i].mapoff+(segcnt-i))*sizeof(int16_t));
-    int chk=0;
     for ( i=0; i<segcnt; ++i ) {
 	if ( cmapseg[i].use_delta )
 	    continue;
 	for ( j=cmapseg[i].start; j<=cmapseg[i].end; ++j ) {
-	    chk++;
 	    if ( avail[j]==-1 )
 		putshort(format4,0);
 	    else

--- a/fontforge/tottfaat.c
+++ b/fontforge/tottfaat.c
@@ -198,7 +198,7 @@ static void ttf_dumpsfkerns(struct alltabs *at, SplineFont *sf, int tupleIndex, 
 return;
 
     if ( tupleIndex==-1 ) tupleIndex = 0;
-    
+
     for ( isv=0; isv<2; ++isv ) {
 	c = isv ? kcnt.vcnt : kcnt.cnt;
 	bmax = isv ? kcnt.vsubs : kcnt.hsubs;
@@ -296,14 +296,6 @@ return;
 	    /* If we are here, we must be using version 1 */
 	    uint32_t len_pos = ftell(at->kern), pos;
 	    uint16_t *class1, *class2;
-	    int first_cnt = kc->first_cnt;
-
-	    /* OpenType fonts can actually have a set of glyphs in class[0] of*/
-	    /*  the first class. This happens when there are glyphs in the */
-	    /*  coverage table which are not in any of the classes. Otherwise */
-	    /*  class 0 is sort of useless in opentype */
-	    if ( kc->firsts[0]!=NULL )
-		++first_cnt;
 
 	    putlong(at->kern,0); /* subtable length */
 	    putshort(at->kern,(isv?0x8002:2)|	/* format 2, horizontal/vertical flags (coverage) */
@@ -1427,7 +1419,7 @@ return( NULL );
     ret[scnt] = 0;
 return( ret );
 }
-    
+
 int Macable(SplineFont *sf, OTLookup *otl) {
     int ft, fs;
     FeatureScriptLangList *features;
@@ -1974,7 +1966,7 @@ return;
 	morxDumpChain(at,features,features_by_type,i,temp);
     fclose(temp);
     morxfeaturesfree(features_by_type);
-    
+
     at->morxlen = ftell(at->morx);
     if ( at->morxlen&1 )
 	putc('\0',at->morx);
@@ -2311,7 +2303,7 @@ int16_t *PerGlyphDefBaseline(SplineFont *sf,int *def_baseline) {
 	if ( bsln!=0xffff )
 	    ++counts[bsln];
     }
-    
+
     bestbsln = 0;
     bestcnt = 0;
     any = 0;
@@ -2436,7 +2428,7 @@ return;
 	putshort(at->bsln,0);
     free(baselines);
 }
-	
+
 /* ************************************************************************** */
 /* *************************    utility routines    ************************* */
 /* ************************************************************************** */
@@ -2465,7 +2457,7 @@ return( true );
 	}
     *featureType = (tag >> 16);
     *featureSetting = (tag & 0xFFFF);
-	/* Ranges taken from Apple Font Registry. An OT tag without a 
+	/* Ranges taken from Apple Font Registry. An OT tag without a
     corresponding mac feature should fail this test.*/
     if (*featureType >= 0 && *featureType < 105 && *featureSetting < 16)
         return ( true );
@@ -2486,9 +2478,9 @@ static struct feature *featureFromTag(SplineFont *sf, uint32_t tag ) {
         feat->mf = FindMacFeature(sf,feat->featureType,&feat->smf);
         feat->ms = FindMacSetting(sf,feat->featureType,feat->featureSetting,&feat->sms);
         feat->needsOff = feat->mf!=NULL && !feat->mf->ismutex;
-        feat->vertOnly = tag==CHR('v','r','t','2') || tag==CHR('v','k','n','a');    
+        feat->vertOnly = tag==CHR('v','r','t','2') || tag==CHR('v','k','n','a');
     }
-    
+
     return( feat );
 }
 
@@ -2512,7 +2504,7 @@ static struct feature *featureFromSubtable(SplineFont *sf, struct lookup_subtabl
   }
   return( featureFromTag(sf,fl->featuretag));
 }
-    
+
 static int PSTHasTag(PST *pst, uint32_t tag) {
     FeatureScriptLangList *fl;
 

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -708,7 +708,6 @@ static void dumpcoveragetable(FILE *gpos,SplineChar **glyphs) {
 
 	// We will not emit glyphs with -1 identifiers.
 	// We count the valid glyphs and the ranges.
-	int glyph_cnt = 0;
 	for (i=0; glyphs[i]!=NULL; i++) {
 		if (i > 0 && glyphs[i]->ttf_glyph <= glyphs[i-1]->ttf_glyph) {
 			LogError(_("Glyphs must be ordered when creating coverage table"));
@@ -716,7 +715,6 @@ static void dumpcoveragetable(FILE *gpos,SplineChar **glyphs) {
 		if (glyphs[i]->ttf_glyph < 0) {
 			LogError(_("-1 glyph index in dumpcoveragetable.\n"));
 		} else {
-			glyph_cnt++;
 			// On the first validly TrueType-indexed glyph or at the start of any discontinuity, start a new range.
 			if (range_cnt == 0 || glyphs[i]->ttf_glyph > last + 1)
 				range_cnt++;

--- a/fontforge/tottfvar.c
+++ b/fontforge/tottfvar.c
@@ -572,26 +572,12 @@ return;
 	}
 	/* Now output the corresponding deltas for those points */
 	for ( j=0; j<pcnt; ) {
-	    if ( deltas[i][j]>0x7f || deltas[i][j]<0x80 ) {
 		for ( rj=j+1; rj<j+0x40 && rj<pcnt; ++rj ) {
-		    if ( deltas[i][pts[rj]]>0x7f || deltas[i][pts[rj]]<0x80 ||
-			    (rj+1<j+0x40 && rj+1<pcnt && (deltas[i][pts[rj+1]]>0x7f || deltas[i][pts[rj+1]]<0x80)) )
-			/* Keep going with a big run */;
-		    else
-		break;
+		    ;
 		}
 		putc( (rj-j-1)|0x40,at->cvar );
 		for ( ; j<rj ; ++j )
 		    putshort( at->cvar, deltas[i][pts[j]] );
-	    } else {
-		for ( rj=j+1; rj<j+0x40 && rj<pcnt; ++rj ) {
-		    if ( deltas[i][pts[rj]]>0x7f || deltas[i][pts[rj]]<0x80 )
-		break;
-		}
-		putc( rj-j-1,at->cvar );
-		for ( ; j<rj ; ++j )
-		    putc( deltas[i][pts[j]], at->cvar );
-	    }
 	}
 	free(pts);
 	end = ftell(at->cvar);
@@ -622,28 +608,12 @@ static void dumpdeltas(struct alltabs *at,int16_t *deltas,int ptcnt) {
 	    j = rj;
     continue;
 	}
-	if ( deltas[j]>0x7f || deltas[j]<0x80 ) {
 	    for ( rj=j+1; rj<j+0x40 && rj<ptcnt; ++rj ) {
-		if ( deltas[rj]>0x7f || deltas[rj]<0x80 ||
-			(rj+1<j+0x40 && rj+1<ptcnt && (deltas[rj+1]>0x7f || deltas[rj+1]<0x80)) )
-		    /* Keep going with a big run */;
-		else
-	    break;
+		;
 	    }
 	    putc( (rj-j-1)|0x40,at->gvar );
 	    for ( ; j<rj ; ++j )
 		putshort( at->gvar, deltas[j] );
-	} else {
-	    for ( rj=j+1; rj<j+0x40 && rj<ptcnt; ++rj ) {
-		if ( deltas[rj]>0x7f || deltas[rj]<0x80 ||
-			(deltas[rj]==0 && rj+1<j+0x40 && rj+1<ptcnt &&
-			    deltas[rj+1]<=0x7f && deltas[rj+1]>=0x80 && deltas[rj+1]!=0 ))
-	    break;
-	    }
-	    putc( rj-j-1,at->gvar );
-	    for ( ; j<rj ; ++j )
-		putc( deltas[j], at->gvar );
-	}
     }
 }
 

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -3465,7 +3465,6 @@ return;
 	    // We prepare to populate it. We will match to native glyphs first (in order to validate) and then convert back to strings later.
 	    RefChar *members_native = NULL;
 	    RefChar *member_native_current = NULL;
-	    int member_count = 0;
 	    int member_list_length = 0; // This makes it easy to allocate a string at the end.
 	    // We fetch the contents now. They are in an array, but we do not verify that.
 	    keys = value;
@@ -3474,7 +3473,7 @@ return;
 		    keyname = (char *) xmlNodeListGetString(doc,subkeys->children,true); // Get the member name.
 		    SplineChar *ssc = SFGetChar(sf,-1,keyname); // Try to match an existing glyph.
 		    if ( ssc==NULL ) { LogError(_("Skipping non-existent glyph %s in group %s.\n"), keyname, current_group->classname); free(keyname); keyname = NULL; continue; }
-		    member_list_length += strlen(keyname) + 1; member_count++; // Make space for its name.
+		    member_list_length += strlen(keyname) + 1; // Make space for its name.
 		    free(keyname); // Free the name for now. (We get it directly from the SplineChar later.)
 		    RefChar *member_native_temp = calloc(1, sizeof(RefChar)); // Make an entry in the list for the native reference.
 		    member_native_temp->sc = ssc; ssc = NULL;

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -355,7 +355,7 @@ xmlDocPtr PlistInit() {
     // Some of this code is pasted from libxml2 samples.
     xmlDocPtr doc = NULL;
     xmlNodePtr root_node = NULL;
-    
+
 
     LIBXML_TEST_VERSION;
 
@@ -575,7 +575,7 @@ xmlNodePtr PythonLibToXML(void *python_persistent, const SplineChar *sc, int has
     xmlNodePtr retval = NULL, dictnode = NULL;
     // retval = xmlNewNode(NULL, BAD_CAST "lib"); //     "<lib>"
     dictnode = xmlNewNode(NULL, BAD_CAST "dict"); //     "  <dict>"
-    if ( has_hints 
+    if ( has_hints
 #ifndef _NO_PYTHON
          || (python_persistent!=NULL && PyMapping_Check((PyObject *)python_persistent))
 #endif
@@ -834,7 +834,7 @@ xmlNodePtr _GlifToXML(const SplineChar *sc, int layer, int version) {
           xmlSetPropPrintf(unicodexml, BAD_CAST "hex", "%04X", altuni->unienc);
         }
         // "<unicode hex=\"%04X\"/>" altuni->unienc
-    
+
 	if (version >= 3) {
 		// Handle the guidelines.
 		GuidelineSet *gl;
@@ -859,7 +859,7 @@ xmlNodePtr _GlifToXML(const SplineChar *sc, int layer, int version) {
 		    if (gl->identifier != NULL)
 		        xmlSetPropPrintf(guidelinexml, BAD_CAST "identifier", "%s", gl->identifier);
 		    // "<guideline/>\n"
-		    
+
 		}
 		// Handle the anchors. Put global anchors only in the foreground layer.
 		if (layer == ly_fore)
@@ -1978,7 +1978,7 @@ int WriteUFOFontFlex(const char *basedir, SplineFont *sf, enum fontformat ff, in
 	numberedname = NULL;
     }
     glif_name_index_destroy(glif_name_hash); // Close the hash table.
-    
+
     struct glif_name_index * layer_name_hash = glif_name_index_new(); // Open the hash table.
     struct glif_name_index * layer_path_hash = glif_name_index_new(); // Open the hash table.
 
@@ -2228,7 +2228,7 @@ return( Py_BuildValue("d",val));
 	free(contents);
 return( ret );
       }
-      
+
       free( contents );
     }
     if (has_lists) {
@@ -2463,7 +2463,7 @@ static void *UFOLoadGuideline(SplineFont *sf, SplineChar *sc, int layer, xmlDocP
 		what_is_defined |= 0x20;
 		gl->flags |= 0x20;
 		int colori;
-		off_t colorp, colorps;
+		off_t colorp = 0, colorps;
 		double colorv;
 		for (colori = 0; colori < 4; colori++) {
 			while (colors[colorp] == ' ' || colors[colorp] == ',') colorp++;
@@ -2596,7 +2596,7 @@ static SplineChar *_UFOLoadGlyph(SplineFont *sf, xmlDocPtr doc, char *glifname, 
     } else if ( name==NULL )
 		name = copy("nameless");
 	// We assign a placeholder name if no name exists.
-	// We create a new SplineChar 
+	// We create a new SplineChar
 	if (existingglyph != NULL) {
 		sc = existingglyph;
 		free(name); name = NULL;

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -367,7 +367,7 @@ int CVInSpiro( CharView *cv )
 {
     int inspiro = 0;
     int canspiro = hasspiro();
-    if( cv ) 
+    if( cv )
 	inspiro = canspiro && cv->b.sc->inspiro;
     return inspiro;
 }
@@ -820,7 +820,7 @@ static int FmtReal(char *buf, int buflen, real r)
 
 	if ((ct = snprintf(buf, buflen, "%.3f", r)) >= buflen)
 	    ct = buflen-1;
-    
+
 	if (strchr(buf, '.')) {
 	    while (buf[ct-1] == '0') {
 		--ct;
@@ -833,13 +833,13 @@ static int FmtReal(char *buf, int buflen, real r)
 	return ct;
     }
     return -1;
-}	    
-	
+}
+
 /*
  * Write the given spline point's coordinates in the form (xxx,yyy)
  * into the buffer provided, rounding fractions to the nearest .001
  * and discarding trailing zeroes.
- */ 
+ */
 static int SplinePointCoords(char *buf, int buflen, SplinePoint *sp)
 {
     if (buf && buflen > 0) {
@@ -1498,7 +1498,6 @@ void CVDrawSplineSet(CharView *cv, GWindow pixmap, SplinePointList *set,
 void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *set,
 				Color fg, int dopoints, DRect *clip, enum outlinesfm_flags strokeFillMode ) {
     SplinePointList *spl;
-    int currentSplineCounter = 0;
     int activelayer = CVLayer(&cv->b);
     CharViewTab* tab = CVGetActiveTab(cv);
 
@@ -1537,7 +1536,6 @@ void CVDrawSplineSetOutlineOnly(CharView *cv, GWindow pixmap, SplinePointList *s
 	    x = rpt(cv,  tab->xoff + spl->first->me.x*tab->scale);
 	    y = rpt(cv, -tab->yoff + cv->height - spl->first->me.y*tab->scale);
 	    GDrawPathMoveTo(pixmap,x+.5,y+.5);
-	    currentSplineCounter++;
 	    for ( spline=spl->first->next, first=NULL; spline!=first && spline!=NULL; spline=spline->to->next ) {
 		x = rpt(cv,  tab->xoff + spline->to->me.x*tab->scale);
 		y = rpt(cv, -tab->yoff + cv->height - spline->to->me.y*tab->scale);
@@ -1731,11 +1729,11 @@ static void CVDrawLayerSplineSet(CharView *cv, GWindow pixmap, Layer *layer,
 
     if ( ml && !active && layer!=&cv->b.sc->layers[ly_back] )
 	GDrawSetDashedLine(pixmap,5,5,tab->xoff+cv->height-tab->yoff);
-    
+
     CVDrawSplineSetSpecialized( cv, pixmap, layer->splines,
 				fg, dopoints && active, clip,
 				strokeFillMode, 0 );
-    
+
     if ( ml && !active && layer!=&cv->b.sc->layers[ly_back] )
 	GDrawSetDashedLine(pixmap,0,0,0);
 }
@@ -2754,7 +2752,7 @@ static int CVExposeGlyphFill(CharView *cv, GWindow pixmap, GEvent *event, DRect*
 	    filled = 1;
 	}
     } else {
-	if (( cv->showfore || cv->b.drawmode==dm_fore ) && cv->showfilled && 
+	if (( cv->showfore || cv->b.drawmode==dm_fore ) && cv->showfilled &&
 	    cv->filled!=NULL ) {
 	    GDrawDrawImage(pixmap, &cv->gi, NULL,
 			   tab->xoff + cv->filled->xmin,
@@ -2769,7 +2767,7 @@ static void CVExposeReferences( CharView *cv, GWindow pixmap, SplineChar* sc, in
 {
     RefChar *rf = 0;
     int rlayer = 0;
-    
+
     for ( rf = sc->layers[layer].refs; rf!=NULL; rf = rf->next )
     {
 	if ( cv->showrefnames )
@@ -2980,7 +2978,7 @@ static void CVExpose(CharView *cv, GWindow pixmap, GEvent *event ) {
 	    CVDrawLayerSplineSet( cv,pixmap,&cv->b.sc->layers[layer],foreoutlinecol,
 	    			  cv->showpoints ,&clip, strokeFillMode );
 
-	    
+
 	    int showpoints = 0;
 	    enum outlinesfm_flags sm = sfm_stroke;
 	    if( cv->inPreviewMode ) {
@@ -3011,13 +3009,13 @@ static void CVExpose(CharView *cv, GWindow pixmap, GEvent *event ) {
 	    }
 
 
-	    
+
 	    if( cv->additionalCharsToShowActiveIndex > 0 )
 	    {
 		int i = 1;
 		int originalxoff = tab->xoff;
 		int offset = 0;
-		    
+
 		for( i=cv->additionalCharsToShowActiveIndex-1; i >= 0; i-- )
 		{
 //		    TRACE("expose(left) loop:%d\n", i );
@@ -3033,7 +3031,7 @@ static void CVExpose(CharView *cv, GWindow pixmap, GEvent *event ) {
 		}
 		tab->xoff = originalxoff;
 	    }
-		
+
 //	    TRACE("expose(e) ridx:%d\n", ridx );
 
 	}
@@ -3576,7 +3574,7 @@ static void CVSetCharSelectorValueFromSC( CharView *cv, SplineChar *sc )
     const char* title = Wordlist_getSCName( sc );
     GGadgetSetTitle8(cv->charselector, title);
 }
-	    
+
 // See comment in gtabset.c (fn GTabSetRemoveTabByPos)
 static void CVMenuCloseTab(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e));
 static void CVTabSetRemoveSync(GWindow gw, int pos) {
@@ -3620,7 +3618,7 @@ void CVChangeSC( CharView *cv, SplineChar *sc )
     memset( cv->additionalCharsToShow, 0, sizeof(SplineChar*) * additionalCharsToShowLimit );
     cv->additionalCharsToShowActiveIndex = 0;
     cv->additionalCharsToShow[0] = sc;
-    
+
     CVDebugFree(cv->dv);
 
     if ( cv->expandedge != ee_none ) {
@@ -3714,7 +3712,7 @@ void CVChangeSC( CharView *cv, SplineChar *sc )
                     GTabSetChangeTabName(cv->tabs, t->charselected, i);
                 }
             }
-            
+
 	    GTabSetRemetric(cv->tabs);
 	    GTabSetSetSel(cv->tabs,0);	/* This does a redraw */
 	    if ( !GGadgetIsVisible(cv->tabs) && cv->showtabs )
@@ -3881,7 +3879,7 @@ static void CVCharUp(CharView *cv, GEvent *event ) {
 	CVInfoDraw(cv,cv->gw);
     }
 
-    
+
 
 //    TRACE("CVCharUp() ag:%d key:%d\n", cv_auto_goto, event->u.chr.keysym );
     if( !cv_auto_goto )
@@ -3939,7 +3937,7 @@ static void CVCharUp(CharView *cv, GEvent *event ) {
 	    GWidgetIndicateFocusGadget( cv->charselector );
 	}
     }
-    
+
 
 #if _ModKeysAutoRepeat
     /* Under cygwin these keys auto repeat, they don't under normal X */
@@ -4050,8 +4048,8 @@ void CVInfoDrawText(CharView *cv, GWindow pixmap ) {
 	    strcat( buffer, "Interpolate" );
 	GDrawDrawText8(pixmap,FLAGS_DATA,ybase,buffer,-1,fg);
     }
-    
-    
+
+
     if ( cv->coderange!=cr_none ) {
 	GDrawDrawText8(pixmap,CODERANGE_DATA,ybase,
 		cv->coderange==cr_fpgm ? _("'fpgm'") :
@@ -4361,7 +4359,7 @@ static int16_t MouseToCX( CharView *cv, int16_t mx )
     return( mx - tab->xoff ) / tab->scale;
 }
 
-    
+
 static void SetFS( FindSel *fs, PressedOn *p, CharView *cv, GEvent *event) {
     CharViewTab* tab = CVGetActiveTab(cv);
     extern int snaptoint;
@@ -4638,7 +4636,7 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
 		return;
 	}
     }
-    
+
     cv->changedActiveGlyph = 1;
     TRACE("CVSwitchActiveSC(b) activeidx:%d newidx:%d\n", cv->additionalCharsToShowActiveIndex, idx );
     for( i=0; i < additionalCharsToShowLimit; i++ )
@@ -4676,11 +4674,11 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
 		scroll_offset -= xc->width;
 	}
     }
-    
-    
 
 
-    
+
+
+
     CVUnlinkView( cv );
     cv->b.sc = sc;
     cv->b.next = sc->views;
@@ -4697,7 +4695,7 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
     CVInfoDraw(cv,cv->gw);
     free(title);
     _CVPaletteActivate(cv,true,false);
-    
+
     TRACE("CVSwitchActiveSC() idx:%d\n", idx );
 
     cv->additionalCharsToShowActiveIndex = idx;
@@ -4711,7 +4709,7 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
 	int endsWithSlash = u_endswith( srctxt, c_to_u("/"));
 
 	unichar_t* p = 0;
-	p = Wordlist_selectionClear( sf, map, srctxt );	
+	p = Wordlist_selectionClear( sf, map, srctxt );
 	p = Wordlist_selectionAdd(   sf, map, p, idx );
 	if( endsWithSlash )
 	    uc_strcat( p, "/" );
@@ -4724,8 +4722,8 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
 	    GGadgetSetTitle( cv->charselector, p );
 	}
     }
-    
-    
+
+
     cv->b.next = sc->views;
     sc->views = &cv->b;
 
@@ -4733,10 +4731,10 @@ static void CVSwitchActiveSC( CharView *cv, SplineChar* sc, int idx )
     // box has moved rather than all the characters.
     if( scroll_offset )
 	CVHScrollSetPos( cv, tab->xoff + scroll_offset * tab->scale );
-    
+
 //    if ( CVClearSel(cv))
 //	SCUpdateAll(cv->b.sc);
-    
+
 }
 
 static void CVMouseDown(CharView *cv, GEvent *event ) {
@@ -4781,7 +4779,7 @@ return;		/* I treat this more like a modifier key change than a button press */
 	if( found && !cv->p.sp )
 	    override_showing_tool = cvt_curve;
     }
-    
+
     if( cv->charselector && cv->charselector == GWindowGetFocusGadgetOfWindow(cv->gw))
 	GWindowClearFocusGadgetOfWindow(cv->gw);
 
@@ -4794,7 +4792,7 @@ return;		/* I treat this more like a modifier key change than a button press */
     cv->needsrasterize = false;
     cv->recentchange = false;
 
-    
+
     SetFS(&fs,&cv->p,cv,event);
     if ( event->u.mouse.state&ksm_shift )
 	event = CVConstrainedMouseDown(cv,event,&fake);
@@ -4819,7 +4817,7 @@ return;		/* I treat this more like a modifier key change than a button press */
 
 //	TRACE("cvmousedown tab->xoff:%d\n", tab->xoff );
 //	TRACE("cvmousedown x:%d y:%d\n",   event->u.mouse.x, event->u.mouse.y );
-	    
+
 	if( !cv->p.anysel && cv->b.drawmode != dm_grid )
 	{
 	    // If we are in left-right arrow cursor mode to move
@@ -4837,7 +4835,7 @@ return;		/* I treat this more like a modifier key change than a button press */
 		SplineChar* xc = 0;
 		int xcidx = -1;
 		int borderFudge = 20;
-	    
+
 		{
 		    int offset = cv->b.sc->width;
 		    int cumulativeLeftSideBearing = 0;
@@ -4855,7 +4853,7 @@ return;		/* I treat this more like a modifier key change than a button press */
 			{
 			    OffsetForDoingCharNextToActive = borderFudge;
 			}
-		    
+
 
 			cumulativeLeftSideBearing += offset;
 			/* TRACE("1 adj. x:%f %f\n",fsadjusted.xl,fsadjusted.xh); */
@@ -4882,7 +4880,7 @@ return;		/* I treat this more like a modifier key change than a button press */
 			if( found )
 			{
 			    TRACE("FOUND FOUND FOUND FOUND FOUND FOUND FOUND \n");
-			
+
 			    xcidx = i;
 //		    CVChangeSC(cv,xc);
 			    break;
@@ -4938,7 +4936,7 @@ return;		/* I treat this more like a modifier key change than a button press */
 			    cumulativeLeftSideBearing,
 			    fsadjusted.p->cx,
 			    cumulativeLeftSideBearing + xc->width - OffsetForDoingCharNextToActive );
-		    
+
 			TRACE("cvmousedown i:%d found:%d\n", i, found );
 			if( found )
 			{
@@ -4960,8 +4958,8 @@ return;		/* I treat this more like a modifier key change than a button press */
 		}
 	    }
 	}
-	    
-	    
+
+
 
     } else if ( cv->active_tool == cvt_curve || cv->active_tool == cvt_corner ||
 	    cv->active_tool == cvt_tangent || cv->active_tool == cvt_hvcurve ||
@@ -5011,7 +5009,7 @@ return;		/* I treat this more like a modifier key change than a button press */
       break;
       case cvt_magnify: case cvt_minify:
           //When scroll zooming, the old showing tool is the normal pointer.
-          old_showing_tool = cv->active_tool;    
+          old_showing_tool = cv->active_tool;
       break;
       case cvt_hand:
 	CVMouseDownHand(cv);
@@ -5535,8 +5533,8 @@ static void CVMouseUp(CharView *cv, GEvent *event ) {
 	/* _CVTestSelectFromEvent(cv,&fs); */
 	/* fs.p = &cv->p; */
     }
-    
-    
+
+
     switch ( cv->active_tool ) {
       case cvt_pointer:
 	CVMouseUpPointer(cv);
@@ -7501,7 +7499,7 @@ return;
     }
 
     int curenc = CVCurEnc(cv);
-    
+
     if( cv->charselector )
     {
         char* txt = GGadgetGetTitle8( cv->charselector );
@@ -7527,7 +7525,7 @@ return;
             return;
         }
     }
-    
+
     if ( mid == MID_Next ) {
 	pos = curenc+1;
     } else if ( mid == MID_Prev ) {
@@ -7749,7 +7747,7 @@ void FE_adjustBCPByDeltaWhilePreservingBCPAngle( void* key,
 		if( m < 0 )
 		    datadx *= -1;
 	    }
-	    
+
 	    real dx = near->x - far->x;
 	    real m = (near->y - far->y) / dx;
 	    to.x = which->x + datadx;
@@ -7887,7 +7885,7 @@ void CVFindAndVisitSelectedControlPoints( CharView *cv, bool preserveState,
     GHashTable* col = getSelectedControlPoints( cv, &cv->p );
     if(!col)
 	return;
-    
+
     if( g_hash_table_size( col ) )
     {
 	if( preserveState )
@@ -7958,7 +7956,7 @@ void CVChar(CharView *cv, GEvent *event ) {
 
     /* TRACE("GK_Control_L:%d\n", ( event->u.chr.keysym == GK_Control_L )); */
     /* TRACE("GK_Meta_L:%d\n", ( event->u.chr.keysym == GK_Meta_L )); */
-    
+
     int oldactiveModifierControl = cv->activeModifierControl;
     int oldactiveModifierAlt = cv->activeModifierAlt;
     cv->activeModifierControl |= ( event->u.chr.keysym == GK_Control_L || event->u.chr.keysym == GK_Control_R
@@ -7971,8 +7969,8 @@ void CVChar(CharView *cv, GEvent *event ) {
     {
 	CVInfoDraw(cv,cv->gw);
     }
-    
-    
+
+
 #if _ModKeysAutoRepeat
 	/* Under cygwin these keys auto repeat, they don't under normal X */
 	if ( cv->autorpt!=NULL ) {
@@ -8002,7 +8000,7 @@ return;
     CVPaletteActivate(cv);
     CVToolsSetCursor(cv,TrueCharState(event),NULL);
 
-    
+
 	/* The window check is to prevent infinite loops since DVChar can */
 	/*  call CVChar too */
     if ( cv->dv!=NULL && (event->w==cv->gw || event->w==cv->v) && DVChar(cv->dv,event))
@@ -8066,7 +8064,7 @@ return;
 	    event->u.chr.keysym == GK_KP_Down )
     {
 	TRACE("key left/right/up/down...\n");
-	
+
 	GGadget *active = GWindowGetFocusGadgetOfWindow(cv->gw);
 	if( active == cv->charselector )
 	{
@@ -8079,8 +8077,8 @@ return;
 
 	    return;
 	}
-	
-	
+
+
 	real dx=0, dy=0; int anya;
 	switch ( event->u.chr.keysym ) {
 	  case GK_Left: case GK_KP_Left:
@@ -12753,7 +12751,7 @@ static int CV_OnCharSelectorTextChanged( GGadget *g, GEvent *e )
 		return 0;
 	    }
 	}
-	
+
 	cv->charselectoridx = pos;
 	char* txt = GGadgetGetTitle8( cv->charselector );
 	TRACE("char selector @%d changed to:%s\n", pos, txt );
@@ -12766,7 +12764,7 @@ static int CV_OnCharSelectorTextChanged( GGadget *g, GEvent *e )
 	    GTabSetRemetric(cv->tabs);
 	    GTabSetSetSel(cv->tabs,tabnum);	/* This does a redraw */
 	}
-	
+
 	memset( cv->additionalCharsToShow, 0, sizeof(SplineChar*) * additionalCharsToShowLimit );
 	cv->additionalCharsToShowActiveIndex = 0;
 	cv->additionalCharsToShow[0] = cv->b.sc;
@@ -12793,7 +12791,7 @@ static int CV_OnCharSelectorTextChanged( GGadget *g, GEvent *e )
 		    i++;
 		    continue;
 		}
-		
+
 		cv->additionalCharsToShow[i] = tpt->sc;
 
 		i++;
@@ -12823,7 +12821,7 @@ static int CV_OnCharSelectorTextChanged( GGadget *g, GEvent *e )
 			    CVHScrollSetPos( cv, xoff );
 			    hadSelection = 1;
 			}
-			
+
 		    }
 		}
 	    }
@@ -12961,7 +12959,7 @@ CharView *CharViewCreateExtended(SplineChar *sc, FontView *fv,int enc, int show 
         label[0].text_is_1byte = true;
         cv->charselectorNext = GButtonCreate(cv->gw,&xgd,cv);
     }
-    
+
 
     memset(aspects,0,sizeof(aspects));
     aspects[0].text = (unichar_t *) sc->name;
@@ -13645,7 +13643,7 @@ bool CVShouldInterpolateCPsOnMotion( CharView* cv )
 
     if( cv->activeModifierControl && cv->activeModifierAlt )
 	ret = !ret;
-    
+
     return ret;
 }
 

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -4184,9 +4184,7 @@ static void cflistcheck(GWindow UNUSED(gw), struct gmenuitem *mi, GEvent *UNUSED
     }
 }
 
-static void sllistcheck(GWindow gw, struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
-    FontView *fv = (FontView *) GDrawGetUserData(gw);
-    fv = fv;
+static void sllistcheck(GWindow UNUSED(gw), struct gmenuitem *UNUSED(mi), GEvent *UNUSED(e)) {
 }
 
 static void htlistcheck(GWindow gw, struct gmenuitem *mi, GEvent *UNUSED(e)) {

--- a/fontforgeexe/prefs.c
+++ b/fontforgeexe/prefs.c
@@ -413,7 +413,7 @@ static struct prefs_list {
 #endif
 
 	{ N_("GenerateHintWidthEqualityTolerance"), pr_real, &GenerateHintWidthEqualityTolerance, NULL, NULL, '\0', NULL, 0, N_( "When generating a font, ignore slight rounding errors for hints that should be at the top or bottom of the glyph. For example, you might like to set this to 0.02 so that 19.999 will be considered 20. But only for the hint width value.") },
-	
+
 	PREFS_LIST_EMPTY
 },
  hints_list[] = {
@@ -2551,7 +2551,7 @@ static void PrefsSubSetDlg(CharView *cv,char* windowTitle,struct prefs_list* pli
     GTabInfo aspects[TOPICS+5], subaspects[3];
     GGadgetCreateData **hvarray, boxes[2*TOPICS];
     struct pref_data p;
-    int line = 0,line_max = 3;
+    int line_max = 3;
     int i = 0, gc = 0, ii, y=0, si=0, k=0;
     char buf[20];
     char *tempstr;
@@ -2765,7 +2765,6 @@ static void PrefsSubSetDlg(CharView *cv,char* windowTitle,struct prefs_list* pli
 		y += 26;
 	      break;
 	    }
-	    ++line;
 	    hvarray[si++] = NULL;
 
     }

--- a/fontforgeexe/problems.c
+++ b/fontforgeexe/problems.c
@@ -602,7 +602,7 @@ return;
 	    explain==_("The selected point is not at integral coordinates") ||
 	    explain==_("The selected point does not have integral control points") ||
 	    explain==_("This glyph is mapped to a unicode code point which is different from its name.");
-	    
+
     GGadgetSetVisible(GWidgetGetControl(p->explainw,CID_Fix),fixable);
 
     if ( explain==_("This glyph contains a substitution or ligature entry which refers to an empty char") ) {
@@ -650,7 +650,7 @@ return;
 	GDrawProcessPendingEvents(NULL);
 	GDrawProcessPendingEvents(NULL);
     }
-	
+
     SCUpdateAll(sc);		/* We almost certainly just selected something */
 
     GDrawSetVisible(p->explainw,true);
@@ -813,7 +813,7 @@ static int HVITest(struct problems *p,BasePoint *to, BasePoint *from,
 		base = to;
 		other = from;
 	    }
-	} else if ( abs(yoff)>abs(xoff) )
+	} else if ( fabs(yoff)>fabs(xoff) )
 	    type = ((yoff>0) ^ isto)?1:2;
 	else
 	    type = ((xoff>0) ^ isto)?3:4;
@@ -1648,7 +1648,7 @@ static int SCProblems(CharView *cv,SplineChar *sc,struct problems *p) {
 	Layer *layer;
 	int lastscan= -1;
 	int self_intersects, dir;
-	
+
 	if ( cv!=NULL )
 	    layer = cv->b.layerheads[cv->b.drawmode];
 	else
@@ -2476,7 +2476,7 @@ return( true );
     }
 return( found );
 }
-	
+
 static int SCMissingGlyph(struct problems *p,SplineChar *sc) {
     PST *pst, *next;
     int found = false;
@@ -2639,7 +2639,7 @@ return( true );
     }
 return( found );
 }
-    
+
 static int SCMissingScriptFeat(struct problems *p,SplineFont *sf,SplineChar *sc) {
     PST *pst;
     int found = false;
@@ -3011,7 +3011,7 @@ static void DummyFindProblems(CharView *cv) {
     p.hintsmax = 96;
 
     p.explain = true;
-    
+
     DoProbs(&p);
     if ( p.explainw!=NULL )
 	GDrawDestroyWindow(p.explainw);
@@ -3109,7 +3109,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[0].text_is_1byte = true;
     plabel[0].text_in_resource = true;
     pgcd[0].gd.label = &plabel[0];
-    pgcd[0].gd.pos.x = 3; pgcd[0].gd.pos.y = 5; 
+    pgcd[0].gd.pos.x = 3; pgcd[0].gd.pos.y = 5;
     pgcd[0].gd.flags = gg_visible | gg_enabled;
     if ( nonintegral ) pgcd[0].gd.flags |= gg_cb_on;
     pgcd[0].gd.popup_msg = _(
@@ -3127,7 +3127,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[1].text_in_resource = true;
     pgcd[1].gd.label = &plabel[1];
     pgcd[1].gd.mnemonic = 'X';
-    pgcd[1].gd.pos.x = 3; pgcd[1].gd.pos.y = pgcd[0].gd.pos.y+17; 
+    pgcd[1].gd.pos.x = 3; pgcd[1].gd.pos.y = pgcd[0].gd.pos.y+17;
     pgcd[1].gd.flags = gg_visible | gg_enabled;
     if ( doxnear ) pgcd[1].gd.flags |= gg_cb_on;
     pgcd[1].gd.popup_msg = _("Allows you to check that vertical stems in several\ncharacters start at the same location.");
@@ -3157,7 +3157,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[3].text_in_resource = true;
     pgcd[3].gd.label = &plabel[3];
     pgcd[3].gd.mnemonic = 'Y';
-    pgcd[3].gd.pos.x = 3; pgcd[3].gd.pos.y = pgcd[1].gd.pos.y+24; 
+    pgcd[3].gd.pos.x = 3; pgcd[3].gd.pos.y = pgcd[1].gd.pos.y+24;
     pgcd[3].gd.flags = gg_visible | gg_enabled;
     if ( doynear ) pgcd[3].gd.flags |= gg_cb_on;
     pgcd[3].gd.popup_msg = _("Allows you to check that horizontal stems in several\ncharacters start at the same location.");
@@ -3187,7 +3187,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[5].text_in_resource = true;
     pgcd[5].gd.label = &plabel[5];
     pgcd[5].gd.mnemonic = 'S';
-    pgcd[5].gd.pos.x = 3; pgcd[5].gd.pos.y = pgcd[3].gd.pos.y+18; 
+    pgcd[5].gd.pos.x = 3; pgcd[5].gd.pos.y = pgcd[3].gd.pos.y+18;
     pgcd[5].gd.flags = gg_visible | gg_enabled;
     if ( doynearstd ) pgcd[5].gd.flags |= gg_cb_on;
     pgcd[5].gd.popup_msg = _("Allows you to find points which are slightly\noff from the baseline, xheight, cap height,\nascender, descender heights.");
@@ -3200,7 +3200,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[6].text_in_resource = true;
     pgcd[6].gd.label = &plabel[6];
     pgcd[6].gd.mnemonic = 'C';
-    pgcd[6].gd.pos.x = 3; pgcd[6].gd.pos.y = pgcd[5].gd.pos.y+14; 
+    pgcd[6].gd.pos.x = 3; pgcd[6].gd.pos.y = pgcd[5].gd.pos.y+14;
     pgcd[6].gd.flags = gg_visible | gg_enabled;
     if ( cpstd ) pgcd[6].gd.flags |= gg_cb_on;
     pgcd[6].gd.popup_msg = _("Allows you to find control points which are almost,\nbut not quite horizontal or vertical\nfrom their base point\n(or at the italic angle).");
@@ -3213,7 +3213,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[7].text_in_resource = true;
     pgcd[7].gd.label = &plabel[7];
     pgcd[7].gd.mnemonic = 'b';
-    pgcd[7].gd.pos.x = 3; pgcd[7].gd.pos.y = pgcd[6].gd.pos.y+14; 
+    pgcd[7].gd.pos.x = 3; pgcd[7].gd.pos.y = pgcd[6].gd.pos.y+14;
     pgcd[7].gd.flags = gg_visible | gg_enabled;
     if ( cpodd ) pgcd[7].gd.flags |= gg_cb_on;
     pgcd[7].gd.popup_msg = _("Allows you to find control points which when projected\nonto the line segment between the two end points lie\noutside of those end points");
@@ -3225,7 +3225,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[8].text_is_1byte = true;
     plabel[8].text_in_resource = true;
     pgcd[8].gd.label = &plabel[8];
-    pgcd[8].gd.pos.x = 3; pgcd[8].gd.pos.y = pgcd[7].gd.pos.y+14; 
+    pgcd[8].gd.pos.x = 3; pgcd[8].gd.pos.y = pgcd[7].gd.pos.y+14;
     pgcd[8].gd.flags = gg_visible | gg_enabled;
     if ( irrelevantcp ) pgcd[8].gd.flags |= gg_cb_on;
     pgcd[8].gd.popup_msg = _("Control points are irrelevant if they are too close to the main\npoint to make a significant difference in the shape of the curve.");
@@ -3237,7 +3237,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[9].text_is_1byte = true;
     plabel[9].text_in_resource = true;
     pgcd[9].gd.label = &plabel[9];
-    pgcd[9].gd.pos.x = 20; pgcd[9].gd.pos.y = pgcd[8].gd.pos.y+17; 
+    pgcd[9].gd.pos.x = 20; pgcd[9].gd.pos.y = pgcd[8].gd.pos.y+17;
     pgcd[9].gd.flags = gg_visible | gg_enabled;
     pgcd[9].gd.popup_msg = _("A control point is deemed irrelevant if the distance between it and the main\n(end) point is less than this times the distance between the two end points");
     pgcd[9].creator = GLabelCreate;
@@ -3248,7 +3248,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[10].text_is_1byte = true;
     pgcd[10].gd.label = &plabel[10];
     pgcd[10].gd.pos.x = 105; pgcd[10].gd.pos.y = pgcd[9].gd.pos.y-3;
-    pgcd[10].gd.pos.width = 50; 
+    pgcd[10].gd.pos.width = 50;
     pgcd[10].gd.flags = gg_visible | gg_enabled;
     pgcd[10].gd.popup_msg = _("A control point is deemed irrelevant if the distance between it and the main\n(end) point is less than this times the distance between the two end points");
     pgcd[10].gd.cid = CID_IrrelevantFactor;
@@ -3258,7 +3258,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[11].text = (unichar_t *) "%";
     plabel[11].text_is_1byte = true;
     pgcd[11].gd.label = &plabel[11];
-    pgcd[11].gd.pos.x = 163; pgcd[11].gd.pos.y = pgcd[9].gd.pos.y; 
+    pgcd[11].gd.pos.x = 163; pgcd[11].gd.pos.y = pgcd[9].gd.pos.y;
     pgcd[11].gd.flags = gg_visible | gg_enabled;
     pgcd[11].gd.popup_msg = _("A control point is deemed irrelevant if the distance between it and the main\n(end) point is less than this times the distance between the two end points");
     pgcd[11].creator = GLabelCreate;
@@ -3273,7 +3273,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[12].text_is_1byte = true;
     plabel[12].text_in_resource = true;
     pgcd[12].gd.label = &plabel[12];
-    pgcd[12].gd.pos.x = 3; pgcd[12].gd.pos.y = pgcd[11].gd.pos.y+14; 
+    pgcd[12].gd.pos.x = 3; pgcd[12].gd.pos.y = pgcd[11].gd.pos.y+14;
     pgcd[12].gd.flags = gg_visible | gg_enabled;
     if ( pointstooclose ) pgcd[12].gd.flags |= gg_cb_on;
     pgcd[12].gd.popup_msg = _("If two adjacent points on the same path are less than a few\nemunits apart they will cause problems for some of FontForge's\ncommands. PostScript shouldn't care though.");
@@ -3285,7 +3285,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     plabel[13].text_is_1byte = true;
     plabel[13].text_in_resource = true;
     pgcd[13].gd.label = &plabel[13];
-    pgcd[13].gd.pos.x = 3; pgcd[13].gd.pos.y = pgcd[12].gd.pos.y+14; 
+    pgcd[13].gd.pos.x = 3; pgcd[13].gd.pos.y = pgcd[12].gd.pos.y+14;
     pgcd[13].gd.flags = gg_visible | gg_enabled;
     if ( pointstoofar ) pgcd[13].gd.flags |= gg_cb_on;
     pgcd[13].gd.popup_msg = _("Most font formats cannot specify adjacent points (or control points)\nwhich are more than 32767 em-units apart in either the x or y direction");
@@ -3308,7 +3308,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     palabel[0].text_in_resource = true;
     pagcd[0].gd.label = &palabel[0];
     pagcd[0].gd.mnemonic = 'P';
-    pagcd[0].gd.pos.x = 3; pagcd[0].gd.pos.y = 6; 
+    pagcd[0].gd.pos.x = 3; pagcd[0].gd.pos.y = 6;
     pagcd[0].gd.flags = gg_visible | gg_enabled;
     if ( openpaths ) pagcd[0].gd.flags |= gg_cb_on;
     pagcd[0].gd.popup_msg = _("All paths should be closed loops, there should be no exposed endpoints");
@@ -3320,7 +3320,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     palabel[1].text_is_1byte = true;
     pagcd[1].gd.label = &palabel[1];
     pagcd[1].gd.mnemonic = 'E';
-    pagcd[1].gd.pos.x = 3; pagcd[1].gd.pos.y = pagcd[0].gd.pos.y+17; 
+    pagcd[1].gd.pos.x = 3; pagcd[1].gd.pos.y = pagcd[0].gd.pos.y+17;
     pagcd[1].gd.flags = gg_visible | gg_enabled;
     if ( intersectingpaths ) pagcd[1].gd.flags |= gg_cb_on;
     pagcd[1].gd.popup_msg = _("No paths with within a glyph should intersect");
@@ -3333,7 +3333,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     palabel[2].text_in_resource = true;
     pagcd[2].gd.label = &palabel[2];
     pagcd[2].gd.mnemonic = 'E';
-    pagcd[2].gd.pos.x = 3; pagcd[2].gd.pos.y = pagcd[1].gd.pos.y+17; 
+    pagcd[2].gd.pos.x = 3; pagcd[2].gd.pos.y = pagcd[1].gd.pos.y+17;
     pagcd[2].gd.flags = gg_visible | gg_enabled;
     if ( linestd ) pagcd[2].gd.flags |= gg_cb_on;
     pagcd[2].gd.popup_msg = _("Allows you to find lines which are almost,\nbut not quite horizontal or vertical\n(or at the italic angle).");
@@ -3346,7 +3346,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     palabel[3].text_in_resource = true;
     pagcd[3].gd.label = &palabel[3];
     pagcd[3].gd.mnemonic = 'S';
-    pagcd[3].gd.pos.x = 3; pagcd[3].gd.pos.y = pagcd[2].gd.pos.y+17; 
+    pagcd[3].gd.pos.x = 3; pagcd[3].gd.pos.y = pagcd[2].gd.pos.y+17;
     pagcd[3].gd.flags = gg_visible | gg_enabled;
     if ( direction ) pagcd[3].gd.flags |= gg_cb_on;
     pagcd[3].gd.popup_msg = _("FontForge internally uses paths drawn in a\nclockwise direction. This lets you check that they are.\nBefore doing this test insure that\nno paths self-intersect.");
@@ -3358,7 +3358,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     palabel[4].text_is_1byte = true;
     palabel[4].text_in_resource = true;
     pagcd[4].gd.label = &palabel[4];
-    pagcd[4].gd.pos.x = 3; pagcd[4].gd.pos.y = pagcd[3].gd.pos.y+17; 
+    pagcd[4].gd.pos.x = 3; pagcd[4].gd.pos.y = pagcd[3].gd.pos.y+17;
     pagcd[4].gd.flags = gg_visible | gg_enabled;
     if ( missingextrema ) pagcd[4].gd.flags |= gg_cb_on;
     pagcd[4].gd.popup_msg = _("PostScript and TrueType require that when a path\nreaches its maximum or minimum position\nthere must be a point at that location.");
@@ -3371,7 +3371,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     palabel[5].text_in_resource = true;
     pagcd[5].gd.label = &palabel[5];
     pagcd[5].gd.mnemonic = 'r';
-    pagcd[5].gd.pos.x = 3; pagcd[5].gd.pos.y = pagcd[4].gd.pos.y+21; 
+    pagcd[5].gd.pos.x = 3; pagcd[5].gd.pos.y = pagcd[4].gd.pos.y+21;
     pagcd[5].gd.flags = gg_visible | gg_enabled;
     if ( toomanypoints ) pagcd[5].gd.flags |= gg_cb_on;
     pagcd[5].gd.popup_msg = _("The PostScript Language Reference Manual (Appendix B) says that\nan interpreter need not support paths with more than 1500 points.\nI think this count includes control points. From PostScript's point\nof view, all the contours in a character make up one path. Modern\ninterpreters tend to support paths with more points than this limit.\n(Note a truetype font after conversion to PS will contain\ntwice as many control points)");
@@ -3384,7 +3384,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     palabel[6].text_is_1byte = true;
     pagcd[6].gd.label = &palabel[6];
     pagcd[6].gd.pos.x = 105; pagcd[6].gd.pos.y = pagcd[5].gd.pos.y-3;
-    pagcd[6].gd.pos.width = 50; 
+    pagcd[6].gd.pos.width = 50;
     pagcd[6].gd.flags = gg_visible | gg_enabled;
     pagcd[6].gd.popup_msg = _("The PostScript Language Reference Manual (Appendix B) says that\nan interpreter need not support paths with more than 1500 points.\nI think this count includes control points. From PostScript's point\nof view, all the contours in a character make up one path. Modern\ninterpreters tend to support paths with more points than this limit.\n(Note a truetype font after conversion to PS will contain\ntwice as many control points)");
     pagcd[6].gd.cid = CID_PointsMax;
@@ -3411,7 +3411,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rflabel[0].text_in_resource = true;
     rfgcd[0].gd.label = &rflabel[0];
     rfgcd[0].gd.mnemonic = 'r';
-    rfgcd[0].gd.pos.x = 3; rfgcd[0].gd.pos.y = 6; 
+    rfgcd[0].gd.pos.x = 3; rfgcd[0].gd.pos.y = 6;
     rfgcd[0].gd.flags = gg_visible | gg_enabled;
     if ( flippedrefs ) rfgcd[0].gd.flags |= gg_cb_on;
     rfgcd[0].gd.popup_msg = _("PostScript and TrueType require that paths be drawn\nin a clockwise direction. If you have a reference\nthat has been flipped then the paths in that reference will\nprobably be counter-clockwise. You should unlink it and do\nElement->Correct direction on it.");
@@ -3425,7 +3425,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rflabel[1].text_in_resource = true;
     rfgcd[1].gd.label = &rflabel[1];
     rfgcd[1].gd.mnemonic = 'r';
-    rfgcd[1].gd.pos.x = 3; rfgcd[1].gd.pos.y = rfgcd[0].gd.pos.y+17; 
+    rfgcd[1].gd.pos.x = 3; rfgcd[1].gd.pos.y = rfgcd[0].gd.pos.y+17;
     rfgcd[1].gd.flags = gg_visible | gg_enabled;
     if ( refsbadtransformttf ) rfgcd[1].gd.flags |= gg_cb_on;
     rfgcd[1].gd.popup_msg = _("TrueType requires that all scaling and rotational\nentries in a transformation matrix be between -2 and 2");
@@ -3438,7 +3438,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rflabel[2].text_in_resource = true;
     rfgcd[2].gd.label = &rflabel[2];
     rfgcd[2].gd.mnemonic = 'r';
-    rfgcd[2].gd.pos.x = 3; rfgcd[2].gd.pos.y = rfgcd[1].gd.pos.y+17; 
+    rfgcd[2].gd.pos.x = 3; rfgcd[2].gd.pos.y = rfgcd[1].gd.pos.y+17;
     rfgcd[2].gd.flags = gg_visible | gg_enabled;
     if ( mixedcontoursrefs ) rfgcd[2].gd.flags |= gg_cb_on;
     rfgcd[2].gd.popup_msg = _("TrueType glyphs can either contain references or contours.\nNot both.");
@@ -3452,7 +3452,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rflabel[3].text_in_resource = true;
     rfgcd[3].gd.label = &rflabel[3];
     rfgcd[3].gd.mnemonic = 'r';
-    rfgcd[3].gd.pos.x = 3; rfgcd[3].gd.pos.y = rfgcd[2].gd.pos.y+17; 
+    rfgcd[3].gd.pos.x = 3; rfgcd[3].gd.pos.y = rfgcd[2].gd.pos.y+17;
     rfgcd[3].gd.flags = gg_visible | gg_enabled;
     if ( refsbadtransformps ) rfgcd[3].gd.flags |= gg_cb_on;
     rfgcd[3].gd.popup_msg = _("Type1 and 2 fonts only support translation of references.\nThe first four entries of the transformation matrix should be\n[1 0 0 1].");
@@ -3466,7 +3466,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rflabel[4].text_in_resource = true;
     rfgcd[4].gd.label = &rflabel[4];
     rfgcd[4].gd.mnemonic = 'r';
-    rfgcd[4].gd.pos.x = 3; rfgcd[4].gd.pos.y = rfgcd[3].gd.pos.y+21; 
+    rfgcd[4].gd.pos.x = 3; rfgcd[4].gd.pos.y = rfgcd[3].gd.pos.y+21;
     rfgcd[4].gd.flags = gg_visible | gg_enabled;
     if ( toodeeprefs ) rfgcd[4].gd.flags |= gg_cb_on;
     rfgcd[4].gd.popup_msg = _("The Type 2 Charstring Reference (Appendix B) says that\nsubroutines may not be nested more than 10 deep. Each\nnesting level for references requires one subroutine\nlevel, and hints may require another level.");
@@ -3479,7 +3479,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rflabel[5].text_is_1byte = true;
     rfgcd[5].gd.label = &rflabel[5];
     rfgcd[5].gd.pos.x = 140; rfgcd[5].gd.pos.y = rfgcd[4].gd.pos.y-3;
-    rfgcd[5].gd.pos.width = 40; 
+    rfgcd[5].gd.pos.width = 40;
     rfgcd[5].gd.flags = gg_visible | gg_enabled;
     rfgcd[5].gd.popup_msg = _("The Type 2 Charstring Reference (Appendix B) says that\nsubroutines may not be nested more than 10 deep. Each\nnesting level for references requires one subroutine\nlevel, and hints may require another level.");
     rfgcd[5].gd.cid = CID_RefDepthMax;
@@ -3496,7 +3496,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rflabel[6].text_in_resource = true;
     rfgcd[6].gd.label = &rflabel[6];
     rfgcd[6].gd.mnemonic = 'r';
-    rfgcd[6].gd.pos.x = 3; rfgcd[6].gd.pos.y = rfgcd[5].gd.pos.y+24; 
+    rfgcd[6].gd.pos.x = 3; rfgcd[6].gd.pos.y = rfgcd[5].gd.pos.y+24;
     rfgcd[6].gd.flags = gg_visible | gg_enabled;
     if ( ptmatchrefsoutofdate ) rfgcd[6].gd.flags |= gg_cb_on;
     rfgcd[6].gd.popup_msg = _("If a glyph has been edited so that it has a different\nnumber of points now, then any references\nwhich use point matching and depended on that glyph's\npoint count will be incorrect.");
@@ -3531,7 +3531,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     hlabel[0].text_in_resource = true;
     hgcd[0].gd.label = &hlabel[0];
     hgcd[0].gd.mnemonic = 'H';
-    hgcd[0].gd.pos.x = 3; hgcd[0].gd.pos.y = 5; 
+    hgcd[0].gd.pos.x = 3; hgcd[0].gd.pos.y = 5;
     hgcd[0].gd.flags = gg_visible | gg_enabled;
     if ( hintnopt ) hgcd[0].gd.flags |= gg_cb_on;
     hgcd[0].gd.popup_msg = _("Ghostview (perhaps other interpreters) has a problem when a\nhint exists without any points that lie on it.");
@@ -3544,7 +3544,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     hlabel[1].text_in_resource = true;
     hgcd[1].gd.label = &hlabel[1];
     hgcd[1].gd.mnemonic = 'H';
-    hgcd[1].gd.pos.x = 3; hgcd[1].gd.pos.y = hgcd[0].gd.pos.y+17; 
+    hgcd[1].gd.pos.x = 3; hgcd[1].gd.pos.y = hgcd[0].gd.pos.y+17;
     hgcd[1].gd.flags = gg_visible | gg_enabled;
     if ( ptnearhint ) hgcd[1].gd.flags |= gg_cb_on;
     hgcd[1].gd.popup_msg = _("Often if a point is slightly off from a hint\nit is because a stem is made up\nof several segments, and one of them\nhas the wrong width.");
@@ -3620,7 +3620,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     hlabel[6].text_is_1byte = true;
     hlabel[6].text_in_resource = true;
     hgcd[6].gd.label = &hlabel[6];
-    hgcd[6].gd.pos.x = 3; hgcd[6].gd.pos.y = hgcd[5].gd.pos.y+21; 
+    hgcd[6].gd.pos.x = 3; hgcd[6].gd.pos.y = hgcd[5].gd.pos.y+21;
     hgcd[6].gd.flags = gg_visible | gg_enabled;
     if ( toomanyhints ) hgcd[6].gd.flags |= gg_cb_on;
     hgcd[6].gd.popup_msg = _("The Type 2 Charstring Reference (Appendix B) says that\nthere may be at most 96 horizontal and vertical stem hints\nin a character.");
@@ -3633,7 +3633,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     hlabel[7].text_is_1byte = true;
     hgcd[7].gd.label = &hlabel[7];
     hgcd[7].gd.pos.x = 105; hgcd[7].gd.pos.y = hgcd[6].gd.pos.y-3;
-    hgcd[7].gd.pos.width = 50; 
+    hgcd[7].gd.pos.width = 50;
     hgcd[7].gd.flags = gg_visible | gg_enabled;
     hgcd[7].gd.popup_msg = _("The Type 2 Charstring Reference (Appendix B) says that\nthere may be at most 96 horizontal and vertical stem hints\nin a character.");
     hgcd[7].gd.cid = CID_HintsMax;
@@ -3673,7 +3673,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rlabel[0].text_in_resource = true;
     rgcd[0].gd.label = &rlabel[0];
     rgcd[0].gd.mnemonic = 'r';
-    rgcd[0].gd.pos.x = 3; rgcd[0].gd.pos.y = 6; 
+    rgcd[0].gd.pos.x = 3; rgcd[0].gd.pos.y = 6;
     rgcd[0].gd.flags = gg_visible | gg_enabled;
     if ( bitmaps ) rgcd[0].gd.flags |= gg_cb_on;
     rgcd[0].gd.popup_msg = _("Are there any outline characters which don't have a bitmap version in one of the bitmap fonts?\nConversely are there any bitmap characters without a corresponding outline character?");
@@ -3685,7 +3685,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rlabel[1].text_in_resource = true;
     rgcd[1].gd.label = &rlabel[1];
     rgcd[1].gd.mnemonic = 'r';
-    rgcd[1].gd.pos.x = 3; rgcd[1].gd.pos.y = 6; 
+    rgcd[1].gd.pos.x = 3; rgcd[1].gd.pos.y = 6;
     rgcd[1].gd.flags = gg_visible | gg_enabled;
     if ( bitmapwidths ) rgcd[1].gd.flags |= gg_cb_on;
     rgcd[1].gd.popup_msg = _("Are there any bitmap glyphs whose advance width\nis not is expected from scaling and rounding\nthe outline's advance width?");
@@ -3695,7 +3695,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rlabel[2].text = (unichar_t *) _("Check multiple Unicode");
     rlabel[2].text_is_1byte = true;
     rgcd[2].gd.label = &rlabel[2];
-    rgcd[2].gd.pos.x = 3; rgcd[2].gd.pos.y = rgcd[1].gd.pos.y+15; 
+    rgcd[2].gd.pos.x = 3; rgcd[2].gd.pos.y = rgcd[1].gd.pos.y+15;
     rgcd[2].gd.flags = gg_visible | gg_enabled;
     if ( multuni ) rgcd[2].gd.flags |= gg_cb_on;
     rgcd[2].gd.popup_msg = _("Check multiple Unicode");
@@ -3705,7 +3705,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rlabel[3].text = (unichar_t *) _("Check multiple Names");
     rlabel[3].text_is_1byte = true;
     rgcd[3].gd.label = &rlabel[3];
-    rgcd[3].gd.pos.x = 3; rgcd[3].gd.pos.y = rgcd[2].gd.pos.y+15; 
+    rgcd[3].gd.pos.x = 3; rgcd[3].gd.pos.y = rgcd[2].gd.pos.y+15;
     rgcd[3].gd.flags = gg_visible | gg_enabled;
     if ( multname ) rgcd[3].gd.flags |= gg_cb_on;
     rgcd[3].gd.popup_msg = _("Check for multiple characters with the same name");
@@ -3715,7 +3715,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     rlabel[4].text = (unichar_t *) _("Check Unicode/Name mismatch");
     rlabel[4].text_is_1byte = true;
     rgcd[4].gd.label = &rlabel[4];
-    rgcd[4].gd.pos.x = 3; rgcd[4].gd.pos.y = rgcd[3].gd.pos.y+15; 
+    rgcd[4].gd.pos.x = 3; rgcd[4].gd.pos.y = rgcd[3].gd.pos.y+15;
     rgcd[4].gd.flags = gg_visible | gg_enabled;
     if ( uninamemismatch ) rgcd[4].gd.flags |= gg_cb_on;
     rgcd[4].gd.popup_msg = _("Check for characters whose name maps to a unicode code point\nwhich does not map the character's assigned code point.");
@@ -3741,7 +3741,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     bblabel[0].text_in_resource = true;
     bbgcd[0].gd.label = &bblabel[0];
     bbgcd[0].gd.mnemonic = 'r';
-    bbgcd[0].gd.pos.x = 3; bbgcd[0].gd.pos.y = 6; 
+    bbgcd[0].gd.pos.x = 3; bbgcd[0].gd.pos.y = 6;
     bbgcd[0].gd.flags = gg_visible | gg_enabled;
     if ( bbymax ) bbgcd[0].gd.flags |= gg_cb_on;
     bbgcd[0].gd.popup_msg = _("Are there any glyph's whose bounding boxes extend above this number?");
@@ -3770,7 +3770,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     bblabel[2].text_in_resource = true;
     bbgcd[2].gd.label = &bblabel[2];
     bbgcd[2].gd.mnemonic = 'r';
-    bbgcd[2].gd.pos.x = 3; bbgcd[2].gd.pos.y = bbgcd[0].gd.pos.y+21; 
+    bbgcd[2].gd.pos.x = 3; bbgcd[2].gd.pos.y = bbgcd[0].gd.pos.y+21;
     bbgcd[2].gd.flags = gg_visible | gg_enabled;
     if ( bbymin ) bbgcd[2].gd.flags |= gg_cb_on;
     bbgcd[2].gd.popup_msg = _("Are there any glyph's whose bounding boxes extend below this number?");
@@ -3793,7 +3793,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     bblabel[4].text_is_1byte = true;
     bblabel[4].text_in_resource = true;
     bbgcd[4].gd.label = &bblabel[4];
-    bbgcd[4].gd.pos.x = 3; bbgcd[4].gd.pos.y = bbgcd[2].gd.pos.y+21; 
+    bbgcd[4].gd.pos.x = 3; bbgcd[4].gd.pos.y = bbgcd[2].gd.pos.y+21;
     bbgcd[4].gd.flags = gg_visible | gg_enabled;
     if ( bbxmax ) bbgcd[4].gd.flags |= gg_cb_on;
     bbgcd[4].gd.popup_msg = _("Are there any glyphs whose bounding boxes extend to the right of this number?");
@@ -3816,7 +3816,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     bblabel[6].text_is_1byte = true;
     bblabel[6].text_in_resource = true;
     bbgcd[6].gd.label = &bblabel[6];
-    bbgcd[6].gd.pos.x = 3; bbgcd[6].gd.pos.y = bbgcd[4].gd.pos.y+21; 
+    bbgcd[6].gd.pos.x = 3; bbgcd[6].gd.pos.y = bbgcd[4].gd.pos.y+21;
     bbgcd[6].gd.flags = gg_visible | gg_enabled;
     if ( bbxmin ) bbgcd[6].gd.flags |= gg_cb_on;
     bbgcd[6].gd.popup_msg = _("Are there any glyph's whose bounding boxes extend to the left of this number?");
@@ -3917,7 +3917,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     clabel[1].text_in_resource = true;
     cgcd[1].gd.label = &clabel[1];
     cgcd[1].gd.mnemonic = 'S';
-    cgcd[1].gd.pos.x = 3; cgcd[1].gd.pos.y = cgcd[0].gd.pos.y+17; 
+    cgcd[1].gd.pos.x = 3; cgcd[1].gd.pos.y = cgcd[0].gd.pos.y+17;
     cgcd[1].gd.flags = gg_visible | gg_enabled;
     if ( cidblank ) cgcd[1].gd.flags |= gg_cb_on;
     cgcd[1].gd.popup_msg = _("Check whether a CID is undefined in all sub-fonts");
@@ -3964,7 +3964,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     alabel[2].text = (unichar_t *) _("Check substitutions for empty chars");
     alabel[2].text_is_1byte = true;
     agcd[2].gd.label = &alabel[2];
-    agcd[2].gd.pos.x = 3; agcd[2].gd.pos.y = agcd[1].gd.pos.y+15; 
+    agcd[2].gd.pos.x = 3; agcd[2].gd.pos.y = agcd[1].gd.pos.y+15;
     agcd[2].gd.flags = gg_visible | gg_enabled;
     if ( badsubs ) agcd[2].gd.flags |= gg_cb_on;
     agcd[2].gd.popup_msg = _("Check for characters which contain 'GSUB' entries which refer to empty characters");
@@ -3975,7 +3975,7 @@ void FindProblems(FontView *fv,CharView *cv, SplineChar *sc) {
     alabel[3].text = (unichar_t *) _("Check for incomplete mark to base subtables");
     alabel[3].text_is_1byte = true;
     agcd[3].gd.label = &alabel[3];
-    agcd[3].gd.pos.x = 3; agcd[3].gd.pos.y = agcd[1].gd.pos.y+15; 
+    agcd[3].gd.pos.x = 3; agcd[3].gd.pos.y = agcd[1].gd.pos.y+15;
     agcd[3].gd.flags = gg_visible | gg_enabled;
     if ( missinganchor ) agcd[3].gd.flags |= gg_cb_on;
     agcd[3].gd.popup_msg = _(
@@ -4454,7 +4454,7 @@ static void VW_SetSb(struct val_data *vw) {
     GScrollBarSetBounds(vw->vsb,0,vw->lcnt,vw->vlcnt);
     GScrollBarSetPos(vw->vsb,vw->loff_top);
 }
-    
+
 static void VW_Remetric(struct val_data *vw) {
     int gid,k, cidmax = vw->cidmax;
     SplineFont *sub, *sf = vw->sf;
@@ -4766,7 +4766,7 @@ return;
 	GDrawRequestExpose(vw->v,NULL,false);
     }
 }
-    
+
 
 #define MID_SelectOpen	102
 #define MID_SelectRO	103
@@ -4907,7 +4907,7 @@ static void VWMenuManyCorrectDir(GWindow gw,struct gmenuitem *mi,GEvent *e) {
 	    SCPreserveLayer(sc,vw->layer,false);
 	    /* But a flipped reference is just wrong so I have no compunctions*/
 	    /*  about inlining it and then correcting its direction */
-	    
+
 	    for ( ref= sc->layers[vw->layer].refs; ref!=NULL; ref=refnext ) {
 		refnext = ref->next;
 		if ( ref->transform[0]*ref->transform[3]<0 ||
@@ -5253,7 +5253,7 @@ static int VW_OK(GGadget *g, GEvent *e) {
     }
 return( true );
 }
-	
+
 static int vwv_e_h(GWindow gw, GEvent *event) {
     struct val_data *vw = (struct val_data *) GDrawGetUserData(gw);
 

--- a/gdraw/gfilechooser.c
+++ b/gdraw/gfilechooser.c
@@ -502,8 +502,8 @@ return( true );
 #ifdef _WIN32
     local_toFree = u_GFileNormalizePath(u_copy(spt));
     pt = spt = local_toFree;
-#endif    
-    
+#endif
+
     if ( pt==NULL )
 return( true );
     gfc = (GFileChooser *) GGadgetGetUserData(t);
@@ -544,7 +544,7 @@ return( true );
     free(gfc->lastname); gfc->lastname = NULL;
     if(pt_toFree)
 	free(pt_toFree);
-    
+
     if (local_toFree)
         free(local_toFree);
 
@@ -609,16 +609,15 @@ static unichar_t *GFileChooserGetCurDir(GFileChooser *gfc,int dirindex) {
     ti = GGadgetGetList(&gfc->directories->g,&len);
     if ( dirindex==-1 )
         dirindex = 0;
-    dirindex = dirindex;
 
     for ( j=len-1,cnt=0; j>=dirindex; --j ) {
-        if (ti[j]->userdata != NULL) 
+        if (ti[j]->userdata != NULL)
             continue;
         cnt += u_strlen(ti[j]->text)+1;
     }
     pt = dir = malloc((cnt+1)*sizeof(unichar_t));
     for ( j=len-1; j>=dirindex; --j ) {
-        if (ti[j]->userdata != NULL) 
+        if (ti[j]->userdata != NULL)
             continue;
         u_strcpy(pt,ti[j]->text);
         pt += u_strlen(pt);

--- a/gdraw/hotkeys.c
+++ b/gdraw/hotkeys.c
@@ -196,7 +196,7 @@ Hotkey* hotkeySetFull( const char* action, const char* keydefinition, int append
 	free(hk);
 	return NULL;
     }
-	
+
     // If we already have a binding for that hotkey combination
     // for this window, forget the old one. One combo = One action.
     Hotkey* oldkey = hotkeyFindByStateAndKeysym( hotkeyGetWindowTypeString(hk),
@@ -211,7 +211,7 @@ Hotkey* hotkeySetFull( const char* action, const char* keydefinition, int append
 	dlist_erase( &hotkeys, (struct dlistnode *)oldkey );
 	free(oldkey);
     }
-	
+
     hk->source = source;
     dlist_pushfront( &hotkeys, (struct dlistnode *)hk );
     return hk;
@@ -233,7 +233,7 @@ static void loadHotkeysFromFile( const char* filename, enum hk_source source, in
 
     while ( fgets(line,sizeof(line),f)!=NULL ) {
 	int append = 0;
-	
+
 	if ( *line=='#' )
 	    continue;
 	char* pt = strchr(line,':');
@@ -248,7 +248,7 @@ static void loadHotkeysFromFile( const char* filename, enum hk_source source, in
 	    append = 1;
 	    action++;
 	}
-	
+
 	hotkeySetFull( action, keydefinition, append, source );
     }
     fclose(f);
@@ -380,8 +380,6 @@ Hotkey* isImmediateKey( GWindow w, char* path, GEvent *event )
 //    printf("line:%s\n",line);
     Hotkey* hk = hotkeyFindByAction( line );
     if( !hk )
-	return 0;
-    if( !hk->action )
 	return 0;
 
     if( event->u.chr.keysym == hk->keysym )

--- a/inc/basics.h
+++ b/inc/basics.h
@@ -60,7 +60,7 @@ typedef uint32_t unichar_t;
 #ifndef NDEBUG
 #define TRACE(...) fprintf(stderr, __VA_ARGS__)
 #else
-#define TRACE(...) while(0)
+#define TRACE(...) do {} while(0)
 #endif
 
 /* assert() with an otherwise unused variable
@@ -104,7 +104,7 @@ static inline int imax(int a, int b)
  * example:
  * MyListObjectType* newfoolast = 0;
  * MyListObjectType* newfoolist = 0;
- * 
+ *
  * for( ... iterate a source collection of foos ... )
  * {
  *    MyListObjectType* foocopy = CopyIt( foo );


### PR DESCRIPTION
### Type of change
- **Non-breaking change**

These were found in a default build on clang trunk.

I prioritised retaining actual behaviour. There are probably one or two spots (the tautological comparisons, first_cnt most likely) where I actually found and enshrined a bug! Don't apply any of these without validating!

Also:
```
[66/280] Building C object fontforge/CMakeFiles/fontforge.dir/encoding.c.o
/home/nabijaczleweli/uwu/fontforge/fontforge/encoding.c:2269:28: warning: variable 'refs' used in loop condition not modified in loop body [-Wfor-loop-analysis]
 2269 |             for ( bref=bfc->refs; refs!=NULL; bref = brnext ) {
      |                                   ^~~~
1 warning generated.
```
this is an infinite loop if `refs!=NULL`. So `refs == NULL` always at this point. Someone who understands this code should either remove the loop or fix the condition.

I *ignored* -Wmaybe-uninitialized. There's *so many*. Someone who understands the code should build with Clang and see!