### PR TITLE
October 2025 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # Update the version for each new release
-project(fontforge VERSION 20230101 LANGUAGES C CXX)
+project(fontforge VERSION 20251001 LANGUAGES C CXX)
 
 # No in source builds
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # Update the version for each new release
-project(fontforge VERSION 20251001 LANGUAGES C CXX)
+project(fontforge VERSION 20251009 LANGUAGES C CXX)
 
 # No in source builds
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/desktop/org.fontforge.FontForge.appdata.xml.in
+++ b/desktop/org.fontforge.FontForge.appdata.xml.in
@@ -32,7 +32,7 @@
   <update_contact>fontforge-devel@lists.sourceforge.net</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
-    <release date="2025-10-01" version="20251001" />
+    <release date="2025-10-01" version="20251009" />
     <release date="2023-01-01" version="20230101" />
     <release date="2022-03-08" version="20220308" />
     <release date="2020-11-07" version="20201107" />

--- a/desktop/org.fontforge.FontForge.appdata.xml.in
+++ b/desktop/org.fontforge.FontForge.appdata.xml.in
@@ -32,6 +32,7 @@
   <update_contact>fontforge-devel@lists.sourceforge.net</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2025-10-01" version="20251001" />
     <release date="2023-01-01" version="20230101" />
     <release date="2022-03-08" version="20220308" />
     <release date="2020-11-07" version="20201107" />

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.abspath('_extensions'))
 # -- Project information -----------------------------------------------------
 
 project = 'FontForge'
-copyright = '2000-2012 by George Williams, 2012-2020 by FontForge authors'
+copyright = '2000-2012 by George Williams, 2012-2025 by FontForge authors'
 author = 'FontForge authors'
 
 # The full version, including alpha/beta/rc tags

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -17,7 +17,7 @@ copyright = '2000-2012 by George Williams, 2012-2020 by FontForge authors'
 author = 'FontForge authors'
 
 # The full version, including alpha/beta/rc tags
-release = '20230101'
+release = '20251001'
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -17,7 +17,7 @@ copyright = '2000-2012 by George Williams, 2012-2025 by FontForge authors'
 author = 'FontForge authors'
 
 # The full version, including alpha/beta/rc tags
-release = '20251001'
+release = '20251009'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
**Things to do before the merge**

- [x] Merge pending PRs #5621, #5625
- [x] Sanity test (open font, do some edits in FontView, CharView, test "Add Encoding Slots...", save font, check saved font)
  - [x] Windows appimage
  - [x] Windows installer
  - [x] Linux appimage (X11)
  - [x] Linux appimage (Wayland)
  - [x] Mac appbundle (tested in Monterey under VirtualBox, special build without Python)
- [x] Merge CI fix for `MINGW32` fontforge/fontforgebuilds#6
- [x] Adjust to actual release date

**Things to do after the merge**

- [ ] Follow the procedure in https://github.com/fontforge/fontforge/wiki/Making-a-release
- [ ] Check propagation into major distributions / packages
  - [x] Debian - https://tracker.debian.org/pkg/fontforge
  - [x] Homebrew - https://github.com/Homebrew/homebrew-core/blob/main/Formula/f/fontforge.rb
  - [x] MSYS2 - https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-fontforge
  - [x] Fedora - https://src.fedoraproject.org/rpms/fontforge/tree/rawhide
  - [ ] FreeBSD - https://www.freshports.org/print/fontforge
  - [ ] Ubuntu - adopts Debian package as is https://launchpad.net/~fontforge
