### PR TITLE
Fix a crash caused by deleting a glyph with vertical kerning pairs.

### DIFF
--- a/fontforge/encoding.c
+++ b/fontforge/encoding.c
@@ -2217,10 +2217,23 @@ return;
 
     /* Remove any kerning pairs that look at this character */
     for ( i=0; i<sf->glyphcnt; ++i ) if ( sf->glyphs[i]!=NULL ) {
+	/* Remove matching horizontal kerning pairs */
 	for ( kprev=NULL, kp=sf->glyphs[i]->kerns; kp!=NULL; kprev = kp, kp=kp->next ) {
 	    if ( kp->sc==sc ) {
 		if ( kprev==NULL )
 		    sf->glyphs[i]->kerns = kp->next;
+		else
+		    kprev->next = kp->next;
+		kp->next = NULL;
+		KernPairsFree(kp);
+	break;
+	    }
+	}
+	/* Remove matching vertical kerning pairs */
+	for ( kprev=NULL, kp=sf->glyphs[i]->vkerns; kp!=NULL; kprev = kp, kp=kp->next ) {
+	    if ( kp->sc==sc ) {
+		if ( kprev==NULL )
+		    sf->glyphs[i]->vkerns = kp->next;
 		else
 		    kprev->next = kp->next;
 		kp->next = NULL;


### PR DESCRIPTION
- SFRemoveGlyph removed the horizontal kerning pairs but left vertical kerning pairs pointing to the deleted glyph.
- This could cause crashes when then accessing the vkerns.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- Fixes #5591