### PR TITLE
Fix crash in Metrics View

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -6174,7 +6174,7 @@ int _WriteTTFFont(FILE *ttf,SplineFont *sf,enum fontformat format,
 
 	fake_mappings = calloc(sf->glyphcnt,sizeof(bool));
 	for (i = 0; i < sf->glyphcnt; ++i) {
-	    if (sf->glyphs[i]->unicodeenc == -1) {
+	    if (sf->glyphs[i] && sf->glyphs[i]->unicodeenc == -1) {
 		sf->glyphs[i]->unicodeenc = fake_unicode_base + sf->glyphs[i]->orig_pos;
 		fake_mappings[i] = true;
 	    }
@@ -6222,7 +6222,7 @@ int _WriteTTFFont(FILE *ttf,SplineFont *sf,enum fontformat format,
     // Remove temporarily assigned fake Private Area unicode point from all unmapped glyphs
     if (flags & ttf_flag_fake_map) {
 	for (i = 0; i < sf->glyphcnt; ++i) {
-	    if (fake_mappings[i])
+	    if (sf->glyphs[i] && fake_mappings[i])
 		sf->glyphs[i]->unicodeenc = -1;
 	}
 	free(fake_mappings);

--- a/fontforge/ufo.c
+++ b/fontforge/ufo.c
@@ -1050,7 +1050,7 @@ void clear_cached_ufo_paths(SplineFont * sf) {
   // First we clear the glif names.
   for (i = 0; i < sf->glyphcnt; i++) {
     struct splinechar * sc = sf->glyphs[i];
-    if (sc->glif_name != NULL) { free(sc->glif_name); sc->glif_name = NULL; }
+    if (sc && sc->glif_name != NULL) { free(sc->glif_name); sc->glif_name = NULL; }
   }
   // Then we clear the layer names.
   for (i = 0; i < sf->layer_cnt; i++) {


### PR DESCRIPTION
Interestingly, the original crash stack could not be observed, and there were quite a lot of changes in Metrics View code since than. But there is another crash in the same workflow, fixing it here.

Fixes #4706, fixes #5664.