### PR TITLE
Fix iconv(3) arguments.

### DIFF
--- a/fontforge/macenc.c
+++ b/fontforge/macenc.c
@@ -1132,7 +1132,7 @@ return( NULL );
 					    macenc==sm_korean ? "EUC-KR" :
 			                    macenc==sm_tradchinese ? "Big5" :
 			                      "EUC-CN" );
-	iconv_t *toutf8;
+	iconv_t toutf8;
 	ICONV_CONST char *in;
 	char *out;
 	size_t inlen, outlen;

--- a/fontforge/splinefont.h
+++ b/fontforge/splinefont.h
@@ -747,8 +747,8 @@ typedef struct enc {
     int iso_2022_escape_len;
     int low_page, high_page;
     char *iconv_name;	/* For compatibility to old versions we might use a different name from that used by iconv. */
-    iconv_t *tounicode;
-    iconv_t *fromunicode;
+    iconv_t tounicode;
+    iconv_t fromunicode;
     int (*tounicode_func)(int);
     int (*fromunicode_func)(int);
     unsigned int is_temporary: 1;	/* freed when the map gets freed */


### PR DESCRIPTION
iconv(3) expects an "iconv_t" as first argument, not an "iconv_t *".

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
