### PR TITLE
fix memleak in function utf7toutf8_copy

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -449,6 +449,7 @@ return( NULL );
 
     ucs2_str = (unichar_t *) malloc((strlen(_str)+1)*sizeof(unichar_t));
     utf162u_strcpy(ucs2_str, utf16buf);
+    free(utf16buf);
     utf8_buf = u2utf8_copy(ucs2_str); /* Convert from ucs2 to utf8 */
     free(ucs2_str);
 


### PR DESCRIPTION
- **Bug fix**
A memory leak issue exist in function utf7toutf8_copy

LeakSanitizer result：
==821283==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 140 byte(s) in 4 object(s) allocated from:
    #0 0x7fee68a14302 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
    #1 0x7fee68629bc6 in utf7toutf8_copy /root/fuzz/fuzz_fontforge/fontforge/fontforge/sfd.c:378

Reproduction:
export CFLAGS="-g -O0 -fsanitize=leak" CXXFLAGS="-g -O0 -fsanitize=leak"
cmake ..
make && make install
/usr/local/bin/fontforge -lang=ff -c 'Open($1)'  poc_file
poc_file: [poc_file.zip](https://github.com/user-attachments/files/17725772/poc_file.zip)
