### PR TITLE
Performance fixes for GSUB/GPOS dumps

### DIFF
--- a/fontforge/CMakeLists.txt
+++ b/fontforge/CMakeLists.txt
@@ -57,6 +57,7 @@ set(FONTFORGE_NOINST_HEADERS
   splineutil.h
   splineutil2.h
   start.h
+  std_maps.hpp
   svg.h
   tottf.h
   tottfaat.h
@@ -199,6 +200,7 @@ add_library(fontforge
   splineutil2.c
   start.c
   stemdb.c
+  std_maps.cpp
   svg.c
   tottf.c
   tottfaat.c

--- a/fontforge/lookups.h
+++ b/fontforge/lookups.h
@@ -4,6 +4,8 @@
 #include "splinefont.h"
 #include "uiinterface.h"
 
+typedef struct cpp_SubtableMap cpp_SubtableMap;
+
 struct sllk {
 	uint32_t script;
 	int cnt;
@@ -68,7 +70,8 @@ extern OTLookup *OTLookupCopyInto(SplineFont *into_sf, SplineFont *from_sf, OTLo
 extern OTLookup *SFFindLookup(SplineFont *sf, const char *name);
 extern OTLookup **SFLookupsInScriptLangFeature(SplineFont *sf, int gpos, uint32_t script, uint32_t lang, uint32_t feature);
 extern SplineChar **SFGlyphsWithLigatureinLookup(SplineFont *sf, struct lookup_subtable *subtable);
-extern SplineChar **SFGlyphsWithPSTinSubtable(SplineFont *sf, struct lookup_subtable *subtable);
+extern void SFCollectSubtableMap(SplineFont *sf, cpp_SubtableMap *map);
+extern SplineChar **SFGlyphsWithPSTinSubtable(SplineFont *sf, struct lookup_subtable *subtable, cpp_SubtableMap *map);
 extern struct lookup_subtable *SFFindLookupSubtableAndFreeName(SplineFont *sf, char *name);
 extern struct lookup_subtable *SFSubTableFindOrMake(SplineFont *sf, uint32_t tag, uint32_t script, int lookup_type);
 extern struct lookup_subtable *SFSubTableMake(SplineFont *sf, uint32_t tag, uint32_t script, int lookup_type);

--- a/fontforge/namehash.h
+++ b/fontforge/namehash.h
@@ -28,7 +28,7 @@
 #ifndef FONTFORGE_NAMEHASH_H
 #define FONTFORGE_NAMEHASH_H
 
-#define GN_HSIZE	257
+#define GN_HSIZE	65530
 
 struct glyphnamebucket {
     SplineChar *sc;

--- a/fontforge/namelist.c
+++ b/fontforge/namelist.c
@@ -62,8 +62,7 @@ NameList *namelist_for_new_fonts = &agl_nf;
 /* 0xf6be is named dotlessj, 0x237 should be */
 
 static int psnamesinited=false;
-#define HASH_SIZE	257
-struct psbucket { const char *name; int uni; struct psbucket *prev; } *psbuckets[HASH_SIZE];
+struct psbucket { const char *name; int uni; struct psbucket *prev; } *psbuckets[GN_HSIZE];
 
 static void psaddbucket(const char *name, int uni) {
     unsigned int hash = hashname(name);
@@ -110,7 +109,7 @@ static void psreinitnames(void) {
     int i;
     NameList *nl;
 
-    for ( i=0; i<HASH_SIZE; ++i ) {
+    for ( i=0; i<GN_HSIZE; ++i ) {
 	struct psbucket *cur, *prev;
 	for ( cur = psbuckets[i]; cur!=NULL; cur=prev ) {
 	    prev = cur->prev;

--- a/fontforge/std_maps.cpp
+++ b/fontforge/std_maps.cpp
@@ -54,6 +54,17 @@ void SubtableMap_add_pst(cpp_SubtableMap* map, struct lookup_subtable* subtable,
     st_map[subtable].second.push_back({gid, pst});
 }
 
+int SubtableMap_get_size(cpp_SubtableMap* map,
+                                        struct lookup_subtable* subtable) {
+    SubtableMap& st_map = *reinterpret_cast<SubtableMap*>(map);
+    auto map_it = st_map.find(subtable);
+    if (map_it == st_map.end()) {
+        return 0;
+    } else {
+	return map_it->second.first.size() + map_it->second.second.size();
+    }
+}
+
 struct kp_list* SubtableMap_get_kp_list(cpp_SubtableMap* map,
                                         struct lookup_subtable* subtable) {
     SubtableMap& st_map = *reinterpret_cast<SubtableMap*>(map);

--- a/fontforge/std_maps.cpp
+++ b/fontforge/std_maps.cpp
@@ -1,0 +1,87 @@
+/* Copyright 2025 Maxim Iorsh <iorsh@users.sourceforge.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "std_maps.hpp"
+
+cpp_SubtableMap* SubtableMap_new() {
+    SubtableMap* st_map = new SubtableMap();
+    return reinterpret_cast<cpp_SubtableMap*>(st_map);
+}
+
+void SubtableMap_delete(cpp_SubtableMap** p_map) {
+    if (p_map == nullptr) {
+        return;
+    }
+
+    SubtableMap* st_map = reinterpret_cast<SubtableMap*>(*p_map);
+    delete st_map;
+    *p_map = nullptr;
+}
+
+void SubtableMap_add_kp(cpp_SubtableMap* map, struct lookup_subtable* subtable,
+                        int gid, KernPair* kp) {
+    SubtableMap& st_map = *reinterpret_cast<SubtableMap*>(map);
+    st_map[subtable].first.push_back({gid, kp});
+}
+
+void SubtableMap_add_pst(cpp_SubtableMap* map, struct lookup_subtable* subtable,
+                         int gid, PST* pst) {
+    SubtableMap& st_map = *reinterpret_cast<SubtableMap*>(map);
+    st_map[subtable].second.push_back({gid, pst});
+}
+
+struct kp_list* SubtableMap_get_kp_list(cpp_SubtableMap* map,
+                                        struct lookup_subtable* subtable) {
+    SubtableMap& st_map = *reinterpret_cast<SubtableMap*>(map);
+    auto map_it = st_map.find(subtable);
+    if (map_it == st_map.end() || map_it->second.first.empty()) {
+        return nullptr;
+    } else {
+        // Make sure the list ends with NULL
+        std::vector<kp_list>& list = map_it->second.first;
+        if (list.back().kp != nullptr) {
+            list.push_back({-1, nullptr});
+        }
+        return list.data();
+    }
+}
+
+struct pst_list* SubtableMap_get_pst_list(cpp_SubtableMap* map,
+                                          struct lookup_subtable* subtable) {
+    SubtableMap& st_map = *reinterpret_cast<SubtableMap*>(map);
+    auto map_it = st_map.find(subtable);
+    if (map_it == st_map.end() || map_it->second.second.empty()) {
+        return nullptr;
+    } else {
+        // Make sure the list ends with NULL
+        std::vector<pst_list>& list = map_it->second.second;
+        if (list.back().pst != nullptr) {
+            list.push_back({-1, nullptr});
+        }
+        return list.data();
+    }
+}

--- a/fontforge/std_maps.hpp
+++ b/fontforge/std_maps.hpp
@@ -1,0 +1,75 @@
+/* Copyright 2025 Maxim Iorsh <iorsh@users.sourceforge.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Dummy incomplete type which can be casted to C++ type SubtableMap */
+typedef struct cpp_SubtableMap cpp_SubtableMap;
+
+typedef struct kernpair KernPair;
+typedef struct generic_pst PST;
+
+struct kp_list {
+    int gid;
+    KernPair* kp;
+};
+
+struct pst_list {
+    int gid;
+    PST* pst;
+};
+
+cpp_SubtableMap* SubtableMap_new();
+
+void SubtableMap_delete(cpp_SubtableMap** p_map);
+
+void SubtableMap_add_kp(cpp_SubtableMap* map, struct lookup_subtable* subtable,
+                        int gid, KernPair* kp);
+
+void SubtableMap_add_pst(cpp_SubtableMap* map, struct lookup_subtable* subtable,
+                         int gid, PST* pst);
+
+struct kp_list* SubtableMap_get_kp_list(cpp_SubtableMap* map,
+                                        struct lookup_subtable* subtable);
+
+struct pst_list* SubtableMap_get_pst_list(cpp_SubtableMap* map,
+                                          struct lookup_subtable* subtable);
+
+#ifdef __cplusplus
+}
+
+#include <unordered_map>
+#include <vector>
+
+using SubtableMap = std::unordered_map<
+    struct lookup_subtable*,
+    std::pair<std::vector<struct kp_list>, std::vector<struct pst_list>>>;
+
+#endif  // __cplusplus

--- a/fontforge/std_maps.hpp
+++ b/fontforge/std_maps.hpp
@@ -56,6 +56,9 @@ void SubtableMap_add_kp(cpp_SubtableMap* map, struct lookup_subtable* subtable,
 void SubtableMap_add_pst(cpp_SubtableMap* map, struct lookup_subtable* subtable,
                          int gid, PST* pst);
 
+int SubtableMap_get_size(cpp_SubtableMap* map,
+                                        struct lookup_subtable* subtable);
+
 struct kp_list* SubtableMap_get_kp_list(cpp_SubtableMap* map,
                                         struct lookup_subtable* subtable);
 

--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -5344,6 +5344,7 @@ static void ATmaxpInit(struct alltabs *at,SplineFont *sf, enum fontformat format
 static void initATTables(struct alltabs *at, SplineFont *sf, enum fontformat format) {
     setos2(&at->os2,at,sf,format);	/* should precede kern/ligature output */
     if ( at->opentypemode ) {
+	SFCollectSubtableMap(sf, at->subtable_map);
 	SFFindUnusedLookups(sf);
 	otf_dumpgpos(at,sf);
 	otf_dumpgsub(at,sf);
@@ -6127,6 +6128,7 @@ static void ATinit(struct alltabs *at,SplineFont *sf,EncMap *map,int flags, int 
     }
     at->sf = sf;
     at->map = map;
+    at->subtable_map = SubtableMap_new();
 }
 
 int _WriteTTFFont(FILE *ttf,SplineFont *sf,enum fontformat format,
@@ -6183,6 +6185,7 @@ int _WriteTTFFont(FILE *ttf,SplineFont *sf,enum fontformat format,
 	    dumpttf(ttf,&at);
     }
     switch_to_old_locale(&tmplocale, &oldlocale); // Switch to the cached locale.
+    SubtableMap_delete(&at.subtable_map);
     if ( at.error || ferror(ttf))
 return( 0 );
 

--- a/fontforge/tottfgpos.c
+++ b/fontforge/tottfgpos.c
@@ -1230,7 +1230,7 @@ static void dumpGPOSpairpos(FILE *gpos,SplineFont *sf,struct lookup_subtable *su
     int32_t coverage_pos, offset_pos, end, start, pos;
     PST *pst;
     KernPair *kp;
-    int vf1 = 0, vf2=0, i, j, k, tot, bit_cnt, v;
+    int vf1 = 0, vf2=0, i, j, tot, bit_cnt, v;
     int start_cnt, end_cnt;
     int chunk_cnt, chunk_max;
     SplineChar *sc, **glyphs, *gtemp;
@@ -1241,52 +1241,48 @@ static void dumpGPOSpairpos(FILE *gpos,SplineFont *sf,struct lookup_subtable *su
     /* Figure out all the data we need. First the glyphs with kerning info */
     /*  then the glyphs to which they kern, and by how much */
     glyphs = SFOrderedGlyphsWithPSTinSubtable(sf,sub,at->subtable_map);
+    int max_entries = SubtableMap_get_size(at->subtable_map, sub);
+    struct sckppst *tmp_seconds = calloc(max_entries+1,sizeof(struct sckppst));
+
     for ( cnt=0; glyphs[cnt]!=NULL; ++cnt);
     seconds = malloc(cnt*sizeof(struct sckppst *));
     for ( cnt=0; glyphs[cnt]!=NULL; ++cnt) {
-	for ( k=0; k<2; ++k ) {
-	    devtablen = 0;
-	    tot = 0;
-	    for ( pst=glyphs[cnt]->possub; pst!=NULL; pst=pst->next ) {
-		if ( pst->subtable==sub && pst->type==pst_pair &&
-			(sc = SFGetChar(sf,-1,pst->u.pair.paired))!=NULL &&
-			sc->ttf_glyph!=-1 ) {
-		    if ( k ) {
-			seconds[cnt][tot].sc = sc;
-			seconds[cnt][tot].other_gid = sc->ttf_glyph;
-			seconds[cnt][tot].pst = pst;
-			devtablen += ValDevTabLen(pst->u.pair.vr[0].adjust) +
-				 ValDevTabLen(pst->u.pair.vr[1].adjust);
-
-		    }
+	devtablen = 0;
+	tot = 0;
+	for ( pst=glyphs[cnt]->possub; pst!=NULL; pst=pst->next ) {
+	    if ( pst->subtable==sub && pst->type==pst_pair &&
+		 (sc = SFGetChar(sf,-1,pst->u.pair.paired))!=NULL &&
+		 sc->ttf_glyph!=-1 ) {
+		tmp_seconds[tot].sc = sc;
+		tmp_seconds[tot].other_gid = sc->ttf_glyph;
+		tmp_seconds[tot].pst = pst;
+		devtablen += ValDevTabLen(pst->u.pair.vr[0].adjust) +
+			     ValDevTabLen(pst->u.pair.vr[1].adjust);
+		++tot;
+	    }
+	}
+	for ( v=0; v<2; ++v ) {
+	    for ( kp = v ? glyphs[cnt]->vkerns : glyphs[cnt]->kerns; kp!=NULL; kp=kp->next ) {
+		if( kp->subtable!=sub ) continue; // process only glyphs from the current subtable
+		if ( kp->sc->ttf_glyph!=-1 ) {
+		    tmp_seconds[tot].other_gid = kp->sc->ttf_glyph;
+		    tmp_seconds[tot].sc = kp->sc;
+		    tmp_seconds[tot].kp = kp;
+		    tmp_seconds[tot].isv = v;
+		    devtablen += DevTabLen(kp->adjust);
 		    ++tot;
 		}
 	    }
-	    for ( v=0; v<2; ++v ) {
-		for ( kp = v ? glyphs[cnt]->vkerns : glyphs[cnt]->kerns; kp!=NULL; kp=kp->next ) {
-		    if( kp->subtable!=sub ) continue; // process only glyphs from the current subtable
-		    if ( kp->sc->ttf_glyph!=-1 ) {
-			if ( k ) {
-			    seconds[cnt][tot].other_gid = kp->sc->ttf_glyph;
-			    seconds[cnt][tot].sc = kp->sc;
-			    seconds[cnt][tot].kp = kp;
-			    seconds[cnt][tot].isv = v;
-			    devtablen += DevTabLen(kp->adjust);
-			}
-			++tot;
-		    }
-		}
-	    }
-	    if ( k==0 ) {
-		seconds[cnt] = calloc(tot+1,sizeof(struct sckppst));
-	    } else {
-		qsort(seconds[cnt],tot,sizeof(struct sckppst),cmp_gid);
-		seconds[cnt][0].tot = tot;
-		/* Devtablen is 0 unless we are configured for device tables */
-		seconds[cnt][0].devtablen = devtablen;
-		seconds[cnt][0].samewas = 0xffff;
-	    }
 	}
+	qsort(tmp_seconds,tot,sizeof(struct sckppst),cmp_gid);
+	tmp_seconds[0].tot = tot;
+	/* Devtablen is 0 unless we are configured for device tables */
+	tmp_seconds[0].devtablen = devtablen;
+	tmp_seconds[0].samewas = 0xffff;
+
+	seconds[cnt] = calloc(tot+1,sizeof(struct sckppst));
+	memcpy(seconds[cnt], tmp_seconds, (tot+1)*sizeof(struct sckppst));
+	memset(tmp_seconds, 0, (tot+1)*sizeof(struct sckppst));
     }
 
     /* Some fonts do a primitive form of class based kerning, several glyphs */
@@ -1500,6 +1496,7 @@ static void dumpGPOSpairpos(FILE *gpos,SplineFont *sf,struct lookup_subtable *su
     for ( i=0; i<cnt; ++i )
 	free(seconds[i]);
     free(seconds);
+    free(tmp_seconds);
     free(glyphs);
 }
 

--- a/fontforge/ttf.h
+++ b/fontforge/ttf.h
@@ -29,6 +29,7 @@
 #define FONTFORGE_TTF_H
 
 #include "psfont.h"		/* for struct fddata */
+#include "std_maps.hpp"
 
 #define MAC_DELETED_GLYPH_NAME	"<Delete>"
 
@@ -734,6 +735,7 @@ struct alltabs {
     EncMap *map;
     struct ttf_table *oldcvt;
     unsigned oldcvtlen;
+    cpp_SubtableMap* subtable_map;
 };
 
 struct subhead { uint16_t first, cnt, delta, rangeoff; };	/* a sub header in 8/16 cmap table */


### PR DESCRIPTION
This PR improves the performance of saving large OpenType GPOS/GSUB tables. 

@khaledhosny, on my machine the performance of saving Amiri font improved roughly from 68s to 10s, with comparable HarfBuzz metrics view (#5522) improvement. This is still suboptimal, but some Amiri kerning features are loaded as subtable with 6.8M (yes, six million) kerning pairs. I don't know what causes it, as the original font doesn't have anything like that.

### Type of change
- **Non-breaking change**
