### PR TITLE
FindMatchingHVEdge: report problematic glyph (#5087)

### DIFF
--- a/fontforge/stemdb.c
+++ b/fontforge/stemdb.c
@@ -811,7 +811,10 @@ return( 0 );
 	winding += nw;
     }
     if ( space[i]==NULL ) {
-	fprintf( stderr, "FindMatchinHVEdge didn't\n" );
+	if ( gd->sc )
+	    fprintf( stderr, "FindMatchingHVEdge didn't: 0x%X, '%s'\n", gd->sc->unicodeenc, gd->sc->name );
+	else
+	    fprintf( stderr, "FindMatchingHVEdge didn't: unknown glyph\n" );
 return( 0 );
     }
 


### PR DESCRIPTION
This PR is a tiny bit reformatted version of the original patch attached to #5087.

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Non-breaking change** (Fixes #5087)
