### PR TITLE
Fix CVE-2025-15269: Use-after-free in SFD ligature parsing

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -4711,6 +4711,7 @@ static PST1 *LigaCreateFromOldStyleMultiple(PST1 *liga) {
     while ( (pt = strrchr(liga->pst.u.lig.components,';'))!=NULL ) {
 	new = chunkalloc(sizeof( PST1 ));
 	*new = *liga;
+	new->pst.next = NULL;
 	new->pst.u.lig.components = copy(pt+1);
 	last->pst.next = (PST *) new;
 	last = new;


### PR DESCRIPTION
Prevent circular linked list in LigaCreateFromOldStyleMultiple by clearing the next pointer after shallow copy. The shallow copy propagates liga's modified next pointer from previous iterations, creating a cycle that causes double-free when the list is traversed and freed.

Fixes: 
CVE-2025-15269 
ZDI-CAN-28564
[ZDI-25-1195](https://www.zerodayinitiative.com/advisories/ZDI-25-1195/)

Type of change:
- **Bug fix**

This PR is related to the issue https://github.com/fontforge/fontforge/issues/5706
