### PR TITLE
Modernize fixed pitch flag computation

### DIFF
--- a/doc/sphinx/olddocs/old/ja/splinefont.html
+++ b/doc/sphinx/olddocs/old/ja/splinefont.html
@@ -860,7 +860,7 @@ struct charprocs;
 enum charset;			<!--/* in charset.h */-->/* charset.hにある */
 
 extern SplineFont *SplineFontFromPSFont(struct fontdict *fd);
-extern int SFOneWidth(SplineFont *sf);
+extern bool SFIsFixedWidth(SplineFont *sf);
 extern struct chars *SplineFont2Chrs(SplineFont *sf, int round);
 enum fontformat { ff_pfa, ff_pfb, ff_ptype3, ff_ptype0, ff_ttf, ff_none };
 extern int WritePSFont(char *fontname,SplineFont *sf,enum fontformat format);

--- a/doc/sphinx/techref/splinefont.rst
+++ b/doc/sphinx/techref/splinefont.rst
@@ -704,7 +704,7 @@ Function declarations
    enum charset;                   /* in charset.h */
    
    extern SplineFont *SplineFontFromPSFont(struct fontdict *fd);
-   extern int SFOneWidth(SplineFont *sf);
+   extern bool SFIsFixedWidth(SplineFont *sf);
    extern struct chars *SplineFont2Chrs(SplineFont *sf, int round);
    enum fontformat { ff_pfa, ff_pfb, ff_ptype3, ff_ptype0, ff_ttf, ff_none };
    extern int WritePSFont(char *fontname,SplineFont *sf,enum fontformat format);

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -1714,7 +1714,7 @@ static void dumpfontinfo(void (*dumpchar)(int ch,void *data), void *data, Spline
 	dumpf(dumpchar,data," /FSType %d def\n", sf->pfminfo.fstype );
     if ( sf->subfontcnt==0 ) {
 	dumpf(dumpchar,data," /ItalicAngle %g def\n", (double) sf->italicangle );
-	dumpf(dumpchar,data," /isFixedPitch %s def\n", SFOneWidth(sf)!=-1?"true":"false" );
+	dumpf(dumpchar,data," /isFixedPitch %s def\n", SFIsFixedWidth(sf)?"true":"false" );
 	if ( format==ff_type42 || format==ff_type42cid ) {
 	    if ( sf->upos )
 		dumpf(dumpchar,data," /UnderlinePosition %g def\n", (double) (sf->upos/(sf->ascent+sf->descent)) );

--- a/fontforge/macbinary.c
+++ b/fontforge/macbinary.c
@@ -508,7 +508,7 @@ static uint32_t DummyNFNT(FILE *res, BDFFont *bdf, EncMap *map) {
     if ( descentMax>bdf->descent ) descentMax = bdf->descent;
 
     putlong(res,26);		/* Length */
-    putshort(res,SFOneWidth(bdf->sf)!=-1?0xf000:0xd000);	/* fontType */
+    putshort(res,SFIsFixedWidth(bdf->sf)?0xf000:0xd000);	/* fontType */
     putshort(res,0);
     putshort(res,255);
     putshort(res,widMax);

--- a/fontforge/splinesave.c
+++ b/fontforge/splinesave.c
@@ -1853,7 +1853,7 @@ bool SFIsFixedWidth(SplineFont *sf) {
 	-1: variable or dual pitch
 	width>0: fixed pitch with given character width
 */
-int CIDOneWidth(SplineFont *_sf) {
+int SFOneWidth(SplineFont *_sf) {
     int width, total_width = -2;
     int k = 0;
     SplineFont *sf;
@@ -2070,13 +2070,13 @@ struct pschars *SplineFont2ChrsSubrs(SplineFont *sf, int iscjk,
 	fixed = 0;
 	for ( i=0; i<instance_count; ++i ) {
 	    MarkTranslationRefs(mm->instances[i],layer);
-	    fixed = CIDOneWidth(mm->instances[i]);
+	    fixed = SFOneWidth(mm->instances[i]);
 	    if ( fixed==-1 )
 	break;
 	}
     } else {
 	MarkTranslationRefs(sf,layer);
-	fixed = CIDOneWidth(sf);
+	fixed = SFOneWidth(sf);
 	instance_count = 1;
     }
 
@@ -2112,7 +2112,7 @@ struct pschars *SplineFont2ChrsSubrs(SplineFont *sf, int iscjk,
 	dummynotdef.parent = sf;
 	dummynotdef.layer_cnt = sf->layer_cnt;
 	dummynotdef.layers = calloc(sf->layer_cnt,sizeof(Layer));
-	dummynotdef.width = CIDOneWidth(sf);
+	dummynotdef.width = SFOneWidth(sf);
 	if ( dummynotdef.width==-1 )
 	    dummynotdef.width = (sf->ascent+sf->descent)/2;
 	gi.gb[0].sc = &dummynotdef;
@@ -2188,7 +2188,7 @@ struct pschars *CID2ChrsSubrs(SplineFont *cidmaster,struct cidbytes *cidbytes,in
 	dummynotdef.parent = cidmaster->subfonts[0];
 	dummynotdef.layer_cnt = layer+1;
 	dummynotdef.layers = calloc(layer+1,sizeof(Layer));
-	dummynotdef.width = CIDOneWidth(dummynotdef.parent);
+	dummynotdef.width = SFOneWidth(dummynotdef.parent);
 	if ( dummynotdef.width==-1 )
 	    dummynotdef.width = (dummynotdef.parent->ascent+dummynotdef.parent->descent);
     }
@@ -3266,7 +3266,7 @@ struct pschars *SplineFont2ChrsSubrs2(SplineFont *sf, int nomwid, int defwid,
 	    dummynotdef.parent = sf;
 	    dummynotdef.layer_cnt = sf->layer_cnt;
 	    dummynotdef.layers = calloc(sf->layer_cnt,sizeof(Layer));
-	    dummynotdef.width = CIDOneWidth(sf);
+	    dummynotdef.width = SFOneWidth(sf);
 	    if ( dummynotdef.width==-1 )
 		dummynotdef.width = (sf->ascent+sf->descent)/2;
 	    Type2NotDefSplines(sf,&dummynotdef,layer);
@@ -3496,7 +3496,7 @@ struct pschars *CID2ChrsSubrs2(SplineFont *cidmaster,struct fd2data *fds,
 	    dummynotdef.parent = sf;
 	    dummynotdef.layer_cnt = layer+1;
 	    dummynotdef.layers = calloc(layer+1,sizeof(Layer));
-	    dummynotdef.width = CIDOneWidth(sf);
+	    dummynotdef.width = SFOneWidth(sf);
 	    if ( dummynotdef.width==-1 )
 		dummynotdef.width = (sf->ascent+sf->descent);
 	    Type2NotDefSplines(sf,&dummynotdef,layer);

--- a/fontforge/splinesave.h
+++ b/fontforge/splinesave.h
@@ -8,7 +8,7 @@
  */
 extern bool equalWithTolerence(real a, real b, real tolerence);
 
-extern int CIDOneWidth(SplineFont *_sf);
+extern int SFOneWidth(SplineFont *_sf);
 extern int CvtPsStem3(GrowBuf *gb, SplineChar *scs[MmMax], int instance_count, int ishstem, int round);
 extern int SFIsCJK(SplineFont *sf, EncMap *map);
 extern int SFOneHeight(SplineFont *sf);

--- a/fontforge/splinesave.h
+++ b/fontforge/splinesave.h
@@ -12,7 +12,7 @@ extern int CIDOneWidth(SplineFont *_sf);
 extern int CvtPsStem3(GrowBuf *gb, SplineChar *scs[MmMax], int instance_count, int ishstem, int round);
 extern int SFIsCJK(SplineFont *sf, EncMap *map);
 extern int SFOneHeight(SplineFont *sf);
-extern int SFOneWidth(SplineFont *sf);
+extern bool SFIsFixedWidth(SplineFont *sf);
 extern struct pschars *CID2ChrsSubrs2(SplineFont *cidmaster, struct fd2data *fds, int flags, struct pschars **_glbls, int layer);
 extern struct pschars *SplineFont2ChrsSubrs2(SplineFont *sf, int nomwid, int defwid, const int *bygid, int cnt, int flags, struct pschars **_subrs, int layer);
 extern void debug_printHintInstance(HintInstance* hi, int hin, char* msg);

--- a/fontforge/splinesaveafm.c
+++ b/fontforge/splinesaveafm.c
@@ -1219,7 +1219,7 @@ static void AfmSplineFontHeader(FILE *afm, SplineFont *sf, int formattype,
 	fprintf( afm, "IsCIDFont true\n" );
     }
     fprintf( afm, "ItalicAngle %g\n", (double) sf->italicangle );
-    width = CIDOneWidth(sf);
+    width = SFOneWidth(sf);
     fprintf( afm, "IsFixedPitch %s\n", width==-1?"false":"true" );
     fprintf( afm, "UnderlinePosition %g\n", (double) sf->upos );
     fprintf( afm, "UnderlineThickness %g\n", (double) sf->uwidth );

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -3006,7 +3006,7 @@ void SFDefaultOS2Info(struct pfminfo *pfminfo,SplineFont *sf,char *fontname) {
 	    hold.hheadset = hold.vheadset = false;
 	memset(pfminfo,'\0',sizeof(*pfminfo));
 	SFDefaultOS2Simple(pfminfo,sf);
-	samewid = CIDOneWidth(sf);
+	samewid = SFOneWidth(sf);
 
 	pfminfo->pfmfamily = 0x10;
 	if ( samewid>0 ) {
@@ -6111,7 +6111,7 @@ static void ATinit(struct alltabs *at,SplineFont *sf,EncMap *map,int flags, int 
     if ( bsizes!=NULL && !at->applebitmaps && !at->otbbitmaps && !at->msbitmaps )
 	at->msbitmaps = true;		/* They asked for bitmaps, but no bitmap type selected */
     at->gi.bsizes = bsizes;
-    at->gi.fixed_width = CIDOneWidth(sf);
+    at->gi.fixed_width = SFOneWidth(sf);
     at->isotf = format==ff_otf || format==ff_otfcid;
     at->format = format;
     at->next_strid = 256;
@@ -6611,7 +6611,7 @@ return( NULL );
 return( NULL );
     }
 
-    ret[fcnt].gi.fixed_width = CIDOneWidth(sf);
+    ret[fcnt].gi.fixed_width = SFOneWidth(sf);
     ret[fcnt].gi.bygid = bygid;
     ret[fcnt].gi.gcnt = ret[fcnt].maxp.numGlyphs = dummysf->glyphcnt;
     if ( format==ff_ttf )

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -35,6 +35,7 @@
 #include "gfile.h"
 #include "glif_name_hash.h"
 #include "lookups.h"
+#include "splinesave.h"
 #include "splinesaveafm.h"
 #include "splineutil.h"
 #include "splineutil2.h"
@@ -1350,6 +1351,7 @@ static int UFOOutputFontInfo(const char *basedir, SplineFont *sf, int layer, int
     /* UniqueID is obsolete */
     PListAddInteger(dictnode,"postscriptUnderlineThickness",sf->uwidth);
     PListAddInteger(dictnode,"postscriptUnderlinePosition",sf->upos);
+    PListAddBoolean(dictnode,"postscriptIsFixedPitch", SFIsFixedWidth(sf));
     if ( sf->private!=NULL ) {
 	char *pt;
 	PListAddPrivateArray(dictnode, "BlueValues", sf->private);


### PR DESCRIPTION
This PR allows monospace fonts with modern features
* Zero-width glyphs are allowed, such as control characters or diacritical marks
* Dual-width glyphs are alowed, such as emojis or kanij

Fixes #5489