### PR TITLE
Fix CVE-2025-15275: Heap buffer overflow in SFD image parsing

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -3653,6 +3653,10 @@ static ImageList *SFDGetImage(FILE *sfd) {
     getint(sfd,&image_type);
     getint(sfd,&bpl);
     getint(sfd,&clutlen);
+    if ( clutlen < 0 || clutlen > 256 ) {
+        LogError(_("Invalid clut length %d in sfd file, must be between 0 and 256"), clutlen);
+        return NULL;
+    }
     gethex(sfd,&trans);
     image = GImageCreate(image_type,width,height);
     base = image->list_len==0?image->u.image:image->u.images[0];


### PR DESCRIPTION
Validate clutlen parameter (0-256) before use to prevent heap buffer overflow when writing to fixed-size clut array.

Fixes: 
CVE-2025-15275  
ZDI-CAN-28543
[ZDI-25-1189](https://www.zerodayinitiative.com/advisories/ZDI-25-1189/)

Type of change:
- **Bug fix**

This PR is related to the issue #5706 
