### PR TITLE
Fix hotkeys in BitmapView

### DIFF
--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -2434,6 +2434,7 @@ BitmapView *BitmapViewCreate(BDFChar *bc, BDFFont *bdf, FontView *fv, int enc) {
     wattrs.event_masks = -1;
     wattrs.cursor = ( bc->refs == NULL ) ? ct_pencil : ct_pointer;
     bv->v = GWidgetCreateSubWindow(gw,&pos,v_e_h,bv,&wattrs);
+    GDrawSetWindowTypeName(bv->v, "BitmapView");
 
     bv->height = pos.height; bv->width = pos.width;
     bv->b1_tool = ( bc->refs == NULL ) ? bvt_pencil : bvt_pointer; bv->cb1_tool = bvt_pointer;

--- a/fontforgeexe/bitmapview.c
+++ b/fontforgeexe/bitmapview.c
@@ -2381,6 +2381,7 @@ BitmapView *BitmapViewCreate(BDFChar *bc, BDFFont *bdf, FontView *fv, int enc) {
 
     bv->gw = gw = GDrawCreateTopWindow(NULL,&pos,bv_e_h,bv,&wattrs);
     free( (unichar_t *) wattrs.icon_title );
+    GDrawSetWindowTypeName(bv->gw, "BitmapView");
 
     GDrawGetSize(GDrawGetRoot(screen_display),&zoom);
     zoom.x = BVPalettesWidth(); zoom.width -= zoom.x-10;

--- a/share/default
+++ b/share/default
@@ -616,3 +616,75 @@ CharView.Menu.View.Show.Tab.Tab4:Alt+5
 CharView.Menu.View.Show.Tab.Tab5:Alt+6
 
 +CharView._ImmediateKeys.TogglePreview:`
+
+
+
+BitmapView.Menu.File.New:Ctl+N
+BitmapView.Menu.File.Open:Ctl+O
+BitmapView.Menu.File.Close:Ctl+Shft+Q
+BitmapView.Menu.File.Save:Ctl+S
+BitmapView.Menu.File.Save as...:Ctl+Shft+S
+BitmapView.Menu.File.Generate Fonts...:Ctl+Shft+G
+BitmapView.Menu.File.Generate Mac Family...:Alt+Ctl+G
+BitmapView.Menu.File.Generate TTC...:No Shortcut
+BitmapView.Menu.File.Export...:No Shortcut
+BitmapView.Menu.File.Import...:Ctl+Shft+I
+BitmapView.Menu.File.Revert File:Ctl+Shft+R
+BitmapView.Menu.File.Preferences...:No Shortcut
+BitmapView.Menu.File.Appearance Editor...:No Shortcut
+BitmapView.Menu.File.Configure Plugins...:No Shortcut
+BitmapView.Menu.File.Quit:Ctl+Q
+
+BitmapView.Menu.Edit.Undo:Ctrl+Z
+BitmapView.Menu.Edit.Redo:Ctrl+Y
+BitmapView.Menu.Edit.Cut:Ctrl+X
+BitmapView.Menu.Edit.Copy:Ctrl+C
+BitmapView.Menu.Edit.Copy Reference:Ctrl+G
+BitmapView.Menu.Edit.Paste:Ctrl+V
+BitmapView.Menu.Edit.Clear:Delete
+BitmapView.Menu.Edit.Select All:Ctrl+A
+BitmapView.Menu.Edit.Remove Undoes:No Shortcut
+BitmapView.Menu.Edit.Unlink Reference:Ctrl+U
+
+BitmapView.Menu.Element.Font Info...:Ctl+Shft+F
+BitmapView.Menu.Element.Glyph Info...:Ctl+I
+BitmapView.Menu.Element.BDF Info...:No Shortcut
+BitmapView.Menu.Element.Bitmap Strikes Available...:Ctl+Shft+B
+BitmapView.Menu.Element.Regenerate Bitmap Glyphs...:Ctl+B
+BitmapView.Menu.Element.Remove This Glyph:No Shortcut
+BitmapView.Menu.Element.Transformations.Flip Horizontally:No Shortcut
+BitmapView.Menu.Element.Transformations.Flip Vertically:No Shortcut
+BitmapView.Menu.Element.Transformations.Rotate 90 CW:No Shortcut
+BitmapView.Menu.Element.Transformations.Rotate 90 CCW:No Shortcut
+BitmapView.Menu.Element.Transformations.Rotate 180:No Shortcut
+BitmapView.Menu.Element.Transformations.Skew...:No Shortcut
+
+BitmapView.Menu.View.Palettes.Tools:No Shortcut
+BitmapView.Menu.View.Palettes.Layers:No Shortcut
+BitmapView.Menu.View.Palettes.Shades:No Shortcut
+BitmapView.Menu.View.Palettes.Docked Palettes:No Shortcut
+BitmapView.Menu.View.Fit:Ctl+F
+BitmapView.Menu.View.Zoom out:Alt+Ctl+-
+BitmapView.Menu.View.Zoom in:Alt+Ctl+Shft++
+BitmapView.Menu.View.Next Glyph:Ctrl+]
+BitmapView.Menu.View.Prev Glyph:Ctrl+[
+BitmapView.Menu.View.Next Defined Glyph:Alt+Ctrl+]
+BitmapView.Menu.View.Prev Defined Glyph:Alt+Ctrl+[
+BitmapView.Menu.View.Goto:Ctl+Shft+>
+BitmapView.Menu.View.Find In Font View:Ctl+Shft+<
+BitmapView.Menu.View.Bigger Pixel Size:Ctl+Shft++
+BitmapView.Menu.View.Smaller Pixel Size:Ctl+-
+
+BitmapView.Menu.Metrics.Set Width...:Ctl+Shft+L
+BitmapView.Menu.Metrics.Set Vertical Width...:Ctl+Shft+L
+
+BitmapView.Menu.Window.New Outline Window:Ctl+H
+BitmapView.Menu.Window.New Bitmap Window:Ctl+J
+BitmapView.Menu.Window.New Metrics Window:Ctl+K
+BitmapView.Menu.Window.Warnings:No Shortcut
+
+BitmapView.Menu.Help.Help:F1
+BitmapView.Menu.Help.Overview:Shift+F1
+BitmapView.Menu.Help.Index:Ctrl+F1
+BitmapView.Menu.Help.About...:No Shortcut
+BitmapView.Menu.Help.License...:No Shortcut


### PR DESCRIPTION
It turns out that in order to get BitmapView's hotkeys working, the top-level window (bv->gw) needs its 'Type Name' set (by calling `GDrawSetWindowTypeName(bv->gw, "BitmapView");` after it's created in fontforgeexe/bitmapview.c), and the hotkeys added to share/default.

None of the other views (such as CharView, FontView, and MetricsView) even set the hotkeys within the source code itself anymore, and doing so doesn't actually work it seems, so I could also add a commit to set all of those to 'No Shortcut' within the C code.. But in the meantime, I wanted to have the minimal number of changes to the code, so that this fix could be included as easily as possible.

I also noticed that the share/default file is kinda.. Haphazardly organized. It's not clear whether these should be added to the start or the end, since mostly (but not entirely) the views are organized alphabetically (CharView, FontView, MetricsView), but there's some CharView things added to the very top and very bottom, seemingly out of place.

To avoid messing with where existing hotkeys exist within the file I added the new BitmapView hotkeys to the bottom, but I can move them to the top if that's preferred.

### Type of change
- **Bug fix**
- Fixes #5150