### PR TITLE
Bump GitHub CI runner to Ubuntu 22

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         os: ["ubuntu-latest"]
         target: ["NoUI", "Debug"]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: Release
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/scripts/ffappimagebuild.sh
+++ b/.github/workflows/scripts/ffappimagebuild.sh
@@ -17,6 +17,9 @@ fi
 
 echo "Starting appimage build, folder is $APPDIR with version $VERSION"
 
+# AppImage still needs libfuse2. See https://github.com/AppImage/AppImageKit/issues/1235.
+sudo apt-get install -y libfuse2
+
 # TODO: AppStream metainfo
 PYVER=$(ldd $APPDIR/usr/bin/fontforge | grep -Eom1 'python[0-9\.]+[0-9]+' | head -1 | cut -c 7-)
 echo "FontForge built against Python $PYVER"


### PR DESCRIPTION
Ubuntu 20.04 CI runner dead - see https://github.com/actions/runner-images/issues/11101