### PR TITLE
Fix for cmake installation in MacOS CI runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           # Disable fc-cache on fontconfig install. Because it's slow.
           sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/f/fontconfig.rb"
-          (brew list cmake || brew install cmake)
+          (brew list cmake > /dev/null || brew install cmake)
           brew install pkg-config ruby ninja
           brew install cairo coreutils fontconfig gettext giflib gtk+3 gtkmm3 jpeg libpng libspiro libtiff libtool libuninameslist python@3 wget woff2
           PREFIX=$GITHUB_WORKSPACE/target

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,8 @@ jobs:
         run: |
           # Disable fc-cache on fontconfig install. Because it's slow.
           sed -i.bak '/fc-cache/d' "$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/f/fontconfig.rb"
-          brew install pkg-config ruby cmake ninja
+          (brew list cmake || brew install cmake)
+          brew install pkg-config ruby ninja
           brew install cairo coreutils fontconfig gettext giflib gtk+3 gtkmm3 jpeg libpng libspiro libtiff libtool libuninameslist python@3 wget woff2
           PREFIX=$GITHUB_WORKSPACE/target
           echo "PREFIX=$PREFIX" >> $GITHUB_ENV


### PR DESCRIPTION
`brew install cmake` fails in recent MacOS runners due to change in actions/runner-images#12791.

This is a know issue - see actions/runner-images#12912. Fixed per comment by @XuehaiPan. 

### Type of change
- **Non-breaking change**
