### PR TITLE
python: use PyConfig_InitIsolatedConfig to initialize the embedded Python

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -20155,7 +20155,7 @@ void FontForge_InitializeEmbeddedPython(void) {
 
     PyConfig config;
     PyStatus status;
-    PyConfig_InitPythonConfig(&config);
+    PyConfig_InitIsolatedConfig(&config);
 
     status = PyConfig_SetBytesString(&config, &config.program_name,
                                      "fontforge");


### PR DESCRIPTION
## Motivation for change

Reduce surprising and security-sensitive loading of Python modules based on the current working directory where the `fontforge` program is run. After this change, the Python scripts which are explicitly loaded based on `fontforge`'s command line flags, plus hard-coded ones like `pkg_resources`, are the only ones used.

This is a breaking change!

From the [docs](https://docs.python.org/3/c-api/init_config.html#init-isolated-conf):

> `PyConfig_InitIsolatedConfig()` creates a configuration to isolate Python
> from the system. This is ideal to embed Python into an application.
>
> This configuration ignores global configuration variables, environment
> variables, command line arguments (`PyConfig.argv` is not parsed) and
> user site directory. The C standard streams (ex: stdout) and the
> `LC_CTYPE` locale are left unchanged. Signal handlers are not installed.
>
> Configuration files are still used with this configuration to determine
> paths that are unspecified. Ensure `PyConfig.home` is specified to avoid
> computing the default path configuration.

This will change the default behavior of Python in FontForge from loading whatever is in the current working directory to loading what's installed as part of the system Python or the venv Python, which ever gets loaded as the shared library.

### **Breaking changes**

- Python modules in the current working directory will no longer be loaded preferentially ([aka disabled `safe_path`](https://docs.python.org/3/c-api/init_config.html#c.PyConfig.safe_path)). The files processed by `LoadFilesInPythonInitDir` will still be loaded.
- Locale will no longer be [auto-configured](https://docs.python.org/3/c-api/init_config.html#c.PyPreConfig.configure_locale). 
- C locale will [no longer be possibly coerced](https://docs.python.org/3/c-api/init_config.html#c.PyPreConfig.coerce_c_locale).
- C input streams will no longer [be mutated by Python initialization](https://docs.python.org/3/c-api/init_config.html#c.PyConfig.configure_c_stdio).
- Environment variables will [no longer influence behavior](https://docs.python.org/3/c-api/init_config.html#c.PyPreConfig.use_environment).
- Python signal handlers will [no longer be installed.](https://docs.python.org/3/c-api/init_config.html#c.PyConfig.install_signal_handlers) 
- UTF-8 mode will no longer [be possibly set](https://docs.python.org/3/c-api/init_config.html#c.PyPreConfig.utf8_mode).
- Command line parameters understood by Python will [no longer be read](https://docs.python.org/3/c-api/init_config.html#c.PyConfig.parse_argv). 
- The user site directory will not [be added to the configuration](https://docs.python.org/3/c-api/init_config.html#c.PyConfig.user_site_directory).

 