### PR TITLE
fix pyhook install dir for /usr/local

### DIFF
--- a/pyhook/CMakeLists.txt
+++ b/pyhook/CMakeLists.txt
@@ -44,10 +44,11 @@ else()
       OUTPUT_VARIABLE _platlib_path_abs
       OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT _platlib_path_abs OR _platlib_path_abs_result)
-      message(FATAL_ERROR "Could not determine the path to install pyhook binaries to, got '${PYHOOK_INSTALL_DIR}' with return value ${_pyhook_install_dir_result}")
+      message(FATAL_ERROR "Could not determine the path to install pyhook binaries to, got '${_platlib_path_abs}' with return value ${_platlib_path_abs_result}")
     endif()
     # Convert platlib dir from absolute to prefix-relative
-    file(RELATIVE_PATH PYHOOK_INSTALL_DIR
+    file(RELATIVE_PATH
+      PYHOOK_INSTALL_DIR
       "${CMAKE_INSTALL_PREFIX}"
       "${_platlib_path_abs}")
     set(PYHOOK_INSTALL_DIR "${PYHOOK_INSTALL_DIR}" CACHE STRING "Path to install pyhook to")

--- a/pyhook/CMakeLists.txt
+++ b/pyhook/CMakeLists.txt
@@ -36,16 +36,20 @@ else()
   # So do it ourselves, getting the prefix-relative path instead
   if(NOT DEFINED PYHOOK_INSTALL_DIR)
     if(APPLE)
-      set(_PYHOOK_SYSCONFIG_PREFIX " 'posix_prefix',")
+      set(_PYHOOK_SYSCONFIG_PREFIX ", 'posix_prefix'")
     endif()
     execute_process(
-      COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig as sc; print(sc.get_path('platlib',${_PYHOOK_SYSCONFIG_PREFIX} vars={'platbase': '.'}))"
-      RESULT_VARIABLE _pyhook_install_dir_result
-      OUTPUT_VARIABLE PYHOOK_INSTALL_DIR
+      COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig as sc; print(sc.get_path('platlib'${_PYHOOK_SYSCONFIG_PREFIX}))"
+      RESULT_VARIABLE _platlib_path_abs_result
+      OUTPUT_VARIABLE _platlib_path_abs
       OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT PYHOOK_INSTALL_DIR OR _pyhook_install_dir_result)
+    if(NOT _platlib_path_abs OR _platlib_path_abs_result)
       message(FATAL_ERROR "Could not determine the path to install pyhook binaries to, got '${PYHOOK_INSTALL_DIR}' with return value ${_pyhook_install_dir_result}")
     endif()
+    # Convert platlib dir from absolute to prefix-relative
+    file(RELATIVE_PATH PYHOOK_INSTALL_DIR
+      "${CMAKE_INSTALL_PREFIX}"
+      "${_platlib_path_abs}")
     set(PYHOOK_INSTALL_DIR "${PYHOOK_INSTALL_DIR}" CACHE STRING "Path to install pyhook to")
   endif()
 


### PR DESCRIPTION
On my machine:
`$ python3 -c "import sysconfig as sc; print(sc.get_path('platlib'))"`
/usr/local/lib/python3.13/dist-packages
`$ python3 -c "import sysconfig as sc; print(sc.get_config_var('platbase'))"`
/usr
So making `platbase=.` only removes `/usr/` and keeps `local/`, making `${CMAKE_INSTALL_PREFIX}/${PYHOOK_INSTALL_DIR}`:
`/usr/local/local/lib/python3.13/dist-packages/`, when the install prefix is the default `/usr/local`.

**[EDIT]:** looking at CI, it seems that this behavior is intended. I wonder why not install the modules to be useable by the existing python installation.