### PR TITLE
macOS: ad-hoc code sign the app bundle, with a Developer ID path

### DIFF
--- a/.github/workflows/mac-signing-rehearsal.yml
+++ b/.github/workflows/mac-signing-rehearsal.yml
@@ -1,0 +1,162 @@
+# Manual rehearsal of the macOS Developer ID signing path, using a throwaway
+# self-signed certificate generated on the runner.
+#
+# Purpose: exercise everything the real signing path does EXCEPT notarization,
+# which a self-signed cert cannot do (Apple's notary service requires a genuine
+# Developer ID Application certificate). In particular this validates the one
+# thing the ad-hoc path can never test: that under the hardened runtime, the
+# `disable-library-validation` entitlement actually lets FontForge's embedded
+# Python interpreter load a third-party (foreign-signed) C extension.
+#
+# This workflow is workflow_dispatch only: it never runs on push and never
+# produces a release artifact. The bundle it builds is SELF-SIGNED and must
+# NOT be distributed.
+name: macOS signing rehearsal (self-signed)
+
+on:
+  workflow_dispatch:
+    inputs:
+      foreign_test_package:
+        description: 'PyPI package with a compiled C extension, used to test disable-library-validation under the hardened runtime'
+        type: string
+        default: cffi
+
+jobs:
+  rehearsal:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: repo
+
+      # --- Mirror the normal mac build (deps + build) -----------------------
+      - name: Install dependencies
+        run: |
+          brew install cairo coreutils fontconfig gettext giflib gtk+3 gtkmm3 jpeg libpng libspiro libtiff libtool libuninameslist python@3 wget woff2 --quiet
+          PREFIX=$GITHUB_WORKSPACE/target
+          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig" >> $GITHUB_ENV
+          echo "PATH=/usr/local/opt/ruby/bin:/usr/local/opt/gettext/bin:$PATH" >> $GITHUB_ENV
+          echo "PYTHONPATH=$PREFIX" >> $GITHUB_ENV
+      - name: Build FontForge
+        working-directory: repo
+        run: |
+          FFCONFIG="-DCMAKE_INSTALL_PREFIX=$PREFIX -DENABLE_FONTFORGE_EXTRAS=ON -DCMAKE_FIND_ROOT_PATH=/usr/local/opt/gettext"
+          mkdir build && pushd build && cmake -GNinja $FFCONFIG .. && popd
+          ninja -C build install
+
+      # --- Generate + import a throwaway self-signed code-signing cert -------
+      # Use the system (LibreSSL) openssl so the PKCS#12 is readable by the
+      # macOS keychain without needing the `-legacy` flag.
+      - name: Generate and import self-signed certificate
+        run: |
+          WORK="$RUNNER_TEMP/selfsign"
+          mkdir -p "$WORK"
+          cat > "$WORK/cert.conf" <<'EOF'
+          [req]
+          distinguished_name = dn
+          x509_extensions = v3
+          prompt = no
+          [dn]
+          CN = FontForge Rehearsal Self-Signed
+          [v3]
+          basicConstraints = critical,CA:FALSE
+          keyUsage = critical,digitalSignature
+          extendedKeyUsage = critical,codeSigning
+          EOF
+          /usr/bin/openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout "$WORK/key.pem" -out "$WORK/cert.pem" \
+            -days 2 -config "$WORK/cert.conf"
+          /usr/bin/openssl pkcs12 -export \
+            -inkey "$WORK/key.pem" -in "$WORK/cert.pem" \
+            -out "$WORK/cert.p12" -passout pass:rehearsal \
+            -name "FontForge Rehearsal Self-Signed"
+
+          KEYCHAIN="$RUNNER_TEMP/rehearsal.keychain-db"
+          security create-keychain -p actions "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p actions "$KEYCHAIN"
+          security import "$WORK/cert.p12" -k "$KEYCHAIN" -P rehearsal -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k actions "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$KEYCHAIN"
+
+          # Drive ffosxbuild.sh down its Developer ID branch (hardened runtime +
+          # entitlements). NOTE: we intentionally do NOT set any notary secrets,
+          # so notarization is correctly skipped -- self-signed cannot notarize.
+          echo "CODESIGN_IDENTITY=FontForge Rehearsal Self-Signed" >> "$GITHUB_ENV"
+
+      - name: Build App Bundle (hardened runtime, self-signed)
+        working-directory: repo/build
+        run: ninja macbundle
+
+      # --- Verify the signing we just rehearsed -----------------------------
+      - name: Verify signature and hardened runtime
+        working-directory: repo/build/osx
+        run: |
+          set -e
+          APP="$PWD/FontForge.app"
+          MAIN="$APP/Contents/Resources/opt/local/bin/fontforge"
+
+          echo "::group::codesign --verify (whole bundle)"
+          codesign --verify --strict --verbose=2 "$APP"
+          echo "::endgroup::"
+
+          echo "::group::Main executable signature (expect runtime flag + entitlements)"
+          codesign -dvvv "$MAIN" 2>&1 | grep -Ei 'Identifier|Signature|flags|TeamIdentifier' || true
+          codesign -d --entitlements :- "$MAIN" 2>&1 || true
+          echo "::endgroup::"
+
+          # Sanity: the hardened runtime flag must be present on the main exec.
+          if ! codesign -dvvv "$MAIN" 2>&1 | grep -q 'flags=.*runtime'; then
+            echo "ERROR: hardened runtime flag not set on main executable"
+            exit 1
+          fi
+
+          # Expected: spctl REJECTS a self-signed (un-notarized) bundle. This is
+          # not a failure of our signing -- only Developer ID + notarization
+          # passes spctl. We log it for visibility but do not fail on it.
+          echo "::group::spctl assessment (expected to be rejected)"
+          spctl -a -t exec -vv "$APP" || echo "(expected) spctl rejected the self-signed bundle"
+          echo "::endgroup::"
+
+      - name: Test embedded interpreter loads a foreign C extension
+        working-directory: repo/build/osx
+        env:
+          FOREIGN_PKG: ${{ inputs.foreign_test_package }}
+        run: |
+          set -e
+          APP="$PWD/FontForge.app"
+          FF="$APP/Contents/Resources/opt/local/bin/fontforge"
+          FFPY="$APP/Contents/MacOS/FFPython"
+          SITE="$RUNNER_TEMP/foreign-site"
+
+          # Install the foreign package AFTER the bundle was signed, so its .so
+          # keeps its own (non-our-identity) signature. Importing it through the
+          # hardened-runtime `fontforge` binary therefore exercises
+          # disable-library-validation: without that entitlement, Library
+          # Validation would reject the foreign-signed module.
+          "$FFPY" -m pip install --target "$SITE" --no-input "$FOREIGN_PKG"
+
+          cat > "$RUNNER_TEMP/import_test.py" <<EOF
+          import importlib, os, sys
+          print("python:", sys.version.split()[0])
+          import fontforge
+          print("fontforge:", fontforge.version())
+          # Import the package's compiled module to force a foreign dlopen.
+          mod = importlib.import_module("$FOREIGN_PKG")
+          print("imported foreign package:", mod.__name__, getattr(mod, "__file__", "?"))
+          # Confirm at least one compiled .so came from the foreign site dir.
+          so = [f for r,_,fs in os.walk("$SITE") for f in fs if f.endswith(".so")]
+          print("foreign .so files:", so or "(none -- pick a package with a C extension)")
+          EOF
+
+          echo "Running import test through the hardened-runtime fontforge binary..."
+          PYTHONPATH="$SITE" "$FF" -lang=py -script "$RUNNER_TEMP/import_test.py"
+          echo "OK: embedded interpreter loaded the foreign C extension under the hardened runtime."
+
+      - name: Rehearsal artifact (self-signed -- DO NOT DISTRIBUTE)
+        uses: actions/upload-artifact@v7
+        with:
+          name: macOS_appbundle_REHEARSAL_self-signed_DO_NOT_DISTRIBUTE
+          path: repo/build/osx/FontForge-*.dmg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,9 +116,47 @@ jobs:
           PYTHON=`grep -m1 'Python3_EXECUTABLE.*=' build/CMakeCache.txt | cut -d= -f2`
           PYTHONPATH=$PYTHONPATH:$PREFIX/$($PYTHON -c "import sysconfig as sc; print(sc.get_path('platlib', 'posix_prefix', vars={'platbase': '.'}))")
           $PYTHON tests/pyhook_smoketest.py
