### PR TITLE
Fix memory corruption in SFUnicodeRanges()

### DIFF
--- a/fontforge/unicoderange.c
+++ b/fontforge/unicoderange.c
@@ -92,7 +92,7 @@ struct rangeinfo *SFUnicodeRanges(SplineFont *sf, int include_empty) {
             } else if (!isunicodepointassigned(ch)) {
                 /* glyphs attached to code points which have not been assigned in */
                 /*  the version of unicode I know about */
-                ++ri[num_planes = num_blocks + 1].cnt;
+                ++ri[num_planes + num_blocks + 1].cnt;
             }
         }
     }

--- a/fontforgeexe/basedlg.c
+++ b/fontforgeexe/basedlg.c
@@ -624,9 +624,8 @@ return( true );
 		int tag = md[cols*r+1].u.md_ival;
 		for ( j=0; stdtags[j]!=0 && stdtags[j]!=tag; ++j );
 		if ( stdtags[j]==0 || mapping[ j ]==-1 ) {
-		    ff_post_error(_("Bad default baseline"),_("Script '%c%c%c%c' claims baseline '%c%c%c%c' as its default, but that baseline is not currently active."),
-			    md[cols*r+0].u.md_ival>>24, md[cols*r+0].u.md_ival>>16,
-			    md[cols*r+0].u.md_ival>>8, md[cols*r+0].u.md_ival,
+		    ff_post_error(_("Bad default baseline"),_("Script '%s' claims baseline '%c%c%c%c' as its default, but that baseline is not currently active."),
+			    md[cols*r+0].u.md_str,
 			    tag>>24, tag>>16, tag>>8, tag );
 return( true );
 		}


### PR DESCRIPTION
Typo fix, partially addresses https://github.com/fontforge/fontforge/issues/5536