### PR TITLE
Document `no-mac-names` flag for font.generate

### DIFF
--- a/doc/sphinx/scripting/python/fontforge.rst
+++ b/doc/sphinx/scripting/python/fontforge.rst
@@ -4545,7 +4545,7 @@ This type may not be pickled.
    .. object:: no-mac-names
 
       Do not include Mac names used on Classic Mac OS. This option does not
-      affect native Mac OS X applications.
+      affect native macOS (formerly known as Mac OS X) applications.
 
    .. object:: round
 


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

For `font.generate`, `no-mac-names` flag gets implemented several years ago, but does not get documented yet. This PR documents the flag.

### Type of change
- **Non-breaking change**
