### PR TITLE
Windows build fixes

### DIFF
--- a/Packaging/win/ffbuild.sh
+++ b/Packaging/win/ffbuild.sh
@@ -149,7 +149,7 @@ done
 
 # Set working folders
 BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-BUILD_DIR=${BUILD_DIR:-$BASE/build}
+BUILD_DIR=${BUILD_DIR:-$(cd "$BASE/../.." && pwd)/build}
 # Convert Windows paths to Unix paths if needed (for MSYS2 compatibility)
 if command -v cygpath &> /dev/null; then
     BUILD_DIR=$(cygpath -u "$BUILD_DIR")
@@ -195,17 +195,20 @@ PYINST=python
 
 # Check for AppVeyor specific settings
 if (($appveyor)); then
+    echo "AppVeyor build settings enabled!"
     yes=1
     TAR="tar axf"
     export PYTHONHOME=/$MINGVER
     FFPATH=`cygpath -m $APPVEYOR_BUILD_FOLDER`
 elif (($ghactions)); then
+    echo "GitHub Actions build settings enabled!"
     yes=1
     TAR="tar axf"
     export PYTHONHOME=/$MINGVER
     FFPATH=`cygpath -m $GITHUB_WORKSPACE/repo`
 else
-    FFPATH=$WORK/fontforge
+    echo "Local build settings enabled!"
+    FFPATH=$(cd "$BASE/../.." && pwd)
     TAR="tar axvf"
 fi
 
@@ -227,7 +230,7 @@ export ACLOCAL_PATH="m4:/$MINGVER/share/aclocal"
 export ACLOCAL="/bin/aclocal"
 export M4="/bin/m4"
 # Compiler flags
-export LDFLAGS="-L/$MINGVER/lib -L/usr/local/lib -L/lib"
+export LDFLAGS="-L/$MINGVER/lib -L/usr/local/lib -L/lib -Wl,--allow-multiple-definition"
 export CFLAGS="-DWIN32 -I/$MINGVER/include -I/usr/local/include -I/include -g"
 export CPPFLAGS="${CFLAGS}"
 export LIBS=""
@@ -325,15 +328,8 @@ if (( ! $nomake )); then
         tar -C "$WORK" -axf "$SOURCE/$FREETYPE_ARCHIVE" || bail "FreeType extraction"
     fi
 
-    log_status "Finished installing prerequisites, attempting to install FontForge!"
-    # fontforge
-    if (( ! ($appveyor+$ghactions) )) && [ ! -d fontforge ]; then
-        log_status "Cloning the fontforge repository from https://github.com/$github/fontforge..."
-        git clone "https://github.com/$github/fontforge" || bail "Cloning fontforge"
-        cd "fontforge"
-    else
-        cd "$FFPATH";
-    fi
+    log_status "Finished installing prerequisites, proceeding to build FontForge!"
+    cd "$FFPATH";
 
     if [ -f CMakeLists.txt ]; then
         if [ ! -f build/fontforge.configure-complete ] || (($reconfigure)); then

--- a/Packaging/win/ffbuild.sh
+++ b/Packaging/win/ffbuild.sh
@@ -459,6 +459,7 @@ if [ -d "$RELEASE/lib/$PYVER" ]; then
 else
     if [ ! -d "$BINARY/$PYVER" ]; then
         log_note "Python folder not found - running 'strip-python'..."
+        export BUILD_DIR
         $BASE/strip-python.sh "$PYVER" || bail "Python generation failed"
     fi
     cp -r "$BINARY/$PYVER" "$RELEASE/lib" || bail "Python folder could not be copied"

