### PR TITLE
Improve menu interactions (hover, sticky menus)

### DIFF
--- a/fontforgeexe/pixmaps/tango/resources.in
+++ b/fontforgeexe/pixmaps/tango/resources.in
@@ -440,7 +440,7 @@ Gdraw.GGroup.Box.Padding: 0
 Gdraw.GMenuBar.Box.BorderOuter: False
 Gdraw.GMenuBar.Box.GradientStartCol: #e5e4e3
 Gdraw.GMenuBar.Box.BorderInnerCol: #edeceb
-Gdraw.GMenuBar.Box.ActiveBorder: #ededed
+Gdraw.GMenuBar.Box.ActiveBorder: #88b2de
 Gdraw.GMenuBar.Box.BorderShape: rect
 Gdraw.GMenuBar.Box.BorderWidth: 1
 Gdraw.GMenuBar.Box.Radius: 2

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -1010,10 +1010,20 @@ static void _GGDKDraw_DispatchEvent(GdkEvent *event, gpointer data) {
             Log(LOGDEBUG, "Button %7s: [%f %f]", evt->type == GDK_BUTTON_PRESS ? "press" : "release", evt->x, evt->y);
 
 #ifdef GDK_WINDOWING_QUARTZ
-            // Quartz backend fails to give a button press event
+            // Quartz backend fails to give a button press event when the click
+            // lands outside a grabbed window (e.g. clicking off an open menu to
+            // dismiss it): only the release is delivered, never the press.
             // https://bugzilla.gnome.org/show_bug.cgi?id=769961
+            //
+            // Synthesize the missing press when an out-of-bounds release arrives
+            // and no real press is currently held down (which is what tells us
+            // the press was swallowed, rather than this being the release of a
+            // genuine press-inside/drag-outside gesture). Gating on the button
+            // actually being down fixes dismissal on the *first* click; the old
+            // heuristic (release_w == gw) only became true after a first,
+            // wasted click had already set release_w to this window.
             if (!evt->send_event && evt->type == GDK_BUTTON_RELEASE &&
-                    gdisp->bs.release_w == gw &&
+                    !gdisp->bs.is_pressed &&
                     (evt->x < 0 || evt->x > gw->pos.width ||
                      evt->y < 0 || evt->y > gw->pos.height)) {
                 evt->send_event = true;
@@ -1040,12 +1050,19 @@ static void _GGDKDraw_DispatchEvent(GdkEvent *event, gpointer data) {
                     gdisp->bs.cur_click = 1;
                 }
                 gdisp->bs.last_press_time = gevent.u.mouse.time;
+                // Track only genuine presses; a synthetic press (see the Quartz
+                // workaround above) is marked send_event and must not register as
+                // a real button-down, or the paired release would look unbalanced.
+                if (!evt->send_event) {
+                    gdisp->bs.is_pressed = true;
+                }
             } else {
                 gevent.type = et_mouseup;
                 gdisp->bs.release_w = gw;
                 gdisp->bs.release_x = evt->x;
                 gdisp->bs.release_y = evt->y;
                 gdisp->bs.release_button = evt->button;
+                gdisp->bs.is_pressed = false;
             }
             gevent.u.mouse.clicks = gdisp->bs.cur_click;
         }

--- a/gdraw/ggdkdrawP.h
+++ b/gdraw/ggdkdrawP.h
@@ -99,6 +99,7 @@ typedef struct ggdkbuttonstate {
     int16_t cur_click;
     int16_t double_time;		// max milliseconds between release & click
     int16_t double_wiggle;	// max pixel wiggle allowed between release&click
+    bool is_pressed;		// a real (non-synthetic) button is currently held down
 } GGDKButtonState;
 
 typedef struct ggdkkeystate {

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -701,14 +701,15 @@ return( (GDrawGetEH(testm->menubar->g.base))(testm->menubar->g.base,event));
 	    GMenuDismissAll(m);
 	else if ( event->type==et_mouseup )
 	    GMenuSetPressed(m,false);
-	else if ( m->pressed )
+	else if ( event->type==et_mousemove )
+	    /* A displayed menu tracks the pointer whether or not a button is
+	     * held (sticky menus): moving off the menu clears the highlight. */
 	    GMenuChangeSelection(m,-1,event);
 return( true );
     }
 
     event->u.mouse.x = p.x; event->u.mouse.y = p.y; event->w = m->w;
