### PR TITLE
Fix typos in Python module docs

### DIFF
--- a/doc/sphinx/scripting/python/fontforge.rst
+++ b/doc/sphinx/scripting/python/fontforge.rst
@@ -252,7 +252,7 @@ Module functions
    do not have a method to indicate version numbers, but there is a limited
    method to estimate versions {'0.0'..'0.5'}. '0.0' if FontForge has no LibSpiro
    available. '0.1' if LibSpiro 20071029 is available. '0.2' if LibSpiro 0.2 to
-   0.5 is available. LibSpiro 0.6 and higher reports back it's version available.
+   0.5 is available. LibSpiro 0.6 and higher reports back its version available.
 
 .. function:: version()
 
@@ -532,7 +532,7 @@ Not a very useful example.
    of :doc:`Extending FontForge with Python </techref/pyextend>`
 
    **Note:** The positional interface is forward-compatible with earlier
-   verions of FontForge.
+   versions of FontForge.
 
    .. object:: callback
 
@@ -545,8 +545,8 @@ Not a very useful example.
    .. object:: enable
 
       When specified this function is called with the same arguments as ``callback``
-      right before the menu or submenu is diplayed. When it returns ``True``
-      the menu item will be enabled and when it returns``False`` it will be
+      right before the menu or submenu is displayed. When it returns ``True``
+      the menu item will be enabled and when it returns ``False`` it will be
       disabled. (When ``enable`` is ``None`` the menu item is always enabled.)
 
    .. object:: data
@@ -617,7 +617,7 @@ Not a very useful example.
       identifier_string)``, or a string which is treated as the
       ``localized_name``. Submenus can and should also specify a *mnemonic*.
 
-      In the future the ``identfier_string`` will allow a whole submenu to be
+      In the future the ``identifier_string`` will allow a whole submenu to be
       moved to a different location in the menu hierarchy.
 
    .. object:: submenu_names
@@ -644,7 +644,7 @@ Not a very useful example.
    This will add the capability to import or export files of a given type,
    presumably a way of specifying the splines in a given glyph.
 
-   .. object:: import-function
+   .. object:: import_function
 
       The function to call to import a file into a glyph. It will be called
       with: The data argument (specified below), A pointer to the glyph into
@@ -652,7 +652,7 @@ Not a very useful example.
       import should go to the background layer or foreground. This function may
       be ``None``. In which case there is no import method for this file type.
 
-   .. object:: export-function
+   .. object:: export_function
 
       The function to call to export a glyph into a file. It will be called
       with: The data argument (see below), a pointer to the glyph, and a
@@ -663,7 +663,10 @@ Not a very useful example.
 
       Anything you like (including ``None``). It will be passed to the
       import/export routines and can provide them with context if they need that.
-      name The name to be displayed in the user interface for this file type.
+
+   .. object:: name
+
+      The name to be displayed in the user interface for this file type.
       This may just be the extension, or it might be something more informative.
 
    .. object:: extension
@@ -671,7 +674,7 @@ Not a very useful example.
       This is the default extension for this file type. It is used by the
       export dialog to pick an extension for the generated filename.
 
-   .. object:: extension-list
+   .. object:: extension_list
 
       Some file types have more than one common extension (eps files are usually
       named "eps", but I have also seen "ps" and "art" used). The import dialog
@@ -728,7 +731,7 @@ Not a very useful example.
 
    The first argument is the dialog's title, the second is the question to be
    asked, the third is a tuple of strings -- each string will become a button,
-   the fourth and fifth arguments are option, the fourth is the index in the
+   the fourth and fifth arguments are optional, the fourth is the index in the
    answer array that will be the default answer (the one invoked if the user
    presses the [Return] key), and the fifth is the answer invoked if the user
    presses the [Escape] key. If omitted the default answer will be the first,
@@ -747,7 +750,7 @@ Not a very useful example.
 
    The first argument is the dialog's title, the second is the question to be
    asked, the third is a tuple of strings -- each string will become a button,
-   the fourth and fifth arguments are option, the fourth is the index in the
+   the fourth and fifth arguments are optional, the fourth is the index in the
    answer array that will be the default answer (the one invoked if the user
    presses the [Return] key). If omitted the default answer will be the first.
 
