### PR TITLE
Remove X11 backend options from CLI and from documentation

### DIFF
--- a/doc/sphinx/techref/cliargs.rst
+++ b/doc/sphinx/techref/cliargs.rst
@@ -47,29 +47,9 @@ FontForge recognizes the following options:
    Will read a font from "foo.sfd" and then generate a truetype font from it
    called "foo.ttf"
 
-.. option:: -cmap type
-
-   Where type may be
-
-   Current | Copy | Private
-
-   Gives the user some control over :ref:`colormap handling <xres.Colormap>` on
-   8bit screens.
-
-.. option:: -depth val
-
-   Specifies that FontForge should search for a visual with the given depth
-
 .. option:: -display name
 
    Specifies the name of the display on which FontForge will open its windows
-
-.. option:: -dontopenxdevices
-
-   Various people have complained that when FontForge attempts to open the
-   devices of the wacom graphics tablet, the X server gives a BadDevice error. I
-   can't duplicate this, the open works fine on my system, but this argument
-   allows them to tell fontforge not to try to use the tablet.
 
 .. option:: -help
 
@@ -84,33 +64,6 @@ FontForge recognizes the following options:
 .. option:: -version
 
    Prints out the source version and exits.
-
-.. option:: -keyboard type
-
-   .. warning:: Deprecated option, may not do anything
-
-   Where type may be
-
-   ibm | mac | sun | ppc | 0 | 1 | 2 | 3
-
-   Allows you to specify the type of keyboard. Currently this is only relevant
-   when generating menus. The modifier keys are in different locations on
-   different keyboards (under different operating systems) and if FontForge
-   knows what keyboard you are using it can make the hot-keys have better
-   labels.
-
-   * ibm | 0
-
-        Uses the Control and Alt keys
-   * mac | 1
-
-        Uses the Control and Option keys (Mac OS/X, Mac keyboard)
-   * ppc | 3
-
-        Uses the Control and Command keys (Suse ppc linux, Mac keyboard)
-   * sun | 2
-
-        Uses the Control and Meta keys
 
 .. option:: -last
 
@@ -189,16 +142,6 @@ FontForge recognizes the following options:
 .. option:: -usage
 
    Display a brief description of the options
-
-.. option:: -vc type
-
-   Where type may be:
-
-   StaticGray GrayScale StaticColor PseudoColor TrueColor DirectColor
-
-   (See the X manuals for a description of what these mean). FontForge will
-   search through the visuals in an attempt to find one with the desired
-   VisualClass (given here) and depth (given with the -depth option).
 
 
 .. _cliargs.Environment:

--- a/doc/sphinx/ui/misc/HotKeys.rst
+++ b/doc/sphinx/ui/misc/HotKeys.rst
@@ -134,12 +134,6 @@ I am aware of the following significant differences:
   when not using X)
 * On Suns the meta (diamond) key is equivalent to the Alt modifier key.
 
-FontForge will attempt to guess what keyboard you are using and produce menus
-with hot-key indicators that match the host machine. If you are displaying on a
-different machine from the one you are running on the menu names may be wrong.
-You can fix this up with the :ref:`keyboard resource <xres.Keyboard>`, or the
--keyboard command line argument.
-
 
 Tool modifiers in the Outline Glyph Window
 ------------------------------------------

--- a/doc/sphinx/ui/misc/xres.rst
+++ b/doc/sphinx/ui/misc/xres.rst
@@ -864,71 +864,6 @@ GDraw
 
    Whether to synchronize the display before raising the first window.
 
