### PR TITLE
Expose the `xheight_percent` parameter to Python

### DIFF
--- a/doc/sphinx/scripting/python/fontforge.rst
+++ b/doc/sphinx/scripting/python/fontforge.rst
@@ -4814,7 +4814,7 @@ This type may not be pickled.
 
    Returns whether the named subtable contains a vertical kerning data
 
-.. method:: font.italicize(italic_angle=, ia=lc_condense=, lc=uc_condense=, uc=symbol_condense=, symbol=deserif_flat=, deserif_slant=, deserif_pen=, baseline_serifs=, xheight_serifs=, ascent_serifs=, descent_serifs=, diagonal_serifs=, a=, f=, u0438=, u043f=, u0442=, u0444=, u0448=, u0452=, u045f=)
+.. method:: font.italicize(italic_angle=, ia=lc_condense=, lc=uc_condense=, uc=symbol_condense=, symbol=deserif_flat=, deserif_slant=, deserif_pen=, baseline_serifs=, xheight_serifs=, ascent_serifs=, descent_serifs=, diagonal_serifs=, a=, f=, u0438=, u043f=, u0442=, u0444=, u0448=, u0452=, u045f=, xheight_percent=)
 
    This function uses keyword parameters. None are required, if omitted a
    default value will be used. Some keywords have abbreviations ("ia" for
@@ -4840,6 +4840,10 @@ This type may not be pickled.
    transformations of glyphs like "f", setting it to 1 will give "f" a tail
    which looks like a rotated version of its head, and setting it to 2 will
    simply extend the main stem of "f" below the baseline.
+
+   The ``xheight_percent`` keyword specifies how much the x-height should be
+   changed by the transformation. The default value is 0.95, which reduces the
+   x-height to 95% of its original size; a value of 1.0 means no change.
 
 .. method:: font.lookupSetFeatureList(lookup_name, feature_script_lang_tuple)
 

--- a/fontforge/python.cpp
+++ b/fontforge/python.cpp
@@ -18699,6 +18699,7 @@ static const char *italicize_keywords[] = {
     "u0448",
     "u0452",
     "u045f",
+    "xheight_percent",
     NULL
 };
 
@@ -18766,7 +18767,7 @@ static int Parse_ItalicArgs(ItalicInfo *ii, PyObject *args, PyObject *keywds) {
     int u045f = default_ii.cyrl_dzhe;
 
     *ii = default_ii;
-    if ( !PyArg_ParseTupleAndKeywords(args,keywds,"|ddOOOOOOiiiiiiiiiiiiiiiii",(char **)italicize_keywords,
+    if ( !PyArg_ParseTupleAndKeywords(args,keywds,"|ddOOOOOOiiiiiiiiiiiiiiiiid",(char **)italicize_keywords,
 	    &ii->italic_angle, &ii->italic_angle,
 	    &lc, &lc,
 	    &uc, &uc,
@@ -18774,7 +18775,8 @@ static int Parse_ItalicArgs(ItalicInfo *ii, PyObject *args, PyObject *keywds) {
 	    &deserif_flat, &deserif_slant, &deserif_pen,
 	    &bottom_serif, &xh_serif, &as_serif, &dg_serif, &ds_serif,
 	    &a, &f,
-	    &u0444, &u0438, &u043f, &u0442, &u0448, &u0452, &u045f ))
+	    &u0444, &u0438, &u043f, &u0442, &u0448, &u0452, &u045f,
+	    &ii->xheight_percent ))
 return( false );
     if ( !SquashParse(&ii->lc,lc) || !SquashParse(&ii->uc,uc) || !SquashParse(&ii->neither,symbols))
 return( false );

--- a/tests/test_italicize.py
+++ b/tests/test_italicize.py
@@ -4,5 +4,10 @@ import sys, fontforge
 ambrosia = sys.argv[1]
 font = fontforge.open(ambrosia)
 
+# Make sure that this doesn't segfault
 font.italicize(lc_condense=(0.9, 0.9, 0.9, 0.9))
+
+# Test the new xheight_percent keyword argument
+font.italicize(xheight_percent=0.80)
+
 font.close()


### PR DESCRIPTION
Previously, the Python `font.italicize()` function had no interface to change the x-height of the font, which meant that the function unconditionally used the default value of 95%. This commit exposes this parameter to Python via a new keyword argument.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **New feature**
