### PR TITLE
Don't apply DESTDIR twice when installing libraries

### DIFF
--- a/pyhook/CMakeLists.txt
+++ b/pyhook/CMakeLists.txt
@@ -101,7 +101,7 @@ else()
 
       # Install the module files
       file(INSTALL
-        DESTINATION \"\${_dest}\"
+        DESTINATION \"${CMAKE_INSTALL_PREFIX}/${PYHOOK_INSTALL_DIR}\"
         TYPE MODULE
         FILES
           \"$<TARGET_FILE:fontforge_pyhook>\"


### PR DESCRIPTION
CMake's `install()` adds `DESTDIR` to the supplied path, so passing `_dest` (which starts with `DESTDIR` too) as the argument here meant that the Python module libraries were installed in the wrong place.

The bug was introduced in f118600c9774a9ca9d826a0ba20facb59caa2871.