### PR TITLE
Fix CVE-2025-15279: Move bounds check inside cnt >= 3 block

### DIFF
--- a/gutils/gimagereadbmp.c
+++ b/gutils/gimagereadbmp.c
@@ -190,10 +190,10 @@ static int readpixels(FILE *file,struct bmpheader *head) {
 		    head->byte_pixels[ii++] = ch;
 	    } else {
 		cnt = getc(file);
-		if (cnt < 0 || ii + cnt > head->height * head->width) {
-		    return 0;
-		}
 		if ( cnt>= 3 ) {
+		    if (ii + cnt > head->height * head->width) {
+			return 0;
+		    }
 		    int odd = cnt&1;
 		    while ( --cnt>=0 )
 			head->byte_pixels[ii++] = getc(file);


### PR DESCRIPTION
Move the bounds check to inside the 'if (cnt >= 3)' block. This fixes the issue where cnt == 0, cnt == 1, and cnt == 2 require different ii calculations (end-of-line, end-of-bitmap, delta) and the bounds check before the conditional would incorrectly reject valid operations.

CVE-2025-15279
ZDI-CAN-27517
[ZDI-25-1184](https://www.zerodayinitiative.com/advisories/ZDI-25-1184/)

Type of change:
- **Bug fix**

This PR is related to the issue #5706 