--- a/Packaging/win/setup/fontforgesetup.iss
+++ b/Packaging/win/setup/fontforgesetup.iss
@@ -52,6 +52,7 @@ InfoBeforeFile={#BUILD_DIR}\ReleasePackage\VERSION.txt
 OutputDir=.
 OutputBaseFilename=FontForge-{#MyAppVersionDesc}-Windows-{#ARCHDESC}
 SetupIconFile=Graphics\fontforge-installer-icon.ico
+UninstallDisplayIcon={app}\fontforge-installer-icon.ico
 ;WizardImageFile=Graphics\fontforge-wizard.bmp
 WizardSmallImageFile=Graphics\fontforge-wizard.bmp
 Compression=lzma2/max
@@ -92,6 +93,7 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 [Files]
 Source: "{#BUILD_DIR}\ReleasePackage\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Excludes: "fontforge.bat"
 Source: "fontforge.bat"; DestDir: "{app}"; Flags: ignoreversion;
+Source: "Graphics\fontforge-installer-icon.ico"; DestDir: "{app}"; Flags: ignoreversion;
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/Packaging/win/strip-python.sh
+++ b/Packaging/win/strip-python.sh
@@ -6,12 +6,6 @@ set -eo pipefail
 
 export LC_ALL=C
 
-BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-BUILD_DIR=${BUILD_DIR:-$BASE/build}
-# Convert Windows paths to Unix paths if needed
-if command -v cygpath &> /dev/null; then
-    BUILD_DIR=$(cygpath -u "$BUILD_DIR")
-fi
 BINARY=$BUILD_DIR/downloads/
 
 PACKAGE=$PMPREFIX-python
@@ -37,6 +31,7 @@ if [ ! -d $PYVER ]; then
 fi
 
 cd $PYVER
-rm -rfv "config-${PYVER}" idlelib test turtledemo config
-find . -regextype sed -regex ".*\.py[co]" | xargs rm -rfv
-find . -name __pycache__ | xargs rm -rfv
+echo "Stripping Python directory..."
+rm -rf "config-${PYVER}" idlelib test turtledemo config
+find . -regextype sed -regex ".*\.py[co]" | xargs rm -rf
+find . -name __pycache__ | xargs rm -rf

--- a/gutils/fsys.cpp
+++ b/gutils/fsys.cpp
@@ -710,15 +710,10 @@ void FindProgRoot(const char *prog) {
     }
 #endif
 
-/* If the fontforge binary path includes "build" or "target" according to platform,
-   we are in the development mode. */
-#if defined(__MINGW32__) || defined(_MSC_VER)
-    const char* dev_dir_test = "target";
-#else
-    const char* dev_dir_test = "build";
-#endif
-    if (strstr(program_root, dev_dir_test)) {
-	devel_env = true;
+    /* If the fontforge binary path includes "build",
+       we are in the development mode. */
+    if (strstr(program_root, "build")) {
+        devel_env = true;
     }
 
 #ifdef HAVE_GLIB
@@ -741,11 +736,7 @@ const char *getLocaleDir(void) {
     static char *localedir = NULL;
     if (!localedir) {
 	if (devel_env) {
-#if defined(_MSC_VER) || defined(__MINGW32__)
-            localedir = smprintf("%s/share/locale", program_root);
-#else
             localedir = smprintf("%s/po", program_root);
-#endif
 	} else {
             localedir = smprintf("%s/share/locale", program_root);
 	}
@@ -757,12 +748,8 @@ const char *getPixmapDir(void) {
     static char *pixmapdir=NULL;
     if (!pixmapdir) {
 	if (devel_env) {
-	    /* GUI_THEME macro is imported from the CMake ${GUI_THEME} variable */
-#if defined(_MSC_VER) || defined(__MINGW32__)
-            char *theme_src = smprintf("%s/../../work/mingw64/fontforge/fontforgeexe/pixmaps/%s", program_root, GUI_THEME);
-#else
+            /* GUI_THEME macro is imported from the CMake ${GUI_THEME} variable */
             char *theme_src = smprintf("%s/../fontforgeexe/pixmaps/%s", program_root, GUI_THEME);
-#endif
             pixmapdir = GFileGetAbsoluteName(theme_src);
             free(theme_src);
 	} else {

--- a/inc/basics.h
+++ b/inc/basics.h
@@ -43,6 +43,10 @@ typedef uint32_t unichar_t;
 
 #define FF_PI 3.1415926535897932
 
+#if defined(_WIN32) && !defined(LIBINTL_VERSION)
+# define vsnprintf _vsprintf_p
+#endif
+
 /* A macro to mark unused function parameters with. We often
  * have such parameters, because of extensive use of callbacks.
  */


### PR DESCRIPTION
- Add Uninstall icon to Windows setup
- `vsnprintf()` is broken in UCRT64, replace with `_vsprintf_p()` - fixes #5788
- Fix development mode dirs for Windows
- Stop cloning fontforge inside `ffbuild.sh` script
