### PR TITLE
Make SmallCaps() create symbols

### DIFF
--- a/doc/sphinx/scripting/scripting-alpha.rst
+++ b/doc/sphinx/scripting/scripting-alpha.rst
@@ -2689,8 +2689,13 @@ the fourth argument you must specify the second and third arguments too.
 
 .. function:: SmallCaps([v-scale[,h-scale[,stemw-scale[,stemh-scale]]]])
 
-   Create small capitals from the selected glyphs. The following optional
-   arguments are accepted:
+   Create small capitals from the selected glyphs.  When the function
+   generates a new glyph from an (uppercase) letter it names it like
+   the lowercase letter and appends ".sc", e.g., "A" becomes "a.sc".
+   Anything not a letter, i.e., digits and symbols, gets the extension
+   ".taboldstyle".
+
+   The following optional arguments are accepted:
 
    .. object:: v-scale
 

--- a/fontforge/scripting.c
+++ b/fontforge/scripting.c
@@ -4821,6 +4821,7 @@ static void bSmallCaps(Context *c) {
 	.hcounter_scale = 0.66, .lsb_scale = 0.66, .rsb_scale = 0.66,
 	.v_scale = 0.675,
 	.gc = gc_smallcaps,
+        .do_smallcap_symbols = 1,
 	.extension_for_letters = "sc",
 	.extension_for_symbols = "taboldstyle",
 	.use_vert_mapping = 1,


### PR DESCRIPTION
**Bug fix**

The script function `SmallCaps` does not create symbols, only letters.
However, the GUI as well as the Python interface allow to generate
smallcaps symbols.

The fix for this problem is trivial as it boils down to a flag that must be set.

The documentation of `SmallCaps` is extended to mention both the
`.sc` and `.taboldstyle` namespaces of letters and symbols, respectively.
