### PR TITLE
Remove animated GImage support

### DIFF
--- a/contrib/admintools/gen_splash.py
+++ b/contrib/admintools/gen_splash.py
@@ -51,7 +51,7 @@ static struct _GImage splashimage0_base = {{
     0xffffffff
 }};
 
-GImage splashimage = {{ 0, {{ &splashimage0_base }}, NULL }};
+GImage splashimage = {{ &splashimage0_base, NULL }};
 """
 
 if __name__ == "__main__":

--- a/fontforge/autotrace.c
+++ b/fontforge/autotrace.c
@@ -268,7 +268,7 @@ void _SCAutoTrace(SplineChar *sc, int layer, char **args) {
 	return;
     ispotrace = (strstrmatch(prog,"potrace")!=NULL );
     for ( images = sc->layers[ly_back].images; images!=NULL; images=images->next ) {
-	ib = images->image->list_len==0 ? images->image->u.image : images->image->u.images[0];
+	ib = images->image->image;
 	if ( ib->width==0 || ib->height==0 ) {
 	    continue;
 	}
@@ -367,7 +367,7 @@ return;
 /* the linker tells me not to use tempnam(). Which does almost exactly what */
 /*  I want. So we go through a much more complex set of machinations to make */
 /*  it happy. */
-	ib = images->image->list_len==0 ? images->image->u.image : images->image->u.images[0];
+	ib = images->image->image;
 	if ( ib->width==0 || ib->height==0 ) {
 	    /* pk fonts can have 0 sized bitmaps for space characters */
 	    /*  but autotrace gets all snooty about being given an empty image */

--- a/fontforge/cvexport.c
+++ b/fontforge/cvexport.c
@@ -542,7 +542,7 @@ int ExportImage(char *filename,SplineChar *sc, int layer, int format, int pixels
     memset(&gi,'\0', sizeof(gi));
     memset(&base,'\0', sizeof(base));
     memset(&clut,'\0', sizeof(clut));
-    gi.u.image = &base;
+    gi.image = &base;
 
     if ( bitsperpixel==1 ) {
 	if ( (freetypecontext = FreeTypeFontContext(sc->parent,sc,NULL,layer))==NULL )
@@ -632,7 +632,7 @@ int BCExportXBM(char *filename,BDFChar *bdfc, int format) {
 
     memset(&gi,'\0', sizeof(gi));
     memset(&base,'\0', sizeof(base));
-    gi.u.image = &base;
+    gi.image = &base;
 
     if ( !bdfc->byte_data ) {
 	BCRegularizeBitmap(bdfc);

--- a/fontforge/cvimages.c
+++ b/fontforge/cvimages.c
@@ -112,8 +112,7 @@ return;
 	    sc->layers[pos].splines = e->u.splines.splines;
 	} else if ( e->type == et_image ) {
 	    ImageList *ilist = chunkalloc(sizeof(ImageList));
-	    struct _GImage *base = e->u.image.image->list_len==0?
-		    e->u.image.image->u.image:e->u.image.image->u.images[0];
+	    struct _GImage *base = e->u.image.image->image;
 	    sc->layers[pos].images = ilist;
 	    sc->layers[pos].dofill = base->image_type==it_mono && base->trans!=(Color)-1;
 	    sc->layers[pos].fill_brush.col = e->u.image.col==0xffffffff ?
@@ -909,14 +908,14 @@ return;
 /************************** Normal Image Import *******************************/
 
 GImage *ImageAlterClut(GImage *image) {
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     GClut *clut;
 
     if ( base->image_type!=it_mono ) {
 	/* png b&w images come through as indexed, not mono */
 	if ( base->clut!=NULL && base->clut->clut_len==2 ) {
 	    GImage *new = GImageCreate(it_mono,base->width,base->height);
-	    struct _GImage *nbase = new->u.image;
+	    struct _GImage *nbase = new->image;
 	    int i,j;
 	    memset(nbase->data,0,nbase->height*nbase->bytes_per_line);
 	    for ( i=0; i<base->height; ++i ) for ( j=0; j<base->width; ++j )
@@ -1119,7 +1118,7 @@ return( false );
 		ff_post_error(_("Bad image file"),_("Bad image file: %.100s"),start);
     continue;
 	    }
-	    base = image->list_len==0?image->u.image:image->u.images[0];
+	    base = image->image;
 	    if ( base->image_type!=it_mono ) {
 		ff_post_error(_("Bad image file"),_("Bad image file, not a bitmap: %.100s"),start);
 		GImageDestroy(image);

--- a/fontforge/dumppfa.c
+++ b/fontforge/dumppfa.c
@@ -947,7 +947,7 @@ static void dumpimage(void (*dumpchar)(int ch,void *data), void *data,
 	ImageList *imgl, int use_imagemask, int pdfopers,
 	int layer, int icnt, SplineChar *sc ) {
     GImage *image = imgl->image;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
 
     if ( pdfopers ) {
 	dumpf( dumpchar, data, "  q 1 0 0 1 %g %g cm %g 0 0 %g 0 0 cm\n",
@@ -1141,7 +1141,7 @@ return( true );
 return( true );
 	for ( img = sc->layers[l].images; img!=NULL; img=img->next ) {
 	    GImage *image = img->image;
-	    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+	    struct _GImage *base = image->image;
 	    if ( base->image_type!=it_mono )
 return( true );
 	    if ( !sc->layers[l].dofill )

--- a/fontforge/fvimportbdf.c
+++ b/fontforge/fvimportbdf.c
@@ -2390,7 +2390,7 @@ static void SFAddToBackground(SplineFont *sf,BDFFont *bdf) {
 	    base->clut = clut;
 
 	    img = calloc(1,sizeof(GImage));
-	    img->u.image = base;
+	    img->image = base;
 
 	    SCInsertImage(sc,img,scale,yoff+(bdfc->ymax+1)*scale,bdfc->xmin*scale,ly_back);
 	}
@@ -2472,7 +2472,7 @@ return;
 	if ( sc->layers[ly_fore].splines!=NULL || sc->layers[ly_fore].refs!=NULL )
 return;
 	if ( (il = sc->layers[ly_fore].images)!=NULL ) {
-	    base = il->image->list_len==0 ? il->image->u.image : il->image->u.images[0];
+	    base = il->image->image;
 	    if ( il->next!=NULL )
 return;
 	    if ( base->image_type!=it_mono )
@@ -2515,7 +2515,7 @@ return;			/* No images */
 	if ( (il = sc->layers[ly_fore].images)==NULL )
 	    bdfc->bitmap = malloc(1);
 	else {
-	    base = il->image->list_len==0 ? il->image->u.image : il->image->u.images[0];
+	    base = il->image->image;
 	    bdfc->xmin = rint(il->xoff/scale);
 	    bdfc->ymax = rint(il->yoff/scale);
 	    bdfc->xmax = bdfc->xmin + base->width -1;

--- a/fontforge/print.c
+++ b/fontforge/print.c
@@ -647,7 +647,7 @@ static void pdf_ImageCheck(PI *pi,struct glyph_res *gr,ImageList *images,
 
     while ( images!=NULL ) {
 	img = images->image;
-	base = img->list_len==0 ? img->u.image : img->u.images[1];
+	base = img->image;
 
 	if ( gr->image_cnt>=gr->image_max ) {
 	    gr->image_names = realloc(gr->image_names,(gr->image_max+=100)*sizeof(char *));
@@ -850,7 +850,7 @@ static int pdf_charproc(PI *pi, SplineChar *sc) {
 		(sc->layers[i].dostroke && (sc->layers[i].stroke_pen.brush.col!=COLOR_INHERITED|| sc->layers[i].stroke_pen.brush.gradient!=NULL || sc->layers[i].stroke_pen.brush.pattern!=NULL)) )
     break;
 	for ( img=sc->layers[i].images; img!=NULL; img=img->next )
-	    if ( img->image->u.image->image_type != it_mono )
+	    if ( img->image->image->image_type != it_mono )
 	break;
 	if ( img!=NULL )
     break;
@@ -860,7 +860,7 @@ static int pdf_charproc(PI *pi, SplineChar *sc) {
 			(ref->layers[j].dostroke && (ref->layers[j].stroke_pen.brush.col!=COLOR_INHERITED|| ref->layers[j].stroke_pen.brush.gradient!=NULL || ref->layers[j].stroke_pen.brush.pattern!=NULL)) )
 	    break;
 		for ( img=ref->layers[j].images; img!=NULL; img=img->next )
-		    if ( img->image->u.image->image_type != it_mono )
+		    if ( img->image->image->image_type != it_mono )
 		break;
 		if ( img!=NULL )
 	    break;

--- a/fontforge/psread.c
+++ b/fontforge/psread.c
@@ -1194,7 +1194,7 @@ return( sp-5 );
     trans[5] = stack[sp-2].u.dict.entries[5].u.val;
 
     gi = GImageCreate(it_mono,width,height);
-    base = gi->u.image;
+    base = gi->image;
     base->trans = 1;
     if ( polarity ) {
 	for ( i=0; i<datalen; ++i )

--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -884,7 +884,7 @@ void SFDDumpUndo(FILE *sfd,SplineChar *sc,Undoes *u, const char* keyPrefix, int 
 
 static void SFDDumpImage(FILE *sfd,ImageList *img) {
     GImage *image = img->image;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     struct enc85 enc;
     int rlelen;
     uint8_t *rle;
@@ -3587,7 +3587,7 @@ static ImageList *SFDGetImage(FILE *sfd) {
     getint(sfd,&clutlen);
     gethex(sfd,&trans);
     image = GImageCreate(image_type,width,height);
-    base = image->list_len==0?image->u.image:image->u.images[0];
+    base = image->image;
     img = calloc(1,sizeof(ImageList));
     img->image = image;
     getreal(sfd,&img->xoff);

--- a/fontforge/sflayout.c
+++ b/fontforge/sflayout.c
@@ -947,13 +947,13 @@ return( ret );
     }
 
     if ( ret->bdf->clut ) {
-	ret->gi.u.image = &ret->base;
+	ret->gi.image = &ret->base;
 	ret->base.image_type = it_index;
 	ret->base.clut = ret->bdf->clut;
 	ret->base.trans = 0;
     } else {
 	memset(&ret->clut,'\0',sizeof(ret->clut));
-	ret->gi.u.image = &ret->base;
+	ret->gi.image = &ret->base;
 	ret->base.image_type = it_mono;
 	ret->base.clut = &ret->clut;
 	ret->clut.clut_len = 2;
@@ -1287,7 +1287,7 @@ void FontImage(SplineFont *sf,char *filename,Array *arr,int width,int height) {
 	height = li->lineheights[li->lcnt-1].y + li->lineheights[li->lcnt-1].fh + 2 + ybase;
 
     image = GImageCreate(it_index,width,height);
-    base = image->u.image;
+    base = image->image;
     memset(base->data,0,base->bytes_per_line*base->height);
     for ( i=0; i<256; ++i )
 	base->clut->clut[i] = (255-i)*0x010101;

--- a/fontforge/splinefill.c
+++ b/fontforge/splinefill.c
@@ -1237,8 +1237,7 @@ static void FillImages(uint8_t *bytemap,EdgeList *es,ImageList *img,Layer *layer
 	fillcol = 0x000000;
 
     while ( img!=NULL ) {
-	struct _GImage *base = img->image->list_len==0?
-		img->image->u.image:img->image->u.images[0];
+	struct _GImage *base = img->image->image;
 
 	y1 = es->cnt-1 - (img->yoff*es->scale - es->mmin);
 	y2 = es->cnt-1 - ((img->yoff-base->height*img->yscale)*es->scale -es->mmin);

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -1712,12 +1712,12 @@ ImageList *ImageListTransform(ImageList *img, real transform[6],int everything) 
 		img->yoff = transform[1]*x + transform[3]*img->yoff + transform[5];
 		if (( img->xscale *= transform[0])<0 ) {
 		    img->xoff += img->xscale *
-			(img->image->list_len==0?img->image->u.image:img->image->u.images[0])->width;
+			img->image->image->width;
 		    img->xscale = -img->xscale;
 		}
 		if (( img->yscale *= transform[3])<0 ) {
 		    img->yoff += img->yscale *
-			(img->image->list_len==0?img->image->u.image:img->image->u.images[0])->height;
+			img->image->image->height;
 		    img->yscale = -img->yscale;
 		}
 		img->bb.minx = img->xoff; img->bb.maxy = img->yoff;

--- a/fontforge/svg.c
+++ b/fontforge/svg.c
@@ -391,7 +391,7 @@ static void DataURI_ImageDump(FILE *file,struct gimage *img) {
     int done = false;
     int threechars[3], fourchars[4], i, ch, ch_on_line;
 #if !defined( _NO_LIBJPEG)
-    struct _GImage *base = img->list_len==0 ? img->u.image : img->u.images[0];
+    struct _GImage *base = img->image;
 #endif
 
     /* Technically we can only put a file into an URI if the whole thing is */
@@ -641,8 +641,7 @@ static void svg_dumptype3(FILE *file,SplineChar *sc,const char *name,int istop) 
 	for ( images=sc->layers[i].images ; images!=NULL; images = images->next ) {
 	    struct _GImage *base;
 	    fprintf(file, "      <image\n" );
-	    base = images->image->list_len==0 ? images->image->u.image :
-		    images->image->u.images[0];
+	    base = images->image->image;
 	    fprintf(file, "\twidth=\"%g\"\n\theight=\"%g\"\n",
 		    (double) (base->width*images->xscale), (double) (base->height*images->yscale) );
 	    fprintf(file, "\tx=\"%g\"\n\ty=\"%g\"\n", (double) images->xoff, (double) images->yoff );
@@ -2444,7 +2443,7 @@ return( NULL );		/* I can only handle data URIs */
     free(val);
     if ( img==NULL )
 return( NULL );
-    base = img->list_len==0 ? img->u.image : img->u.images[0];
+    base = img->image;
 
     ent = chunkalloc(sizeof(Entity));
     ent->type = et_image;

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -860,7 +860,7 @@ return;
 	memset(&gi,'\0',sizeof(gi));
 	memset(&base,'\0',sizeof(base));
 	memset(&clut,'\0',sizeof(clut));
-	gi.u.image = &base;
+	gi.image = &base;
 	if ( bv->bdf->clut==NULL ) {
 	    base.image_type = it_mono;
 	    base.clut = &clut;

--- a/fontforgeexe/charinfo.c
+++ b/fontforgeexe/charinfo.c
@@ -2856,7 +2856,7 @@ return( NULL );
 	if ( maxx<other->xmax + rint(old[cols*ci->r+PAIR_DX2].u.md_ival*scale) ) maxx = other->xmax+ rint(old[cols*ci->r+PAIR_DX2].u.md_ival*scale) ;
 
 	img = GImageCreate(it_index,maxx-minx+2,height);
-	base = img->u.image;
+	base = img->image;
 	memset(base->data,'\0',base->bytes_per_line*base->height);
 
 	yoffset = 1 + maxy - vwidth - kern - rint(old[cols*ci->r+PAIR_DY1].u.md_ival*scale);
@@ -2897,7 +2897,7 @@ return( NULL );
 	if ( maxy<other->ymax + rint(old[cols*ci->r+PAIR_DY2+coff2].u.md_ival*scale) ) maxy = other->ymax+ rint(old[cols*ci->r+PAIR_DY2+coff2].u.md_ival*scale) ;
 
 	img = GImageCreate(it_index,width,maxy-miny+2);
-	base = img->u.image;
+	base = img->image;
 	memset(base->data,'\0',base->bytes_per_line*base->height);
 
 	xoffset = rint(old[cols*ci->r+PAIR_DX1+coff1].u.md_ival*scale) + 1 - minx;
@@ -2968,7 +2968,7 @@ return( NULL );
     pixel = me->depth == 8 ? 0xff : 0xf;
 
     img = GImageCreate(it_index,maxx-minx+2,maxy-miny+2);
-    base = img->u.image;
+    base = img->image;
     memset(base->data,'\0',base->bytes_per_line*base->height);
 
     xoffset = 1 - minx;
@@ -3056,7 +3056,7 @@ return( NULL );
 	if ( ymax<=ICON_WIDTH ) ymax = ICON_WIDTH;
 	if ( ymin>0 ) ymin = 0;
 	img = GImageCreate(it_index,width+10,ymax-ymin+2);
-	base = img->u.image;
+	base = img->image;
 	memset(base->data,'\0',base->bytes_per_line*base->height);
 
 	++xoff;		/* One pixel margin */
@@ -3141,7 +3141,7 @@ return( NULL );
 	if ( ymax<=ICON_WIDTH ) ymax = ICON_WIDTH;
 	if ( ymin>0 ) ymin = 0;
 	img = GImageCreate(it_index,width+2,ymax-ymin+2);
-	base = img->u.image;
+	base = img->image;
 	memset(base->data,'\0',base->bytes_per_line*base->height);
 
 	++xoff;		/* One pixel margin */
@@ -3291,7 +3291,7 @@ return( NULL );
     if ( xmin>0 ) xmin = 0;
 
     img = GImageCreate(it_index,xmax - xmin + 2,ymax-ymin+2);
-    base = img->u.image;
+    base = img->image;
     memset(base->data,'\0',base->bytes_per_line*base->height);
 
     width = -xmin;
@@ -3793,7 +3793,7 @@ static void CI_SetColorList(CharInfo *ci,Color color) {
     }
     if ( std_colors[i].image==NULL ) {
 	std_colors[i].image = &customcolor_image;
-	customcolor_image.u.image->clut->clut[1] = color;
+	customcolor_image.image->clut->clut[1] = color;
 	std_colors[i].userdata = (void *) (intptr_t) color;
     }
     GGadgetSetList(GWidgetGetControl(ci->gw,CID_Color), GTextInfoArrayFromList(std_colors,&junk), false);

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -2295,8 +2295,7 @@ static void DrawImageList(CharView *cv,GWindow pixmap,ImageList *backimages) {
     CharViewTab* tab = CVGetActiveTab(cv);
 
     while ( backimages!=NULL ) {
-	struct _GImage *base = backimages->image->list_len==0?
-		backimages->image->u.image:backimages->image->u.images[0];
+	struct _GImage *base = backimages->image->image;
 
 	GDrawDrawImageMagnified(pixmap, backimages->image, NULL,
 		(int) (tab->xoff + rint(backimages->xoff * tab->scale)),
@@ -3188,13 +3187,13 @@ void CVRegenFill(CharView *cv) {
 	    cv->filled = SplineCharRasterize(cv->b.sc,layer,size+.1);
 	if ( cv->filled==NULL )
 return;
-	cv->gi.u.image->image_type = clut_len==2 ? it_mono : it_index;
-	cv->gi.u.image->data = cv->filled->bitmap;
-	cv->gi.u.image->bytes_per_line = cv->filled->bytes_per_line;
-	cv->gi.u.image->width = cv->filled->xmax-cv->filled->xmin+1;
-	cv->gi.u.image->height = cv->filled->ymax-cv->filled->ymin+1;
-	if ( clut_len!=cv->gi.u.image->clut->clut_len ) {
-	    GClut *clut = cv->gi.u.image->clut;
+	cv->gi.image->image_type = clut_len==2 ? it_mono : it_index;
+	cv->gi.image->data = cv->filled->bitmap;
+	cv->gi.image->bytes_per_line = cv->filled->bytes_per_line;
+	cv->gi.image->width = cv->filled->xmax-cv->filled->xmin+1;
+	cv->gi.image->height = cv->filled->ymax-cv->filled->ymin+1;
+	if ( clut_len!=cv->gi.image->clut->clut_len ) {
+	    GClut *clut = cv->gi.image->clut;
 	    int i;
 	    Color bg = view_bgcol;
 	    for ( i=0; i<clut_len; ++i ) {
@@ -3425,7 +3424,7 @@ static GWindow CharIcon(CharView *cv, FontView *fv) {
 	memset(&gi,'\0',sizeof(gi));
 	memset(&base,'\0',sizeof(base));
 	memset(&clut,'\0',sizeof(clut));
-	gi.u.image = &base;
+	gi.image = &base;
 	base.trans = -1;
 	base.clut = &clut;
 	if ( bdfc->byte_data ) { int i;
@@ -6196,7 +6195,7 @@ void LogoExpose(GWindow pixmap,GEvent *event, GRect *r,enum drawmode dm) {
 	GImage *which = (dm==dm_fore) ? &GIcon_FontForgeLogo :
 			(dm==dm_back) ? &GIcon_FontForgeBack :
 			    &GIcon_FontForgeGuide;
-	struct _GImage *base = which->u.image;
+	struct _GImage *base = which->image;
 	xoff = (sbsize-base->width);
 	yoff = (sbsize-base->height);
 	GDrawPushClip(pixmap,r,&old);
@@ -12645,13 +12644,13 @@ static void _CharViewCreate(CharView *cv, SplineChar *sc, FontView *fv,int enc,i
     cv->nfh = as+ds; cv->nas = as;
 
     cv->height = pos.height; cv->width = pos.width;
-    cv->gi.u.image = calloc(1,sizeof(struct _GImage));
-    cv->gi.u.image->image_type = it_mono;
-    cv->gi.u.image->clut = calloc(1,sizeof(GClut));
-    cv->gi.u.image->clut->trans_index = cv->gi.u.image->trans = 0;
-    cv->gi.u.image->clut->clut_len = 2;
-    cv->gi.u.image->clut->clut[0] = view_bgcol;
-    cv->gi.u.image->clut->clut[1] = fillcol;
+    cv->gi.image = calloc(1,sizeof(struct _GImage));
+    cv->gi.image->image_type = it_mono;
+    cv->gi.image->clut = calloc(1,sizeof(GClut));
+    cv->gi.image->clut->trans_index = cv->gi.image->trans = 0;
+    cv->gi.image->clut->clut_len = 2;
+    cv->gi.image->clut->clut[0] = view_bgcol;
+    cv->gi.image->clut->clut[1] = fillcol;
     cv->b1_tool = cv_b1_tool; cv->cb1_tool = cv_cb1_tool;
     cv->b1_tool_old = cv->b1_tool;
     cv->b2_tool = cv_b2_tool; cv->cb2_tool = cv_cb2_tool;
@@ -13025,8 +13024,8 @@ void CharViewFree(CharView *cv) {
 	GDrawDestroyWindow(cv->ruler_linger_w);
 	cv->ruler_linger_w = NULL;
     }
-    free(cv->gi.u.image->clut);
-    free(cv->gi.u.image);
+    free(cv->gi.image->clut);
+    free(cv->gi.image);
 #if HANYANG
     if ( cv->jamodisplay!=NULL )
 	Disp_DoFinish(cv->jamodisplay,true);

--- a/fontforgeexe/combinations.c
+++ b/fontforgeexe/combinations.c
@@ -486,7 +486,7 @@ static void KP_ExposeKerns(KPData *kpd,GWindow pixmap,GRect *rect) {
 
     memset(&gi,'\0',sizeof(gi));
     memset(&base,'\0',sizeof(base));
-    gi.u.image = &base;
+    gi.image = &base;
     base.image_type = it_index;
     GDrawSetDither(NULL, false);
 

--- a/fontforgeexe/cvdebug.c
+++ b/fontforgeexe/cvdebug.c
@@ -117,7 +117,7 @@ static void DVRasterExpose(GWindow pixmap,DebugView *dv,GEvent *event) {
 	memset(&gi,'\0',sizeof(gi));
 	memset(&base,'\0',sizeof(base));
 	memset(&clut,'\0',sizeof(clut));
-	gi.u.image = &base;
+	gi.image = &base;
 	base.clut = &clut;
 	if ( cv->raster->num_greys<=2 ) {
 	    base.image_type = it_mono;

--- a/fontforgeexe/cvgetinfo.c
+++ b/fontforgeexe/cvgetinfo.c
@@ -654,8 +654,7 @@ static void ImgGetInfo(CharView *cv, ImageList *img) {
     GGadgetCreateData gcd[12], boxes[3], *varray[11], *harray[6];
     GTextInfo label[12];
     char posbuf[100], scalebuf[100], sizebuf[100];
-    struct _GImage *base = img->image->list_len==0?
-	    img->image->u.image:img->image->u.images[0];
+    struct _GImage *base = img->image->image;
 
     gi.cv = cv;
     gi.sc = cv->b.sc;

--- a/fontforgeexe/cvimportdlg.c
+++ b/fontforgeexe/cvimportdlg.c
@@ -117,7 +117,7 @@ static int BVImportImage(BitmapView *bv,char *path) {
 	ff_post_error(_("Bad image file"),_("Bad image file: %.100s"), path);
 return(false);
     }
-    base = image->list_len==0?image->u.image:image->u.images[0];
+    base = image->image;
     BCPreserveState(bc);
     BCFlattenFloat(bc);
     free(bc->bitmap);

--- a/fontforgeexe/cvpalettes.c
+++ b/fontforgeexe/cvpalettes.c
@@ -895,7 +895,7 @@ static GImage *spirosmalls[] = { &GIcon_smallpointer, &GIcon_smallmag,
 
 static int getSmallIconsHeight()
 {
-    return GIcon_smallpointer.u.image->height;
+    return GIcon_smallpointer.image->height;
 }
 
 static int getToolbarWidth( CharView *cv ) 
@@ -906,7 +906,7 @@ static int getToolbarWidth( CharView *cv )
 	int i = 0;
 	
 	for ( i=0; buttons[0][i][0]; ++i ) {
-	    cache = MAX( cache, buttons[0][i][0]->u.image->width + buttons[0][i][1]->u.image->width );
+	    cache = MAX( cache, buttons[0][i][0]->image->width + buttons[0][i][1]->image->width );
 	}
     }
     return cache;
@@ -920,7 +920,7 @@ static int getToolbarHeight( CharView *cv )
 	int i = 0;
 	
 	for ( i=0; buttons[0][i][0]; ++i ) {
-	    cache += MAX( buttons[0][i][0]->u.image->height, buttons[0][i][1]->u.image->height );
+	    cache += MAX( buttons[0][i][0]->image->height, buttons[0][i][1]->image->height );
 	}
     }
     cache += getSmallIconsHeight() * 4;
@@ -967,9 +967,9 @@ static void visitButtons( CharView* cv, visitButtonsVisitor v, void* udata )
 	    }
 	    
 	    v( cv, buttons[sel][mi][j], mi, i, j, iconx, icony, sel, udata );
-	    iconx += buttons[sel][mi][j]->u.image->width;
+	    iconx += buttons[sel][mi][j]->image->width;
 	}
-	icony += MAX( buttons[0][i][0]->u.image->width, buttons[0][i][1]->u.image->width );
+	icony += MAX( buttons[0][i][0]->image->width, buttons[0][i][1]->image->width );
     }
 }
 
@@ -984,8 +984,8 @@ static void getIJFromMouseVisitor( CharView *cv, GImage* gimage,
 				   int iconx, int icony, int selected, void* udata )
 {
     getIJFromMouseVisitorData* d = (getIJFromMouseVisitorData*)udata;
-    if( IS_IN_ORDER3( iconx, d->mx, iconx + gimage->u.image->width )
-	&& IS_IN_ORDER3( icony, d->my, icony + gimage->u.image->height ))
+    if( IS_IN_ORDER3( iconx, d->mx, iconx + gimage->image->width )
+	&& IS_IN_ORDER3( icony, d->my, icony + gimage->image->height ))
 	{
 	    d->ret.i = i;
 	    d->ret.j = j;
@@ -1012,8 +1012,8 @@ static IJ getIJFromMouse( CharView* cv, int mx, int my )
  */
 
 void cvp_draw_relief(GWindow pixmap, GImage *iconimg, int iconx, int icony, int selected) {
-	int iconw = iconimg->u.image->width;
-	int iconh = iconimg->u.image->height;
+	int iconw = iconimg->image->width;
+	int iconh = iconimg->image->height;
 	int norm = !selected;
 	// Note: The original code placed the right and bottom fake relief
 	// outside of the button image area (offset by 25 instead of 24),
@@ -1051,7 +1051,7 @@ static void ToolsExposeVisitor( CharView *cv, GImage* gimage,
 		if (cvbutton3d > 0) cvp_draw_relief(d->pixmap, buttons[0][mi][j], iconx, icony, selected);
 
     d->maxicony = MAX( d->maxicony, icony );
-    d->lastIconHeight = buttons[selected][mi][j]->u.image->height;
+    d->lastIconHeight = buttons[selected][mi][j]->image->height;
 }
 
 
@@ -1661,7 +1661,7 @@ return;
 
     memset(&gi,0,sizeof(gi));
     memset(&base,0,sizeof(base));
-    gi.u.image = &base;
+    gi.image = &base;
     base.image_type = it_index;
     base.clut = layer2.clut;
     base.trans = -1;
@@ -2253,7 +2253,7 @@ return;
 
     memset(&gi,0,sizeof(gi));
     memset(&base,0,sizeof(base));
-    gi.u.image = &base;
+    gi.image = &base;
     base.image_type = it_index;
     base.clut = layer2.clut;
     base.trans = -1;

--- a/fontforgeexe/fontview.c
+++ b/fontforgeexe/fontview.c
@@ -316,7 +316,7 @@ static void FVDrawGlyph(GWindow pixmap, FontView *fv, int index, int request_exp
 	    memset(&gi,'\0',sizeof(gi));
 	    memset(&base,'\0',sizeof(base));
 	    if ( bdfc->byte_data ) {
-		gi.u.image = &base;
+		gi.image = &base;
 		base.image_type = it_index;
 		if ( !fv->b.selected[index] )
 		    base.clut = fv->show->clut;
@@ -337,7 +337,7 @@ static void FVDrawGlyph(GWindow pixmap, FontView *fv, int index, int request_exp
 		GDrawSetDither(NULL, false);	/* on 8 bit displays we don't want any dithering */
 	    } else {
 		memset(&clut,'\0',sizeof(clut));
-		gi.u.image = &base;
+		gi.image = &base;
 		base.image_type = it_mono;
 		base.clut = &clut;
 		clut.clut_len = 2;
@@ -5972,14 +5972,14 @@ static void FVExpose(FontView *fv,GWindow pixmap, GEvent *event) {
     memset(&gi,'\0',sizeof(gi));
     memset(&base,'\0',sizeof(base));
     if ( fv->show->clut!=NULL ) {
-	gi.u.image = &base;
+	gi.image = &base;
 	base.image_type = it_index;
 	base.clut = fv->show->clut;
 	GDrawSetDither(NULL, false);
 	base.trans = -1;
     } else {
 	memset(&clut,'\0',sizeof(clut));
-	gi.u.image = &base;
+	gi.image = &base;
 	base.image_type = it_mono;
 	base.clut = &clut;
 	clut.clut_len = 2;

--- a/fontforgeexe/images.c
+++ b/fontforgeexe/images.c
@@ -2597,86 +2597,86 @@ static struct _GImage press2ptr0_base = {
     1
 };
 
-GImage GIcon_press2ptr = { 0, { &press2ptr0_base }, NULL };
-GImage GIcon_hand = { 0, { &hand0_base }, NULL };
-GImage GIcon_line = { 0, { &line0_base }, NULL };
-GImage GIcon_pencil = { 0, { &pencil0_base }, NULL };
-GImage GIcon_shift = { 0, { &shift0_base }, NULL };
-GImage GIcon_star = { 0, { &star0_base }, NULL };
-GImage GIcon_poly = { 0, { &poly0_base }, NULL };
-GImage GIcon_elipse = { 0, { &elipse0_base }, NULL };
-GImage GIcon_rrect = { 0, { &rrect0_base }, NULL };
-GImage GIcon_rect = { 0, { &rect0_base }, NULL };
-GImage GIcon_squarecap = { 0, { &squarecap0_base }, NULL };
-GImage GIcon_roundjoin = { 0, { &roundjoin0_base }, NULL };
-GImage GIcon_roundcap = { 0, { &roundcap0_base }, NULL };
-GImage GIcon_miterjoin = { 0, { &miterjoin0_base }, NULL };
-GImage GIcon_buttcap = { 0, { &buttcap0_base }, NULL };
-GImage GIcon_beveljoin = { 0, { &beveljoin0_base }, NULL };
-GImage GIcon_freehand = { 0, { &freehand0_base }, NULL };
-GImage GIcon_greyfree = { 0, { &greyfree0_base }, NULL };
-GImage GIcon_pen = { 0, { &pen0_base }, NULL };
-GImage GIcon_knife = { 0, { &knife0_base }, NULL };
-GImage GIcon_scale = { 0, { &scale0_base }, NULL };
-GImage GIcon_flip = { 0, { &flip0_base }, NULL };
-GImage GIcon_skew = { 0, { &skew0_base }, NULL };
-GImage GIcon_rotate = { 0, { &rotate0_base }, NULL };
-GImage GIcon_3drotate = { 0, { &rotate3d0_base }, NULL };
-GImage GIcon_perspective = { 0, { &perspective0_base }, NULL };
-GImage GIcon_tangent = { 0, { &tangent0_base }, NULL };
-GImage GIcon_curve = { 0, { &curve0_base }, NULL };
-GImage GIcon_hvcurve = { 0, { &hvcurve0_base }, NULL };
-GImage GIcon_corner = { 0, { &corner0_base }, NULL };
-GImage GIcon_spirocorner = { 0, { &spirocorner0_base }, NULL };
-GImage GIcon_spirocurve = { 0, { &spirocurve0_base }, NULL };
-GImage GIcon_spirog2curve = { 0, { &spirog2curve0_base }, NULL };
-GImage GIcon_spiroright = { 0, { &spiroright0_base }, NULL };
-GImage GIcon_spiroleft = { 0, { &spiroleft0_base }, NULL };
-GImage GIcon_spirodisabled = { 0, { &spirodisabled0_base }, NULL };
-GImage GIcon_spiroup = { 0, { &spiroup0_base }, NULL };
-GImage GIcon_spirodown = { 0, { &spirodown0_base }, NULL };
-GImage GIcon_ruler = { 0, { &ruler0_base }, NULL };
-GImage GIcon_pointer = { 0, { &pointer0_base }, NULL };
-GImage GIcon_magnify = { 0, { &magnify0_base }, NULL };
+GImage GIcon_press2ptr = { &press2ptr0_base, NULL };
+GImage GIcon_hand = { &hand0_base, NULL };
+GImage GIcon_line = { &line0_base, NULL };
+GImage GIcon_pencil = { &pencil0_base, NULL };
+GImage GIcon_shift = { &shift0_base, NULL };
+GImage GIcon_star = { &star0_base, NULL };
+GImage GIcon_poly = { &poly0_base, NULL };
+GImage GIcon_elipse = { &elipse0_base, NULL };
+GImage GIcon_rrect = { &rrect0_base, NULL };
+GImage GIcon_rect = { &rect0_base, NULL };
+GImage GIcon_squarecap = { &squarecap0_base, NULL };
+GImage GIcon_roundjoin = { &roundjoin0_base, NULL };
+GImage GIcon_roundcap = { &roundcap0_base, NULL };
+GImage GIcon_miterjoin = { &miterjoin0_base, NULL };
+GImage GIcon_buttcap = { &buttcap0_base, NULL };
+GImage GIcon_beveljoin = { &beveljoin0_base, NULL };
+GImage GIcon_freehand = { &freehand0_base, NULL };
+GImage GIcon_greyfree = { &greyfree0_base, NULL };
+GImage GIcon_pen = { &pen0_base, NULL };
+GImage GIcon_knife = { &knife0_base, NULL };
+GImage GIcon_scale = { &scale0_base, NULL };
+GImage GIcon_flip = { &flip0_base, NULL };
+GImage GIcon_skew = { &skew0_base, NULL };
+GImage GIcon_rotate = { &rotate0_base, NULL };
+GImage GIcon_3drotate = { &rotate3d0_base, NULL };
+GImage GIcon_perspective = { &perspective0_base, NULL };
+GImage GIcon_tangent = { &tangent0_base, NULL };
+GImage GIcon_curve = { &curve0_base, NULL };
+GImage GIcon_hvcurve = { &hvcurve0_base, NULL };
+GImage GIcon_corner = { &corner0_base, NULL };
+GImage GIcon_spirocorner = { &spirocorner0_base, NULL };
+GImage GIcon_spirocurve = { &spirocurve0_base, NULL };
+GImage GIcon_spirog2curve = { &spirog2curve0_base, NULL };
+GImage GIcon_spiroright = { &spiroright0_base, NULL };
+GImage GIcon_spiroleft = { &spiroleft0_base, NULL };
+GImage GIcon_spirodisabled = { &spirodisabled0_base, NULL };
+GImage GIcon_spiroup = { &spiroup0_base, NULL };
+GImage GIcon_spirodown = { &spirodown0_base, NULL };
+GImage GIcon_ruler = { &ruler0_base, NULL };
+GImage GIcon_pointer = { &pointer0_base, NULL };
+GImage GIcon_magnify = { &magnify0_base, NULL };
 
-GImage GIcon_pointer_selected = { 0, { &pointer0_base }, NULL };
-GImage GIcon_magnify_selected = { 0, { &magnify0_base }, NULL };
-GImage GIcon_freehand_selected = { 0, { &freehand0_base }, NULL };
-GImage GIcon_hand_selected = { 0, { &hand0_base }, NULL };
-GImage GIcon_knife_selected = { 0, { &knife0_base }, NULL };
-GImage GIcon_ruler_selected = { 0, { &ruler0_base }, NULL };
-GImage GIcon_pen_selected = { 0, { &pen0_base }, NULL };
-GImage GIcon_spiroup_selected = { 0, { &spiroup0_base }, NULL };
-GImage GIcon_spirocorner_selected = { 0, { &spirocorner0_base }, NULL };
-GImage GIcon_spirocurve_selected = { 0, { &spirocurve0_base }, NULL };
-GImage GIcon_spirog2curve_selected = { 0, { &spirog2curve0_base }, NULL };
-GImage GIcon_spiroright_selected = { 0, { &spiroright0_base }, NULL };
-GImage GIcon_spiroleft_selected = { 0, { &spiroleft0_base }, NULL };
-GImage GIcon_spirodisabled_selected = { 0, { &spirodisabled0_base }, NULL };
-GImage GIcon_spirodown_selected = { 0, { &spirodown0_base }, NULL };
-GImage GIcon_curve_selected = { 0, { &curve0_base }, NULL };
-GImage GIcon_hvcurve_selected = { 0, { &hvcurve0_base }, NULL };
-GImage GIcon_corner_selected = { 0, { &corner0_base }, NULL };
-GImage GIcon_tangent_selected = { 0, { &tangent0_base }, NULL };
-GImage GIcon_scale_selected = { 0, { &scale0_base }, NULL };
-GImage GIcon_rotate_selected = { 0, { &rotate0_base }, NULL };
-GImage GIcon_flip_selected = { 0, { &flip0_base }, NULL };
-GImage GIcon_skew_selected = { 0, { &skew0_base }, NULL };
-GImage GIcon_3drotate_selected = { 0, { &rotate3d0_base }, NULL };
-GImage GIcon_perspective_selected = { 0, { &perspective0_base }, NULL };
-GImage GIcon_rect_selected = { 0, { &rect0_base }, NULL };
-GImage GIcon_poly_selected = { 0, { &poly0_base }, NULL };
-GImage GIcon_elipse_selected = { 0, { &elipse0_base }, NULL };
-GImage GIcon_star_selected = { 0, { &star0_base }, NULL };
-GImage GIcon_line_selected = { 0, { &line0_base }, NULL };
-GImage GIcon_pencil_selected = { 0, { &pencil0_base }, NULL };
-GImage GIcon_shift_selected = { 0, { &shift0_base }, NULL };
-GImage GIcon_greyfree_selected = { 0, { &greyfree0_base }, NULL };
+GImage GIcon_pointer_selected = { &pointer0_base, NULL };
+GImage GIcon_magnify_selected = { &magnify0_base, NULL };
+GImage GIcon_freehand_selected = { &freehand0_base, NULL };
+GImage GIcon_hand_selected = { &hand0_base, NULL };
+GImage GIcon_knife_selected = { &knife0_base, NULL };
+GImage GIcon_ruler_selected = { &ruler0_base, NULL };
+GImage GIcon_pen_selected = { &pen0_base, NULL };
+GImage GIcon_spiroup_selected = { &spiroup0_base, NULL };
+GImage GIcon_spirocorner_selected = { &spirocorner0_base, NULL };
+GImage GIcon_spirocurve_selected = { &spirocurve0_base, NULL };
+GImage GIcon_spirog2curve_selected = { &spirog2curve0_base, NULL };
+GImage GIcon_spiroright_selected = { &spiroright0_base, NULL };
+GImage GIcon_spiroleft_selected = { &spiroleft0_base, NULL };
+GImage GIcon_spirodisabled_selected = { &spirodisabled0_base, NULL };
+GImage GIcon_spirodown_selected = { &spirodown0_base, NULL };
+GImage GIcon_curve_selected = { &curve0_base, NULL };
+GImage GIcon_hvcurve_selected = { &hvcurve0_base, NULL };
+GImage GIcon_corner_selected = { &corner0_base, NULL };
+GImage GIcon_tangent_selected = { &tangent0_base, NULL };
+GImage GIcon_scale_selected = { &scale0_base, NULL };
+GImage GIcon_rotate_selected = { &rotate0_base, NULL };
+GImage GIcon_flip_selected = { &flip0_base, NULL };
+GImage GIcon_skew_selected = { &skew0_base, NULL };
+GImage GIcon_3drotate_selected = { &rotate3d0_base, NULL };
+GImage GIcon_perspective_selected = { &perspective0_base, NULL };
+GImage GIcon_rect_selected = { &rect0_base, NULL };
+GImage GIcon_poly_selected = { &poly0_base, NULL };
+GImage GIcon_elipse_selected = { &elipse0_base, NULL };
+GImage GIcon_star_selected = { &star0_base, NULL };
+GImage GIcon_line_selected = { &line0_base, NULL };
+GImage GIcon_pencil_selected = { &pencil0_base, NULL };
+GImage GIcon_shift_selected = { &shift0_base, NULL };
+GImage GIcon_greyfree_selected = { &greyfree0_base, NULL };
 
-GImage GIcon_midtangent = { 0, { &tangent1_base }, NULL };
-GImage GIcon_midcurve = { 0, { &curve1_base }, NULL };
-GImage GIcon_midhvcurve = { 0, { &hvcurve1_base }, NULL };
-GImage GIcon_midcorner = { 0, { &corner1_base }, NULL };
+GImage GIcon_midtangent = { &tangent1_base, NULL };
+GImage GIcon_midcurve = { &curve1_base, NULL };
+GImage GIcon_midhvcurve = { &hvcurve1_base, NULL };
+GImage GIcon_midcorner = { &corner1_base, NULL };
 
 /* Small (16x12) images */
 
@@ -3609,15 +3609,15 @@ static struct _GImage custom_base = {
     COLOR_UNKNOWN
 };
 
-GImage def_image = { 0, { &def_base }, NULL };
-GImage red_image = { 0, { &red_base }, NULL };
-GImage blue_image = { 0, { &blue_base }, NULL };
-GImage green_image = { 0, { &green_base }, NULL };
-GImage magenta_image = { 0, { &magenta_base }, NULL };
-GImage yellow_image = { 0, { &yellow_base }, NULL };
-GImage cyan_image = { 0, { &cyan_base }, NULL };
-GImage white_image = { 0, { &white_base }, NULL };
-GImage customcolor_image = { 0, { &custom_base }, NULL };
+GImage def_image = { &def_base, NULL };
+GImage red_image = { &red_base, NULL };
+GImage blue_image = { &blue_base, NULL };
+GImage green_image = { &green_base, NULL };
+GImage magenta_image = { &magenta_base, NULL };
+GImage yellow_image = { &yellow_base, NULL };
+GImage cyan_image = { &cyan_base, NULL };
+GImage white_image = { &white_base, NULL };
+GImage customcolor_image = { &custom_base, NULL };
 
 static uint8_t continue_data[] = {
     0xfe, 0xff, 
@@ -4584,71 +4584,71 @@ static struct _GImage lock0_base = {
 };
 
 
-GImage GIcon_small3drotate = { 0, { &small3drotate0_base }, NULL };
-GImage GIcon_smallperspective = { 0, { &smallperspective0_base }, NULL };
-GImage GIcon_smallskew = { 0, { &smallskew0_base }, NULL };
-GImage GIcon_smallscale = { 0, { &smallscale0_base }, NULL };
-GImage GIcon_smallrotate = { 0, { &smallrotate0_base }, NULL };
-GImage GIcon_smallflip = { 0, { &smallflip0_base }, NULL };
-GImage GIcon_smalltangent = { 0, { &smalltangent0_base }, NULL };
-GImage GIcon_smallcorner = { 0, { &smallcorner0_base }, NULL };
-GImage GIcon_smallcurve = { 0, { &smallcurve0_base }, NULL };
-GImage GIcon_smallhvcurve = { 0, { &smallhvcurve0_base }, NULL };
-GImage GIcon_smallspirocorner = { 0, { &smallspirocorner0_base }, NULL };
-GImage GIcon_smallspirog2curve = { 0, { &smallspirog2curve0_base }, NULL };
-GImage GIcon_smallspirocurve = { 0, { &smallspirocurve0_base }, NULL };
-GImage GIcon_smallspiroright = { 0, { &smallspiroright0_base }, NULL };
-GImage GIcon_smallspiroleft = { 0, { &smallspiroleft0_base }, NULL };
-GImage GIcon_smallmag = { 0, { &smallmag0_base }, NULL };
-GImage GIcon_smallknife = { 0, { &smallknife0_base }, NULL };
-GImage GIcon_smallhand = { 0, { &smallhand0_base }, NULL };
-GImage GIcon_smallpen = { 0, { &smallpen0_base }, NULL };
-GImage GIcon_smallpencil = { 0, { &smallpencil0_base }, NULL };
-GImage GIcon_smallpointer = { 0, { &smallpointer0_base }, NULL };
-GImage GIcon_smallruler = { 0, { &smallruler0_base }, NULL };
-GImage GIcon_smallelipse = { 0, { &smallelipse0_base }, NULL };
-GImage GIcon_smallrect = { 0, { &smallrect0_base }, NULL };
-GImage GIcon_smallpoly = { 0, { &smallpoly0_base }, NULL };
-GImage GIcon_smallstar = { 0, { &smallstar0_base }, NULL };
-GImage GIcon_FontForgeLogo = { 0, { &logo_base }, NULL };
-GImage GIcon_FontForgeBack = { 0, { &logoback_base }, NULL };
-GImage GIcon_FontForgeGuide = { 0, { &logogrid_base }, NULL };
+GImage GIcon_small3drotate = { &small3drotate0_base, NULL };
+GImage GIcon_smallperspective = { &smallperspective0_base, NULL };
+GImage GIcon_smallskew = { &smallskew0_base, NULL };
+GImage GIcon_smallscale = { &smallscale0_base, NULL };
+GImage GIcon_smallrotate = { &smallrotate0_base, NULL };
+GImage GIcon_smallflip = { &smallflip0_base, NULL };
+GImage GIcon_smalltangent = { &smalltangent0_base, NULL };
+GImage GIcon_smallcorner = { &smallcorner0_base, NULL };
+GImage GIcon_smallcurve = { &smallcurve0_base, NULL };
+GImage GIcon_smallhvcurve = { &smallhvcurve0_base, NULL };
+GImage GIcon_smallspirocorner = { &smallspirocorner0_base, NULL };
+GImage GIcon_smallspirog2curve = { &smallspirog2curve0_base, NULL };
+GImage GIcon_smallspirocurve = { &smallspirocurve0_base, NULL };
+GImage GIcon_smallspiroright = { &smallspiroright0_base, NULL };
+GImage GIcon_smallspiroleft = { &smallspiroleft0_base, NULL };
+GImage GIcon_smallmag = { &smallmag0_base, NULL };
+GImage GIcon_smallknife = { &smallknife0_base, NULL };
+GImage GIcon_smallhand = { &smallhand0_base, NULL };
+GImage GIcon_smallpen = { &smallpen0_base, NULL };
+GImage GIcon_smallpencil = { &smallpencil0_base, NULL };
+GImage GIcon_smallpointer = { &smallpointer0_base, NULL };
+GImage GIcon_smallruler = { &smallruler0_base, NULL };
+GImage GIcon_smallelipse = { &smallelipse0_base, NULL };
+GImage GIcon_smallrect = { &smallrect0_base, NULL };
+GImage GIcon_smallpoly = { &smallpoly0_base, NULL };
+GImage GIcon_smallstar = { &smallstar0_base, NULL };
+GImage GIcon_FontForgeLogo = { &logo_base, NULL };
+GImage GIcon_FontForgeBack = { &logoback_base, NULL };
+GImage GIcon_FontForgeGuide = { &logogrid_base, NULL };
 
-GImage GIcon_continue = { 0, { &continue_base }, NULL };
-GImage GIcon_stepout = { 0, { &stepout_base }, NULL };
-GImage GIcon_stepover = { 0, { &stepover_base }, NULL };
-GImage GIcon_stepinto = { 0, { &stepinto_base }, NULL };
-GImage GIcon_watchpnt = { 0, { &watchpnt_base }, NULL };
-GImage GIcon_menudelta = { 0, { &menudelta_base }, NULL };
-GImage GIcon_exit = { 0, { &exit_base }, NULL };
+GImage GIcon_continue = { &continue_base, NULL };
+GImage GIcon_stepout = { &stepout_base, NULL };
+GImage GIcon_stepover = { &stepover_base, NULL };
+GImage GIcon_stepinto = { &stepinto_base, NULL };
+GImage GIcon_watchpnt = { &watchpnt_base, NULL };
+GImage GIcon_menudelta = { &menudelta_base, NULL };
+GImage GIcon_exit = { &exit_base, NULL };
 
-GImage GIcon_Stopped = { 0, { &stopped_base }, NULL };
-GImage GIcon_Stop = { 0, { &stop_base }, NULL };
+GImage GIcon_Stopped = { &stopped_base, NULL };
+GImage GIcon_Stop = { &stop_base, NULL };
 
-GImage GIcon_exclude = { 0, { &exclude_base }, NULL };
-GImage GIcon_intersection = { 0, { &intersection_base }, NULL };
-GImage GIcon_rmoverlap = { 0, { &rmoverlap_base }, NULL };
-GImage GIcon_findinter = { 0, { &findinter_base }, NULL };
+GImage GIcon_exclude = { &exclude_base, NULL };
+GImage GIcon_intersection = { &intersection_base, NULL };
+GImage GIcon_rmoverlap = { &rmoverlap_base, NULL };
+GImage GIcon_findinter = { &findinter_base, NULL };
 
-GImage GIcon_styles = { 0, { &styles_base }, NULL };
-GImage GIcon_bold = { 0, { &bold_base }, NULL };
-GImage GIcon_italic = { 0, { &italic_base }, NULL };
-GImage GIcon_oblique = { 0, { &oblique_base }, NULL };
-GImage GIcon_changexheight = { 0, { &changexheight_base }, NULL };
-GImage GIcon_smallcaps = { 0, { &smallcaps_base }, NULL };
-GImage GIcon_subsup = { 0, { &subsuper0_base }, NULL };
-GImage GIcon_condense = { 0, { &condense_base }, NULL };
-GImage GIcon_outline = { 0, { &outline_base }, NULL };
-GImage GIcon_inline = { 0, { &inline_base }, NULL };
-GImage GIcon_shadow = { 0, { &shadow_base }, NULL };
-GImage GIcon_wireframe = { 0, { &wireframe_base }, NULL };
+GImage GIcon_styles = { &styles_base, NULL };
+GImage GIcon_bold = { &bold_base, NULL };
+GImage GIcon_italic = { &italic_base, NULL };
+GImage GIcon_oblique = { &oblique_base, NULL };
+GImage GIcon_changexheight = { &changexheight_base, NULL };
+GImage GIcon_smallcaps = { &smallcaps_base, NULL };
+GImage GIcon_subsup = { &subsuper0_base, NULL };
+GImage GIcon_condense = { &condense_base, NULL };
+GImage GIcon_outline = { &outline_base, NULL };
+GImage GIcon_inline = { &inline_base, NULL };
+GImage GIcon_shadow = { &shadow_base, NULL };
+GImage GIcon_wireframe = { &wireframe_base, NULL };
 
-GImage GIcon_menumark = { 0, { &menumark_base }, NULL };
+GImage GIcon_menumark = { &menumark_base, NULL };
 
-GImage GIcon_up = { 0, { &upicon0_base }, NULL };
-GImage GIcon_down = { 0, { &downicon0_base }, NULL };
+GImage GIcon_up = { &upicon0_base, NULL };
+GImage GIcon_down = { &downicon0_base, NULL };
 
-GImage GIcon_lock = { 0, { &lock0_base }, NULL };
+GImage GIcon_lock = { &lock0_base, NULL };
 
 static uint8_t OFL_logo0_data[] = {
     0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
@@ -5008,7 +5008,7 @@ static struct _GImage OFL_logo0_base = {
     0xffffffff
 };
 
-GImage OFL_logo = { 0, { &OFL_logo0_base }, NULL };
+GImage OFL_logo = { &OFL_logo0_base, NULL };
 
 static GClut clut = { 2, 0, 1,
     { 0x0, 0xb0b0b0 } };
@@ -5139,12 +5139,12 @@ static struct _GImage magicon0_base = {
     1
 };
 
-GImage GIcon_mag = { 0, { &magicon0_base }, NULL };
-GImage GIcon_angle = { 0, { &angle0_base }, NULL };
-GImage GIcon_distance = { 0, { &distance0_base }, NULL };
-GImage GIcon_selectedpoint = { 0, { &selectedpoint0_base }, NULL };
-GImage GIcon_sel2ptr = { 0, { &sel2ptr0_base }, NULL };
-GImage GIcon_rightpointer = { 0, { &rightpointer0_base }, NULL };
+GImage GIcon_mag = { &magicon0_base, NULL };
+GImage GIcon_angle = { &angle0_base, NULL };
+GImage GIcon_distance = { &distance0_base, NULL };
+GImage GIcon_selectedpoint = { &selectedpoint0_base, NULL };
+GImage GIcon_sel2ptr = { &sel2ptr0_base, NULL };
+GImage GIcon_rightpointer = { &rightpointer0_base, NULL };
 
 static uint8_t BottomSerifs0_data[] = {
     0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 
@@ -12194,36 +12194,36 @@ static struct _GImage u45fItalic_base = {
     0
 };
 
-GImage GIcon_u45fItalic = { 0, { &u45fItalic_base }, NULL };
-GImage GIcon_u452Italic = { 0, { &u452Italic_base }, NULL };
-GImage GIcon_u448Italic = { 0, { &u449Italic_base }, NULL };
-GImage GIcon_u446Italic = { 0, { &u446Italic_base }, NULL };
-GImage GIcon_u444Italic = { 0, { &u444Italic_base }, NULL };
-GImage GIcon_u442Italic = { 0, { &u442Italic_base }, NULL };
-GImage GIcon_u43fItalic = { 0, { &u43fItalic_base }, NULL };
-GImage GIcon_u43cItalic = { 0, { &u43cItalic_base }, NULL };
-GImage GIcon_u438Italic = { 0, { &u438Italic_base }, NULL };
-GImage GIcon_u436Italic = { 0, { &u436Italic_base }, NULL };
-GImage GIcon_u434Italic = { 0, { &u434Italic_base }, NULL };
-GImage GIcon_u433Italic = { 0, { &u433Italic_base }, NULL };
-GImage GIcon_u432Italic = { 0, { &u432Italic_base }, NULL };
-GImage GIcon_zItalic = { 0, { &zItalic_base }, NULL };
-GImage GIcon_yItalic = { 0, { &yItalic_base }, NULL };
-GImage GIcon_xItalic = { 0, { &xItalic_base }, NULL };
-GImage GIcon_wItalic = { 0, { &wItalic_base }, NULL };
-GImage GIcon_vItalic = { 0, { &vItalic_base }, NULL };
-GImage GIcon_pItalic = { 0, { &pItalic_base }, NULL };
-GImage GIcon_kItalic = { 0, { &kItalic_base }, NULL };
-GImage GIcon_gItalic = { 0, { &gItalic_base }, NULL };
-GImage GIcon_f2Italic = { 0, { &f2Italic_base }, NULL };
-GImage GIcon_fItalic = { 0, { &fImage_base }, NULL };
-GImage GIcon_aItalic = { 0, { &aItalic_base }, NULL };
-GImage GIcon_FlatSerif = { 0, { &FlatSerif_base }, NULL };
-GImage GIcon_SlantSerif = { 0, { &SlantSerif_base }, NULL };
-GImage GIcon_PenSerif = { 0, { &PenSerif_base }, NULL };
-GImage GIcon_TopSerifs = { 0, { &TopSerifs_base }, NULL };
-GImage GIcon_BottomSerifs = { 0, { &BottomSerifs0_base }, NULL };
-GImage GIcon_DiagSerifs = { 0, { &DiagSerifs_base }, NULL };
+GImage GIcon_u45fItalic = { &u45fItalic_base, NULL };
+GImage GIcon_u452Italic = { &u452Italic_base, NULL };
+GImage GIcon_u448Italic = { &u449Italic_base, NULL };
+GImage GIcon_u446Italic = { &u446Italic_base, NULL };
+GImage GIcon_u444Italic = { &u444Italic_base, NULL };
+GImage GIcon_u442Italic = { &u442Italic_base, NULL };
+GImage GIcon_u43fItalic = { &u43fItalic_base, NULL };
+GImage GIcon_u43cItalic = { &u43cItalic_base, NULL };
+GImage GIcon_u438Italic = { &u438Italic_base, NULL };
+GImage GIcon_u436Italic = { &u436Italic_base, NULL };
+GImage GIcon_u434Italic = { &u434Italic_base, NULL };
+GImage GIcon_u433Italic = { &u433Italic_base, NULL };
+GImage GIcon_u432Italic = { &u432Italic_base, NULL };
+GImage GIcon_zItalic = { &zItalic_base, NULL };
+GImage GIcon_yItalic = { &yItalic_base, NULL };
+GImage GIcon_xItalic = { &xItalic_base, NULL };
+GImage GIcon_wItalic = { &wItalic_base, NULL };
+GImage GIcon_vItalic = { &vItalic_base, NULL };
+GImage GIcon_pItalic = { &pItalic_base, NULL };
+GImage GIcon_kItalic = { &kItalic_base, NULL };
+GImage GIcon_gItalic = { &gItalic_base, NULL };
+GImage GIcon_f2Italic = { &f2Italic_base, NULL };
+GImage GIcon_fItalic = { &fImage_base, NULL };
+GImage GIcon_aItalic = { &aItalic_base, NULL };
+GImage GIcon_FlatSerif = { &FlatSerif_base, NULL };
+GImage GIcon_SlantSerif = { &SlantSerif_base, NULL };
+GImage GIcon_PenSerif = { &PenSerif_base, NULL };
+GImage GIcon_TopSerifs = { &TopSerifs_base, NULL };
+GImage GIcon_BottomSerifs = { &BottomSerifs0_base, NULL };
+GImage GIcon_DiagSerifs = { &DiagSerifs_base, NULL };
 
 void InitToolIconClut(Color bg) {
     if ( bg==0x000000 ) {

--- a/fontforgeexe/kernclass.c
+++ b/fontforgeexe/kernclass.c
@@ -407,7 +407,7 @@ void KCD_DrawGlyph(GWindow pixmap,int x,int baseline,BDFChar *bdfc,int mag) {
     memset(&gi,'\0',sizeof(gi));
     memset(&base,'\0',sizeof(base));
     memset(&clut,'\0',sizeof(clut));
-    gi.u.image = &base;
+    gi.image = &base;
     base.clut = &clut;
     if ( !bdfc->byte_data ) {
 	base.image_type = it_mono;

--- a/fontforgeexe/lookupui.c
+++ b/fontforgeexe/lookupui.c
@@ -3382,7 +3382,7 @@ static void PSTKern_DrawGlyph(GWindow pixmap,int x,int y, BDFChar *bc, int mag) 
     memset(&gi,'\0',sizeof(gi));
     memset(&base,'\0',sizeof(base));
     memset(&clut,'\0',sizeof(clut));
-    gi.u.image = &base;
+    gi.image = &base;
     base.clut = &clut;
     base.data = bc->bitmap;
     base.bytes_per_line = bc->bytes_per_line;

--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -284,7 +284,7 @@ static void MVSubVExpose(MetricsView *mv, GWindow pixmap, GEvent *event) {
 	    memset(&gi,'\0',sizeof(gi));
 	    memset(&base,'\0',sizeof(base));
 	    memset(&clut,'\0',sizeof(clut));
-	    gi.u.image = &base;
+	    gi.image = &base;
 	    base.clut = &clut;
 	    if ( !bdfc->byte_data ) {
 		base.image_type = it_mono;
@@ -403,7 +403,7 @@ return;
 	    memset(&gi,'\0',sizeof(gi));
 	    memset(&base,'\0',sizeof(base));
 	    memset(&clut,'\0',sizeof(clut));
-	    gi.u.image = &base;
+	    gi.image = &base;
 	    base.clut = &clut;
 	    if ( !bdfc->byte_data ) {
 		base.image_type = it_mono;

--- a/fontforgeexe/sftextfield.c
+++ b/fontforgeexe/sftextfield.c
@@ -824,7 +824,7 @@ return;
 
     image = GImageCreate(it_index,st->g.inner.width+2,
 	    st->li.lineheights[st->li.lcnt-1].y+st->li.lineheights[st->li.lcnt-1].fh+2);
-    base = image->u.image;
+    base = image->image;
     memset(base->data,0,base->bytes_per_line*base->height);
     for ( i=0; i<256; ++i )
 	base->clut->clut[i] = (255-i)*0x010101;

--- a/fontforgeexe/splashimage.c
+++ b/fontforgeexe/splashimage.c
@@ -43771,4 +43771,4 @@ static struct _GImage splashimage0_base = {
     0xffffffff
 };
 
-GImage splashimage_legacy = { 0, { &splashimage0_base }, NULL };
+GImage splashimage_legacy = { &splashimage0_base, NULL };

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -188,7 +188,7 @@ void ShowAboutScreen(void) {
     static int first=1;
 
     if ( first ) {
-	GDrawResize(splashw,splashimagep->u.image->width,splashimagep->u.image->height+linecnt*fh);
+	GDrawResize(splashw,splashimagep->image->width,splashimagep->image->height+linecnt*fh);
 	first = false;
     }
     
@@ -213,7 +213,7 @@ static void SplashLayout() {
 	lastspace = NULL;
 	for ( pt=start; ; ++pt ) {
 	    if ( *pt==' ' || *pt=='\0' ) {
-		if ( GDrawGetTextWidth(splashw,start,pt-start)<splashimagep->u.image->width-10 )
+		if ( GDrawGetTextWidth(splashw,start,pt-start)<splashimagep->image->width-10 )
 		    lastspace = pt;
 		else
 	break;
@@ -402,9 +402,9 @@ static int splash_e_h(GWindow gw, GEvent *event) {
       case et_expose:
 	GDrawPushClip(gw,&event->u.expose.rect,&old);
 	GDrawDrawImage(gw,splashimagep,NULL,0,0);
-	if ((event->u.expose.rect.y+event->u.expose.rect.height) > splashimagep->u.image->height) {
+	if ((event->u.expose.rect.y+event->u.expose.rect.height) > splashimagep->image->height) {
 	    GDrawSetFont(gw,splash_font.fi);
-	    y = splashimagep->u.image->height + as + fh/2;
+	    y = splashimagep->image->height + as + fh/2;
 	    for ( i=1; i<linecnt; ++i ) {
 	    // The number 10 comes from lines[linecnt] created in the function SplashLayout. It refers
 	    // to the line at which we want to make the font monospace. If you add or remove a line, 
@@ -434,8 +434,8 @@ static int splash_e_h(GWindow gw, GEvent *event) {
 	// the splash from being displayed properly unless a resize occurs.
 	// So this forces a resize to make it display properly...
 	GDrawGetSize(gw, &old);
-	if (old.height < splashimagep->u.image->height) {
-	    GDrawResize(gw,splashimagep->u.image->width,splashimagep->u.image->height);
+	if (old.height < splashimagep->image->height) {
+	    GDrawResize(gw,splashimagep->image->width,splashimagep->image->height);
 	}
 	break;
       case et_timer:
@@ -899,8 +899,8 @@ int fontforge_main( int argc, char **argv ) {
 #endif
     pos.x = pos.y = 200;
     SplashImageInit();
-    pos.width = splashimagep->u.image->width;
-    pos.height = splashimagep->u.image->height-1; // See splash_e_h:et_map
+    pos.width = splashimagep->image->width;
+    pos.height = splashimagep->image->height-1; // See splash_e_h:et_map
     GDrawBindSelection(NULL,sn_user1,"FontForge");
     if ( unique && GDrawSelectionOwned(NULL,sn_user1)) {
 	/* Different event handler, not a dialog */

--- a/gdraw/choosericons.c
+++ b/gdraw/choosericons.c
@@ -1362,39 +1362,39 @@ static struct _GImage forward0_base = {
 
 
 
-GImage _GIcon_compressed = { 0, { &compressed0_base }, NULL };
-GImage _GIcon_tar = { 0, { &tar0_base }, NULL };
-GImage _GIcon_ttf = { 0, { &ttf0_base }, NULL };
-GImage _GIcon_unknown = { 0, { &unknown0_base }, NULL };
-GImage _GIcon_texthtml = { 0, { &texthtml0_base }, NULL };
-GImage _GIcon_textxml = { 0, { &textxml0_base }, NULL };
-GImage _GIcon_textcss = { 0, { &textcss0_base }, NULL };
-GImage _GIcon_textjava = { 0, { &textjava0_base }, NULL };
-GImage _GIcon_textfontsfd = { 0, { &textfontsfd0_base }, NULL };
-GImage _GIcon_textfontbdf = { 0, { &textbdf0_base }, NULL };
-GImage _GIcon_textfontps = { 0, { &textfontps0_base }, NULL };
-GImage _GIcon_textps = { 0, { &textps0_base }, NULL };
-GImage _GIcon_textplain = { 0, { &textplain0_base }, NULL };
-GImage _GIcon_textc = { 0, { &textc0_base }, NULL };
-GImage _GIcon_textmake = { 0, { &textmake_base }, NULL };
-GImage _GIcon_object = { 0, { &object0_base }, NULL };
-GImage _GIcon_updir = { 0, { &updir0_base }, NULL };
-GImage _GIcon_dir = { 0, { &dir0_base }, NULL };
-GImage _GIcon_core = { 0, { &core0_base }, NULL };
-GImage _GIcon_image = { 0, { &image0_base }, NULL };
-GImage _GIcon_video = { 0, { &video0_base }, NULL };
-GImage _GIcon_audio = { 0, { &audio0_base }, NULL };
-GImage _GIcon_cid = { 0, { &cid0_base }, NULL };
-GImage _GIcon_mac = { 0, { &mac_base }, NULL };
-GImage _GIcon_macttf = { 0, { &macttf0_base }, NULL };
+GImage _GIcon_compressed = { &compressed0_base, NULL };
+GImage _GIcon_tar = { &tar0_base, NULL };
+GImage _GIcon_ttf = { &ttf0_base, NULL };
+GImage _GIcon_unknown = { &unknown0_base, NULL };
+GImage _GIcon_texthtml = { &texthtml0_base, NULL };
+GImage _GIcon_textxml = { &textxml0_base, NULL };
+GImage _GIcon_textcss = { &textcss0_base, NULL };
+GImage _GIcon_textjava = { &textjava0_base, NULL };
+GImage _GIcon_textfontsfd = { &textfontsfd0_base, NULL };
+GImage _GIcon_textfontbdf = { &textbdf0_base, NULL };
+GImage _GIcon_textfontps = { &textfontps0_base, NULL };
+GImage _GIcon_textps = { &textps0_base, NULL };
+GImage _GIcon_textplain = { &textplain0_base, NULL };
+GImage _GIcon_textc = { &textc0_base, NULL };
+GImage _GIcon_textmake = { &textmake_base, NULL };
+GImage _GIcon_object = { &object0_base, NULL };
+GImage _GIcon_updir = { &updir0_base, NULL };
+GImage _GIcon_dir = { &dir0_base, NULL };
+GImage _GIcon_core = { &core0_base, NULL };
+GImage _GIcon_image = { &image0_base, NULL };
+GImage _GIcon_video = { &video0_base, NULL };
+GImage _GIcon_audio = { &audio0_base, NULL };
+GImage _GIcon_cid = { &cid0_base, NULL };
+GImage _GIcon_mac = { &mac_base, NULL };
+GImage _GIcon_macttf = { &macttf0_base, NULL };
 
-GImage _GIcon_homefolder = { 0, { &homefolder_base }, NULL };
-GImage _GIcon_configtool = { 0, { &configtool0_base }, NULL };
-GImage _GIcon_bookmark   = { 0, { &bookmark0_base }, NULL };
-GImage _GIcon_nobookmark = { 0, { &nobookmark0_base }, NULL };
+GImage _GIcon_homefolder = { &homefolder_base, NULL };
+GImage _GIcon_configtool = { &configtool0_base, NULL };
+GImage _GIcon_bookmark = { &bookmark0_base, NULL };
+GImage _GIcon_nobookmark = { &nobookmark0_base, NULL };
 
-GImage _GIcon_backarrow = { 0, { &back0_base }, NULL };
-GImage _GIcon_forwardarrow = { 0, { &forward0_base }, NULL };
+GImage _GIcon_backarrow = { &back0_base, NULL };
+GImage _GIcon_forwardarrow = { &forward0_base, NULL };
 
 
 /* Some icons in this file, so that FontForge could show anything meaningful */

--- a/gdraw/gcolor.c
+++ b/gdraw/gcolor.c
@@ -48,7 +48,7 @@ static GImage *ColorWheel(int width,int height) {
     hh = height/2.0; hw = width/2.0;
 
     wheel = GImageCreate(it_true,width,height);
-    base = wheel->u.image;
+    base = wheel->image;
     for ( i=0; i<height; ++i ) {
 	row = (uint32_t *) (base->data + i*base->bytes_per_line);
 	y = (i-hh)/(hh-1);
@@ -65,7 +65,7 @@ static GImage *ColorWheel(int width,int height) {
 	    }
 	}
     }
-return( wheel );	
+return( wheel );
 }
 
 #define GRAD_WIDTH	20
@@ -78,7 +78,7 @@ static GImage *Gradient(int height) {
     if ( height<10 ) height = 10;
 
     grad = GImageCreate(it_true,GRAD_WIDTH,height);
-    base = grad->u.image;
+    base = grad->image;
     for ( i=0; i<height; ++i ) {
 	row = (uint32_t *) (base->data + i*base->bytes_per_line);
 	c = 255*(height-1-i)/(height-1);

--- a/gdraw/gdraw.c
+++ b/gdraw/gdraw.c
@@ -459,7 +459,7 @@ void GDrawDrawScaledImage(GWindow w, GImage *img, int32_t x, int32_t y) {
 void GDrawDrawGlyph(GWindow w, GImage *img, GRect *src, int32_t x, int32_t y) {
     GRect r;
     if ( src==NULL ) {
-	struct _GImage *base = img->list_len==0?img->u.image:img->u.images[0];
+	struct _GImage *base = img->image;
 	r.x = r.y = 0;
 	r.width = base->width; r.height = base->height;
 	src = &r;
@@ -480,7 +480,7 @@ void GDrawDrawPixmap(GWindow w, GWindow pixmap, GRect *src, int32_t x, int32_t y
 void GDrawDrawImageMagnified(GWindow w, GImage *img, GRect *dest, int32_t x, int32_t y,
 	int32_t width, int32_t height) {
     GRect temp;
-    struct _GImage *base = img->list_len==0?img->u.image:img->u.images[0];
+    struct _GImage *base = img->image;
 
     /* Not magnified after all */
     if ( base->width==width && base->height==height ) {

--- a/gdraw/ggdkcdraw.c
+++ b/gdraw/ggdkcdraw.c
@@ -252,7 +252,7 @@ static void _GGDKDraw_EllipsePath(cairo_t *cc, double cx, double cy, double widt
 }
 
 static cairo_surface_t *_GGDKDraw_GImage2Surface(GImage *image, GRect *src) {
-    struct _GImage *base = (image->list_len == 0) ? image->u.image : image->u.images[0];
+    struct _GImage *base = image->image;
     cairo_format_t type;
     uint8_t *pt;
     uint32_t *idata, *ipt, *ito;
@@ -498,7 +498,7 @@ static GImage *_GGDKDraw_GImageExtract(struct _GImage *base, GRect *src, GRect *
 
     memset(&temp, 0, sizeof(temp));
     tbase = *base;
-    temp.u.image = &tbase;
+    temp.image = &tbase;
     tbase.width = size->width;
     tbase.height = size->height;
     if (base->image_type == it_mono) {
@@ -965,7 +965,7 @@ void GGDKDrawDrawImage(GWindow w, GImage *image, GRect *src, int32_t x, int32_t 
     _GGDKDraw_CheckAutoPaint(gw);
 
     cairo_surface_t *is = _GGDKDraw_GImage2Surface(image, src), *cs = is;
-    struct _GImage *base = (image->list_len == 0) ? image->u.image : image->u.images[0];
+    struct _GImage *base = image->image;
 
     if (cairo_image_surface_get_format(is) == CAIRO_FORMAT_A1) {
         /* No color info, just alpha channel */
@@ -1007,7 +1007,7 @@ void GGDKDrawDrawGlyph(GWindow w, GImage *image, GRect *src, int32_t x, int32_t 
     GGDKWindow gw = (GGDKWindow)w;
     _GGDKDraw_CheckAutoPaint(gw);
 
-    struct _GImage *base = (image->list_len) == 0 ? image->u.image : image->u.images[0];
+    struct _GImage *base = image->image;
     cairo_surface_t *is;
 
     if (base->image_type != it_index) {
@@ -1052,7 +1052,7 @@ void GGDKDrawDrawImageMagnified(GWindow w, GImage *image, GRect *src, int32_t x,
     GGDKWindow gw = (GGDKWindow)w;
     _GGDKDraw_CheckAutoPaint(gw);
 
-    struct _GImage *base = (image->list_len == 0) ? image->u.image : image->u.images[0];
+    struct _GImage *base = image->image;
     GRect full;
     double xscale, yscale;
     GRect viewable;

--- a/gdraw/gimagexdraw.c
+++ b/gdraw/gimagexdraw.c
@@ -73,7 +73,7 @@ static void gdraw_8_on_1_nomag_dithered_masked(GXDisplay *gdisp,GImage *image,
 	GRect *src) {
     struct gcol clut[256];
     int i,j, index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     unsigned char *pt, *ipt, *mpt;
     short *g_d;
@@ -125,7 +125,7 @@ static void gdraw_8_on_1_nomag_dithered_masked(GXDisplay *gdisp,GImage *image,
 
 static void gdraw_32_on_1_nomag_dithered_masked(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j, index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     uint32_t *pt;
     uint8_t *ipt, *mpt;
@@ -175,7 +175,7 @@ static void gdraw_32_on_1_nomag_dithered_masked(GXDisplay *gdisp, GImage *image,
 static void gdraw_32a_on_1_nomag_dithered(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
     unsigned int index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     uint32_t *pt;
     uint8_t *ipt, *mpt;
@@ -225,7 +225,7 @@ static void gdraw_32a_on_1_nomag_dithered(GXDisplay *gdisp, GImage *image, GRect
 static void gdraw_8_on_1_nomag_dithered_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     struct gcol clut[256];
     int i,j, index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     unsigned char *pt, *ipt;
     short *g_d;
     register int gd;
@@ -269,7 +269,7 @@ static void gdraw_8_on_1_nomag_dithered_nomask(GXDisplay *gdisp, GImage *image, 
 static void gdraw_32_on_1_nomag_dithered_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     struct gcol clut[256];
     int i,j, index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     uint32_t *pt;
     uint8_t *ipt;
     short *g_d;
@@ -312,7 +312,7 @@ static void gdraw_32_on_1_nomag_dithered_nomask(GXDisplay *gdisp, GImage *image,
 static void gdraw_8_on_8_nomag_dithered_masked(GXDisplay *gdisp, GImage *image, GRect *src) {
     struct gcol clut[256];
     int i,j, index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     uint8_t *pt, *ipt, *mpt;
     short *r_d, *g_d, *b_d;
@@ -380,7 +380,7 @@ static void gdraw_8_on_8_nomag_nodithered_masked(GXDisplay *gdisp, GImage *image
     struct gcol clut[256];
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint8_t *pt, *ipt, *mpt;
     struct gcol *pos; const struct gcol *temp;
@@ -435,7 +435,7 @@ static void gdraw_8_on_8_nomag_nodithered_masked(GXDisplay *gdisp, GImage *image
 
 static void gdraw_32_on_8_nomag_dithered_masked(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     uint32_t *pt, index;
     uint8_t *ipt, *mpt;
@@ -499,7 +499,7 @@ static void gdraw_32_on_8_nomag_dithered_masked(GXDisplay *gdisp, GImage *image,
 
 static void gdraw_32a_on_8_nomag_dithered(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     uint32_t *pt, index;
     uint8_t *ipt, *mpt;
@@ -563,7 +563,7 @@ static void gdraw_32a_on_8_nomag_dithered(GXDisplay *gdisp, GImage *image, GRect
 
 static void gdraw_32_on_8_nomag_nodithered_masked(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     uint32_t *pt, index;
     register uint8_t *ipt, *mpt;
@@ -611,7 +611,7 @@ static void gdraw_32_on_8_nomag_nodithered_masked(GXDisplay *gdisp, GImage *imag
 
 static void gdraw_32a_on_8_nomag_nodithered(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     uint32_t *pt, index;
     register uint8_t *ipt, *mpt;
@@ -660,7 +660,7 @@ static void gdraw_32a_on_8_nomag_nodithered(GXDisplay *gdisp, GImage *image, GRe
 static void gdraw_8_on_8_nomag_dithered_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     struct gcol clut[256];
     int i,j, index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     uint8_t *pt, *ipt;
     short *r_d, *g_d, *b_d;
     register int rd, gd, bd;
@@ -695,7 +695,7 @@ static void gdraw_8_on_8_nomag_nodithered_nomask(GXDisplay *gdisp, GImage *image
     struct gcol clut[256];
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     register uint8_t *pt, *ipt;
     struct gcol *pos; const struct gcol *temp;
 
@@ -718,7 +718,7 @@ static void gdraw_8_on_8_nomag_nodithered_nomask(GXDisplay *gdisp, GImage *image
 
 static void gdraw_32_on_8_nomag_dithered_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     uint32_t *pt, index;
     uint8_t *ipt;
     short *r_d, *g_d, *b_d;
@@ -749,7 +749,7 @@ static void gdraw_32_on_8_nomag_dithered_nomask(GXDisplay *gdisp, GImage *image,
 
 static void gdraw_32_on_8_nomag_nodithered_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     uint32_t *pt, index;
     register uint8_t *ipt;
 
@@ -767,7 +767,7 @@ static void gdraw_8_on_16_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *s
     struct gcol clut[256];
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
 #if FAST_BITS==0
     uint16_t *mpt;
@@ -831,7 +831,7 @@ static void gdraw_8_on_16_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *s
 
 static void gdraw_32_on_16_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint32_t *pt, index;
     register uint16_t *ipt;
@@ -887,7 +887,7 @@ static void gdraw_32_on_16_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *
 
 static void gdraw_32a_on_16_nomag(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint32_t *pt, index;
     register uint16_t *ipt;
@@ -945,7 +945,7 @@ static void gdraw_8_on_16_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *s
     struct gcol clut[256];
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     register uint8_t *pt;
     uint16_t *ipt;
     struct gcol *pos;
@@ -972,7 +972,7 @@ static void gdraw_8_on_16_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *s
 
 static void gdraw_32_on_16_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     register uint32_t *pt, index;
     register uint16_t *ipt;
     int endian_mismatch = gdisp->endian_mismatch;
@@ -993,7 +993,7 @@ static void gdraw_8_on_any_nomag_glyph(GXDisplay *gdisp, GImage *image, GRect *s
     struct gcol clut[256];
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint8_t *pt;
     struct gcol *pos;
@@ -1079,7 +1079,7 @@ static void gdraw_8_on_24_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *s
 #if FAST_BITS
     int mbit;
 #endif
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint8_t *ipt;
     register uint8_t *pt, *mpt;
@@ -1142,7 +1142,7 @@ static void gdraw_8_on_24_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *s
 
 static void gdraw_32_on_24_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint32_t *pt, index;
     register uint8_t *mpt, *ipt;
@@ -1200,7 +1200,7 @@ static void gdraw_32_on_24_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *
 
 static void gdraw_32a_on_24_nomag(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint32_t *pt, index;
     register uint8_t *mpt, *ipt;
@@ -1262,7 +1262,7 @@ static void gdraw_8_on_24_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *s
     register uint8_t *pt;
     register int index, j;
     int i;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     struct gcol *pos;
 
     _GDraw_getimageclut(base,clut);
@@ -1296,7 +1296,7 @@ static void gdraw_8_on_24_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *s
 
 static void gdraw_32_on_24_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     register uint32_t *pt, index;
     register uint8_t *ipt;
 
@@ -1327,7 +1327,7 @@ static void gdraw_8_on_32a_nomag(GXDisplay *gdisp, GImage *image, GRect *src) {
     struct gcol clut[256];
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint8_t *pt;
     uint32_t *ipt;
@@ -1357,7 +1357,7 @@ static void gdraw_8a_on_32a_nomag(GXDisplay *gdisp, GImage *image, GRect *src,
 	Color fg) {
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     register uint8_t *pt;
     uint32_t *ipt;
     uint32_t fg_pixel = Pixel32(gdisp,fg) & 0xffffff;
@@ -1374,7 +1374,7 @@ static void gdraw_8a_on_32a_nomag(GXDisplay *gdisp, GImage *image, GRect *src,
 
 static void gdraw_32_on_32a_nomag(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint32_t *pt, index, *ipt;
     int endian_mismatch = gdisp->endian_mismatch;
@@ -1409,7 +1409,7 @@ static void gdraw_8_on_32_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *s
     int mbit;
     register uint8_t *mpt;
 #endif
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint8_t *pt;
     uint32_t *ipt;
@@ -1465,7 +1465,7 @@ static void gdraw_8_on_32_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *s
 
 static void gdraw_32_on_32_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint32_t *pt, index, *ipt;
     int endian_mismatch = gdisp->endian_mismatch;
@@ -1520,7 +1520,7 @@ static void gdraw_32_on_32_nomag_masked(GXDisplay *gdisp, GImage *image, GRect *
 
 static void gdraw_32a_on_32_nomag(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     int trans = base->trans;
     register uint32_t *pt, index, *ipt;
     int endian_mismatch = gdisp->endian_mismatch;
@@ -1577,7 +1577,7 @@ static void gdraw_8_on_32_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *s
     struct gcol clut[256];
     register int j;
     int i,index;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     register uint8_t *pt;
     uint32_t *ipt;
     struct gcol *pos;
@@ -1602,7 +1602,7 @@ static void gdraw_8_on_32_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *s
 
 static void gdraw_32_on_32_nomag_nomask(GXDisplay *gdisp, GImage *image, GRect *src) {
     int i,j;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     register uint32_t *pt, index, *ipt;
     int endian_mismatch = gdisp->endian_mismatch;
 
@@ -1789,7 +1789,7 @@ return;
 }
 
 static void gximage_to_ximage(GXWindow gw, GImage *image, GRect *src) {
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     GXDisplay *gdisp = gw->display;
     int depth;
 
@@ -1936,7 +1936,7 @@ static void gximage_to_ximage(GXWindow gw, GImage *image, GRect *src) {
 void _GXDraw_Image( GWindow _w, GImage *image, GRect *src, int32_t x, int32_t y) {
     GXWindow gw = (GXWindow) _w;
     GXDisplay *gdisp = gw->display;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     Display *display=gdisp->display;
     Window w = gw->w;
     GC gc = gdisp->gcstate[gw->ggc->bitmap_col].gc;
@@ -1965,7 +1965,7 @@ return;
     if ( base->image_type == it_mono ) {
 	/* Mono images are easy, because all X servers (no matter what their */
 	/*  depth) support 1 bit bitmaps */
-	gdraw_bitmap(gw,image->u.image,base->clut,base->trans,src,x,y);
+	gdraw_bitmap(gw,image->image,base->clut,base->trans,src,x,y);
 return;
     }
 
@@ -1996,7 +1996,7 @@ return;
         if (blended != NULL) {
             GImageBlendOver(blended, image, src, 0, 0);
             image = blended;
-            base = image->list_len==0?image->u.image:image->u.images[0];
+            base = image->image;
             src = &blend_src;
         }
     }
@@ -2060,7 +2060,7 @@ return;
 void _GXDraw_Glyph( GWindow _w, GImage *image, GRect *src, int32_t x, int32_t y) {
     GXWindow gw = (GXWindow) _w;
     GXDisplay *gdisp = gw->display;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     Color fg = -1;
 
 #ifndef _NO_LIBCAIRO
@@ -2110,7 +2110,7 @@ GImage *_GImageExtract(struct _GImage *base,GRect *src,GRect *size,
 
     memset(&temp,0,sizeof(temp));
     tbase = *base;
-    temp.u.image = &tbase;
+    temp.image = &tbase;
     tbase.width = size->width; tbase.height = size->height;
     if ( base->image_type==it_mono )
 	tbase.bytes_per_line = (size->width+7)/8;
@@ -2168,7 +2168,7 @@ void _GXDraw_ImageMagnified(GWindow _w, GImage *image, GRect *magsrc,
 	int32_t x, int32_t y, int32_t width, int32_t height) {
     GXWindow gw = (GXWindow) _w;
     GXDisplay *gdisp = gw->display;
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     double xscale, yscale;
     GRect full, viewable;
     GImage *temp;
@@ -2231,7 +2231,7 @@ return( NULL );
         free(gi);
 return( NULL );
     }
-    gi->u.image = base;
+    gi->image = base;
     base->image_type = it_mono;
     base->width = xi->width;
     base->height = xi->height;
@@ -2279,7 +2279,7 @@ return( NULL );
         free(gi);
 return( NULL );
     }
-    gi->u.image = base;
+    gi->image = base;
     base->image_type = it_index;
     base->width = xi->width;
     base->height = xi->height;
@@ -2308,7 +2308,7 @@ static GImage *xi16_to_gi32(GXDisplay *gdisp,XImage *xi) {
 
     if (( gi = GImageCreate(it_true,xi->width,xi->height))==NULL )
 return( NULL );
-    base = gi->u.image;
+    base = gi->image;
 
     rs = gdisp->cs.red_shift; gs = gdisp->cs.green_shift; bs = gdisp->cs.blue_shift;
     rm = gdisp->visual->red_mask; gm = gdisp->visual->green_mask; bm = gdisp->visual->blue_mask;
@@ -2362,7 +2362,7 @@ static GImage *xi24_to_gi32(GXDisplay *gdisp,XImage *xi) {
 
     if (( gi = GImageCreate(it_true,xi->width,xi->height))==NULL )
 return( NULL );
-    base = gi->u.image;
+    base = gi->image;
 
     rs = gdisp->cs.red_shift; gs = gdisp->cs.green_shift; bs = gdisp->cs.blue_shift;
     for ( i=0; i<base->height; ++i ) {
@@ -2392,7 +2392,7 @@ static GImage *xi32_to_gi32(GXDisplay *gdisp,XImage *xi) {
 
     if (( gi = GImageCreate(it_true,xi->width,xi->height))==NULL )
 return( NULL );
-    base = gi->u.image;
+    base = gi->image;
 
     rs = gdisp->cs.red_shift; gs = gdisp->cs.green_shift; bs = gdisp->cs.blue_shift;
     for ( i=0; i<base->height; ++i ) {

--- a/gdraw/gtextinfo.c
+++ b/gdraw/gtextinfo.c
@@ -609,7 +609,7 @@ GImageCacheBucket *_GGadgetImageCache(const char *filename, int keep_empty) {
     }
 
     /* Play with the clut to make white be transparent */
-    struct _GImage *base = img->u.image;
+    struct _GImage *base = img->image;
     if ( base->image_type==it_mono && base->clut==NULL )
 	base->trans = 1;
     else if ( base->image_type!=it_true && base->clut!=NULL && base->trans==0xffffffff ) {

--- a/gdraw/gxcdraw.c
+++ b/gdraw/gxcdraw.c
@@ -449,7 +449,7 @@ void _GXCDraw_PathFillAndStroke(GWindow w,Color fillcol, Color strokecol) {
 /* ****************************** Cairo Images ****************************** */
 /* ************************************************************************** */
 static cairo_surface_t *GImage2Surface(GImage *image, GRect *src, uint8_t **_data) {
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     cairo_format_t type;
     uint8_t *data, *pt;
     uint32_t *idata, *ipt, *ito;
@@ -682,7 +682,7 @@ return( cs );
 void _GXCDraw_Image( GXWindow gw, GImage *image, GRect *src, int32_t x, int32_t y) {
     uint8_t *data;
     cairo_surface_t *is = GImage2Surface(image,src,&data);
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
 
     if ( cairo_image_surface_get_format(is)==CAIRO_FORMAT_A1 ) {
 	/* No color info, just alpha channel */
@@ -705,7 +705,7 @@ void _GXCDraw_Image( GXWindow gw, GImage *image, GRect *src, int32_t x, int32_t 
 
 /* What we really want to do is use the grey levels as an alpha channel */
 void _GXCDraw_Glyph( GXWindow gw, GImage *image, GRect *src, int32_t x, int32_t y) {
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     cairo_surface_t *is;
 
     if ( base->image_type!=it_index )
@@ -746,7 +746,7 @@ void _GXCDraw_Glyph( GXWindow gw, GImage *image, GRect *src, int32_t x, int32_t 
 
 void _GXCDraw_ImageMagnified(GXWindow gw, GImage *image, GRect *magsrc,
 	int32_t x, int32_t y, int32_t width, int32_t height) {
-    struct _GImage *base = image->list_len==0?image->u.image:image->u.images[0];
+    struct _GImage *base = image->image;
     GRect full;
     double xscale, yscale;
     GRect viewable;

--- a/gutils/gimagereadbmp.c
+++ b/gutils/gimagereadbmp.c
@@ -369,9 +369,9 @@ GImage *GImageRead_Bmp(FILE *file) {
 	    goto errorGImageMemBmp;
 	}
 	if ( bmp.bitsperpixel>=16 ) {
-	    ret->u.image->data = (uint8_t *) bmp.int32_pixels;
+	    ret->image->data = (uint8_t *) bmp.int32_pixels;
 	} else if ( bmp.bitsperpixel!=1 ) {
-	    ret->u.image->data = (uint8_t *) bmp.byte_pixels;
+	    ret->image->data = (uint8_t *) bmp.byte_pixels;
 	}
     } else {
 	if ( bmp.bitsperpixel>=16 ) {
@@ -379,7 +379,7 @@ GImage *GImageRead_Bmp(FILE *file) {
 		NoMoreMemMessage();
 		goto errorGImageMemBmp;
 	    }
-	    base = ret->u.image;
+	    base = ret->image;
 	    for ( i=0; i<bmp.height; ++i ) {
 		l = bmp.height-1-i;
 		memcpy(base->data+l*base->bytes_per_line,bmp.int32_pixels+i*bmp.width,bmp.width*sizeof(uint32_t));
@@ -390,7 +390,7 @@ GImage *GImageRead_Bmp(FILE *file) {
 		NoMoreMemMessage();
 		goto errorGImageMemBmp;
 	    }
-	    base = ret->u.image;
+	    base = ret->image;
 	    for ( i=0; i<bmp.height; ++i ) {
 		l = bmp.height-1-i;
 		memcpy(base->data+l*base->bytes_per_line,bmp.byte_pixels+i*bmp.width,bmp.width);
@@ -401,7 +401,7 @@ GImage *GImageRead_Bmp(FILE *file) {
 		NoMoreMemMessage();
 		goto errorGImageMemBmp;
 	    }
-	    base = ret->u.image;
+	    base = ret->image;
 	    for ( i=0; i<bmp.height; ++i ) {
 		l = bmp.height-1-i;
 		memcpy(base->data+l*base->bytes_per_line,bmp.byte_pixels+i*base->bytes_per_line,base->bytes_per_line);
@@ -409,18 +409,18 @@ GImage *GImageRead_Bmp(FILE *file) {
 	    free(bmp.byte_pixels);
 	}
     }
-    if ( ret->u.image->image_type==it_index ) {
-	ret->u.image->clut->clut_len = bmp.colorsused;
-	memcpy(ret->u.image->clut->clut,bmp.clut,bmp.colorsused*sizeof(Color));
-	ret->u.image->clut->trans_index = COLOR_UNKNOWN;
-    } else if ( ret->u.image->image_type==it_mono && bmp.colorsused!=0 ) {
-	if ( (ret->u.image->clut=(GClut *)(calloc(1,sizeof(GClut))))==NULL ) {
+    if ( ret->image->image_type==it_index ) {
+	ret->image->clut->clut_len = bmp.colorsused;
+	memcpy(ret->image->clut->clut,bmp.clut,bmp.colorsused*sizeof(Color));
+	ret->image->clut->trans_index = COLOR_UNKNOWN;
+    } else if ( ret->image->image_type==it_mono && bmp.colorsused!=0 ) {
+	if ( (ret->image->clut=(GClut *)(calloc(1,sizeof(GClut))))==NULL ) {
 	    NoMoreMemMessage();
 	    goto errorGImageMemBmp;
 	}
-	ret->u.image->clut->clut_len = bmp.colorsused;
-	memcpy(ret->u.image->clut->clut,bmp.clut,bmp.colorsused*sizeof(Color));
-	ret->u.image->clut->trans_index = COLOR_UNKNOWN;
+	ret->image->clut->clut_len = bmp.colorsused;
+	memcpy(ret->image->clut->clut,bmp.clut,bmp.colorsused*sizeof(Color));
+	ret->image->clut->trans_index = COLOR_UNKNOWN;
     }
     return( ret );
 

--- a/gutils/gimagereadjpeg.c
+++ b/gutils/gimagereadjpeg.c
@@ -117,7 +117,7 @@ return( NULL );
 	jpeg_destroy_decompress(&cinfo);
 return( NULL );
     }
-    base = ret->u.image;
+    base = ret->image;
 
     (void) jpeg_start_decompress(&cinfo);
     rows[0] = (JSAMPLE *) malloc(3*cinfo.image_width);

--- a/gutils/gimagereadpng.c
+++ b/gutils/gimagereadpng.c
@@ -132,7 +132,7 @@ return( NULL );
     } else if ( png_get_color_type(png_ptr, info_ptr)==PNG_COLOR_TYPE_GRAY || png_get_color_type(png_ptr, info_ptr)==PNG_COLOR_TYPE_GRAY_ALPHA ) {
 	GClut *clut;
 	ret = GImageCreate(it_index,png_get_image_width(png_ptr,info_ptr),png_get_image_height(png_ptr,info_ptr));
-	clut = ret->u.image->clut;
+	clut = ret->image->clut;
 	clut->is_grey = true;
 	clut->clut_len = 256;
 	for ( i=0; i<256; ++i )
@@ -147,9 +147,9 @@ return( NULL );
 	GClut *clut;
 	ret = GImageCreate(png_get_bit_depth(png_ptr,info_ptr) != 1? it_index : it_mono,
 		png_get_image_width(png_ptr,info_ptr),png_get_image_height(png_ptr,info_ptr));
-	clut = ret->u.image->clut;
+	clut = ret->image->clut;
 	if ( clut==NULL )
-	    clut = ret->u.image->clut = (GClut *) calloc(1,sizeof(GClut));
+	    clut = ret->image->clut = (GClut *) calloc(1,sizeof(GClut));
 	clut->is_grey = true;
 	png_get_PLTE(png_ptr,info_ptr,&palette,&num_palette);
 	clut->clut_len = num_palette;
@@ -159,7 +159,7 @@ return( NULL );
 			palette[i].blue);
     }
     png_get_tRNS(png_ptr,info_ptr,&trans_alpha,&num_trans,&trans_color);
-    base = ret->u.image;
+    base = ret->image;
     if ( (png_get_valid(png_ptr,info_ptr,PNG_INFO_tRNS)) && num_trans>0 ) {
 	if ( png_get_color_type(png_ptr, info_ptr)==PNG_COLOR_TYPE_RGB || png_get_color_type(png_ptr, info_ptr)==PNG_COLOR_TYPE_RGB_ALPHA )
 	    base->trans = COLOR_CREATE(

--- a/gutils/gimagereadras.c
+++ b/gutils/gimagereadras.c
@@ -86,7 +86,7 @@ static int getrasheader(SUNRASTER *head, FILE *fp) {
 }
 
 static GImage *ReadRasBitmap(GImage *ret,int width, int height, FILE *fp ) {
-    struct _GImage *base = ret->u.image;
+    struct _GImage *base = ret->image;
     int i,j,len;
     unsigned char *pt, *buf;
 
@@ -112,7 +112,7 @@ static GImage *ReadRasBitmap(GImage *ret,int width, int height, FILE *fp ) {
 }
 
 static GImage *ReadRas8Bit(GImage *ret,int width, int height, FILE *fp ) {
-    struct _GImage *base = ret->u.image;
+    struct _GImage *base = ret->image;
     int i;
 
     for ( i=0; i<height; ++i ) {
@@ -131,7 +131,7 @@ errorReadRas8Bit:
 }
 
 static GImage *ReadRas24Bit(GImage *ret,int width, int height, FILE *fp ) {
-    struct _GImage *base = ret->u.image;
+    struct _GImage *base = ret->image;
     int ch1,ch2,ch3=0;
     int i;
     long *ipt,*end;
@@ -154,7 +154,7 @@ errorReadRas24Bit:
 }
 
 static GImage *ReadRas32Bit(GImage *ret,int width, int height, FILE *fp ) {
-    struct _GImage *base = ret->u.image;
+    struct _GImage *base = ret->image;
     int ch1,ch2,ch3=0;
     int i;
     long *ipt, *end;
@@ -173,7 +173,7 @@ return ret;
 }
 
 static GImage *ReadRas24RBit(GImage *ret,int width, int height, FILE *fp ) {
-    struct _GImage *base = ret->u.image;
+    struct _GImage *base = ret->image;
     int ch1,ch2,ch3=0;
     int i;
     long *ipt,*end;
@@ -196,7 +196,7 @@ errorReadRas24RBit:
 }
 
 static GImage *ReadRas32RBit(GImage *ret,int width, int height, FILE *fp ) {
-    struct _GImage *base = ret->u.image;
+    struct _GImage *base = ret->image;
     int ch1,ch2,ch3=0;
     int i;
     long *ipt, *end;
@@ -217,7 +217,7 @@ return ret;
 static GImage *ReadRle8Bit(GImage *ret,int width, int height, FILE *fp ) {
 /* TODO: Make this an input filter that goes in front of other routines	*/
 /* above so that in can be re-used by the different converters above.	*/
-    struct _GImage *base = ret->u.image;
+    struct _GImage *base = ret->image;
     int x,y,cnt,val = 0;
     unsigned char *pt = NULL;
 
@@ -274,7 +274,7 @@ GImage *GImageReadRas(char *filename) {
     }
 
     /* Convert *.ras ColorMap to one that FF can use */
-    base = ret->u.image;
+    base = ret->image;
     if ( header.ColorMapLength!=0 && base->clut!=NULL ) {
 	unsigned char clutb[3*256]; int i,n;
 	if ( fread(clutb,header.ColorMapLength,1,fp)<1 )

--- a/gutils/gimagereadrgb.c
+++ b/gutils/gimagereadrgb.c
@@ -207,7 +207,7 @@ GImage *GImageReadRgb(char *filename) {
 	fclose(fp);
 	return( NULL );
     }
-    base = ret->u.image;
+    base = ret->image;
 
     if ( header.format==RLE ) {
 	/* Working with RLE image data*/

--- a/gutils/gimagereadtiff.c
+++ b/gutils/gimagereadtiff.c
@@ -67,7 +67,7 @@ GImage *GImageReadTiff(char *filename) {
     /* Read TIF image and process it into an internal FF usable format	*/
     if ( TIFFReadRGBAImage(tif,w,h,raster,0) ) {
 	TIFFClose(tif);
-	base=ret->u.image;
+	base=ret->image;
 	for ( i=0; i<h; ++i ) {
 	    ipt=(uint32_t *)(base->data+i*base->bytes_per_line);
 	    fpt=raster+(h-1-i)*w;

--- a/gutils/gimagereadxbm.c
+++ b/gutils/gimagereadxbm.c
@@ -99,7 +99,7 @@ GImage *GImageReadXbm(char * filename) {
 	goto errorGImageReadXbmMem;
 
     /* Convert *.xbm graphic into one that FF can use */
-    base = gi->u.image;
+    base = gi->image;
     for ( i=0; i<height; ++i ) {
 	scanline = base->data + i*base->bytes_per_line;
 	for ( j=0; j<base->bytes_per_line; ++j ) {

--- a/gutils/gimagereadxpm.c
+++ b/gutils/gimagereadxpm.c
@@ -327,18 +327,18 @@ GImage *GImageReadXpm(char * filename) {
 	fillupclut(clut,tab,0,nchar);
 	if ( (ret=GImageCreate(it_index,width,height))==NULL )
 	    goto errorGImageReadXpmMem;
-	ret->u.image->clut->clut_len = cols;
-	memcpy(ret->u.image->clut->clut,clut,cols*sizeof(Color));
-	ret->u.image->trans = clut[256];
-	ret->u.image->clut->trans_index = clut[256];
+	ret->image->clut->clut_len = cols;
+	memcpy(ret->image->clut->clut,clut,cols*sizeof(Color));
+	ret->image->trans = clut[256];
+	ret->image->clut->trans_index = clut[256];
     } else {
 	if ( (ret=GImageCreate(it_true,width,height))==NULL )
 	    goto errorGImageReadXpmMem;
-	ret->u.image->trans = TRANS;		/* TRANS isn't a valid Color, but it fits in our 32 bit pixels */
+	ret->image->trans = TRANS;		/* TRANS isn't a valid Color, but it fits in our 32 bit pixels */
     }
 
     /* Get image */
-    base = ret->u.image;
+    base = ret->image;
     for ( y=0; y<height; ++y ) {
 	if ( !getdata(line,lsiz,fp))
 	    goto errorGImageReadXpm;

--- a/gutils/gimagewritebmp.c
+++ b/gutils/gimagewritebmp.c
@@ -43,7 +43,7 @@ static void putl(short s, FILE *file) {
 }
 
 int GImageWrite_Bmp(GImage *gi, FILE *file) {
-    struct _GImage *base = gi->list_len==0?gi->u.image:gi->u.images[0];
+    struct _GImage *base = gi->image;
     int headersize=40, preheadersize=14;
     int filesize, offset, imagesize;
     int bitsperpixel, clutsize, ncol;

--- a/gutils/gimagewritegimage.c
+++ b/gutils/gimagewritegimage.c
@@ -117,21 +117,8 @@ int GImageWriteGImage(GImage *gi, char *filename) {
     }
     fprintf(file,"/* This file was generated using GImageWriteGImage(gi,\"%s\") */\n",filename);
     fprintf(file,"#include \"gimage.h\"\n\n" );
-    if ( gi->list_len==0 ) {
-	/* Construct a single image */
-	WriteBase(file,gi->u.image,stem,0);
+	WriteBase(file,gi->image,stem,0);
 	fprintf(file,"GImage %s = { 0, &%s0_base };\n",stem,stem);
-    } else {
-	/* Construct an array of images */
-	for ( i=0; i<gi->list_len; ++i )
-	    WriteBase(file,gi->u.images[i],stem,i);
-	fprintf(file,"static struct _GImage *%s_bases = {\n",stem);
-	for ( i=0; i<gi->list_len; ++i )
-	    fprintf(file,"    &%s%d_base%s\n", stem, i, i==gi->list_len-1?"":"," );
-	fprintf(file,"};\n\n" );
-	
-	fprintf(file,"GImage %s = { %d, (struct _GImage *) %s_bases };\n",stem,gi->list_len,stem);
-    }
     fflush(file);
     i=ferror(file);
     fclose(file);

--- a/gutils/gimagewritejpeg.c
+++ b/gutils/gimagewritejpeg.c
@@ -132,7 +132,7 @@ return;
 
 /* quality is a number between 0 and 100 */
 int GImageWrite_Jpeg(GImage *gi, FILE *outfile, int quality, int progressive) {
-    struct _GImage *base = gi->list_len==0?gi->u.image:gi->u.images[0];
+    struct _GImage *base = gi->image;
     struct jpeg_compress_struct cinfo;
     struct my_error_mgr jerr;
     JSAMPROW row_pointer[1];	/* pointer to JSAMPLE row[s] */

--- a/gutils/gimagewritepng.c
+++ b/gutils/gimagewritepng.c
@@ -60,7 +60,7 @@ static void mem_flush_fn(png_structp UNUSED(png_ptr)) {
 }
 
 static int GImageWritePngFull(GImage *gi, void *io, bool in_memory, int compression_level, bool progressive) {
-    struct _GImage *base = gi->list_len==0?gi->u.image:gi->u.images[0];
+    struct _GImage *base = gi->image;
     png_structp png_ptr;
     png_infop info_ptr;
     png_byte **rows;

--- a/gutils/gimagewritexbm.c
+++ b/gutils/gimagewritexbm.c
@@ -31,7 +31,7 @@
 
 int GImageWriteXbm(GImage *gi, char *filename) {
 /* Export an *.xbm image, return 0 if all done okay */
-    struct _GImage *base = gi->list_len==0?gi->u.image:gi->u.images[0];
+    struct _GImage *base = gi->image;
     FILE *file;
     int i,j, val,val2,k;
     char stem[256];

--- a/gutils/gimagewritexpm.c
+++ b/gutils/gimagewritexpm.c
@@ -48,7 +48,7 @@ return( two );
 
 int GImageWriteXpm(GImage *gi, char *filename) {
 /* Export an *.xpm image. Return 0 if all done okay */
-    struct _GImage *base = gi->list_len==0?gi->u.image:gi->u.images[0];
+    struct _GImage *base = gi->image;
     FILE *file;
     char stem[256];
     char *pt,*color_type; uint8_t *scanline;

--- a/inc/gimage.h
+++ b/inc/gimage.h
@@ -109,11 +109,7 @@ struct _GImage {
 /*  accessing. it_screen means that we've got an image that can be drawn */
 /*  directly on the screen */
 typedef struct gimage {
-    short list_len;		/* length of list */
-    union {			/* depends on whether has_list is set */
 	struct _GImage *image;
-    	struct _GImage **images;
-    } u;
     void *userdata;
 } GImage;
 
@@ -136,8 +132,6 @@ typedef struct gpoint {
 extern GImage *GImageCreate(enum image_type type, int32_t width, int32_t height);
 extern GImage *_GImage_Create(enum image_type type, int32_t width, int32_t height);
 extern void GImageDestroy(GImage *gi);
-extern GImage *GImageCreateAnimation(GImage **images, int n);
-extern GImage *GImageAddImageBefore(GImage *dest, GImage *src, int pos);
 
 extern Color GImageGetPixelRGBA(GImage *base,int x, int y);
 extern int GImageGetWidth(GImage *);


### PR DESCRIPTION
The `GImage` API *technically* supported animated images, and indeed loaded GIFs that way, but we never actually did anything other than access the first frame. As far as I can tell, there was zero code that ever displayed or wrote anything beyond that (there's no GIF writing support even), and no way to access them via the Python API.

This simplifies the code a fair bit. A next step would be to inline the `_GImage` struct back into `GImage` and avoid a double indirection. I'll leave that for a future PR if there's interest.

The main areas of concern are the static icon definitions (I think I got them all, but might've missed some somewhere), and the GIF reading code (I've changed it to only load the first frame; I've tested it manually and it seems to still work).

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change**
