### PR TITLE
Manually install Inno Setup 6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,10 @@ jobs:
       - name: Run InnoSetup
         if: github.ref == 'refs/heads/master'
         working-directory: fontforgebuilds/fontforge-setup
-        run: iscc -Qp fontforgesetup.iss -DMSYSTEM=${{ matrix.arch }}
+        run: |
+          winget install --id JRSoftware.InnoSetup -e -s winget
+          $env:path += ";$env:LOCALAPPDATA/Programs/Inno Setup 6"
+          iscc -Qp fontforgesetup.iss -DMSYSTEM=${{ matrix.arch }}
       - name: Build artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Windows 2025 runner image dropped Inno Setup Windows installer - see actions/runner-images#11644. It was recently elevated to `windows-latest`, and caused CI failure.

This change installs Inno Setup manually from Windows Package Manager.

### Type of change
- **Non-breaking change**
