### PR TITLE
OOB Write in pdf_getcmap()

### DIFF
--- a/fontforge/parsepdf.c
+++ b/fontforge/parsepdf.c
@@ -1840,6 +1840,8 @@ return;
 		    }
 
 		    for (gid=start; gid<=end; gid++) {
+			if (cur >= mappings_length)
+			    break;
 			mappings[cur] = uvals[0] = uni++;
 			add_mapping(basesf, mappings, uvals, 1, gid, pc->cmap_from_cid[font_num], cur);
 			cur++;


### PR DESCRIPTION
1. Basic Information
Reporter: oriotie, ax123, banda, jihyeon4725, lacroix, minzu
Target Version:
FontForge 2025-10-19 Release
Vulnerability Type:
Heap Overflow

2. Summary
Loading crafted .pdf font to fontforge causes Heap Overflow, and potentially
leads to arbitrary code execution.