### PR TITLE
Fix TTF validation on load for fixed pitch fonts

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -6304,9 +6304,13 @@ static SplineFont *SFFillFromTTF(struct ttfinfo *info) {
 			LogError(_("A point in %s is outside the font bounding box data.\n"), sc->name );
 			info->bad_cff = true;
 		    }
-		    if ( info->isFixedPitch && i>2 && sc->width!=info->advanceWidthMax )
-			LogError(_("The advance width of %s (%d) does not match the font's advanceWidthMax (%d) and this is a fixed pitch font\n"),
+		    if ( info->isFixedPitch ) {
+			bool valid = (sc->width==0 || sc->width==info->advanceWidthMax || sc->width==info->advanceWidthMax / 2);
+			if (!valid) {
+			    LogError(_("The advance width of %s (%d) does not match the font's advanceWidthMax (%d) and this is a fixed pitch font\n"),
 				sc->name, sc->width, info->advanceWidthMax );
+			}
+		    }
 		}
 	    }
 	    ++k;


### PR DESCRIPTION
When checking glyph width validity, consider zero, full width and double width for fixed-pitch fonts.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix** - Fixes #5198 