@@ -946,7 +949,7 @@ Two contours may be compared to see if they describe similar paths.
    For more information on what these point types mean see
    `Raph Levien's work <https://www.levien.com/spiro/>`_.
 
-   The flags argument is treated as a bitmap of which currently on one bit (0x1)
+   The flags argument is treated as a bitmap of which currently one bit (0x1)
    is defined. This indicates that this point is selected in the UI.
 
    When you assign a tuple of spiro control points to this member, the point
@@ -1003,13 +1006,13 @@ Does not support the repeat concept.
 
 .. object:: c[i:j]
 
-   The contour containing points between i and j; i must be >= j.
+   The contour containing points between i and j; j must be >= i.
    Alternatively, ``c[j:i:-1]`` returns those points in reverse order (larger
    strides are not supported).
 
 .. object:: c[i:j] = d
 
-   The points between i and j are replaced by those in d; i must be >= j.
+   The points between i and j are replaced by those in d; j must be >= i.
    d can be a contour or a sequence of point initializer tuples, as in
    ``[(1,1,False),(2,1)]``. If ``c[j:i:-1]`` is used instead the points of d
    are assigned in reverse order.
@@ -1037,25 +1040,25 @@ Does not support the repeat concept.
 
 .. method:: contour.lineTo(x, y[, pos])
 
-   Adds an line to the contour. If the optional third argument is give, the
+   Adds a line to the contour. If the optional third argument is given, the
    line will be added after the pos'th point, otherwise it will be at the end
    of the contour.
 
 .. method:: contour.cubicTo((cp1x, cp1y)(cp2x, cp2y)(x, y)[, pos])
 
-   Adds a cubic curve to the contour. If the optional third argument is give,
-   the line will be added after the pos'th point, otherwise it will be at the
+   Adds a cubic curve to the contour. If the optional fourth argument is given,
+   the curve will be added after the pos'th point, otherwise it will be at the
    end of the contour.
 
 .. method:: contour.quadraticTo((cpx, cpy)(x, y)[, pos])
 
    Adds a quadratic curve to the contour. If the optional third argument is
-   give, the line will be added after the pos'th point, otherwise it will be at
+   given, the curve will be added after the pos'th point, otherwise it will be at
    the end of the contour.
 
 .. method:: contour.insertPoint(point[, pos])
 
-   Adds point to the contour. If the optional third argument is give, the line
+   Adds a point to the contour. If the optional second argument is given, the point
    will be added after the pos'th point, otherwise it will be at the end of the
    contour. The point may be either a point or a point initializer tuple.
 
@@ -1125,7 +1128,7 @@ Does not support the repeat concept.
 
 .. method:: contour.merge(pos)
 
-   Removes the on-curve point a the given position and rearranges the other
+   Removes the on-curve point at the given position and rearranges the other
    points to make the curve as similar to the original as possible. (pos may
    also be a tuple of positions, all of which will be removed)
 
@@ -1220,11 +1223,11 @@ A layer is a collection of contours. All the contours must be the same order
 
 Layers may be compared to see if their contours are similar.
 
-.. class:: layer()
+.. class:: layer(is_quadratic=False)
 
    Creates a new layer
 
-.. method:: layer.is_quadratic()
+.. attribute:: layer.is_quadratic
 
    Whether the contours should be interpreted as a set of quadratic cubic
    splines. Setting this value has the side effect of converting the contour
@@ -1522,7 +1525,7 @@ This type may not be pickled.
 
 .. method:: glyphPen.moveTo((x, y))
 
-   With one exception this call begins every contor and creates an on curve
+   With one exception this call begins every contour and creates an on curve
    point at ``(x,y)`` as the start point of that contour. This should be the
    first call after a pen has been created and the call that follows a
    :meth:`glyphPen.closePath()`, :meth:`glyphPen.endPath()`.
@@ -1550,7 +1553,7 @@ This type may not be pickled.
    point mid-way between its control points may be omitted, leading to a run of
    off-curve points (with implied but unspecified on-curve points between them).
 
