### PR TITLE
Optimize `SCOrderAP` for large input

### DIFF
--- a/fontforge/parsettfatt.c
+++ b/fontforge/parsettfatt.c
@@ -867,7 +867,8 @@ static void MarkGlyphsProcessLigs(FILE *ttf,int baseoffset,
 	AnchorClass **classes) {
     int basecnt,compcnt, i, j, k, kbase;
     uint16_t *loffsets, *aoffsets;
-    SplineChar *sc;
+	SplineChar *sc;
+	AnchorPoint **tail, *ap;
 
     fseek(ttf,baseoffset,SEEK_SET);
     basecnt = getushort(ttf);
@@ -880,9 +881,14 @@ return;
     for ( i=0; i<basecnt; ++i )
 	loffsets[i] = getushort(ttf);
     for ( i=0; i<basecnt; ++i ) {
-	sc = info->chars[baseglyphs[i]];
-	if ( baseglyphs[i]>=info->glyph_cnt || sc==NULL )
+		if ( baseglyphs[i]>=info->glyph_cnt )
     continue;
+		sc = info->chars[baseglyphs[i]];
+		if ( sc==NULL )
+    continue;
+		tail = &sc->anchor;
+		while ( *tail!=NULL )
+	    tail = &(*tail)->next;
 	fseek(ttf,baseoffset+loffsets[i],SEEK_SET);
 	compcnt = getushort(ttf);
 	if ( feof(ttf)) {
@@ -895,9 +901,11 @@ return;
 	    aoffsets[k] = getushort(ttf);
 	for ( k=kbase=0; k<compcnt; ++k, kbase+=classcnt ) {
 	    for ( j=0; j<classcnt; ++j ) if ( aoffsets[kbase+j]!=0 ) {
-		sc->anchor = readAnchorPoint(ttf,baseoffset+loffsets[i]+aoffsets[kbase+j],
-			classes[j], at_baselig,sc->anchor,info);
-		sc->anchor->lig_index = k;
+		ap = readAnchorPoint(ttf,baseoffset+loffsets[i]+aoffsets[kbase+j],
+			classes[j], at_baselig,NULL,info);
+		ap->lig_index = k;
+		*tail = ap;
+		tail = &ap->next;
 	    }
 	}
 	free(aoffsets);

--- a/fontforge/splinechar.c
+++ b/fontforge/splinechar.c
@@ -1054,35 +1054,69 @@ void AltUniAdd_DontCheckDups(SplineChar *sc,int uni) {
     }
 }
 
+struct aporder {
+    AnchorPoint *ap;
+    int order;
+};
+
+static int SCOrderAPCmp(const void *a, const void *b) {
+    const struct aporder *ap_a = a, *ap_b = b;
+
+    if ( ap_a->ap->lig_index < ap_b->ap->lig_index )
+return( -1 );
+    if ( ap_a->ap->lig_index > ap_b->ap->lig_index )
+return( 1 );
+return( ap_a->order - ap_b->order );
+}
+
 void SCOrderAP(SplineChar *sc) {
-    int lc=0, cnt=0, out=false, i,j;
-    AnchorPoint *ap, **array;
+    int cnt=0, ascending=true, descending=true, first=true, prev=0, i;
+    AnchorPoint *ap, *next, *rev = NULL;
+    struct aporder *array;
     /* Order so that first ligature index comes first */
 
     for ( ap=sc->anchor; ap!=NULL; ap=ap->next ) {
-	if ( ap->lig_index<lc ) out = true;
-	if ( ap->lig_index>lc ) lc = ap->lig_index;
+	if ( first ) {
+	    prev = ap->lig_index;
+	    first = false;
+	} else {
+	    if ( ap->lig_index < prev )
+		ascending = false;
+	    if ( ap->lig_index > prev )
+		descending = false;
+	    prev = ap->lig_index;
+	}
 	++cnt;
     }
-    if ( !out )
+    if ( cnt<2 || ascending )
 return;
 
-    array = malloc(cnt*sizeof(AnchorPoint *));
-    for ( i=0, ap=sc->anchor; ap!=NULL; ++i, ap=ap->next )
-	array[i] = ap;
-    for ( i=0; i<cnt-1; ++i ) {
-	for ( j=i+1; j<cnt; ++j ) {
-	    if ( array[i]->lig_index>array[j]->lig_index ) {
-		ap = array[i];
-		array[i] = array[j];
-		array[j] = ap;
-	    }
+
+    if ( descending ) {
+	for ( ap = sc->anchor; ap!=NULL; ap=next ) {
+	    next = ap->next;
+	    ap->next = rev;
+	    rev = ap;
 	}
+	sc->anchor = rev;
+	return;
     }
-    sc->anchor = array[0];
+
+    array = malloc(cnt*sizeof(*array));
+    if ( array==NULL )
+return;
+
+    for ( i=0, ap=sc->anchor; ap!=NULL; ++i, ap=ap->next ) {
+	array[i].ap = ap;
+	array[i].order = i;
+    }
+    qsort(array,cnt,sizeof(*array),SCOrderAPCmp);
+
+    sc->anchor = array[0].ap;
     for ( i=0; i<cnt-1; ++i )
-	array[i]->next = array[i+1];
-    array[cnt-1]->next = NULL;
+	array[i].ap->next = array[i+1].ap;
+
+	array[cnt-1].ap->next = NULL;
     free( array );
 }
 


### PR DESCRIPTION
I noticed that a small input PDF to https://github.com/pdf2htmlEX/pdf2htmlEX took seconds to load which was quite unexpected. After quick profiling it pointed to `SCOrderAP` in fontforge. I only briefly checked the code myself and was surprised by the nested loop for sorting the APs. This special PDF contains a font that has characters with >100k APs which hits the $N^2$ loop quite hard.

I then sent off a coding agent to optimize this function which now detects if the input is already sorted, sorted in reverse, or defaults to using `qsort`. https://github.com/fontforge/fontforge/commit/2ea680cb6c39750f7d594bd379398f38000815ea

After that the agent also suggested to reverse the order of the APs already during reading as they are stored in memory in the opposite direction, resulting in the initial poor sorting performance. https://github.com/fontforge/fontforge/commit/78ba37d0e2bafe6e699c59d4ad6780a6fbc001ea

I think https://github.com/fontforge/fontforge/commit/78ba37d0e2bafe6e699c59d4ad6780a6fbc001ea would now actually do the trick by itself but maybe `SCOrderAP` is used in other places and still benefits from the changes.

### Type of change
- **Non-breaking change**
