### PR TITLE
Fix emsize derivation for PostScript fonts

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1840,9 +1840,11 @@ return;
 		    }
 
 		    for (gid=start; gid<=end; gid++) {
-			mappings[cur] = uvals[0] = uni++;
-			add_mapping(basesf, mappings, uvals, 1, gid, pc->cmap_from_cid[font_num], cur);
-			cur++;
+			if (cur < mappings_length) {
+			    mappings[cur] = uvals[0] = uni++;
+			    add_mapping(basesf, mappings, uvals, 1, gid, pc->cmap_from_cid[font_num], cur);
+			    cur++;
+			}
 		    }
 		    free(uvals);
 		} else
@@ -1894,8 +1896,8 @@ return( ret );
 }
 
 static SplineFont *pdf_loadtype3(struct pdfcontext *pc) {
-    char *enc, *cp, *fontmatrix, *name;
-    double emsize;
+    char *enc, *cp, *s_fontmatrix, *name;
+    double fontmatrix[6], emsize;
     SplineFont *sf;
     int flags = -1;
     int i;
@@ -1910,14 +1912,16 @@ static SplineFont *pdf_loadtype3(struct pdfcontext *pc) {
   goto fail;
     if ( (cp=PSDictHasEntry(&pc->pdfdict,"CharProcs"))==NULL )
   goto fail;
-    if ( (fontmatrix=PSDictHasEntry(&pc->pdfdict,"FontMatrix"))==NULL )
+    if ( (s_fontmatrix=PSDictHasEntry(&pc->pdfdict,"FontMatrix"))==NULL )
   goto fail;
-    if ( sscanf(fontmatrix,"[%lg",&emsize)!=1 || emsize==0 )
+    if ( sscanf(s_fontmatrix,"[%lg %lg %lg %lg %lg %lg]", 
+                &fontmatrix[0], &fontmatrix[1], &fontmatrix[2],
+                &fontmatrix[3], &fontmatrix[4], &fontmatrix[5])!=6 )
   goto fail;
     if ( !pdf_getcharprocs(pc,cp))
   goto fail;
 
-    emsize = 1.0/emsize;
+    emsize = PSEmsizeFromFontMatrix(fontmatrix);
     charprocdict = PSDictCopy(&pc->pdfdict);
 
     sf = SplineFontBlank(charprocdict->next);

--- a/fontforge/parsepfa.c
+++ b/fontforge/parsepfa.c
@@ -39,6 +39,7 @@
 #include "utype.h"
 
 #include <locale.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2760,6 +2761,23 @@ void PSFontFree(FontDict *fd) {
     PSDictFree(fd->blendfontinfo);
 
     free(fd);
+}
+
+double PSEmsizeFromFontMatrix(double fontmatrix[6]) {
+    /* NOTE(iorsh): I have a strong suspicion that emsize should not be derived
+     * from FontMatrix at all. In PDF files the font matrix serves to relate the
+     * glyphs to their parent font or to the document or the parent resource
+     * etc. All this has nothing to do with the emsize, which is a property of
+     * the font itself. I'm keeping mostly intact as a legacy capability for
+     * now, but eventually it could be removed. */
+    double emsize;
+    if (fontmatrix[0] == 0 || fontmatrix[0] == 1)
+        /* Zero or identity font matrix should be ignored */
+        emsize = 1000;
+    else
+        emsize = rint(1 / fontmatrix[0]);
+
+    return emsize;
 }
 
 char **_NamesReadPostScript(FILE *ps) {

--- a/fontforge/parsepfa.h
+++ b/fontforge/parsepfa.h
@@ -15,6 +15,7 @@ extern FontDict *_ReadPSFont(FILE *in);
 extern void PSCharsFree(struct pschars *chrs);
 extern void PSDictFree(struct psdict *dict);
 extern void PSFontFree(FontDict *fd);
+extern double PSEmsizeFromFontMatrix(double fontmatrix[6]);
 
 #ifdef __cplusplus
 }

--- a/fontforge/parsettf.c
+++ b/fontforge/parsettf.c
@@ -3698,10 +3698,7 @@ static SplineFont *cffsffillup(struct topdicts *subdict, char **strings,
 	sf->fontname = copy(buffer);
     }
 
-    if ( subdict->fontmatrix[0]==0 )
-	emsize = 1000;
-    else
-	emsize = rint( 1/subdict->fontmatrix[0] );
+    emsize = PSEmsizeFromFontMatrix(subdict->fontmatrix);
     sf->ascent = .8*emsize;
     sf->descent = emsize - sf->ascent;
     if ( subdict->copyright!=-1 )
@@ -3733,10 +3730,7 @@ static void cffinfofillup(struct ttfinfo *info, struct topdicts *dict,
     info->glyph_cnt = dict->glyphs.cnt;
     if ( info->glyph_cnt<0 ) info->glyph_cnt = 0;
 
-    if ( dict->fontmatrix[0]==0 )
-	info->emsize = 1000;
-    else
-	info->emsize = rint( 1/dict->fontmatrix[0] );
+    info->emsize = PSEmsizeFromFontMatrix(dict->fontmatrix);
     info->ascent = .8*info->emsize;
     info->descent = info->emsize - info->ascent;
     if ( dict->copyright!=-1 || dict->notice!=-1 )

--- a/fontforge/splineutil.c
+++ b/fontforge/splineutil.c
@@ -2433,10 +2433,7 @@ static void SplineFontMetaData(SplineFont *sf,struct fontdict *fd) {
     sf->cidversion = fd->cidversion;
     sf->xuid = XUIDFromFD(fd->xuid);
     /*sf->wasbinary = fd->wasbinary;*/
-    if ( fd->fontmatrix[0]==0 )
-	em = 1000;
-    else
-	em = rint(1/fd->fontmatrix[0]);
+    em = PSEmsizeFromFontMatrix(fd->fontmatrix);
     if ( sf->ascent==0 && sf->descent!=0 )
 	sf->ascent = em-sf->descent;
     else if ( fd->fontbb[3]-fd->fontbb[1]==em ) {


### PR DESCRIPTION
Fixes #5582, fixes #5782, fixes #5063

See earlier discussion in #4207 and in #2932

> I have mixed feelings about this issue. FontForge is a font editor, not PDF editor. If the PDF takes an ordinary upright font and mechanically slants it (for its own presentation purposes), it doesn't mean we have to follow that. Our purpose is to retrieve glyph shapes and let user do with these shapes whatever they please. If the PDF applied to the glyphs some sinusoidal distortion, this would not have affected the embedded font itself, and should not have been reflected in the extracted result.
> 
> Maybe when we encounter a non-trivial font matrix, we should just warn the user that the extracted font might look different from what they expect.