### PR TITLE
Ignore bit 1 of head.flags for CFF fonts

### DIFF
--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -5594,9 +5594,8 @@ return( 0 );
 	readttfglyphs(ttf,info);
     } else if ( info->cff_start!=0 ) {
 	info->to_order2 = (loaded_fonts_same_as_new && new_fonts_are_order2);
-	// Relevant only for TrueType: 
+	// Relevant only for TrueType (Font Header Table specification): 
 	// https://learn.microsoft.com/en-us/typography/opentype/spec/head#flags
-	// https://github.com/fontforge/fontforge/issues/5697
 	info->apply_lsb = false;
 	if ( !readcffglyphs(ttf,info) ) {
 	    switch_to_old_locale(&tmplocale, &oldlocale); // Switch to the cached locale.


### PR DESCRIPTION
This bit is “relevant only for TrueType rasterizers” per the spec: https://learn.microsoft.com/en-us/typography/opentype/spec/head#flags

If the bit is unset, FontForge shifts glyph outlines, but this is wrong for CFF fonts.

### Type of change
- **Bug fix**: Fixes #5697