### PR TITLE
Fix double-count of a contour's first point in cv_ptlistcheck

### DIFF
--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -8706,14 +8706,9 @@ static void cv_ptlistcheck(CharView *cv, struct gmenuitem *mi) {
 	    else if ( notimplicit!=spl->first->dontinterpolate ) notimplicit = -2;
 	}
 	for ( spline=spl->first->next; spline!=NULL && spline!=first; spline = spline->to->next ) {
-	    /* On a closed contour this loop walks all the way back to spl->first,
-	       which was already accounted for in the per-contour preamble above.
-	       Skip the per-point bookkeeping for it here so it is not counted
-	       twice -- otherwise selecting just a contour's first point looks like
-	       two selected points (cnt==2), wrongly enabling Make Line/Make Arc and
-	       perturbing the other point-count conditions. The per-spline
-	       spline_selected tally below is unaffected: the wrap spline is a real
-	       spline and must still count. */
+	    /* On a closed contour the walk returns to spl->first, already handled
+	       in the preamble above, so skip it here. (spline_selected below still
+	       counts the wrap spline.) */
 	    if ( spline->to->selected && spline->to!=spl->first ) {
 		if ( type==-2 ) type = spline->to->pointtype;
 		else if ( type!=spline->to->pointtype ) type = -1;

--- a/fontforgeexe/charview.c
+++ b/fontforgeexe/charview.c
@@ -8706,7 +8706,15 @@ static void cv_ptlistcheck(CharView *cv, struct gmenuitem *mi) {
 	    else if ( notimplicit!=spl->first->dontinterpolate ) notimplicit = -2;
 	}
 	for ( spline=spl->first->next; spline!=NULL && spline!=first; spline = spline->to->next ) {
-	    if ( spline->to->selected ) {
+	    /* On a closed contour this loop walks all the way back to spl->first,
+	       which was already accounted for in the per-contour preamble above.
+	       Skip the per-point bookkeeping for it here so it is not counted
+	       twice -- otherwise selecting just a contour's first point looks like
+	       two selected points (cnt==2), wrongly enabling Make Line/Make Arc and
+	       perturbing the other point-count conditions. The per-spline
+	       spline_selected tally below is unaffected: the wrap spline is a real
+	       spline and must still count. */
+	    if ( spline->to->selected && spline->to!=spl->first ) {
 		if ( type==-2 ) type = spline->to->pointtype;
 		else if ( type!=spline->to->pointtype ) type = -1;
 		selpt = spline->to;
@@ -8716,10 +8724,9 @@ static void cv_ptlistcheck(CharView *cv, struct gmenuitem *mi) {
 		    ++ccp_cnt;
 		if ( notimplicit==-1 ) notimplicit = spline->to->dontinterpolate;
 		else if ( notimplicit!=spline->to->dontinterpolate ) notimplicit = -2;
-		if ( spline->from->selected )
-		    ++spline_selected;
 	    }
 	    if ( spline->to->selected && spline->from->selected ) {
+		++spline_selected;
 		if ( acceptable==-1 )
 		    acceptable = spline->acceptableextrema;
 		else if ( acceptable!=spline->acceptableextrema )


### PR DESCRIPTION
`cv_ptlistcheck()` counts the selected points of the active layer to drive the Point menu's enable/disable state. It accounts for `spl->first` in a per-contour preamble and then walks the contour's splines, counting each `spline->to`. On a **closed** contour that walk wraps all the way back around, so the final spline's `->to` is `spl->first` again — and it gets counted a second time.

**Visible effect:** selecting exactly one point that happens to be a contour's first point yields `cnt==2`, so *Make Line* / *Make Arc* (which require two selected points) are wrongly enabled, and the other point-count conditions (Make First, etc.) are perturbed in that same case. Selecting any other single point behaves correctly.

**Fix:** guard the per-point bookkeeping in the loop with `spline->to != spl->first`, so the first point is counted once. The per-spline `spline_selected` tally is moved just below the guard (kept conditional on both endpoints being selected) because the wrap spline is a genuine spline whose selected state must still count — it feeds *Insert Point On Spline At*.

For open contours `spl->first` is never a `spline->to`, so the guard is a no-op there; the change only removes the spurious second count at a closed contour's wrap.
