### PR TITLE
Fix CVE-2025-15279: Heap buffer overflow in BMP RLE decompression

### DIFF
--- a/gutils/gimagereadbmp.c
+++ b/gutils/gimagereadbmp.c
@@ -181,12 +181,18 @@ static int readpixels(FILE *file,struct bmpheader *head) {
 	int ii = 0;
 	while ( ii<head->height*head->width ) {
 	    int cnt = getc(file);
+	    if (cnt < 0 || ii + cnt > head->height * head->width) {
+		return 0;
+	    }
 	    if ( cnt!=0 ) {
 		int ch = getc(file);
 		while ( --cnt>=0 )
 		    head->byte_pixels[ii++] = ch;
 	    } else {
 		cnt = getc(file);
+		if (cnt < 0 || ii + cnt > head->height * head->width) {
+		    return 0;
+		}
 		if ( cnt>= 3 ) {
 		    int odd = cnt&1;
 		    while ( --cnt>=0 )


### PR DESCRIPTION
The readpixels() function reads RLE count values from BMP files without validating buffer bounds. A malicious BMP can specify excessive counts causing heap buffer overflow during pixel decompression, potentially leading to remote code execution.

Add bounds checking after each count read to ensure ii + cnt does not exceed the allocated buffer size (head->height * head->width). Return 0 on validation failure to trigger error handling.

CVE-2025-15279
CVSS: 7.8 (High)
ZDI-CAN-27517
[ZDI-25-1184](https://www.zerodayinitiative.com/advisories/ZDI-25-1184/)

Type of change:
- **Bug fix**

This PR is related to the issue #5706 