### PR TITLE
Metrics view: Fix crash on Up/Down keypress while in the feature list

### DIFF
--- a/fontforgeexe/metricsview.c
+++ b/fontforgeexe/metricsview.c
@@ -4327,8 +4327,12 @@ static void MVChar(MetricsView *mv,GEvent *event)
 	    //      should always move up/down in the list of kerning words.
 	    if( active != mv->text )
 	    {
+		const unichar_t *title = _GGadgetGetTitle(active);
+		if (!title)
+		    return;
+
 		unichar_t *end;
-		double val = u_strtod(_GGadgetGetTitle(active),&end);
+		double val = u_strtod(title,&end);
 		if (isValidInt(end)) {
 		    int dir = ( event->u.chr.keysym == GK_Up || event->u.chr.keysym==GK_KP_Up ) ? 1 : -1;
 		    if( event->u.chr.state&ksm_control && event->u.chr.state&ksm_shift ) {


### PR DESCRIPTION
#19 has introduced a crash when first clicking a feature in the feature list, thus setting the focus on it, and then pressing an Up or Down arrow key.
Then #420 removed the buggy code.
#451 re-introduced the code, and the bug as well.

### Type of change
- **Bug fix**