+      # Import a Developer ID certificate if one is configured. Without the
+      # MACOS_CERT_P12 secret this step is skipped and CODESIGN_IDENTITY stays
+      # unset, so the bundle is ad-hoc signed (launchable on arm64 via the
+      # Gatekeeper bypass). Populate these secrets to enable real signing (#5112).
+      - name: Import signing certificate
+        env:
+          MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+        if: env.MACOS_CERT_P12 != ''
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          security create-keychain -p actions "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p actions "$KEYCHAIN"
+          echo "$MACOS_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k actions "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          echo "CODESIGN_IDENTITY=$MACOS_SIGN_IDENTITY" >> "$GITHUB_ENV"
       - name: Build App Bundle
         working-directory: repo/build
         run: ninja macbundle
+      # Notarize + staple the dmg when notarization credentials are configured.
+      # Skipped (no-op) otherwise. Uses an App Store Connect API key.
+      - name: Notarize and staple
+        working-directory: repo/build/osx
+        env:
+          NOTARY_API_KEY: ${{ secrets.NOTARY_API_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER }}
+        if: env.NOTARY_API_KEY != ''
+        run: |
+          echo "$NOTARY_API_KEY" | base64 --decode > "$RUNNER_TEMP/notary.p8"
+          DMG=$(ls FontForge-*.dmg)
+          xcrun notarytool submit "$DMG" \
+            --key "$RUNNER_TEMP/notary.p8" \
+            --key-id "$NOTARY_KEY_ID" \
+            --issuer "$NOTARY_ISSUER" \
+            --wait
+          xcrun stapler staple "$DMG"
       - name: App Bundle artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/scripts/ffosxbuild.sh
