### PR TITLE
tottf: Fix hmtx table (all widths zero) for monospaced fonts

### DIFF
--- a/fontforge/tottf.c
+++ b/fontforge/tottf.c
@@ -1459,7 +1459,6 @@ static int dumpglyphs(SplineFont *sf,struct glyphinfo *gi) {
     FigureFullMetricsEnd(sf,gi,true);
 
     if ( fixed>0 ) {
-	gi->lasthwidth = 3;
 	gi->hfullcnt = 3;
     }
     for ( i=0; i<gi->gcnt; ++i ) {


### PR DESCRIPTION
<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**

**[why]**
When generating a monospaced (i.e. isFixedPitch) font we assume that all glyphs have the same width, all glyphs expect the first three magic ones (`.notdef` (ID0), `.null` (ID1), and `nonmarkingreturn` (ID2)).

Because `isFixedPitch` means that all glyphs have the same width it is hardcoded that we just include the width of ID3 - all following glyphs will get the same width. This is done to reduce the mtx table size.

There are two reaons why this is not correct.

**a)**

If the font comes with a glyph `NULL` at ID1 (which is allowed) we will move the 'unexpected' `NULL` further on, and insert a new `.null`.

The font will end with this glyph order:
`.notdef` (ID0), `.null` (ID1), `nonmarkingreturn` (ID2), `NULL` (ID3), ...
(The same situation depicted in section _b_ below)

But the width of `NULL` is zero, and so all widths in the font will be zero. Instead of hard-coding 'ID3' as first real width we would need to check if it's a glyph with a width.

Of course we could also correct our auto-inserted magic glyphs and just keep the name `NULL` for ID1. Albeit that might also be desirable, it is not a complete solution, because:

**b)**

With the 'new' (modern?) way to determine `isFixedPitch` (see footnotes), especially with allowing two widths in a fixed pitch font (one "1 cell" wide and one "2 cell" wide width), we need to check and possibly encode all widths.

Example follows, InputMono-Regular.ttf is used with ttx.

Original situation before read in:

    <GlyphOrder>
      <GlyphID id="0" name=".notdef"/>
      <GlyphID id="1" name="NULL"/>
      <GlyphID id="2" name="nonmarkingreturn"/>
      <GlyphID id="3" name="space"/>
      <GlyphID id="4" name="A"/>

After we exported the font:

    <GlyphOrder>
      <GlyphID id="0" name=".notdef"/>
      <GlyphID id="1" name=".null"/>
      <GlyphID id="2" name="nonmarkingreturn"/>
      <GlyphID id="3" name="NULL"/>
      <GlyphID id="4" name="space"/>
      <GlyphID id="5" name="exclam"/>

Note that NULL is moved down to index 3 (and all following glyphs are reordered).

The current code hard codes that ID3 shall be the last entry in mtx, and `NULL` has a width of zero in the example.

Furthermore there are glyphs of zero width or the "2-widths" width, that also all will loose their values (originals following):

    <mtx name="caron" width="700" lsb="139"/>
    <mtx name="caroncmb" width="0" lsb="-211"/>
    <mtx name="caroncmb.salt" width="0" lsb="-114"/>
    <mtx name="ccaron" width="700" lsb="100"/>

Note the cmbs with a zero width and a negative lsb. Even if we correct the `lasthwidth` to for example 4 we would loose all differentiation on widths:

    <mtx name="caron" width="700" lsb="139"/>
    <mtx name="caroncmb" width="700" lsb="-211"/>
    <mtx name="caroncmb.salt" width="700" lsb="-114"/>
    <mtx name="ccaron" width="700" lsb="100"/>

**[how]**
We can not assume any width structure on a `isFixedPitch` font, and the mtx table can not be shortened any more rigorous than usual, meaning we walk backwards through the glyphs and find the last change in width, dropping all numbers in the end that stayed the same.

`FigureFullMetricsEnd()` already finds the optimally short end for the mtx table while making sure to keep all widths.

**[footnotes]**
The 'modern' isFixedPitch is introduced with commit:

  c5eb85bde `Modernize fixed pitch flag computation` (#5506)

The bug turned up in these issues:

* https://github.com/ryanoasis/nerd-fonts/issues/1948
* https://gitlab.archlinux.org/archlinux/packaging/packages/ttf-input-nerd/-/issues/2

**[reproduce]**
Open `InputMono-Regular.ttf` in Fontforge, and then without any change generate a new `ttf` from it.
Compare the `ttx` dumps from before and after; or install the exported font on the system and try to use it.

_Edit: Some typos_