### PR TITLE
Fix `flags` parameter of `font.generateTtc`

### DIFF
--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -18082,7 +18082,7 @@ return( NULL );
 
     locfilename = utf82def_copy(filename);
 
-    if ( !WriteTTC(locfilename,head,ff_ttc,bf,iflags,layer,ittcflags)) {
+    if ( !WriteTTC(locfilename,head,ff_ttc,bf,fmflag2ttfflag(iflags,false),layer,ittcflags)) {
 	PyErr_Format(PyExc_EnvironmentError, "Font generation failed");
 	/* Don't return here, will return after memory is freed below */
     }

--- a/fontforge/savefont.h
+++ b/fontforge/savefont.h
@@ -71,6 +71,7 @@ int _DoSave(SplineFont *sf,char *newname,int32_t *sizes,int res,
 	EncMap *map, char *subfontdefinition,int layer);
 int CheckIfTransparent(SplineFont *sf);
 
+int fmflag2ttfflag(int fmflags, bool is_postscript_or_cff);
 extern int GenerateScript(SplineFont *sf, char *filename, const char *bitmaptype, int fmflags, int res, char *subfontdirectory, struct sflist *sfs, EncMap *map, NameList *rename_to, int layer);
 
 #ifdef FONTFORGE_CONFIG_WRITE_PFM


### PR DESCRIPTION
Fixes #5676

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