-   The first format allows an arbetary number of off-curve points followed by
+   The first format allows an arbitrary number of off-curve points followed by
    one on-curve point.
 
    It is possible to have a contour which consists solely of off-curve points.
@@ -1605,14 +1608,14 @@ must be created through the font.
 .. attribute:: glyph.altuni
 
    Returns additional unicode code points for this glyph. For a primary code
-   point, see :attr:`glyph.unicode` .
+   point, see :attr:`glyph.unicode`.
 
    Returns either None or a tuple of alternate encodings. Each alternate
    encoding is a tuple of ::
 
    (unicode-value, variation-selector, reserved-field)
 
-   The first is an unicode value of this alternate code point. The second is an
+   The first is a unicode value of this alternate code point. The second is an
    integer for variation selector and can be set to -1 if not used. The third
    is an empty field reserved for future use and currently must be set to zero.
 
@@ -1825,7 +1828,7 @@ must be created through the font.
 .. attribute:: glyph.persistent
 
    Whatever you want (these data will be saved as a pickled object in the
-   sfd file. It is your job to insure that whatever you put here can be pickled).
+   sfd file. It is your job to ensure that whatever you put here can be pickled).
    See also the :attr:`glyph.temporary` field.
 
 .. attribute:: glyph.references
@@ -2793,7 +2796,7 @@ This type may not be pickled.
 
      .. object:: encoding
 
-        Interpret integer arguments as encoding indeces.
+        Interpret integer arguments as encoding indices.
 
      .. object:: more
 
@@ -2834,11 +2837,11 @@ This type may not be pickled.
 
 .. method:: private.__iter__()
 
-   Returns an iterator for the dictionary which will return all entres.
+   Returns an iterator for the dictionary which will return all entries.
 
 .. method:: private.guess(name)
 
-   Guess a value for this this entry in the private dictionary. If FontForge
+   Guess a value for this entry in the private dictionary. If FontForge
    can't make a guess it will simply ignore the request.
 
 
@@ -3909,7 +3912,7 @@ This type may not be pickled.
    The field may be unset (in which case when the font is generated, FontForge
    will guess a default value from one of the version strings).
 
-   The value returned with be ``None`` if the field is unset or a double.
+   The value returned will be ``None`` if the field is unset or a double.
 
    You may set it to ``None`` which "unsets" it, or to a double value, or to an
    integer. The integer will be treated as a 32 bit integer and right shifted
@@ -3932,7 +3935,7 @@ This type may not be pickled.
    Otherwise FontForge returns a tuple containing five elements, the design
    size, the bottom of the design range, the top, the style id and a tuple of
    tuples. Each sub-tuple is a language/string pair. Language may be either
-   the (english) name of the language/locale, or The string itself is in UTF-8.
+   the (english) name of the language/locale, or the string itself in UTF-8.
 
 .. attribute:: font.strokedfont
 
@@ -4019,7 +4022,7 @@ This type may not be pickled.
    The field may be unset (in which case when the font is generated, FontForge
    will guess a default value from one of the version strings).
 
-   The value returned with be ``None`` if the field is unset or an integer.
+   The value returned will be ``None`` if the field is unset or an integer.
 
    You may set it to ``None`` which "unsets" it, or to an integer.
 
@@ -4030,7 +4033,7 @@ This type may not be pickled.
    The field may be unset (in which case when the font is generated, FontForge
    will guess a default value from one of the version strings).
 
-   The value returned with be ``None`` if the field is unset or an integer.
+   The value returned will be ``None`` if the field is unset or an integer.
 
    You may set it to ``None`` which "unsets" it, or to an integer.
 
@@ -4075,7 +4078,7 @@ This type may not be pickled.
             font.addKerningClass(lookup_name, new_subtable_name, separation, class_distance, [, onlyCloser, autokern, after])
 
    Creates a new subtable and a new kerning class in the named lookup. The
