### PR TITLE
Fix CI for Ubuntu 24

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches: [ coverity ]
   workflow_dispatch:
-env:
-  PYTHON: python3.10
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   linux:
     runs-on: ${{ matrix.os }}
-    env:
-      PYTHON: python3.10
     strategy:
       matrix:
         os: ["ubuntu-latest"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,12 @@ jobs:
         run: ninja -C repo/build dist
       - name: Run pyhook smoke test
         if: matrix.target != 'NoUI'
-        run: $PYTHON repo/tests/pyhook_smoketest.py
+        working-directory: repo
+        run: |
+          # There can be several Python versions installed. We must use the exact one discovered by CMake.
+          PYTHON=`grep -m1 'Python3_EXECUTABLE.*=' build/CMakeCache.txt | cut -d= -f2`
+          PYTHONPATH=$PYTHONPATH:$PREFIX/$($PYTHON -c "import sysconfig as sc; print(sc.get_path('platlib', 'posix_prefix', vars={'platbase': '.'}))")
+          $PYTHON tests/pyhook_smoketest.py
       - name: Build AppImage
         if: matrix.target == 'Release'
         working-directory: repo/build
@@ -105,8 +110,7 @@ jobs:
       - name: Run pyhook smoke test
         working-directory: repo
         run: |
-          # MacOS runner has way too much preinstalled Python versions. We must
-          # use the exact one discovered by CMake.
+          # There can be several Python versions installed. We must use the exact one discovered by CMake.
           PYTHON=`grep -m1 'Python3_EXECUTABLE.*=' build/CMakeCache.txt | cut -d= -f2`
           PYTHONPATH=$PYTHONPATH:$PREFIX/$($PYTHON -c "import sysconfig as sc; print(sc.get_path('platlib', 'posix_prefix', vars={'platbase': '.'}))")
           $PYTHON tests/pyhook_smoketest.py

--- a/.github/workflows/scripts/ffappimagebuild.sh
+++ b/.github/workflows/scripts/ffappimagebuild.sh
@@ -23,10 +23,8 @@ echo "FontForge built against Python $PYVER"
 
 # In Ubuntu 20-22 the libpython3-minimal is not automatically included with the default Python installation.
 # In Ubuntu 24.04 this doesn't seem to be necessary anymore.
-sudo apt-get install -y libpython${PYVER}-minimal
-
-( cd $APPDIR ; dpkg -x /var/cache/apt/archives/libpython${PYVER}-minimal*.deb . )
-( cd $APPDIR ; dpkg -x /var/cache/apt/archives/libpython${PYVER}-stdlib*.deb . )
+( cd $APPDIR ; apt-get download -y libpython${PYVER}-minimal ; dpkg -x libpython${PYVER}-minimal*.deb . )
+( cd $APPDIR ; apt-get download -y libpython${PYVER}-stdlib ; dpkg -x libpython${PYVER}-stdlib*.deb . )
 "python${PYVER}" -m pip install -I --target "$APPDIR/usr/lib/python${PYVER}/dist-packages" setuptools
 
 if [ ! -f linuxdeployqt.AppImage ]; then

--- a/.github/workflows/scripts/ffappimagebuild.sh
+++ b/.github/workflows/scripts/ffappimagebuild.sh
@@ -21,6 +21,10 @@ echo "Starting appimage build, folder is $APPDIR with version $VERSION"
 PYVER=$(ldd $APPDIR/usr/bin/fontforge | grep -Eom1 'python[0-9\.]+[0-9]+' | head -1 | cut -c 7-)
 echo "FontForge built against Python $PYVER"
 
+# In Ubuntu 20-22 the libpython3-minimal is not automatically included with the default Python installation.
+# In Ubuntu 24.04 this doesn't seem to be necessary anymore.
+sudo apt-get install -y libpython${PYVER}-minimal
+
 ( cd $APPDIR ; dpkg -x /var/cache/apt/archives/libpython${PYVER}-minimal*.deb . )
 ( cd $APPDIR ; dpkg -x /var/cache/apt/archives/libpython${PYVER}-stdlib*.deb . )
 "python${PYVER}" -m pip install -I --target "$APPDIR/usr/lib/python${PYVER}/dist-packages" setuptools

--- a/.github/workflows/scripts/setup_linux_deps.sh
+++ b/.github/workflows/scripts/setup_linux_deps.sh
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+PYTHON=python3
+
 sudo apt-get remove python3-pip
 sudo add-apt-repository -y ppa:deadsnakes/ppa && sudo apt-get update -y
 sudo apt-get install -y autoconf automake libtool gcc g++ gettext \

--- a/.github/workflows/scripts/setup_linux_deps.sh
+++ b/.github/workflows/scripts/setup_linux_deps.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 sudo apt-get remove python3-pip
 sudo add-apt-repository -y ppa:deadsnakes/ppa && sudo apt-get update -y
 sudo apt-get install -y autoconf automake libtool gcc g++ gettext \
-    libjpeg-dev libtiff5-dev libpng-dev libfreetype6-dev libgif-dev \
+    libjpeg-dev libtiff5-dev libpng-dev libfreetype-dev libgif-dev \
     libx11-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev \
     libbrotli-dev libwoff-dev ninja-build cmake lcov $PYTHON-dev $PYTHON-venv
 curl https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON
@@ -23,7 +23,7 @@ if [ ! -d deps/install ]; then
     echo "Custom dependencies not present - will build them"
     rm -rf deps && mkdir deps && cd deps
 
-    FTVER=`dpkg -s libfreetype6-dev | perl -ne 'print $1 if /^Version: (\d+(?:\.\d+)+)/'`
+    FTVER=`dpkg -s libfreetype-dev | perl -ne 'print $1 if /^Version: (\d+(?:\.\d+)+)/'`
     SFFTVER=`echo $FTVER | perl -ne 'print $1 if /^(\d+(?:\.\d+){1,2})/'`
 
     git clone --depth 1 https://github.com/fontforge/libspiro

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ The exact method to do this depends on your OS distribution.
 To download all dependencies on Ubuntu, run:
 
 ```sh
-sudo apt-get install libjpeg-dev libtiff5-dev libpng-dev libfreetype6-dev libgif-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev libwoff-dev python3-dev ninja-build cmake build-essential gettext;
+sudo apt-get install libjpeg-dev libtiff5-dev libpng-dev libfreetype-dev libgif-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev libwoff-dev python3-dev ninja-build cmake build-essential gettext;
 ```
 
 Now run the build and installation scripts:

--- a/cmake/packages/FindSphinx.cmake
+++ b/cmake/packages/FindSphinx.cmake
@@ -59,7 +59,7 @@ function(_sphinx_from_venv)
     return()
   endif()
 
-  execute_process(COMMAND "${_venv_bin}" -m pip install sphinx typing RESULT_VARIABLE _pip_result)
+  execute_process(COMMAND "${_venv_bin}" -m pip install sphinx RESULT_VARIABLE _pip_result)
   if(_pip_result)
     message(WARNING "could not install sphinx")
     return()


### PR DESCRIPTION
`ubuntu-latest` CI runner now defaults to Ubuntu 24.04 (see https://github.com/actions/runner-images/issues/10636). This PR fixes the issues which arose with the new version.