### PR TITLE
Use modern Windows building environments

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ clone_depth: 10
 #cache:
 #  - 'C:\msys64\var\cache\pacman\pkg'
 install:
-  - git clone --depth=1 --branch=master-local https://github.com/fontforge/fontforgebuilds.git
+  - git clone --depth=1 --branch=win64 https://github.com/iorsh/fontforgebuilds.git
   - >-
     move C:\msys64 C:\msys64_old &&
     curl -kLo msys2.tar.xz https://github.com/msys2/msys2-installer/releases/download/nightly-x86_64/msys2-base-x86_64-latest.tar.xz &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,8 +144,8 @@ jobs:
       - name: Checkout FontForgeBuilds
         uses: actions/checkout@v4
         with:
-          repository: fontforge/fontforgebuilds
-          ref: master-local
+          repository: iorsh/fontforgebuilds
+          ref: win64
           path: fontforgebuilds
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2


### PR DESCRIPTION
**TODO: Merge after fontforge/fontforgebuilds#7, remove commit 0e86ae7813720d62c7244523e90c7c5322a49a60 before merging.**

CI actions for Windows64 environments `UCRT64` and `CLANGARM64` - see fontforge/fontforgebuilds#7