-   classes arguments are tuples of tuples of glyph names (each sub-tuble of
+   classes arguments are tuples of tuples of glyph names (each sub-tuple of
    glyph names is a kerning class). The offsets argument is a tuple of kerning
    offsets. There must be as many entries as ::
 
@@ -4103,7 +4106,7 @@ This type may not be pickled.
 .. method:: font.addLookup(new_lookup_name, type, flags, feature_script_lang_tuple[, after_lookup_name)
 
    Creates a new lookup with the given name, type and flags. It will tag it
-   with any indicated features. The type of one of
+   with any indicated features. The type is one of
 
    * ``gsub_single``
    * ``gsub_multiple``
@@ -4143,7 +4146,7 @@ This type may not be pickled.
    language. Example: ``(("liga",(("latn",("dflt")),)),)``
 
    The optional final argument allows you to specify the ordering of the lookup.
-   If not specified the lookup will be come the first lookup in its table.
+   If not specified the lookup will become the first lookup in its table.
 
 .. method:: font.addLookupSubtable(lookup_name, new_subtable_name[, after_subtable_name])
 
@@ -4192,7 +4195,7 @@ This type may not be pickled.
          glyph-name1 glyph-name2 | glyph-name3 @<lookup-name> | glyph-name4
 
       The ``|`` s divide between backtrack, match and lookahead sections. So
-      this example would match it the current glyph were named ``glyph-name3``
+      this example would match if the current glyph were named ``glyph-name3``
       and it were preceded by ``glyph-name2`` and that by ``glyph-name1`` and
       followed by ``glyph-name4``. If the match were successful then the lookup
       named ``lookup-name`` would be applied. The ``@<>`` are literal
@@ -4255,7 +4258,7 @@ This type may not be pickled.
    default value will be used (generally found by analyzing the font).
 
    For each selected letter, this function will create a corresponding small
-   caps glyph. If you set the ``symbol`` keyword to ``True`` it will also
+   caps glyph. If you set the ``symbols`` keyword to ``True`` it will also
    create small caps variants of digits and symbols.
 
    The outlines of the new glyph will be based on the outlines of the
@@ -4280,10 +4283,9 @@ This type may not be pickled.
 .. method:: font.alterKerningClass(subtable_name, first_classes, second_classes, offsets)
 
    Changes the kerning class in the named subtable. The classes arguments are
-   tuples of tuples of glyph names (each sub-tuble of glyph names is a kerning
+   tuples of tuples of glyph names (each sub-tuple of glyph names is a kerning
    class). The offsets argument is a tuple of kerning offsets. There must be as
-   many entries as ``len(first-class)*len(second-class)``. The optional after
-   argument is used to specify the order of the subtable within the lookup.
+   many entries as ``len(first-class)*len(second-class)``.
 
 .. method:: font.autoKern(subtable_name, separation[, minKern=, onlyCloser=, touch=])
             font.autoKern(subtable_name, separation, glyph_list1, glyph_list2[, minKern=, onlyCloser=, touch=])
@@ -4298,12 +4300,12 @@ This type may not be pickled.
 
    It will attempt to guess a good kerning value between the two glyphs -- a
    value which will make the optical separation between the two appear to be
-   ``separation`` em-units. If ``minkern`` is specified then and the (absolute
+   ``separation`` em-units. If ``minKern`` is specified and the (absolute
    value of the) kerning correction is less than this number then no kerning
-   pair will be generated. If ``onlyCloser`` is set true then only negative
-   kerning offsets will be generated (only thing which move two glyphs closer
+   pair will be generated. If ``onlyCloser`` is set to true then only negative
+   kerning offsets will be generated (only thing which moves two glyphs closer
    together). If touch is set to 1 then the kerning offset will not be based on
-   optical distance but on the closest approach between two the two glyphs.
+   optical distance but on the closest approach between the two glyphs.
 
 .. method:: font.appendSFNTName(language, strid, string)
 
@@ -4317,12 +4319,11 @@ This type may not be pickled.
 
    Removes any existing AALT features (and any lookups solely controlled by such
    features) and creates new ones containing all possible single and alternate
-   substutions available for each glyph.
+   substitutions available for each glyph.
 
-.. method:: font.cidConvertByCMap(cmap_filename)
+.. method:: font.cidConvertByCmap(cmap_filename)
 
    Converts a normal font into a CID-keyed font with one subfont using
-
    the CMAP to determine the mapping.
 
 .. method:: font.cidConvertTo(registry, ordering, supplement)
@@ -4355,7 +4356,7 @@ This type may not be pickled.
 
 .. method:: font.compareFonts(other_font, filename, flags_tuple)
 
-   This will compare the current font with the font in ``other-font`` (which
+   This will compare the current font with the font in ``other_font`` (which
    must already have been opened). It will write the results to the
    ``filename``, you may use "-" to send the output to stdout. The ``flags``
    argument is a tuple of strings and controls what will be compared.
@@ -4406,7 +4407,7 @@ This type may not be pickled.
 
       if a glyph exists in the second font but not the first, create that
       glyph in the first and add the outlines from the second into the
-      backgroun layer
+      background layer
 
 
 .. method:: font.createChar(uni[, name])
@@ -4458,7 +4459,7 @@ This type may not be pickled.
    and returns the encoding slot. If the glyph is not present it returns -1.
 
    (If a glyph with that name/unicode is in the font, but is not in the
-   encoding, then an value beyond the end of the encoding will be returned).
+   encoding, then a value beyond the end of the encoding will be returned).
 
 .. method:: font.glyphs([type])
 
@@ -4657,7 +4658,7 @@ This type may not be pickled.
 
    .. note::
 
-      No default value is providedfor this argument you must figure out all the
+      No default value is provided for this argument you must figure out all the
       values yourself.
 
    If ``vCounterType`` is the string "scaled", then vertical counters, and the
@@ -4669,10 +4670,7 @@ This type may not be pickled.
 
    Returns a tuple whose entries are: (first-classes, second-classes, offsets).
    The classes are themselves tuples of tuples of glyph names. The offsets will
-   be a tuple of numeric kerning offsetss a tuple whose entries are:
-   (first-classes, second-classes, offsets). The classes are themselves tuples
-   of tuples of glyph names. The offsets will be a tuple of numeric kerning
-   offsets.
+   be a tuple of numeric kerning offsets.
 
 .. method:: font.getLookupInfo(lookup_name)
 
@@ -4818,13 +4816,13 @@ This type may not be pickled.
 
    .. object:: fontsample
 
-      The third argument should contain a string which will be layed out
+      The third argument should contain a string which will be laid out
       and displayed as well as FontForge can.
 
    .. object:: fontsampleinfile
 
       The third argument should contain the name of a file which contains
-      text to be layed out and displayed.
+      text to be laid out and displayed.
 
    If output is to a file (see :func:`fontforge.printSetup()`) then the last
    argument specifies a file name in which to store output.
@@ -4953,10 +4951,10 @@ See the :class:`selection` type for how to alter the selection.
 
    Extrema should be marked by on-curve points. If a curve in any selected
    glyph lacks a point at a significant extremum this command will add one.
-   
+
 .. method:: font.addInflections()
 
-   Please see :meth:`contour.addInflections()`. 
+   Please see :meth:`contour.addInflections()`.
 
 .. method:: font.autoHint()
 
@@ -4973,7 +4971,7 @@ See the :class:`selection` type for how to alter the selection.
 .. method:: font.autoTrace()
 
    Auto traces any background images in all selected glyphs
-   
+
 .. method:: font.build()
 
    If any of the selected characters is a composite character, then this
@@ -5055,7 +5053,7 @@ See the :class:`selection` type for how to alter the selection.
 .. method:: font.correctReferences()
 
    Checks a font for glyphs with mixed contours and references (or references
-   with transformation matrices which cannot be represented truetype (ie.
+   with transformation matrices which cannot be represented in truetype (ie.
    scaling by 2 or more)). If a mixed case is discovered FontForge will take
    the contours out of the glyph, put them in a new glyph, and make a reference
    to the new glyph.


### PR DESCRIPTION
This PR fixes typos found while working on fontforge [type stubs](https://github.com/chanicpanic/fontforge-stubs).

It also corrects `layer.is_quadratic` to be documented as an attribute instead of a method and documents the `is_quadratic` parameter of the `layer` constructor.

### Type of change
- **Non-breaking change**
