### PR TITLE
Remove `gi` field from charview

### DIFF
--- a/fontforge/views.h
+++ b/fontforge/views.h
@@ -252,7 +252,6 @@ typedef struct charview {
     GPoint e;					/* mouse location */
     GPoint olde;
     BasePoint last_c;
-    GImage gi;					/* used for fill bitmap only */
     int enc;
     EncMap *map_of_enc;				/* Only use for comparison against fontview's map to see if our enc be valid */
 						/*  Will not be updated when fontview is reencoded */

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -12265,13 +12265,6 @@ static void _CharViewCreate(CharView *cv, SplineChar *sc, FontView *fv,int enc,i
     cv->nfh = as+ds; cv->nas = as;
 
     cv->height = pos.height; cv->width = pos.width;
-    cv->gi.u.image = calloc(1,sizeof(struct _GImage));
-    cv->gi.u.image->image_type = it_mono;
-    cv->gi.u.image->clut = calloc(1,sizeof(GClut));
-    cv->gi.u.image->clut->trans_index = cv->gi.u.image->trans = 0;
-    cv->gi.u.image->clut->clut_len = 2;
-    cv->gi.u.image->clut->clut[0] = view_bgcol;
-    cv->gi.u.image->clut->clut[1] = fillcol;
     cv->b1_tool = cv_b1_tool; cv->cb1_tool = cv_cb1_tool;
     cv->b1_tool_old = cv->b1_tool;
     cv->b2_tool = cv_b2_tool; cv->cb2_tool = cv_cb2_tool;
@@ -12644,8 +12637,6 @@ void CharViewFree(CharView *cv) {
 	GDrawDestroyWindow(cv->ruler_linger_w);
 	cv->ruler_linger_w = NULL;
     }
-    free(cv->gi.u.image->clut);
-    free(cv->gi.u.image);
 #if HANYANG
     if ( cv->jamodisplay!=NULL )
 	Disp_DoFinish(cv->jamodisplay,true);


### PR DESCRIPTION
Cleanup from https://github.com/fontforge/fontforge/pull/5612. The `cv->gi` field held a filled preview of the character in the non-Cairo path, but that's gone now.

### Type of change
- **Non-breaking change**