-    if (( m->pressed && event->type==et_mousemove ) ||
-	    event->type == et_mousedown ) {
+    if ( event->type==et_mousemove || event->type == et_mousedown ) {
 	int l = (event->u.mouse.y-m->bp)/m->fh;
 	int i = l + m->offtop;
 	if ( m->scrollit!=NULL )
@@ -1698,11 +1699,26 @@ static int gmenubar_expose(GWindow pixmap, GGadget *g, GEvent *expose) {
 
     r = g->inner;
     for ( i=0; i<mb->lastmi; ++i ) {
-	r.x = mb->xs[i]+mb->g.inner.x; r.width = mb->xs[i+1]-mb->xs[i];
+	int cellx = mb->xs[i]+mb->g.inner.x;
+	int cellw = mb->xs[i+1]-mb->xs[i];
+	/* Draw the active title's highlight ourselves, with horizontal padding
+	 * and filling the bar height, rather than relying on GTextInfoDraw's
+	 * text-tight fill (which hugs the glyphs and looks cramped on macOS).
+	 * We then pass COLOR_DEFAULT below so GTextInfoDraw skips its own fill. */
+	if ( mb->mi[i].ti.selected && mb->g.box->active_border!=COLOR_DEFAULT ) {
+	    GRect hl;
+	    int padx = GDrawPointsToPixels(mb->g.base,5);
+	    int textw = cellw - GDrawPointsToPixels(mb->g.base,8); /* cell = 8pt gap + text */
+	    hl.x = cellx - padx; hl.width = textw + 2*padx;
+	    if ( hl.x < g->inner.x ) { hl.width -= g->inner.x - hl.x; hl.x = g->inner.x; }
+	    hl.y = g->inner.y; hl.height = g->inner.height;
+	    GDrawFillRect(pixmap,&hl,mb->g.box->active_border);
+	}
+	r.x = cellx; r.width = cellw;
 	GDrawPushClip(pixmap,&r,&old3);
 	GTextInfoDraw(pixmap,r.x,r.y,&mb->mi[i].ti,mb->font,
 		mb->mi[i].ti.disabled?mb->g.box->disabled_foreground:fg,
-		mb->g.box->active_border,r.y+r.height, mb->ascender,
+		COLOR_DEFAULT,r.y+r.height, mb->ascender,
 		mb->descender);
 	GDrawPopClip(pixmap,&old3);
     }
@@ -1747,10 +1763,20 @@ return( true );
 	    mb->initial_press = true;
 	    GMenuBarChangeSelection(mb,which,event);
 	}
-    } else if ( event->type == et_mousemove && mb->pressed ) {
-	if ( GGadgetWithin(g,event->u.mouse.x,event->u.mouse.y))
-	    GMenuBarChangeSelection(mb,GMenuBarIndex(mb,event->u.mouse.x),event);
-	else if ( mb->child!=NULL ) {
+    } else if ( event->type == et_mousemove && (mb->pressed || mb->entry_with_mouse!=-1) ) {
+	/* Once a menu is active on the bar, moving across it switches menus on
+	 * hover (sticky menus), not only while a button is held. Keyed off
+	 * entry_with_mouse rather than child!=NULL so that hovering a disabled
+	 * top-level menu (which opens no pulldown) doesn't end navigation. */
+	if ( GGadgetWithin(g,event->u.mouse.x,event->u.mouse.y)) {
+	    int which = GMenuBarIndex(mb,event->u.mouse.x);
+	    /* While hovering (no button held), don't let the pointer passing
+	     * over a gap between titles (which==-1) close the open menu -- that
+	     * causes the menu to flicker shut and reopen. Only switch to another
+	     * real title. A held drag keeps the original close-on-gap behaviour. */
+	    if ( which!=-1 || mb->pressed )
+		GMenuBarChangeSelection(mb,which,event);
+	} else if ( mb->child!=NULL ) {
 	    GPoint p;
 
 	    p.x = event->u.mouse.x; p.y = event->u.mouse.y;

--- a/gdraw/gmenu.c
+++ b/gdraw/gmenu.c
@@ -1763,18 +1763,17 @@ return( true );
 	    mb->initial_press = true;
 	    GMenuBarChangeSelection(mb,which,event);
 	}
-    } else if ( event->type == et_mousemove && (mb->pressed || mb->entry_with_mouse!=-1) ) {
+    } else if ( event->type == et_mousemove && mb->entry_with_mouse!=-1 ) {
 	/* Once a menu is active on the bar, moving across it switches menus on
-	 * hover (sticky menus), not only while a button is held. Keyed off
-	 * entry_with_mouse rather than child!=NULL so that hovering a disabled
-	 * top-level menu (which opens no pulldown) doesn't end navigation. */
+	 * hover. Keyed off entry_with_mouse rather than button state or child!=NULL
+	 * so that hovering a disabled top-level menu (which opens no pulldown)
+	 * doesn't end navigation. */
 	if ( GGadgetWithin(g,event->u.mouse.x,event->u.mouse.y)) {
 	    int which = GMenuBarIndex(mb,event->u.mouse.x);
-	    /* While hovering (no button held), don't let the pointer passing
-	     * over a gap between titles (which==-1) close the open menu -- that
-	     * causes the menu to flicker shut and reopen. Only switch to another
-	     * real title. A held drag keeps the original close-on-gap behaviour. */
-	    if ( which!=-1 || mb->pressed )
+	    /* Don't let the pointer passing over a gap between titles (which==-1)
+	     * close the open menu -- that causes the menu to flicker shut and
+	     * reopen. Only switch to another real title. */
+	    if ( which!=-1 )
 		GMenuBarChangeSelection(mb,which,event);
 	} else if ( mb->child!=NULL ) {
 	    GPoint p;


### PR DESCRIPTION
I've been using FontForge a lot recently on both Fedora KDE and macOS, and I've noticed that the menu behaves oddly. Menus are sticky, i.e. you need to click and sometimes hovering over menu entries doesn't seem to work properly. I never know if the click I'm about to make will actually make it through.

A clicked main menu item also doesn't look properly selected when it's active and there was obvious padding missing as well.

I've tried to address these things in this PR, which was created with some assistance from LLMs, I should note. I've checked the code myself and tested the fixes on macOS, but not on Linux (yet).

So, this PR:

- Ensures that clicks outside of the window consistently dismiss menus
- Addresses sticky menus (hover + clear-on-leave)
- The active title now draws a padded, bar-height highlight instead of a cramped text-tight fill, which looked off

### Changes

| Area | Files |
|------|-------|
| Quartz first-click dismiss | `gdraw/ggdkdraw.c`, `gdraw/ggdkdrawP.h` |
| Sticky hover + menubar switching + highlight padding | `gdraw/gmenu.c` |
| Menubar highlight color | `fontforgeexe/pixmaps/tango/resources.in` |

For comparison, here's a demonstration to illustrate how much smoother things become (with Tango theme on):

### Before

https://github.com/user-attachments/assets/d6b47d73-8a5b-4406-a24a-10a2faced5a9

This is especially frustrating when I have a menu open and I want to navigate to another menu; clicking on it toggles the menu and immediately dismisses it.

### After

https://github.com/user-attachments/assets/60eda7b7-4dff-474c-9d07-662f7cafb2f2

Navigating with the mouse has been clunky, and this improves things significantly.

### Type of change

- **Bug fix** - fixes #2064
- **Non-breaking change**

If any further changes are required, I'd be happy to make them, or if you the original menu click behaviour was as intended, feel free to close this PR. I think it's a significant improvement either way, so I wanted to at the very least open a PR to hear if there's any interest in merging this in.

### Notes

- If necessary, the comments can be stripped if they're too descriptive.
- I haven't tested on Windows and/or Linux. Can someone check?
- For a better user experience, the highlight color for disabled entries could be a different color?