### PR TITLE
Add dependency missing in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ The exact method to do this depends on your OS distribution.
 To download all dependencies on Ubuntu, run:
 
 ```sh
-sudo apt-get install libjpeg-dev libtiff5-dev libpng-dev libfreetype-dev libgif-dev libgtk-3-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev libwoff-dev python3-dev ninja-build cmake build-essential gettext;
+sudo apt-get install libjpeg-dev libtiff5-dev libpng-dev libfreetype-dev libgif-dev libgtk-3-dev libgtkmm-3.0-dev libxml2-dev libpango1.0-dev libcairo2-dev libspiro-dev libwoff-dev python3-dev ninja-build cmake build-essential gettext;
 ```
 
 Now run the build and installation scripts:


### PR DESCRIPTION
### Type of change
- **Bug fix**

(In fact documentation fix)

**[why]**
When building on Ubuntu 25.10 the gtkmm package is missing, even after installing all packages mentioned in INSTALL.md:

    $ cmake -GNinja ..
    CMake Deprecation Warning at CMakeLists.txt:3 (cmake_minimum_required):
    ...
    -- Checking for module 'gtk+-3.0'
    --   Found gtk+-3.0, version 3.24.49
    -- Checking for module 'gtkmm-3.0'
    --   Package 'gtkmm-3.0', required by 'virtual:world', not found
    $

That package is also mentioned in .github/workflows/scripts/setup_linux_deps.sh

    $ git grep -n gtkmm-3.0-dev
    .github/workflows/scripts/setup_linux_deps.sh:12:    libgtkmm-3.0-dev \
    $

**[how]**
Add missing package to list of dependencies.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