+++ b/.github/workflows/scripts/ffosxbuild.sh
@@ -63,6 +63,53 @@ popd
 mkdir -p $APPDIR/Contents/MacOS
 ln -s ../Frameworks/Python.framework/Versions/$PYVER/bin/$PYTHON "$APPDIR/Contents/MacOS/FFPython"
 
+# --- Code signing -----------------------------------------------------------
+# This MUST run after lddx: its install_name_tool rewrites above invalidate the
+# linker's ad-hoc signatures on the collected dylibs/modules. On Apple Silicon
+# every Mach-O must carry a valid signature to load, so we re-sign everything.
+#
+# Defaults to ad-hoc ("-"), which makes the bundle launchable on arm64 with the
+# usual Gatekeeper bypass (right-click -> Open). To produce a hardened-runtime,
+# notarizable bundle instead, set CODESIGN_IDENTITY to a real
+# "Developer ID Application: Name (TEAMID)" identity (see #5112); CI sets this
+# automatically when signing secrets are present.
+IDENTITY="${CODESIGN_IDENTITY:--}"
+ENTITLEMENTS="${CODESIGN_ENTITLEMENTS:-$SCRIPT_BASE/../../../osx/entitlements.plist}"
+
+if [ "$IDENTITY" = "-" ]; then
+    echo "Ad-hoc signing the bundle..."
+    LIB_SIGN=(--force --timestamp=none --sign -)
+    APP_SIGN=(--force --timestamp=none --sign -)
+else
+    echo "Signing the bundle with identity: $IDENTITY"
+    # Hardened runtime + secure timestamp are required for notarization.
+    # Entitlements (incl. disable-library-validation, so the embedded Python
+    # interpreter can load third-party C extensions) go on the main app only.
+    LIB_SIGN=(--force --options runtime --timestamp --sign "$IDENTITY")
+    APP_SIGN=(--force --options runtime --timestamp --sign "$IDENTITY" --entitlements "$ENTITLEMENTS")
+fi
+
+# 1. Sign every nested Mach-O (dylibs, Python .so modules, helper executables).
+#    -type f skips the symlinks created above.
+echo "Signing nested Mach-O files..."
+find "$APPDIR" -type f | while read -r f; do
+    if file "$f" | grep -q "Mach-O"; then
+        codesign "${LIB_SIGN[@]}" "$f"
+    fi
+done
+
+# 2. Sign the embedded Python framework version.
+codesign "${LIB_SIGN[@]}" "$APPDIR/Contents/Frameworks/Python.framework/Versions/$PYVER"
+
+# 3. Sign the app bundle itself last (main executable receives entitlements).
+codesign "${APP_SIGN[@]}" "$APPDIR"
+
+# Verify integrity. Do NOT use spctl here: it rejects ad-hoc signatures by
+# design and would fail CI spuriously. notarytool (when enabled) is the real
+# Gatekeeper-level check.
+codesign --verify --strict --verbose=2 "$APPDIR"
+# ---------------------------------------------------------------------------
+
 # Package it up
 if [ ! -z "$CI" ]; then
     echo "Creating the dmg..."