-GDraw (X backend only)
-~~~~~~~~~~~~~~~~~~~~~~
-
-These are not included in the appearance editor and need to be set
-some other way, perhaps through the normal X Resources system.
-
-.. object:: Gdraw.Depth
-
-   An integer (1, 8, 16, 32)
-
-   You can use this to request a different depth than the default one. Not all
-   servers will support all depths. If FontForge can't find a visual with the
-   desired depth it will use the default depth.
-
-.. object:: Gdraw.VisualClass
-
-   A string ("StaticGray", "GrayScale", "StaticColor", "PseudoColor",
-   "TrueColor", "DirectColor")
-
-   FontForge will search for a visual with the given class (and possibly depth
-   if the depth argument is specified too).
-
-.. _xres.Colormap:
-
-.. object:: Gdraw.Colormap
-
-   An string ("Current", "Copy", "Private")
-
-   You can use this to control what FontForge does about the colormap on an 8bit
-   screen
-
-   * Current -- FontForge will attempt to allocate its colors in the current
-     colormap.
-   * Copy -- FontForge will allocate what colors it can and then copy the current
-     color map into a private copy. This means FontForge has access to a much
-     wider range of colors, and (as long as the shared colormap doesn't change)
-     FontForge's colormap will match that of the rest of the screen.
-   * Private -- FontForge will allocate a private colormap and set the colors just
-     as it wants them. It will almost certainly not match the shared colormap.
-
-.. _xres.Keyboard:
-
-.. object:: Gdraw.Keyboard
-
-   ibm | mac | sun | ppc | 0 | 1 | 2 | 3
-
-   Allows you to specify the type of keyboard. Currently this is only relevant
-   when generating menus. The modifier keys are in different locations on
-   different keyboards (under different operating systems) and if FontForge
-   knows what keyboard you are using it can make the hot-keys have better
-   labels.
-
-   * ibm | 0
-
-     Uses the Control and Alt keys
-   * mac | 1
-
-     Uses the Command and Option keys (Mac OS/X, Mac keyboard)
-   * ppc | 3
-
-     Uses the Control and Command keys (Suse ppc linux, Mac keyboard)
-   * sun | 2
-
-     Uses the Control and Meta keys
-
 Popup
 ~~~~~
 
@@ -1590,11 +1525,6 @@ Almost all keyboards now-a-days will have the needed modifier keys, but which
 key is used for what will depend on the keyboard and the OS (for instance
 XDarwin and suse linux use quite different mappings for the modifier keys on the
 mac keyboard). Usually this is only relevant for menus (and mnemonics).
-FontForge tries to guess the keyboard from the environment in which it was
-compiled. But with X this may not always be appropriate. So the
-":ref:`Gdraw.Keyboard <xres.Keyboard>`" resource above may be used to change
-this. (Currently this setting only control the labels that appear in menus for
-the hotkeys).
 
 Mice are more problematic. On PCs we usually have two button mice and on mac
 single button mice. Many linuxes that run on a PC will give you an option of

--- a/fontforgeexe/fontforge.1
+++ b/fontforgeexe/fontforge.1
@@ -11,13 +11,10 @@ fontforge \- create, modify, and view font files
 .BR fontforge
 [\fB\-allglyphs\fP]
 [\fB\-c\fP\ \fIstring\fP]
-[\fB\-cmap\fP\ \fImaptype\fP]
-[\fB\-depth\fP\ \fIpixeld\fP]
 [\fB\-display\fP\ \fIstr\fP]
 [\fB\-lang\fP=ff]
 [\fB\-lang\fP=py]
 [\fB\-help\fP]
-[\fB\-keyboard\fP\ \fIktype\fP]
 [\fB\-last\fP]
 [\fB\-new\fP]
 [\fB\-nosplash\fP]
@@ -29,7 +26,6 @@ fontforge \- create, modify, and view font files
 [\fB\-sync\fP]
 [\fB\-unique\fP]
 [\fB\-usage\fP]
-[\fB\-vc\fP\ \fIclass\fP]
 [\fB\-version\fP]
 [\fIfontfile\fP\ ...]
 .SH DESCRIPTION
@@ -96,34 +92,8 @@ in it and have this process exit.
 Employ the X display specified by the string
 \fIdisplay-name\fP (for example: localhost:0).
 .TP
-.B \-depth \fIpixeld\fP
-Attempt to employ a visual that matches the specified pixel depth,
-\fIpixeld\fP.
-.TP
-.B \-vc \fIval\fP
-Sets the visual class if possible.
-.TP
-.B \-cmap current\fR|\fPcopy\fR|\fPprivate
-Sets the type of color map.
-\fBcurrent\fP attempts to allocate colors int he current (shared) color map.
-The program will likely not find everything it requires.
-\fBcopy\fP allocates what can be allocated,
-then copies the current color map; it can thus
-make use of cells other programs are using.
-\fBprivate\fP creates a new color map and fills it with the required colors.
-.TP
-.B \-dontopenxdevices
-In case that fails.
-.TP
 .B \-sync
 Syncs the display, debugging.
-.TP
-.B \-keyboard ibm\fR|\fPmac\fR|\fPsun\fR|\fPppc
-Generates appropriate hotkeys in menus.
-Use \fBibm\fP on an IBM-compatible PC.
-Use \fBmac\fP on a Mac computer running Mac\ OS.
-Use \fBsun\fP on a Sun workstation.
-Use \fBppc\fP on Power PC Mac running SUSE GNU/Linux.
 .TP
 .B \-help
 Displays a help message and exits.

--- a/fontforgeexe/startui.c
+++ b/fontforgeexe/startui.c
@@ -90,12 +90,7 @@ static void _dousage(void) {
     printf( "\t-quiet\t\t\t (don't print non-essential\n\t\t\t\t  information to stderr)\n" );
     printf( "\t-unique\t\t\t (if a fontforge is already running open all\n\t\t\t\t  arguments in it and have this process exit)\n" );
     printf( "\t-display display-name\t (sets the X display)\n" );
-    printf( "\t-depth val\t\t (sets the display depth if possible)\n" );
-    printf( "\t-vc val\t\t\t (sets the visual class if possible)\n" );
-    printf( "\t-cmap current|copy|private\t (sets the type of colormap)\n" );
-    printf( "\t-dontopenxdevices\t (in case that fails)\n" );
     printf( "\t-sync\t\t\t (syncs the display, debugging)\n" );
-    printf( "\t-keyboard ibm|mac|sun|ppc  (generates appropriate hotkeys in menus)\n" );
 #if MyMemory
     printf( "\t-memory\t\t\t (turns on memory checks, debugging)\n" );
 #endif
@@ -481,20 +476,6 @@ return( true );
 return( true );
 }
 
-static void  AddR(char *program_name, char *window_name, char *cmndline_val) {
-/* Add this command line value to this GUI resource.			*/
-/* These are the command line options expected when using this routine:	*/
-/*	-depth, -vc,-cmap or -colormap,-dontopenxdevices, -keyboard	*/
-    char *full;
-    if ((full = malloc(strlen(window_name)+strlen(cmndline_val)+4))!=NULL) {
-	strcpy(full,window_name);
-	strcat(full,": ");
-	strcat(full,cmndline_val);
-	GResourceAddResourceString(full,program_name);
-	free(full);
-    }
-}
-
 static int ReopenLastFonts(void) {
     char buffer[1024];
     char *ffdir = getFontForgeUserDir(Config);
@@ -741,16 +722,6 @@ int fontforge_main( int argc, char **argv ) {
 	    ++pt;
 	if ( strcmp(pt,"-sync")==0 )
 	    GResourceAddResourceString("Gdraw.Synchronize: true",argv[0]);
-	else if ( strcmp(pt,"-depth")==0 && i<argc-1 )
-	    AddR(argv[0],"Gdraw.Depth", argv[++i]);
-	else if ( strcmp(pt,"-vc")==0 && i<argc-1 )
-	    AddR(argv[0],"Gdraw.VisualClass", argv[++i]);
-	else if ( (strcmp(pt,"-cmap")==0 || strcmp(pt,"-colormap")==0) && i<argc-1 )
-	    AddR(argv[0],"Gdraw.Colormap", argv[++i]);
-	else if ( (strcmp(pt,"-dontopenxdevices")==0) )
-	    AddR(argv[0],"Gdraw.DontOpenXDevices", "true");
-	else if ( strcmp(pt,"-keyboard")==0 && i<argc-1 )
-	    AddR(argv[0],"Gdraw.Keyboard", argv[++i]);
 	else if ( strcmp(pt,"-display")==0 && i<argc-1 )
 	    display = argv[++i];
 # if MyMemory
@@ -942,14 +913,11 @@ exit( 0 );
 	} else if ( strcmp(pt,"-sync")==0 || strcmp(pt,"-memory")==0 ||
 		    strcmp(pt,"-nosplash")==0 || strcmp(pt,"-recover=none")==0 ||
 		    strcmp(pt,"-recover=clean")==0 || strcmp(pt,"-recover=auto")==0 ||
-		    strcmp(pt,"-dontopenxdevices")==0 || strcmp(pt,"-unique")==0 ||
+		    strcmp(pt,"-unique")==0 ||
 		    strcmp(pt,"-home")==0 || strcmp(pt,"-quiet")==0
 		    || strcmp(pt,"-forceuihidden")==0 )
 	    /* Already done, needed to be before display opened */;
-	else if ( (strcmp(pt,"-depth")==0 || strcmp(pt,"-vc")==0 ||
-		    strcmp(pt,"-cmap")==0 || strcmp(pt,"-colormap")==0 ||
-		    strcmp(pt,"-keyboard")==0 ||
-		    strcmp(pt,"-display")==0 || strcmp(pt,"-recover")==0 ) &&
+	else if ( ( strcmp(pt,"-display")==0 || strcmp(pt,"-recover")==0 ) &&
 		i<argc-1 )
 	    ++i; /* Already done, needed to be before display opened */
 	else if ( strcmp(pt,"-allglyphs")==0 )


### PR DESCRIPTION
There are several command line options which were just channeled to X11 resources. They are not applicable anymore, once the X11 backend was removed in #5612