### PR TITLE
Fix CVE-2025-15270: Heap buffer overflow in SFD kern class parsing

### DIFF
--- a/fontforge/sfd.c
+++ b/fontforge/sfd.c
@@ -8275,6 +8275,10 @@ bool SFD_GetFontMetaData( FILE *sfd,
 	for ( i=classstart; i<kc->first_cnt; ++i ) {
 	  if (kernclassversion < 3) {
 	    getint(sfd,&temp);
+	    if (temp < 0) {
+	      LogError(_("Corrupted SFD file: Invalid kern class name length %d. Aborting load."), temp);
+	      return false;
+	    }
 	    kc->firsts[i] = malloc(temp+1); kc->firsts[i][temp] = '\0';
 	    nlgetc(sfd);	/* skip space */
 	    fread(kc->firsts[i],1,temp,sfd);
@@ -8292,6 +8296,10 @@ bool SFD_GetFontMetaData( FILE *sfd,
 	for ( i=1; i<kc->second_cnt; ++i ) {
 	  if (kernclassversion < 3) {
 	    getint(sfd,&temp);
+	    if (temp < 0) {
+	      LogError(_("Corrupted SFD file: Invalid kern class name length %d. Aborting load."), temp);
+	      return false;
+	    }
 	    kc->seconds[i] = malloc(temp+1); kc->seconds[i][temp] = '\0';
 	    nlgetc(sfd);	/* skip space */
 	    fread(kc->seconds[i],1,temp,sfd);


### PR DESCRIPTION
Add validation to check for negative kern class name length values before using them as array indices. This fixes a heap buffer overflow where malicious SFD files could supply negative length values (e.g., -1, -38, -139), causing writes to memory before the allocated buffer through `kc->firsts[i][temp] = '\0'` and `kc->seconds[i][temp] = '\0'` operations.

CVE-2025-15270  
ZDI-CAN-28563  
[ZDI-25-1194](https://www.zerodayinitiative.com/advisories/ZDI-25-1194/)

Type of change:
- **Bug fix**

This PR is related to the issue #5706