--- a/osx/entitlements.plist
+++ b/osx/entitlements.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for hardened-runtime (Developer ID) signing of the macOS bundle.
+  Ignored under ad-hoc signing (entitlements only take effect with the hardened
+  runtime, which the ad-hoc path does not enable), so this file is dormant until
+  CODESIGN_IDENTITY is set to a real Developer ID. See osx/CMakeLists.txt and
+  .github/workflows/scripts/ffosxbuild.sh.
+
+  - disable-library-validation: FontForge embeds a Python interpreter; users
+    import third-party C extensions (.so) we did not sign. Library Validation
+    (on under hardened runtime) would otherwise reject any module not signed by
+    our Team ID.
+  - allow-jit / allow-unsigned-executable-memory: tolerate JIT / writable-
+    executable memory used by some Python extensions.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
The macOS CI build moved to an arm64 runner (#5642). Unsigned arm64 Mach-O code is rejected by the kernel ("Code Signature Invalid"), and lddx's install_name_tool rewrites invalidate the linker's ad-hoc signatures, so the resulting bundle fails to launch on Apple Silicon.

Re-sign the bundle in ffosxbuild.sh after lddx, defaulting to an ad-hoc signature so the app loads on arm64 (still un-notarized, so it needs the usual Gatekeeper bypass, matching the prior x86 experience). Setting CODESIGN_IDENTITY switches to a hardened-runtime, notarizable build using osx/entitlements.plist; disable-library-validation lets the embedded Python interpreter load third-party C extensions under the hardened runtime. main.yml gains two no-op-by-default steps (cert import, notarize + staple) that activate when the corresponding secrets exist.

Add a workflow_dispatch-only rehearsal that exercises the full signing path (minus notarization, which self-signed certs cannot do) with a throwaway self-signed cert, verifying the hardened-runtime bundle and that disable-library-validation works end to end.

<!-- Provide a description of the change here. -->
<!-- See also: https://github.com/fontforge/fontforge/blob/master/CONTRIBUTING.md -->

### Type of change
<!-- What kind of change is this? Remove non applicable types. -->
<!-- If this fixes a bug, please reference the issue, e.g. 'Fixes #1234' -->
- **Bug fix**
- **New feature**
- **Breaking change**
- **Non-breaking change**
