### PR TITLE
Differentiate Supplementary PUA planes by name

### DIFF
--- a/Unicode/makeutype.py
+++ b/Unicode/makeutype.py
@@ -244,8 +244,8 @@ class UnicodeData:
             (0x20000, 0x2FFFD, "Supplementary Ideographic Plane"),
             (0x30000, 0x3FFFD, "Tertiary Ideographic Plane"),
             (0xE0000, 0xEFFFD, "Supplementary Special-purpose Plane"),
-            (0xF0000, 0xFFFFD, "Supplementary Private Use Area Plane A"),
-            (0x100000, 0x10FFFD, "Supplementary Private Use Area Plane B"),
+            (0xF0000, 0xFFFFD, "Plane 15 (Supplementary Private Use Area-A)"),
+            (0x100000, 0x10FFFD, "Plane 16 (Supplementary Private Use Area-B)"),
         ]
         planes = [
             (s, e, s, sum(1 for i in range(s, e + 1) if table[i]), n)

--- a/Unicode/uninames_data.h
+++ b/Unicode/uninames_data.h
@@ -403,8 +403,8 @@ static const struct unicode_range unicode_planes[] = {
     {0xC0000, 0xCFFFD, 0xC0000, 0, N_("<Unassigned Plane 12>")},
     {0xD0000, 0xDFFFD, 0xD0000, 0, N_("<Unassigned Plane 13>")},
     {0xE0000, 0xEFFFD, 0xE0000, 337, N_("Supplementary Special-purpose Plane")},
-    {0xF0000, 0xFFFFD, 0xF0000, 65534, N_("Supplementary Private Use Area Plane A")},
-    {0x100000, 0x10FFFD, 0x100000, 65534, N_("Supplementary Private Use Area Plane B")},
+    {0xF0000, 0xFFFFD, 0xF0000, 65534, N_("Plane 15 (Supplementary Private Use Area-A)")},
+    {0x100000, 0x10FFFD, 0x100000, 65534, N_("Plane 16 (Supplementary Private Use Area-B)")},
 };
 
 /* lexicon data */


### PR DESCRIPTION
Better distinction between **"Supplementary Private Use Area-A/B"** Unicode ranges and **"Supplementary Private Use Area Plane A/B"** Unicode planes

Fixes #5560